### PR TITLE
fix: integrate annotateWorkingDirs into scan pipelines

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -232,6 +232,7 @@ function startScanIntervals() {
       watcher.pruneKnownHandles(latestAgents);
       await procUtil.enrichWithParentChains(latestAgents);
       procUtil.annotateHostApps(latestAgents);
+      await procUtil.annotateWorkingDirs(latestAgents);
       sendToRenderer('scan-results', latestAgents);
       sendToRenderer('stats-update', getStats());
       sendToRenderer('resource-usage', getResourceUsage());
@@ -400,6 +401,7 @@ app.whenReady().then(() => {
       latestOtherAgents = latestAgents.filter((a) => a.category === 'other');
       await procUtil.enrichWithParentChains(latestAgents);
       procUtil.annotateHostApps(latestAgents);
+      await procUtil.annotateWorkingDirs(latestAgents);
       sendToRenderer('scan-results', latestAgents);
       sendToRenderer('stats-update', getStats());
       sendToRenderer('resource-usage', getResourceUsage());


### PR DESCRIPTION
## Summary

Adds `annotateWorkingDirs()` to both scan paths in main.js where it was missing.

## Changes

1. **Periodic scan** (setInterval, line 235) — `await procUtil.annotateWorkingDirs(latestAgents)` after `annotateHostApps`
2. **Staggered startup** (setTimeout 3s, line 404) — same call in the initial boot scan

Previously the function was only invoked from the IPC handler `scan-processes` (ipc-handlers.js:36), leaving `agent.cwd` and `agent.projectName` undefined for all timer-driven scans.

## Testing
- process-utils.test.js: 11/11 pass
- Full suite: 383 pass / 4 skip / 0 fail
- Build: PASS

## Related
- PR #37 code review HIGH issue #2