### PR TITLE
fix: critical issues from PR #37 code review

### DIFF
--- a/src/main/platform/darwin.js
+++ b/src/main/platform/darwin.js
@@ -6,6 +6,11 @@
 'use strict';
 
 const { execFile } = require('child_process');
+
+let _execFile = execFile;
+/** @internal Override execFile (for tests). */
+function _setExecFileForTest(fn) { _execFile = fn || require('child_process').execFile; }
+
 const {
   parseLsofOutput,
   parseLsofFileHandles,
@@ -34,7 +39,7 @@ const IGNORE_FILE_PATTERNS = [
  */
 function listProcesses() {
   return new Promise((resolve, reject) => {
-    execFile('ps', ['-axo', 'comm=,pid='], { maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
+    _execFile('ps', ['-axo', 'comm=,pid='], { maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
       if (err) {
         reject(err);
         return;
@@ -70,7 +75,7 @@ function listProcesses() {
  */
 function getParentProcessMap() {
   return new Promise((resolve) => {
-    execFile(
+    _execFile(
       'ps',
       ['-axo', 'pid=,ppid=,comm='],
       { maxBuffer: 4 * 1024 * 1024 },
@@ -96,7 +101,7 @@ function getRawTcpConnections(pids) {
       resolve([]);
       return;
     }
-    execFile(
+    _execFile(
       'lsof',
       ['-i', 'TCP', '-n', '-P', '-F', 'pcnT'],
       { timeout: 10000, maxBuffer: 4 * 1024 * 1024 },
@@ -141,4 +146,5 @@ module.exports = {
   suspendProcess,
   resumeProcess,
   IGNORE_FILE_PATTERNS,
+  _setExecFileForTest,
 };

--- a/src/main/platform/linux.js
+++ b/src/main/platform/linux.js
@@ -96,7 +96,7 @@ function getParentProcessMap() {
   }
 
   return new Promise((resolve) => {
-    execFile(
+    _execFile(
       'ps',
       ['-axo', 'pid=,ppid=,comm='],
       { maxBuffer: 4 * 1024 * 1024 },

--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -189,6 +189,8 @@ function getFileHandles(pid) {
  * @returns {Promise<{success: boolean, error?: string}>}
  */
 function killProcess(pid) {
+  pid = Number(pid);
+  if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve({ success: false, error: 'Invalid PID' });
   return new Promise((resolve) => {
     execFile('taskkill', ['/PID', String(pid), '/F'], (err) => {
       resolve(err ? { success: false, error: err.message } : { success: true });
@@ -201,6 +203,8 @@ function killProcess(pid) {
  * @returns {Promise<{success: boolean, error?: string}>}
  */
 function suspendProcess(pid) {
+  pid = Number(pid);
+  if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve({ success: false, error: 'Invalid PID' });
   const script = `Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;public class Ntdll{[DllImport("ntdll.dll")]public static extern int NtSuspendProcess(IntPtr h);}' -PassThru | Out-Null;$h=(Get-Process -Id ${Number(pid)}).Handle;[Ntdll]::NtSuspendProcess($h)`;
   return new Promise((resolve) => {
     execFile(
@@ -219,6 +223,8 @@ function suspendProcess(pid) {
  * @returns {Promise<{success: boolean, error?: string}>}
  */
 function resumeProcess(pid) {
+  pid = Number(pid);
+  if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve({ success: false, error: 'Invalid PID' });
   const script = `Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;public class Ntdll2{[DllImport("ntdll.dll")]public static extern int NtResumeProcess(IntPtr h);}' -PassThru | Out-Null;$h=(Get-Process -Id ${Number(pid)}).Handle;[Ntdll2]::NtResumeProcess($h)`;
   return new Promise((resolve) => {
     execFile(

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -73,8 +73,11 @@ describe('file-watcher', () => {
       expect(fileWatcher.shouldIgnore('/home/user/file.tmp')).toBe(true);
     });
 
-    it('platform-specific patterns (macOS)', () => {
+    it.skipIf(process.platform !== 'darwin')('platform-specific patterns (macOS): /System/', () => {
       expect(fileWatcher.shouldIgnore('/System/Library/something')).toBe(true);
+    });
+
+    it.skipIf(process.platform !== 'darwin')('platform-specific patterns (macOS): .DS_Store', () => {
       expect(fileWatcher.shouldIgnore('/Users/test/.DS_Store')).toBe(true);
     });
 
@@ -82,11 +85,11 @@ describe('file-watcher', () => {
       expect(fileWatcher.shouldIgnore('/home/user/project/index.js')).toBe(false);
     });
 
-    it('/private/var/ on macOS', () => {
+    it.skipIf(process.platform !== 'darwin')('/private/var/ on macOS', () => {
       expect(fileWatcher.shouldIgnore('/private/var/folders/xx/tmp')).toBe(true);
     });
 
-    it('/dev/ paths', () => {
+    it.skipIf(process.platform === 'win32')('/dev/ paths', () => {
       expect(fileWatcher.shouldIgnore('/dev/null')).toBe(true);
     });
   });

--- a/tests/main/ipc-handlers.test.js
+++ b/tests/main/ipc-handlers.test.js
@@ -315,7 +315,7 @@ describe('ipc-handlers', () => {
       const handler = getHandler('get-project-dir');
       const result = handler();
       expect(typeof result).toBe('string');
-      expect(result).toContain('Aegis');
+      expect(result.toLowerCase()).toContain('aegis');
     });
 
     it('save-custom-agents delegates to config', () => {


### PR DESCRIPTION
## Summary

Follow-up fixes from code review of #37 (cross-platform support by @skmelendez).
No business logic changes.

## Changes

**Platform layer:**
- `linux.js`: bare `execFile` -> `_execFile` in ps-fallback (was bypassing DI mock hook)
- `darwin.js`: add `_setExecFileForTest` DI hook (consistency with linux.js + posix-shared.js)
- `win32.js`: PID integer validation in kill/suspend/resume (defence-in-depth)

**Tests:**
- `file-watcher.test.js`: skip 4 darwin/linux-only tests on non-matching platforms
- `ipc-handlers.test.js`: case-insensitive path assertion (Windows casing)

## Testing
- 383 passed, 4 skipped (platform-specific), 0 failed

## Related
- Fixes issues identified in #37 code review
- Co-authored-by: @skmelendez