### PR TITLE
chore: format entire codebase with Prettier

### DIFF
--- a/src/main/audit-logger.js
+++ b/src/main/audit-logger.js
@@ -291,4 +291,13 @@ function getEntriesBefore(beforeTs, limit = 100) {
   return results;
 }
 
-module.exports = { init, log, flush, shutdown, getStats, exportAll, getEntriesBefore, getLogDir: () => _logDir };
+module.exports = {
+  init,
+  log,
+  flush,
+  shutdown,
+  getStats,
+  exportAll,
+  getEntriesBefore,
+  getLogDir: () => _logDir,
+};

--- a/src/main/baselines.js
+++ b/src/main/baselines.js
@@ -23,7 +23,9 @@ function baselinesPath() {
   return _baselinesPath;
 }
 /** @internal Override baselines path (for tests). */
-function _setBaselinesPathForTest(p) { _baselinesPath = p; }
+function _setBaselinesPathForTest(p) {
+  _baselinesPath = p;
+}
 const MAX_BASELINE_SESSIONS = 10;
 let baselines = { agents: {} };
 const sessionData = {};
@@ -46,7 +48,10 @@ function saveBaselines() {
   try {
     fs.writeFileSync(baselinesPath(), JSON.stringify(baselines, null, 2));
   } catch (err) {
-    logger.error('baselines', 'Failed to save baselines', { path: baselinesPath(), error: err.message });
+    logger.error('baselines', 'Failed to save baselines', {
+      path: baselinesPath(),
+      error: err.message,
+    });
   }
 }
 

--- a/src/main/config-manager.js
+++ b/src/main/config-manager.js
@@ -27,7 +27,9 @@ function settingsPath() {
   return _settingsPath;
 }
 /** @internal Override settings path (for tests). */
-function _setSettingsPathForTest(p) { _settingsPath = p; }
+function _setSettingsPathForTest(p) {
+  _settingsPath = p;
+}
 
 const DEFAULT_SETTINGS = {
   scanIntervalSec: 10,
@@ -193,7 +195,10 @@ function saveInstancePermissions(agentName, parentEditor, perms, cwd) {
   try {
     fs.writeFileSync(settingsPath(), JSON.stringify(settings, null, 2));
   } catch (err) {
-    logger.warn('config-manager', 'Failed to persist instance permissions', { key, error: err.message });
+    logger.warn('config-manager', 'Failed to persist instance permissions', {
+      key,
+      error: err.message,
+    });
   }
 }
 
@@ -212,7 +217,10 @@ function trackSeenAgent(agentName) {
     try {
       fs.writeFileSync(settingsPath(), JSON.stringify(settings, null, 2));
     } catch (err) {
-      logger.warn('config-manager', 'Failed to persist seen agent', { agentName, error: err.message });
+      logger.warn('config-manager', 'Failed to persist seen agent', {
+        agentName,
+        error: err.message,
+      });
     }
   }
 }

--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -33,7 +33,9 @@ function _setDepsForTest(overrides) {
   if (overrides.getFileHandles) _getFileHandles = overrides.getFileHandles;
 }
 /** @internal Reset debounce state (for tests). */
-function _resetForTest() { watcherDebounce.clear(); }
+function _resetForTest() {
+  watcherDebounce.clear();
+}
 
 const watcherDebounce = new Map();
 let _state = null;
@@ -65,8 +67,10 @@ function classifySensitive(filePath) {
 
 /** @param {string} filePath @returns {boolean} @since v0.1.0 */
 function shouldIgnore(filePath) {
-  return IGNORE_PATTERNS.some((p) => p.test(filePath)) ||
-    IGNORE_FILE_PATTERNS.some((p) => p.test(filePath));
+  return (
+    IGNORE_PATTERNS.some((p) => p.test(filePath)) ||
+    IGNORE_FILE_PATTERNS.some((p) => p.test(filePath))
+  );
 }
 
 /**

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -53,7 +53,8 @@ function register() {
   ipcMain.on('other-panel-expanded', (_e, val) => deps.setOtherPanelExpanded(val));
 
   ipcMain.handle('test-notification', () => {
-    if (!Notification.isSupported()) return { success: false, error: 'Notifications not supported on this system' };
+    if (!Notification.isSupported())
+      return { success: false, error: 'Notifications not supported on this system' };
     new Notification({
       title: 'AEGIS \u2014 Test Notification',
       body: 'Desktop notifications are working correctly.',
@@ -135,10 +136,13 @@ function register() {
     config.getInstancePermissions(agentName, parentEditor, cwd),
   );
 
-  ipcMain.handle('save-instance-permissions', (_e, { agentName, parentEditor, permissions, cwd }) => {
-    config.saveInstancePermissions(agentName, parentEditor, permissions, cwd);
-    return { success: true };
-  });
+  ipcMain.handle(
+    'save-instance-permissions',
+    (_e, { agentName, parentEditor, permissions, cwd }) => {
+      config.saveInstancePermissions(agentName, parentEditor, permissions, cwd);
+      return { success: true };
+    },
+  );
 
   ipcMain.handle('reset-permissions-to-defaults', () => {
     const settings = config.getSettings();

--- a/src/main/logger.js
+++ b/src/main/logger.js
@@ -80,10 +80,18 @@ function _write(level, mod, message, meta) {
   if (_buffer.length >= FLUSH_THRESHOLD) flush();
 }
 
-function debug(mod, message, meta) { _write('debug', mod, message, meta); }
-function info(mod, message, meta) { _write('info', mod, message, meta); }
-function warn(mod, message, meta) { _write('warn', mod, message, meta); }
-function error(mod, message, meta) { _write('error', mod, message, meta); }
+function debug(mod, message, meta) {
+  _write('debug', mod, message, meta);
+}
+function info(mod, message, meta) {
+  _write('info', mod, message, meta);
+}
+function warn(mod, message, meta) {
+  _write('warn', mod, message, meta);
+}
+function error(mod, message, meta) {
+  _write('error', mod, message, meta);
+}
 
 /**
  * Flush the buffer to disk.

--- a/src/main/network-monitor.js
+++ b/src/main/network-monitor.js
@@ -27,7 +27,10 @@ function _setDepsForTest(overrides) {
   if (overrides.dnsReverse) _dnsReverse = overrides.dnsReverse;
 }
 /** @internal Clear caches (for tests). */
-function _resetForTest() { dnsCache.clear(); networkScanRunning = false; }
+function _resetForTest() {
+  dnsCache.clear();
+  networkScanRunning = false;
+}
 
 const agentDb = JSON.parse(
   fs.readFileSync(path.join(__dirname, '..', 'shared', 'agent-database.json'), 'utf-8'),

--- a/src/main/platform/darwin.js
+++ b/src/main/platform/darwin.js
@@ -9,7 +9,9 @@ const { execFile } = require('child_process');
 
 let _execFile = execFile;
 /** @internal Override execFile (for tests). */
-function _setExecFileForTest(fn) { _execFile = fn || require('child_process').execFile; }
+function _setExecFileForTest(fn) {
+  _execFile = fn || require('child_process').execFile;
+}
 
 const {
   parseLsofOutput,
@@ -75,18 +77,13 @@ function listProcesses() {
  */
 function getParentProcessMap() {
   return new Promise((resolve) => {
-    _execFile(
-      'ps',
-      ['-axo', 'pid=,ppid=,comm='],
-      { maxBuffer: 4 * 1024 * 1024 },
-      (err, stdout) => {
-        if (err) {
-          resolve(new Map());
-          return;
-        }
-        resolve(parseParentProcessMapFromPs(stdout));
-      },
-    );
+    _execFile('ps', ['-axo', 'pid=,ppid=,comm='], { maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
+      if (err) {
+        resolve(new Map());
+        return;
+      }
+      resolve(parseParentProcessMapFromPs(stdout));
+    });
   });
 }
 

--- a/src/main/platform/posix-shared.js
+++ b/src/main/platform/posix-shared.js
@@ -9,7 +9,9 @@ const { execFile: _origExecFile } = require('child_process');
 
 let _execFile = _origExecFile;
 /** @internal Override execFile (for tests). */
-function _setExecFileForTest(fn) { _execFile = fn || _origExecFile; }
+function _setExecFileForTest(fn) {
+  _execFile = fn || _origExecFile;
+}
 
 /**
  * Parse `lsof -i TCP -n -P -F pcnT` output.

--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -190,7 +190,8 @@ function getFileHandles(pid) {
  */
 function killProcess(pid) {
   pid = Number(pid);
-  if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve({ success: false, error: 'Invalid PID' });
+  if (!Number.isInteger(pid) || pid <= 0)
+    return Promise.resolve({ success: false, error: 'Invalid PID' });
   return new Promise((resolve) => {
     execFile('taskkill', ['/PID', String(pid), '/F'], (err) => {
       resolve(err ? { success: false, error: err.message } : { success: true });
@@ -204,7 +205,8 @@ function killProcess(pid) {
  */
 function suspendProcess(pid) {
   pid = Number(pid);
-  if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve({ success: false, error: 'Invalid PID' });
+  if (!Number.isInteger(pid) || pid <= 0)
+    return Promise.resolve({ success: false, error: 'Invalid PID' });
   const script = `Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;public class Ntdll{[DllImport("ntdll.dll")]public static extern int NtSuspendProcess(IntPtr h);}' -PassThru | Out-Null;$h=(Get-Process -Id ${Number(pid)}).Handle;[Ntdll]::NtSuspendProcess($h)`;
   return new Promise((resolve) => {
     execFile(
@@ -224,7 +226,8 @@ function suspendProcess(pid) {
  */
 function resumeProcess(pid) {
   pid = Number(pid);
-  if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve({ success: false, error: 'Invalid PID' });
+  if (!Number.isInteger(pid) || pid <= 0)
+    return Promise.resolve({ success: false, error: 'Invalid PID' });
   const script = `Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;public class Ntdll2{[DllImport("ntdll.dll")]public static extern int NtResumeProcess(IntPtr h);}' -PassThru | Out-Null;$h=(Get-Process -Id ${Number(pid)}).Handle;[Ntdll2]::NtResumeProcess($h)`;
   return new Promise((resolve) => {
     execFile(

--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -23,7 +23,9 @@ function _setPlatformForTest(overrides) {
   if (overrides.listProcesses) _listProcesses = overrides.listProcesses;
 }
 /** @internal Reset state (for tests). */
-function _resetForTest() { lastProcessPidSet = ''; }
+function _resetForTest() {
+  lastProcessPidSet = '';
+}
 
 const agentDb = JSON.parse(
   fs.readFileSync(path.join(__dirname, '..', 'shared', 'agent-database.json'), 'utf-8'),

--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -179,4 +179,11 @@ async function annotateWorkingDirs(agents) {
   }
 }
 
-module.exports = { getParentChains, enrichWithParentChains, annotateHostApps, annotateWorkingDirs, _setPlatformForTest, _resetForTest };
+module.exports = {
+  getParentChains,
+  enrichWithParentChains,
+  annotateHostApps,
+  annotateWorkingDirs,
+  _setPlatformForTest,
+  _resetForTest,
+};

--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -19,9 +19,13 @@
       // Scroll into view
       if (cardEl) cardEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
       // Stop blink after 3 cycles (each cycle is 400ms via CSS)
-      setTimeout(() => { blinking = false; }, 1200);
+      setTimeout(() => {
+        blinking = false;
+      }, 1200);
       // Clear the store so clicking the same dot again works
-      setTimeout(() => { focusedAgentPid.set(null); }, 50);
+      setTimeout(() => {
+        focusedAgentPid.set(null);
+      }, 50);
     }
   });
 
@@ -40,7 +44,8 @@
   });
 
   let agentEvents = $derived.by(() => {
-    return $events.flat()
+    return $events
+      .flat()
       .filter((ev) => ev.pid === agent.pid)
       .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
       .slice(0, 50);
@@ -154,11 +159,17 @@
       {/if}
 
       <div class="pid-actions-row">
-        <span class="pid-info">PID {agent.pid}{agent.process ? ` \u2014 ${agent.process}` : ''}</span>
+        <span class="pid-info"
+          >PID {agent.pid}{agent.process ? ` \u2014 ${agent.process}` : ''}</span
+        >
         <div class="pid-actions">
           <button class="action-btn kill" onclick={(e) => pidAction(e, 'killProcess')}>Kill</button>
-          <button class="action-btn suspend" onclick={(e) => pidAction(e, 'suspendProcess')}>Suspend</button>
-          <button class="action-btn resume" onclick={(e) => pidAction(e, 'resumeProcess')}>Resume</button>
+          <button class="action-btn suspend" onclick={(e) => pidAction(e, 'suspendProcess')}
+            >Suspend</button
+          >
+          <button class="action-btn resume" onclick={(e) => pidAction(e, 'resumeProcess')}
+            >Resume</button
+          >
         </div>
       </div>
     </div>
@@ -171,7 +182,9 @@
     backdrop-filter: blur(var(--glass-blur));
     -webkit-backdrop-filter: blur(var(--glass-blur));
     border: var(--aegis-card-border);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12), var(--glass-highlight);
+    box-shadow:
+      0 2px 8px rgba(0, 0, 0, 0.12),
+      var(--glass-highlight);
     border-radius: var(--md-sys-shape-corner-medium);
     padding: var(--aegis-space-4) var(--aegis-space-6);
     cursor: pointer;
@@ -405,7 +418,12 @@
   }
 
   @keyframes card-blink {
-    0%, 100% { background: var(--md-sys-color-surface-container-low); }
-    50% { background: var(--md-sys-color-primary-container); }
+    0%,
+    100% {
+      background: var(--md-sys-color-surface-container-low);
+    }
+    50% {
+      background: var(--md-sys-color-primary-container);
+    }
   }
 </style>

--- a/src/renderer/lib/components/FeedFilters.svelte
+++ b/src/renderer/lib/components/FeedFilters.svelte
@@ -57,7 +57,9 @@
     backdrop-filter: blur(var(--glass-blur));
     -webkit-backdrop-filter: blur(var(--glass-blur));
     border: var(--aegis-card-border);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12), var(--glass-highlight);
+    box-shadow:
+      0 2px 8px rgba(0, 0, 0, 0.12),
+      var(--glass-highlight);
     border-radius: var(--md-sys-shape-corner-medium);
     flex-wrap: wrap;
   }

--- a/src/renderer/lib/components/GroupedFeed.svelte
+++ b/src/renderer/lib/components/GroupedFeed.svelte
@@ -370,7 +370,8 @@
     font-family: 'DM Mono', monospace;
     font-size: calc(10px * var(--aegis-ui-scale));
     color: var(--md-sys-color-on-surface-variant);
-    padding: var(--aegis-space-1) var(--aegis-space-6) var(--aegis-space-3) calc(26px * var(--aegis-ui-scale));
+    padding: var(--aegis-space-1) var(--aegis-space-6) var(--aegis-space-3)
+      calc(26px * var(--aegis-ui-scale));
     word-break: break-all;
   }
   .detail-link {

--- a/src/renderer/lib/components/Header.svelte
+++ b/src/renderer/lib/components/Header.svelte
@@ -36,7 +36,13 @@
     <span class="stat-text">{filesMonitored} files</span>
   </div>
 
-  <button class="icon-btn" aria-label="Settings" onclick={() => { optionsOpen = true; }}>
+  <button
+    class="icon-btn"
+    aria-label="Settings"
+    onclick={() => {
+      optionsOpen = true;
+    }}
+  >
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
       <path
         d="M6.5.5h3l.4 2 1.3.7 1.8-1 2.1 2.1-1 1.8.7 1.3 2 .4v3l-2 .4-.7 1.3 1 1.8-2.1 2.1-1.8-1-1.3.7-.4 2h-3l-.4-2-1.3-.7-1.8 1L.9 13.3l1-1.8-.7-1.3-2-.4v-3l2-.4.7-1.3-1-1.8L2.9.9l1.8 1 1.3-.7z"

--- a/src/renderer/lib/components/OptionsPanel.svelte
+++ b/src/renderer/lib/components/OptionsPanel.svelte
@@ -22,14 +22,17 @@
       localScale = $uiScale;
       testResult = '';
       if (!loaded && window.aegis) {
-        window.aegis.getSettings().then((s) => {
-          if (!s) return;
-          scanInterval = s.scanIntervalSec ?? 10;
-          notifications = s.notificationsEnabled ?? true;
-          apiKey = s.anthropicApiKey ?? '';
-          customPatterns = (s.customSensitivePatterns || []).join('\n');
-          loaded = true;
-        }).catch(() => {});
+        window.aegis
+          .getSettings()
+          .then((s) => {
+            if (!s) return;
+            scanInterval = s.scanIntervalSec ?? 10;
+            notifications = s.notificationsEnabled ?? true;
+            apiKey = s.anthropicApiKey ?? '';
+            customPatterns = (s.customSensitivePatterns || []).join('\n');
+            loaded = true;
+          })
+          .catch(() => {});
       }
     }
   });
@@ -51,7 +54,10 @@
 
     // Save all settings
     if (window.aegis) {
-      const patterns = customPatterns.split('\n').map((l) => l.trim()).filter(Boolean);
+      const patterns = customPatterns
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
       const current = await window.aegis.getSettings();
       await window.aegis.saveSettings({
         ...current,
@@ -98,7 +104,14 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <div class="overlay" onclick={handleBackdrop} onkeydown={handleKeydown} role="dialog" aria-modal="true" tabindex="-1">
+  <div
+    class="overlay"
+    onclick={handleBackdrop}
+    onkeydown={handleKeydown}
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+  >
     <div class="panel" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
       <h2 class="panel-title">Settings</h2>
 
@@ -109,26 +122,52 @@
         <span class="option-label">Theme</span>
         <div class="theme-toggle">
           <label class="radio-label">
-            <input type="radio" name="theme" value="dark" checked={localTheme === 'dark'} onchange={onThemeChange} />
+            <input
+              type="radio"
+              name="theme"
+              value="dark"
+              checked={localTheme === 'dark'}
+              onchange={onThemeChange}
+            />
             Dark
           </label>
           <label class="radio-label">
-            <input type="radio" name="theme" value="light" checked={localTheme === 'light'} onchange={onThemeChange} />
+            <input
+              type="radio"
+              name="theme"
+              value="light"
+              checked={localTheme === 'light'}
+              onchange={onThemeChange}
+            />
             Light
           </label>
           <label class="radio-label">
-            <input type="radio" name="theme" value="dark-hc" checked={localTheme === 'dark-hc'} onchange={onThemeChange} />
+            <input
+              type="radio"
+              name="theme"
+              value="dark-hc"
+              checked={localTheme === 'dark-hc'}
+              onchange={onThemeChange}
+            />
             Dark HC
           </label>
           <label class="radio-label">
-            <input type="radio" name="theme" value="light-hc" checked={localTheme === 'light-hc'} onchange={onThemeChange} />
+            <input
+              type="radio"
+              name="theme"
+              value="light-hc"
+              checked={localTheme === 'light-hc'}
+              onchange={onThemeChange}
+            />
             Light HC
           </label>
         </div>
       </div>
 
       <div class="option-group">
-        <label class="option-label" for="ui-scale-slider">Interface Scale <span class="scale-value">{scalePercent}%</span></label>
+        <label class="option-label" for="ui-scale-slider"
+          >Interface Scale <span class="scale-value">{scalePercent}%</span></label
+        >
         <input
           id="ui-scale-slider"
           type="range"
@@ -164,7 +203,9 @@
             class="toggle"
             class:toggle-on={notifications}
             aria-label="Toggle notifications"
-            onclick={() => { notifications = !notifications; }}
+            onclick={() => {
+              notifications = !notifications;
+            }}
           >
             <span class="toggle-knob"></span>
           </button>
@@ -186,7 +227,12 @@
           {:else}
             <input type="password" bind:value={apiKey} placeholder="sk-ant-..." class="key-input" />
           {/if}
-          <button class="btn btn-small" onclick={() => { showKey = !showKey; }}>
+          <button
+            class="btn btn-small"
+            onclick={() => {
+              showKey = !showKey;
+            }}
+          >
             {showKey ? 'Hide' : 'Show'}
           </button>
         </div>
@@ -195,13 +241,23 @@
       <div class="option-group">
         <span class="option-label">Custom Sensitive Patterns</span>
         <span class="field-hint">One regex per line</span>
-        <textarea rows="3" bind:value={customPatterns} placeholder="e.g. \.secret$&#10;passwords\.txt"></textarea>
+        <textarea
+          rows="3"
+          bind:value={customPatterns}
+          placeholder="e.g. \.secret$&#10;passwords\.txt"
+        ></textarea>
       </div>
 
       <!-- ── Config ── -->
       <div class="config-actions">
         <button class="btn" onclick={() => window.aegis?.exportConfig()}>Export Config</button>
-        <button class="btn" onclick={async () => { const r = await window.aegis?.importConfig(); if (r?.success) loaded = false; }}>Import Config</button>
+        <button
+          class="btn"
+          onclick={async () => {
+            const r = await window.aegis?.importConfig();
+            if (r?.success) loaded = false;
+          }}>Import Config</button
+        >
       </div>
 
       <div class="panel-actions">
@@ -225,8 +281,12 @@
   }
 
   @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 
   .panel {
@@ -249,7 +309,10 @@
   }
 
   @keyframes scale-in {
-    from { opacity: 0; transform: scale(0.96) translateY(8px); }
+    from {
+      opacity: 0;
+      transform: scale(0.96) translateY(8px);
+    }
   }
 
   .panel-title {
@@ -426,8 +489,14 @@
     color: var(--md-sys-color-on-surface);
     outline: none;
   }
-  .key-input { flex: 1; }
-  textarea { resize: vertical; width: 100%; box-sizing: border-box; }
+  .key-input {
+    flex: 1;
+  }
+  textarea {
+    resize: vertical;
+    width: 100%;
+    box-sizing: border-box;
+  }
   .key-input:focus,
   textarea:focus {
     border-color: var(--md-sys-color-primary);
@@ -457,8 +526,12 @@
     cursor: pointer;
     transition: all 0.3s var(--ease-glass);
   }
-  .btn:hover { opacity: 0.85; }
-  .btn:active { transform: scale(0.97); }
+  .btn:hover {
+    opacity: 0.85;
+  }
+  .btn:active {
+    transform: scale(0.97);
+  }
 
   .btn-small {
     padding: var(--aegis-space-3) var(--aegis-space-6);

--- a/src/renderer/lib/components/PermissionsGrid.svelte
+++ b/src/renderer/lib/components/PermissionsGrid.svelte
@@ -82,10 +82,7 @@
   function setState(catId, newState) {
     if (selectedKey === '__global__') return;
 
-    const allEntries = [
-      ...instanceList.running,
-      ...instanceList.savedDefaults,
-    ];
+    const allEntries = [...instanceList.running, ...instanceList.savedDefaults];
     const entry = allEntries.find((e) => e.key === selectedKey);
     if (!entry) return;
 

--- a/src/renderer/lib/components/Radar.svelte
+++ b/src/renderer/lib/components/Radar.svelte
@@ -37,8 +37,8 @@
   // ═══ DRAWING ═══
 
   function drawBackground(cx, cy, r) {
-    const ringAlpha = isHC ? (isLight ? 0.4 : 0.3) : (isLight ? 0.25 : 0.12);
-    const crossAlpha = isHC ? (isLight ? 0.3 : 0.2) : (isLight ? 0.18 : 0.09);
+    const ringAlpha = isHC ? (isLight ? 0.4 : 0.3) : isLight ? 0.25 : 0.12;
+    const crossAlpha = isHC ? (isLight ? 0.3 : 0.2) : isLight ? 0.18 : 0.09;
     ctx.strokeStyle = `rgba(${lineRgb}, ${ringAlpha})`;
     ctx.lineWidth = 1;
     for (const frac of [0.33, 0.66, 1.0]) {
@@ -58,9 +58,9 @@
 
   function drawSweep(cx, cy, r, angle) {
     const trailLen = Math.PI * 0.4;
-    const midAlpha = isHC ? (isLight ? 0.35 : 0.25) : (isLight ? 0.22 : 0.12);
-    const tipAlpha = isHC ? (isLight ? 0.7 : 0.6) : (isLight ? 0.5 : 0.3);
-    const lineAlpha = isHC ? (isLight ? 0.9 : 0.8) : (isLight ? 0.7 : 0.5);
+    const midAlpha = isHC ? (isLight ? 0.35 : 0.25) : isLight ? 0.22 : 0.12;
+    const tipAlpha = isHC ? (isLight ? 0.7 : 0.6) : isLight ? 0.5 : 0.3;
+    const lineAlpha = isHC ? (isLight ? 0.9 : 0.8) : isLight ? 0.7 : 0.5;
     const trailGrad = ctx.createConicGradient(angle - trailLen, cx, cy);
     trailGrad.addColorStop(0, `rgba(${sweepRgb},0)`);
     trailGrad.addColorStop(0.8, `rgba(${sweepRgb},${midAlpha})`);
@@ -119,12 +119,12 @@
 
       ctx.beginPath();
       ctx.arc(x, y, 3, 0, Math.PI * 2);
-      ctx.fillStyle = `rgba(${lineRgb}, ${isHC ? 0.9 : (isLight ? 0.7 : 0.5)})`;
+      ctx.fillStyle = `rgba(${lineRgb}, ${isHC ? 0.9 : isLight ? 0.7 : 0.5})`;
       ctx.fill();
 
       ctx.font = "500 9px 'DM Sans', sans-serif";
       ctx.textAlign = 'center';
-      ctx.fillStyle = `rgba(${labelRgb}, ${isHC ? 1 : (isLight ? 0.9 : 0.8)})`;
+      ctx.fillStyle = `rgba(${labelRgb}, ${isHC ? 1 : isLight ? 0.9 : 0.8})`;
       ctx.fillText(agent.name?.split(' ')[0] || '', x, y + 14);
     }
   }
@@ -133,7 +133,7 @@
     ctx.font = "600 11px 'Outfit', sans-serif";
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillStyle = `rgba(${labelRgb}, ${isHC ? 1 : (isLight ? 0.85 : 0.7)})`;
+    ctx.fillStyle = `rgba(${labelRgb}, ${isHC ? 1 : isLight ? 0.85 : 0.7})`;
     ctx.fillText('AEGIS', cx, cy);
   }
 

--- a/src/renderer/lib/components/Timeline.svelte
+++ b/src/renderer/lib/components/Timeline.svelte
@@ -11,18 +11,17 @@
   const MIN_TICK_PX = 64;
 
   const ZOOM_LEVELS = [
-    { ms: 3600000 },  // 1h per 120px
-    { ms: 1800000 },  // 30min
-    { ms: 600000  },  // 10min
-    { ms: 300000  },  // 5min
-    { ms: 60000   },  // 1min
-    { ms: 30000   },  // 30s
-    { ms: 10000   },  // 10s (default — most zoomed in)
+    { ms: 3600000 }, // 1h per 120px
+    { ms: 1800000 }, // 30min
+    { ms: 600000 }, // 10min
+    { ms: 300000 }, // 5min
+    { ms: 60000 }, // 1min
+    { ms: 30000 }, // 30s
+    { ms: 10000 }, // 10s (default — most zoomed in)
   ];
 
   const NICE_INTERVALS = [
-    5000, 10000, 15000, 30000, 60000, 120000, 300000,
-    600000, 900000, 1800000, 3600000, 7200000,
+    5000, 10000, 15000, 30000, 60000, 120000, 300000, 600000, 900000, 1800000, 3600000, 7200000,
   ];
 
   function getSeverity(ev) {
@@ -64,7 +63,11 @@
   // Load persisted zoom from settings
   if (window.aegis) {
     window.aegis.getSettings().then((s) => {
-      if (typeof s.timelineZoom === 'number' && s.timelineZoom >= 0 && s.timelineZoom < ZOOM_LEVELS.length) {
+      if (
+        typeof s.timelineZoom === 'number' &&
+        s.timelineZoom >= 0 &&
+        s.timelineZoom < ZOOM_LEVELS.length
+      ) {
         zoomIndex = s.timelineZoom;
       }
     });
@@ -107,17 +110,22 @@
     // Snapshot current timeline origin so we can compensate after load
     prevMinT = minT;
     try {
-      const oldest = historicalEvents.length > 0
-        ? new Date(historicalEvents[0].timestamp).toISOString()
-        : allLiveEvents.length > 0
-          ? new Date(allLiveEvents[0].timestamp).toISOString()
-          : new Date().toISOString();
+      const oldest =
+        historicalEvents.length > 0
+          ? new Date(historicalEvents[0].timestamp).toISOString()
+          : allLiveEvents.length > 0
+            ? new Date(allLiveEvents[0].timestamp).toISOString()
+            : new Date().toISOString();
       const entries = await window.aegis.getAuditEntriesBefore(oldest, HISTORY_BATCH);
       if (entries.length === 0) {
         historyExhausted = true;
       } else {
         const mapped = entries
-          .filter((e) => ['file-access', 'config-access', 'network-connection', 'permission-deny'].includes(e.type))
+          .filter((e) =>
+            ['file-access', 'config-access', 'network-connection', 'permission-deny'].includes(
+              e.type,
+            ),
+          )
           .map(auditToTimelineEvent);
         if (mapped.length === 0) {
           historyExhausted = true;
@@ -144,8 +152,7 @@
       _type: 'network',
       flagged: !!conn.flagged,
     }));
-    return [...fileEvs, ...netEvs]
-      .sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+    return [...fileEvs, ...netEvs].sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
   });
 
   let allEvents = $derived.by(() => {
@@ -164,9 +171,11 @@
   });
 
   // Snap to nearest 10s boundary DOWN for a clean starting point
-  let rawMinT = $derived(allEvents.length > 0 ? (allEvents[0].timestamp || 0) : Date.now());
+  let rawMinT = $derived(allEvents.length > 0 ? allEvents[0].timestamp || 0 : Date.now());
   let minT = $derived(Math.floor(rawMinT / 10000) * 10000);
-  let maxT = $derived(allEvents.length > 0 ? (allEvents[allEvents.length - 1].timestamp || 0) : Date.now());
+  let maxT = $derived(
+    allEvents.length > 0 ? allEvents[allEvents.length - 1].timestamp || 0 : Date.now(),
+  );
   let eventRange = $derived(maxT - minT || 1);
 
   let msPerUnit = $derived(ZOOM_LEVELS[zoomIndex].ms);
@@ -208,7 +217,13 @@
 
   // Load next batch when thumb is at the left edge
   $effect(() => {
-    if (!following && !historyExhausted && !loadingHistory && thumbOffset >= 0 && thumbOffset <= 2) {
+    if (
+      !following &&
+      !historyExhausted &&
+      !loadingHistory &&
+      thumbOffset >= 0 &&
+      thumbOffset <= 2
+    ) {
       loadOlderHistory();
     }
   });
@@ -255,7 +270,10 @@
     let isFirst = true;
     for (let t = firstTick; t <= tickEnd; t += tickInterval) {
       // Skip the very first tick — it sits at the left edge and gets cut off
-      if (isFirst) { isFirst = false; continue; }
+      if (isFirst) {
+        isFirst = false;
+        continue;
+      }
       result.push({ x: tsToX(t), label: formatTick(t, subMinute) });
     }
     return result;
@@ -280,7 +298,9 @@
       }
     }
   });
-  let thumbX = $derived(thumbOffset < 0 ? trackUsable : Math.max(0, Math.min(trackUsable, thumbOffset)));
+  let thumbX = $derived(
+    thumbOffset < 0 ? trackUsable : Math.max(0, Math.min(trackUsable, thumbOffset)),
+  );
 
   function handleWheel(e) {
     e.preventDefault();
@@ -401,23 +421,34 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="timeline-wrap" onwheel={handleWheel} bind:clientWidth={viewportWidth}>
   <div class="timeline-viewport" id="timeline-viewport">
-    <svg width={viewportWidth} height={SVG_H} viewBox={viewBox}>
+    <svg width={viewportWidth} height={SVG_H} {viewBox}>
       <!-- baseline track -->
-      <line x1={clampedScroll + PAD} y1={MID} x2={clampedScroll + viewportWidth - PAD} y2={MID} class="baseline" />
+      <line
+        x1={clampedScroll + PAD}
+        y1={MID}
+        x2={clampedScroll + viewportWidth - PAD}
+        y2={MID}
+        class="baseline"
+      />
 
       <!-- ticks -->
       {#each ticks as t (t.x)}
-        <line x1={t.x} y1={TICK_TOP} x2={t.x} y2={TICK_TOP + TICK_H}
-          class="tick-line" />
-        <text x={t.x} y={TICK_TOP + TICK_H + 1} text-anchor="middle"
-          class="tick-label">{t.label}</text>
+        <line x1={t.x} y1={TICK_TOP} x2={t.x} y2={TICK_TOP + TICK_H} class="tick-line" />
+        <text x={t.x} y={TICK_TOP + TICK_H + 1} text-anchor="middle" class="tick-label"
+          >{t.label}</text
+        >
       {/each}
 
       <!-- dots -->
       {#each dots as dot (dot.idx)}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <circle cx={dot.x} cy={MID} r={DOT_R} fill={dot.color} opacity="0.85"
+        <circle
+          cx={dot.x}
+          cy={MID}
+          r={DOT_R}
+          fill={dot.color}
+          opacity="0.85"
           class="dot"
           onmouseenter={(e) => handleDotEnter(e, dot)}
           onmousemove={(e) => handleDotMove(e)}
@@ -438,8 +469,8 @@
       class:dragging
       style="width:{thumbWidth}px; left:{thumbX}px"
       onmousedown={handleThumbDown}
-      onmouseenter={() => thumbHover = true}
-      onmouseleave={() => thumbHover = false}
+      onmouseenter={() => (thumbHover = true)}
+      onmouseleave={() => (thumbHover = false)}
       role="scrollbar"
       aria-controls="timeline-viewport"
       aria-valuenow={clampedScroll}
@@ -447,7 +478,9 @@
       aria-valuemax={maxScroll}
       aria-orientation="horizontal"
       tabindex="0"
-    ><div class="grip"><span></span><span></span><span></span></div></div>
+    >
+      <div class="grip"><span></span><span></span><span></span></div>
+    </div>
   </div>
 </div>
 
@@ -466,7 +499,9 @@
     backdrop-filter: blur(var(--glass-blur));
     -webkit-backdrop-filter: blur(var(--glass-blur));
     border: var(--aegis-card-border);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12), var(--glass-highlight);
+    box-shadow:
+      0 2px 8px rgba(0, 0, 0, 0.12),
+      var(--glass-highlight);
     border-radius: var(--md-sys-shape-corner-small);
     padding: 3px 0;
     overflow: hidden;
@@ -476,8 +511,20 @@
     width: 100%;
     height: var(--aegis-size-timeline);
     overflow: hidden;
-    -webkit-mask-image: linear-gradient(to right, transparent, black 28px, black calc(100% - 28px), transparent);
-    mask-image: linear-gradient(to right, transparent, black 28px, black calc(100% - 28px), transparent);
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent,
+      black 28px,
+      black calc(100% - 28px),
+      transparent
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      black 28px,
+      black calc(100% - 28px),
+      transparent
+    );
   }
 
   svg {
@@ -506,7 +553,8 @@
 
   .dot {
     cursor: pointer;
-    transition: opacity var(--md-sys-motion-duration-short, 100ms) var(--md-sys-motion-easing-standard, ease);
+    transition: opacity var(--md-sys-motion-duration-short, 100ms)
+      var(--md-sys-motion-easing-standard, ease);
   }
 
   .dot:hover {
@@ -546,7 +594,9 @@
     background: var(--aegis-scrub-thumb);
     border: 1px solid var(--aegis-scrub-thumb-border);
     box-shadow: var(--aegis-scrub-thumb-shadow);
-    transition: box-shadow 150ms ease, filter 150ms ease;
+    transition:
+      box-shadow 150ms ease,
+      filter 150ms ease;
     cursor: grab;
   }
 

--- a/src/renderer/lib/styles/tokens.css
+++ b/src/renderer/lib/styles/tokens.css
@@ -84,37 +84,49 @@
   --md-sys-typescale-display-large-size: calc(32px * var(--aegis-ui-scale));
   --md-sys-typescale-display-large-line: calc(40px * var(--aegis-ui-scale));
   --md-sys-typescale-display-large-family: 'Outfit', sans-serif;
-  --md-sys-typescale-display-large: var(--md-sys-typescale-display-large-weight) var(--md-sys-typescale-display-large-size) / var(--md-sys-typescale-display-large-line) var(--md-sys-typescale-display-large-family);
+  --md-sys-typescale-display-large: var(--md-sys-typescale-display-large-weight)
+    var(--md-sys-typescale-display-large-size) / var(--md-sys-typescale-display-large-line)
+    var(--md-sys-typescale-display-large-family);
 
   --md-sys-typescale-headline-medium-weight: 600;
   --md-sys-typescale-headline-medium-size: calc(20px * var(--aegis-ui-scale));
   --md-sys-typescale-headline-medium-line: calc(28px * var(--aegis-ui-scale));
   --md-sys-typescale-headline-medium-family: 'Outfit', sans-serif;
-  --md-sys-typescale-headline-medium: var(--md-sys-typescale-headline-medium-weight) var(--md-sys-typescale-headline-medium-size) / var(--md-sys-typescale-headline-medium-line) var(--md-sys-typescale-headline-medium-family);
+  --md-sys-typescale-headline-medium: var(--md-sys-typescale-headline-medium-weight)
+    var(--md-sys-typescale-headline-medium-size) / var(--md-sys-typescale-headline-medium-line)
+    var(--md-sys-typescale-headline-medium-family);
 
   --md-sys-typescale-title-medium-weight: 600;
   --md-sys-typescale-title-medium-size: calc(14px * var(--aegis-ui-scale));
   --md-sys-typescale-title-medium-line: calc(20px * var(--aegis-ui-scale));
   --md-sys-typescale-title-medium-family: 'Outfit', sans-serif;
-  --md-sys-typescale-title-medium: var(--md-sys-typescale-title-medium-weight) var(--md-sys-typescale-title-medium-size) / var(--md-sys-typescale-title-medium-line) var(--md-sys-typescale-title-medium-family);
+  --md-sys-typescale-title-medium: var(--md-sys-typescale-title-medium-weight)
+    var(--md-sys-typescale-title-medium-size) / var(--md-sys-typescale-title-medium-line)
+    var(--md-sys-typescale-title-medium-family);
 
   --md-sys-typescale-label-large-weight: 600;
   --md-sys-typescale-label-large-size: calc(13px * var(--aegis-ui-scale));
   --md-sys-typescale-label-large-line: calc(18px * var(--aegis-ui-scale));
   --md-sys-typescale-label-large-family: 'DM Sans', sans-serif;
-  --md-sys-typescale-label-large: var(--md-sys-typescale-label-large-weight) var(--md-sys-typescale-label-large-size) / var(--md-sys-typescale-label-large-line) var(--md-sys-typescale-label-large-family);
+  --md-sys-typescale-label-large: var(--md-sys-typescale-label-large-weight)
+    var(--md-sys-typescale-label-large-size) / var(--md-sys-typescale-label-large-line)
+    var(--md-sys-typescale-label-large-family);
 
   --md-sys-typescale-body-medium-weight: 400;
   --md-sys-typescale-body-medium-size: calc(13px * var(--aegis-ui-scale));
   --md-sys-typescale-body-medium-line: calc(20px * var(--aegis-ui-scale));
   --md-sys-typescale-body-medium-family: 'DM Sans', sans-serif;
-  --md-sys-typescale-body-medium: var(--md-sys-typescale-body-medium-weight) var(--md-sys-typescale-body-medium-size) / var(--md-sys-typescale-body-medium-line) var(--md-sys-typescale-body-medium-family);
+  --md-sys-typescale-body-medium: var(--md-sys-typescale-body-medium-weight)
+    var(--md-sys-typescale-body-medium-size) / var(--md-sys-typescale-body-medium-line)
+    var(--md-sys-typescale-body-medium-family);
 
   --md-sys-typescale-label-medium-weight: 500;
   --md-sys-typescale-label-medium-size: calc(11px * var(--aegis-ui-scale));
   --md-sys-typescale-label-medium-line: calc(16px * var(--aegis-ui-scale));
   --md-sys-typescale-label-medium-family: 'DM Sans', sans-serif;
-  --md-sys-typescale-label-medium: var(--md-sys-typescale-label-medium-weight) var(--md-sys-typescale-label-medium-size) / var(--md-sys-typescale-label-medium-line) var(--md-sys-typescale-label-medium-family);
+  --md-sys-typescale-label-medium: var(--md-sys-typescale-label-medium-weight)
+    var(--md-sys-typescale-label-medium-size) / var(--md-sys-typescale-label-medium-line)
+    var(--md-sys-typescale-label-medium-family);
 
   /* ── Shape ── */
   --md-sys-shape-corner-small: 8px;


### PR DESCRIPTION
## Summary

Runs Prettier across all source files to resolve CI lint failures.

**Zero logic changes** — formatting only. Every file passes `format:check` after this PR.

## CI Status Before
- `format:check` failed on 50 files (pre-existing since PR #37)

## Testing
- All 383 tests pass, 4 skipped, 0 fail
- `npm run format:check`: PASS
- `npm run lint`: PASS