### PR TITLE
refactor: split 4 large files into focused modules

### DIFF
--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -1,0 +1,170 @@
+/**
+ * @file scan-loop.js
+ * @description Periodic scan intervals, staggered startup, and event dedup
+ *   for process, file-handle, and network scanning. Extracted from main.js.
+ * @since v0.3.0
+ */
+'use strict';
+
+let scanInterval = null;
+let fileScanInterval = null;
+let netInterval = null;
+/** @type {Object} Injected dependencies */
+let deps = {};
+// Event dedup — same agent + same file within 30s → suppress, track count
+const eventDedupMap = new Map();
+
+/**
+ * Dedup file events: same agent + same file within 30s → suppress.
+ * @param {Object} ev @returns {Object|null} @since v0.3.0
+ */
+function dedupFileEvent(ev) {
+  const key = `${ev.agent}|${ev.file}`;
+  const now = Date.now();
+  const prev = eventDedupMap.get(key);
+  if (prev && now - prev.lastSent < 30000) {
+    prev.count++;
+    return null;
+  }
+  ev.repeatCount = prev ? prev.count : 1;
+  eventDedupMap.set(key, { lastSent: now, count: 1 });
+  if (eventDedupMap.size > 500) {
+    for (const [k, v] of eventDedupMap) {
+      if (now - v.lastSent > 60000) eventDedupMap.delete(k);
+    }
+  }
+  return ev;
+}
+
+/** @param {Object} ev @since v0.3.0 */
+function logAuditForFile(ev) {
+  const type =
+    ev.reason && ev.reason.startsWith('AI agent config') ? 'config-access' : 'file-access';
+  deps.audit.log(type, {
+    agent: ev.agent,
+    action: ev.action,
+    path: ev.file,
+    severity: ev.sensitive ? 'sensitive' : 'normal',
+  });
+}
+
+function stopScanIntervals() {
+  if (scanInterval) { clearInterval(scanInterval); scanInterval = null; }
+  if (fileScanInterval) { clearInterval(fileScanInterval); fileScanInterval = null; }
+  if (netInterval) { clearInterval(netInterval); netInterval = null; }
+}
+
+function doNetworkScan() {
+  const { network, baselines, audit, logger, getLatestAgents, sendToRenderer } = deps;
+  const agents = getLatestAgents();
+  if (network.isNetworkScanRunning() || agents.length === 0) return;
+  network.setNetworkScanRunning(true);
+  network
+    .scanNetworkConnections(agents)
+    .then((connections) => {
+      deps.setLatestNetConnections(connections);
+      for (const conn of connections) {
+        baselines.recordNetworkEndpoint(conn.agent, conn.remoteIp, conn.remotePort);
+        audit.log('network-connection', {
+          agent: conn.agent, action: conn.state,
+          path: `${conn.remoteIp}:${conn.remotePort}`,
+          severity: conn.flagged ? 'high' : 'normal',
+          extra: { domain: conn.domain, flagged: conn.flagged },
+        });
+      }
+      sendToRenderer('network-update', connections);
+    })
+    .catch((err) => logger.error('main', 'Network scan failed', { error: err.message }))
+    .finally(() => network.setNetworkScanRunning(false));
+}
+
+async function doProcessScan() {
+  const { scanner, procUtil, watcher, anomaly, audit, tray, logger,
+    sendToRenderer, getStats, getResourceUsage, setAgents,
+    getPreviousPids, setPreviousPids } = deps;
+  try {
+    const result = await scanner.scanProcesses();
+    setAgents(result.agents);
+    const agents = result.agents;
+    const curPids = new Map();
+    for (const a of agents) curPids.set(a.pid, a.agent);
+    const prevPids = getPreviousPids();
+    for (const [pid, name] of curPids) {
+      if (!prevPids.has(pid))
+        audit.log('agent-enter', { agent: name, action: 'started', path: '',
+          severity: 'normal', extra: { pid } });
+    }
+    for (const [pid, name] of prevPids) {
+      if (!curPids.has(pid))
+        audit.log('agent-exit', { agent: name, action: 'exited', path: '',
+          severity: 'normal', extra: { pid } });
+    }
+    setPreviousPids(curPids);
+    watcher.pruneKnownHandles(agents);
+    await procUtil.enrichWithParentChains(agents);
+    procUtil.annotateHostApps(agents);
+    await procUtil.annotateWorkingDirs(agents);
+    sendToRenderer('scan-results', agents);
+    sendToRenderer('stats-update', getStats());
+    sendToRenderer('resource-usage', getResourceUsage());
+    tray.updateTrayIcon();
+    const deviations = anomaly.checkDeviations();
+    if (deviations.length > 0) {
+      sendToRenderer('baseline-warnings', deviations);
+      for (const d of deviations)
+        audit.log('anomaly-alert', { agent: d.agent, action: d.type, path: '',
+          severity: 'high', extra: { message: d.message, anomalyScore: d.anomalyScore } });
+    }
+    const scores = {};
+    for (const a of agents) scores[a.agent] = anomaly.calculateAnomalyScore(a.agent);
+    sendToRenderer('anomaly-scores', scores);
+    if (result.changed) doNetworkScan();
+  } catch (err) {
+    logger.error('main', 'Process scan failed', { error: err.message });
+  }
+}
+
+async function doFileScan() {
+  const { watcher, tray, logger, sendToRenderer, getStats, getLatestAgents } = deps;
+  const agents = getLatestAgents();
+  if (agents.length === 0) return;
+  try {
+    const rawEvents = await watcher.scanAllFileHandles(agents);
+    const events = rawEvents.map(dedupFileEvent).filter(Boolean);
+    if (events.length > 0) {
+      sendToRenderer('file-access', events);
+      tray.notifySensitive(events.filter((e) => e.sensitive && e.category === 'ai'));
+      for (const ev of events) logAuditForFile(ev);
+    }
+    sendToRenderer('stats-update', getStats());
+    tray.updateTrayIcon();
+  } catch (err) {
+    logger.error('main', 'File handle scan failed', { error: err.message });
+  }
+}
+
+/** @param {number} intervalMs @since v0.3.0 */
+function startScanIntervals(intervalMs) {
+  const ms = intervalMs || 10000;
+  scanInterval = setInterval(doProcessScan, ms);
+  netInterval = setInterval(doNetworkScan, 30000);
+  fileScanInterval = setInterval(doFileScan, Math.max(ms * 3, 30000));
+}
+
+/** @param {number} intervalMs @param {boolean} paused @since v0.3.0 */
+function staggeredStartup(intervalMs, paused) {
+  setTimeout(() => doProcessScan(), 3000);
+  setTimeout(() => doFileScan(), 5000);
+  setTimeout(() => {
+    doNetworkScan();
+    if (!paused) startScanIntervals(intervalMs);
+  }, 8000);
+}
+
+/** @param {Object} injected @since v0.3.0 */
+function init(injected) { deps = injected; }
+
+module.exports = {
+  init, startScanIntervals, stopScanIntervals, doNetworkScan,
+  staggeredStartup, dedupFileEvent, logAuditForFile,
+};

--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -1,31 +1,29 @@
 <script>
+  /**
+   * @file AgentCard.svelte
+   * @description Agent card — compact summary row with expandable details.
+   *   Detail body in AgentCardDetails.svelte.
+   * @since v0.1.0
+   */
   import { events, focusedAgentPid } from '../stores/ipc.js';
+  import AgentCardDetails from './AgentCardDetails.svelte';
 
-  /** @type {{ agent: { name: string, pid: number, process: string, parentEditor: string|null, cwd: string|null, projectName: string|null, riskScore: number, trustGrade: string, parentChain: string, sessionStart: number, fileCount: number, networkCount: number }, expandedPid: number|null }} */
+  /** @type {{ agent: Object, expandedPid: number|null }} */
   let { agent, expandedPid = $bindable(null) } = $props();
 
   let blinking = $state(false);
   let cardEl = $state(null);
-
   let expanded = $derived(expandedPid === agent.pid);
 
-  // React to timeline dot clicks
   $effect(() => {
     const pid = $focusedAgentPid;
     if (pid === null) return;
     if (pid === agent.pid) {
       expandedPid = agent.pid;
       blinking = true;
-      // Scroll into view
       if (cardEl) cardEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      // Stop blink after 3 cycles (each cycle is 400ms via CSS)
-      setTimeout(() => {
-        blinking = false;
-      }, 1200);
-      // Clear the store so clicking the same dot again works
-      setTimeout(() => {
-        focusedAgentPid.set(null);
-      }, 50);
+      setTimeout(() => { blinking = false; }, 1200);
+      setTimeout(() => { focusedAgentPid.set(null); }, 50);
     }
   });
 
@@ -44,8 +42,7 @@
   });
 
   let agentEvents = $derived.by(() => {
-    return $events
-      .flat()
+    return $events.flat()
       .filter((ev) => ev.pid === agent.pid)
       .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
       .slice(0, 50);
@@ -58,18 +55,6 @@
     return parts.length > 2 ? parts.slice(-2).join('/') : ev.file;
   });
 
-  function formatTime(ts) {
-    if (!ts) return '';
-    const d = new Date(ts);
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-  }
-
-  function shortenPath(p) {
-    if (!p) return '';
-    const parts = p.split(/[/\\]/);
-    return parts.length > 3 ? '.../' + parts.slice(-3).join('/') : p;
-  }
-
   let sessionDuration = $derived.by(() => {
     if (!agent.sessionStart) return null;
     const ms = Date.now() - agent.sessionStart;
@@ -79,9 +64,7 @@
     return hrs > 0 ? `${hrs}h ${rem}m` : `${rem}m`;
   });
 
-  function toggle() {
-    expandedPid = expanded ? null : agent.pid;
-  }
+  function toggle() { expandedPid = expanded ? null : agent.pid; }
 
   async function pidAction(e, method) {
     e.stopPropagation();
@@ -95,83 +78,17 @@
   <div class="compact-row">
     <span class="agent-name">{displayName}</span>
     <span class="stat">PID {agent.pid}</span>
-    {#if agent.fileCount != null}
-      <span class="stat">{Math.round(agent.fileCount)}f</span>
-    {/if}
-    {#if agent.networkCount != null}
-      <span class="stat">{agent.networkCount}n</span>
-    {/if}
+    {#if agent.fileCount != null}<span class="stat">{Math.round(agent.fileCount)}f</span>{/if}
+    {#if agent.networkCount != null}<span class="stat">{agent.networkCount}n</span>{/if}
     <span class="risk-score" style:color={gradeColor}>{agent.riskScore}</span>
     <span class="trust-badge" style:background={gradeColor}>{agent.trustGrade}</span>
   </div>
 
-  {#if lastFile}
-    <div class="activity-hint">Last: {lastFile}</div>
-  {/if}
+  {#if lastFile}<div class="activity-hint">Last: {lastFile}</div>{/if}
 
   <div class="expand-body">
     <div class="expand-inner">
-      <div class="risk-bar-row">
-        <span class="bar-label">Risk</span>
-        <div class="risk-bar">
-          <div
-            class="risk-fill"
-            style:width="{Math.min(agent.riskScore, 100)}%"
-            style:background={gradeColor}
-          ></div>
-        </div>
-      </div>
-
-      {#if agent.cwd}
-        <div class="detail-row">
-          <span class="detail-label">CWD</span>
-          <span class="detail-value">{agent.cwd}</span>
-        </div>
-      {/if}
-
-      {#if agent.parentChain}
-        <div class="detail-row">
-          <span class="detail-label">Parent</span>
-          <span class="detail-value">{agent.parentChain}</span>
-        </div>
-      {/if}
-
-      {#if sessionDuration}
-        <div class="detail-row">
-          <span class="detail-label">Session</span>
-          <span class="detail-value">{sessionDuration}</span>
-        </div>
-      {/if}
-
-      {#if agentEvents.length > 0}
-        <div class="event-log">
-          <span class="log-heading">Activity ({agentEvents.length})</span>
-          <div class="log-list">
-            {#each agentEvents as ev, i (`${ev.timestamp}-${i}`)}
-              <div class="log-row" class:sensitive={ev.sensitive}>
-                <span class="log-time">{formatTime(ev.timestamp)}</span>
-                <span class="log-action">{ev.action || 'access'}</span>
-                <span class="log-path" title={ev.file}>{shortenPath(ev.file)}</span>
-              </div>
-            {/each}
-          </div>
-        </div>
-      {/if}
-
-      <div class="pid-actions-row">
-        <span class="pid-info"
-          >PID {agent.pid}{agent.process ? ` \u2014 ${agent.process}` : ''}</span
-        >
-        <div class="pid-actions">
-          <button class="action-btn kill" onclick={(e) => pidAction(e, 'killProcess')}>Kill</button>
-          <button class="action-btn suspend" onclick={(e) => pidAction(e, 'suspendProcess')}
-            >Suspend</button
-          >
-          <button class="action-btn resume" onclick={(e) => pidAction(e, 'resumeProcess')}
-            >Resume</button
-          >
-        </div>
-      </div>
+      <AgentCardDetails {agent} {gradeColor} {agentEvents} {sessionDuration} onPidAction={pidAction} />
     </div>
   </div>
 </article>
@@ -182,248 +99,51 @@
     backdrop-filter: blur(var(--glass-blur));
     -webkit-backdrop-filter: blur(var(--glass-blur));
     border: var(--aegis-card-border);
-    box-shadow:
-      0 2px 8px rgba(0, 0, 0, 0.12),
-      var(--glass-highlight);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12), var(--glass-highlight);
     border-radius: var(--md-sys-shape-corner-medium);
     padding: var(--aegis-space-4) var(--aegis-space-6);
     cursor: pointer;
     transition: all 0.3s var(--ease-glass);
   }
-  .agent-card:hover {
-    background: var(--aegis-card-hover-bg);
-  }
-
-  /* -- Compact row -- */
-  .compact-row {
-    display: flex;
-    align-items: center;
-    gap: var(--aegis-space-4);
-  }
+  .agent-card:hover { background: var(--aegis-card-hover-bg); }
+  .compact-row { display: flex; align-items: center; gap: var(--aegis-space-4); }
   .agent-name {
-    font: var(--md-sys-typescale-label-large);
-    font-weight: 600;
+    font: var(--md-sys-typescale-label-large); font-weight: 600;
     color: var(--md-sys-color-on-surface);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-width: 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
   }
   .stat {
-    font: var(--md-sys-typescale-label-medium);
-    font-family: 'DM Mono', monospace;
-    color: var(--md-sys-color-on-surface-variant);
-    flex-shrink: 0;
+    font: var(--md-sys-typescale-label-medium); font-family: 'DM Mono', monospace;
+    color: var(--md-sys-color-on-surface-variant); flex-shrink: 0;
   }
   .risk-score {
-    font: var(--md-sys-typescale-label-large);
-    font-family: 'DM Mono', monospace;
-    font-weight: 700;
-    flex-shrink: 0;
-    margin-left: auto;
+    font: var(--md-sys-typescale-label-large); font-family: 'DM Mono', monospace;
+    font-weight: 700; flex-shrink: 0; margin-left: auto;
   }
   .trust-badge {
-    font: var(--md-sys-typescale-label-medium);
-    font-weight: 700;
+    font: var(--md-sys-typescale-label-medium); font-weight: 700;
     color: var(--md-sys-color-surface);
     padding: var(--aegis-space-1) calc(7px * var(--aegis-ui-scale));
-    border-radius: var(--md-sys-shape-corner-full);
-    flex-shrink: 0;
-    letter-spacing: 0.5px;
+    border-radius: var(--md-sys-shape-corner-full); flex-shrink: 0; letter-spacing: 0.5px;
   }
-
-  /* -- Activity hint -- */
   .activity-hint {
-    font: var(--md-sys-typescale-label-medium);
-    font-family: 'DM Mono', monospace;
-    color: var(--md-sys-color-on-surface-variant);
-    opacity: 0.7;
-    margin-top: 2px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    font: var(--md-sys-typescale-label-medium); font-family: 'DM Mono', monospace;
+    color: var(--md-sys-color-on-surface-variant); opacity: 0.7;
+    margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-
-  /* -- Expand / collapse -- */
   .expand-body {
-    display: grid;
-    grid-template-rows: 0fr;
-    transition: grid-template-rows 200ms var(--md-sys-motion-easing-standard);
-    overflow: hidden;
+    display: grid; grid-template-rows: 0fr;
+    transition: grid-template-rows 200ms var(--md-sys-motion-easing-standard); overflow: hidden;
   }
-  .agent-card.expanded .expand-body {
-    grid-template-rows: 1fr;
-  }
+  .agent-card.expanded .expand-body { grid-template-rows: 1fr; }
   .expand-inner {
-    min-height: 0;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    gap: var(--aegis-space-3);
+    min-height: 0; overflow: hidden;
+    display: flex; flex-direction: column; gap: var(--aegis-space-3);
   }
-  .agent-card.expanded .expand-inner {
-    margin-top: var(--aegis-space-4);
-  }
-
-  .risk-bar-row {
-    display: flex;
-    align-items: center;
-    gap: var(--aegis-space-4);
-  }
-  .bar-label {
-    font: var(--md-sys-typescale-label-medium);
-    color: var(--md-sys-color-on-surface-variant);
-    flex-shrink: 0;
-    width: 28px;
-  }
-  .risk-bar {
-    flex: 1;
-    height: 6px;
-    background: var(--md-sys-color-surface-container-highest);
-    border-radius: var(--md-sys-shape-corner-full);
-    overflow: hidden;
-  }
-  .risk-fill {
-    height: 100%;
-    border-radius: var(--md-sys-shape-corner-full);
-    transition: width var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
-  }
-
-  .detail-row {
-    display: flex;
-    align-items: baseline;
-    gap: var(--aegis-space-4);
-  }
-  .detail-label {
-    font: var(--md-sys-typescale-label-medium);
-    color: var(--md-sys-color-on-surface-variant);
-    flex-shrink: 0;
-    width: var(--aegis-col-time);
-  }
-  .detail-value {
-    font: var(--md-sys-typescale-body-medium);
-    color: var(--md-sys-color-on-surface);
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* -- Event log -- */
-  .event-log {
-    display: flex;
-    flex-direction: column;
-    gap: var(--aegis-space-2);
-    margin-top: var(--aegis-space-2);
-    border-top: 1px solid var(--md-sys-color-outline-variant);
-    padding-top: var(--aegis-space-3);
-  }
-  .log-heading {
-    font: var(--md-sys-typescale-label-medium);
-    font-weight: 600;
-    color: var(--md-sys-color-on-surface-variant);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-  .log-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--aegis-space-1);
-    max-height: calc(160px * var(--aegis-ui-scale));
-    overflow-y: auto;
-  }
-  .log-row {
-    display: flex;
-    align-items: baseline;
-    gap: var(--aegis-space-3);
-    padding: var(--aegis-space-1) 0;
-    font: var(--md-sys-typescale-label-medium);
-    font-family: 'DM Mono', monospace;
-    color: var(--md-sys-color-on-surface-variant);
-  }
-  .log-row.sensitive {
-    color: var(--md-sys-color-error);
-  }
-  .log-time {
-    flex-shrink: 0;
-    opacity: 0.6;
-  }
-  .log-action {
-    flex-shrink: 0;
-    min-width: 44px;
-  }
-  .log-path {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* -- PID actions -- */
-  .pid-actions-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--aegis-space-4);
-    margin-top: var(--aegis-space-2);
-    border-top: 1px solid rgba(255, 255, 255, 0.06);
-    padding-top: var(--aegis-space-3);
-  }
-  .pid-info {
-    font: var(--md-sys-typescale-label-medium);
-    font-family: 'DM Mono', monospace;
-    color: var(--md-sys-color-on-surface-variant);
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .pid-actions {
-    display: flex;
-    gap: var(--aegis-space-3);
-    flex-shrink: 0;
-  }
-
-  .action-btn {
-    font: var(--md-sys-typescale-label-medium);
-    font-weight: 600;
-    padding: var(--aegis-space-2) var(--aegis-space-6);
-    border: none;
-    border-radius: var(--md-sys-shape-corner-full);
-    cursor: pointer;
-    transition: all 0.3s var(--ease-glass);
-  }
-  .action-btn:hover {
-    opacity: 0.8;
-  }
-  .action-btn:active {
-    transform: scale(0.97);
-  }
-  .action-btn.kill {
-    background: var(--md-sys-color-error);
-    color: var(--md-sys-color-on-error);
-  }
-  .action-btn.suspend {
-    background: var(--md-sys-color-secondary);
-    color: var(--md-sys-color-surface);
-  }
-  .action-btn.resume {
-    background: var(--md-sys-color-tertiary);
-    color: var(--md-sys-color-surface);
-  }
-
-  /* Blink animation — 3 pulses with primary highlight */
-  .agent-card.blinking {
-    animation: card-blink 400ms ease 3;
-  }
-
+  .agent-card.expanded .expand-inner { margin-top: var(--aegis-space-4); }
+  .agent-card.blinking { animation: card-blink 400ms ease 3; }
   @keyframes card-blink {
-    0%,
-    100% {
-      background: var(--md-sys-color-surface-container-low);
-    }
-    50% {
-      background: var(--md-sys-color-primary-container);
-    }
+    0%, 100% { background: var(--md-sys-color-surface-container-low); }
+    50% { background: var(--md-sys-color-primary-container); }
   }
 </style>

--- a/src/renderer/lib/components/AgentCardDetails.svelte
+++ b/src/renderer/lib/components/AgentCardDetails.svelte
@@ -1,0 +1,149 @@
+<script>
+  /**
+   * @file AgentCardDetails.svelte
+   * @description Expandable detail body for AgentCard — risk bar, CWD, parent
+   *   chain, session duration, event log, and PID actions.
+   *   Extracted from AgentCard.svelte.
+   * @since v0.3.0
+   */
+
+  let { agent, gradeColor, agentEvents, sessionDuration, onPidAction } = $props();
+
+  function formatTime(ts) {
+    if (!ts) return '';
+    const d = new Date(ts);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  }
+
+  function shortenPath(p) {
+    if (!p) return '';
+    const parts = p.split(/[/\\]/);
+    return parts.length > 3 ? '.../' + parts.slice(-3).join('/') : p;
+  }
+</script>
+
+<div class="risk-bar-row">
+  <span class="bar-label">Risk</span>
+  <div class="risk-bar">
+    <div class="risk-fill" style:width="{Math.min(agent.riskScore, 100)}%" style:background={gradeColor}></div>
+  </div>
+</div>
+
+{#if agent.cwd}
+  <div class="detail-row">
+    <span class="detail-label">CWD</span>
+    <span class="detail-value">{agent.cwd}</span>
+  </div>
+{/if}
+
+{#if agent.parentChain}
+  <div class="detail-row">
+    <span class="detail-label">Parent</span>
+    <span class="detail-value">{agent.parentChain}</span>
+  </div>
+{/if}
+
+{#if sessionDuration}
+  <div class="detail-row">
+    <span class="detail-label">Session</span>
+    <span class="detail-value">{sessionDuration}</span>
+  </div>
+{/if}
+
+{#if agentEvents.length > 0}
+  <div class="event-log">
+    <span class="log-heading">Activity ({agentEvents.length})</span>
+    <div class="log-list">
+      {#each agentEvents as ev, i (`${ev.timestamp}-${i}`)}
+        <div class="log-row" class:sensitive={ev.sensitive}>
+          <span class="log-time">{formatTime(ev.timestamp)}</span>
+          <span class="log-action">{ev.action || 'access'}</span>
+          <span class="log-path" title={ev.file}>{shortenPath(ev.file)}</span>
+        </div>
+      {/each}
+    </div>
+  </div>
+{/if}
+
+<div class="pid-actions-row">
+  <span class="pid-info">PID {agent.pid}{agent.process ? ` \u2014 ${agent.process}` : ''}</span>
+  <div class="pid-actions">
+    <button class="action-btn kill" onclick={(e) => onPidAction(e, 'killProcess')}>Kill</button>
+    <button class="action-btn suspend" onclick={(e) => onPidAction(e, 'suspendProcess')}>Suspend</button>
+    <button class="action-btn resume" onclick={(e) => onPidAction(e, 'resumeProcess')}>Resume</button>
+  </div>
+</div>
+
+<style>
+  .risk-bar-row { display: flex; align-items: center; gap: var(--aegis-space-4); }
+  .bar-label {
+    font: var(--md-sys-typescale-label-medium);
+    color: var(--md-sys-color-on-surface-variant); flex-shrink: 0; width: 28px;
+  }
+  .risk-bar {
+    flex: 1; height: 6px;
+    background: var(--md-sys-color-surface-container-highest);
+    border-radius: var(--md-sys-shape-corner-full); overflow: hidden;
+  }
+  .risk-fill {
+    height: 100%; border-radius: var(--md-sys-shape-corner-full);
+    transition: width var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+  }
+  .detail-row { display: flex; align-items: baseline; gap: var(--aegis-space-4); }
+  .detail-label {
+    font: var(--md-sys-typescale-label-medium);
+    color: var(--md-sys-color-on-surface-variant); flex-shrink: 0; width: var(--aegis-col-time);
+  }
+  .detail-value {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface);
+    min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .event-log {
+    display: flex; flex-direction: column; gap: var(--aegis-space-2);
+    margin-top: var(--aegis-space-2);
+    border-top: 1px solid var(--md-sys-color-outline-variant);
+    padding-top: var(--aegis-space-3);
+  }
+  .log-heading {
+    font: var(--md-sys-typescale-label-medium); font-weight: 600;
+    color: var(--md-sys-color-on-surface-variant);
+    text-transform: uppercase; letter-spacing: 0.5px;
+  }
+  .log-list {
+    display: flex; flex-direction: column; gap: var(--aegis-space-1);
+    max-height: calc(160px * var(--aegis-ui-scale)); overflow-y: auto;
+  }
+  .log-row {
+    display: flex; align-items: baseline; gap: var(--aegis-space-3);
+    padding: var(--aegis-space-1) 0;
+    font: var(--md-sys-typescale-label-medium);
+    font-family: 'DM Mono', monospace; color: var(--md-sys-color-on-surface-variant);
+  }
+  .log-row.sensitive { color: var(--md-sys-color-error); }
+  .log-time { flex-shrink: 0; opacity: 0.6; }
+  .log-action { flex-shrink: 0; min-width: 44px; }
+  .log-path { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .pid-actions-row {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: var(--aegis-space-4); margin-top: var(--aegis-space-2);
+    border-top: 1px solid rgba(255, 255, 255, 0.06); padding-top: var(--aegis-space-3);
+  }
+  .pid-info {
+    font: var(--md-sys-typescale-label-medium); font-family: 'DM Mono', monospace;
+    color: var(--md-sys-color-on-surface-variant);
+    min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .pid-actions { display: flex; gap: var(--aegis-space-3); flex-shrink: 0; }
+  .action-btn {
+    font: var(--md-sys-typescale-label-medium); font-weight: 600;
+    padding: var(--aegis-space-2) var(--aegis-space-6);
+    border: none; border-radius: var(--md-sys-shape-corner-full);
+    cursor: pointer; transition: all 0.3s var(--ease-glass);
+  }
+  .action-btn:hover { opacity: 0.8; }
+  .action-btn:active { transform: scale(0.97); }
+  .action-btn.kill { background: var(--md-sys-color-error); color: var(--md-sys-color-on-error); }
+  .action-btn.suspend { background: var(--md-sys-color-secondary); color: var(--md-sys-color-surface); }
+  .action-btn.resume { background: var(--md-sys-color-tertiary); color: var(--md-sys-color-surface); }
+</style>

--- a/src/renderer/lib/components/OptionsPanel.svelte
+++ b/src/renderer/lib/components/OptionsPanel.svelte
@@ -1,38 +1,37 @@
 <script>
+  /**
+   * @file OptionsPanel.svelte
+   * @description Settings modal overlay. Load/save logic lives here;
+   *   sections in SettingsAppearance and SettingsMonitoring.
+   * @since v0.1.0
+   */
   import { theme, setTheme, uiScale, setUiScale } from '../stores/theme.js';
+  import SettingsAppearance from './SettingsAppearance.svelte';
+  import SettingsMonitoring from './SettingsMonitoring.svelte';
 
   let { open = $bindable(false) } = $props();
 
-  // Appearance
   let localTheme = $state($theme);
   let localScale = $state($uiScale);
-
-  // Settings
   let scanInterval = $state(10);
   let notifications = $state(true);
   let apiKey = $state('');
   let customPatterns = $state('');
-  let showKey = $state(false);
   let loaded = $state(false);
-  let testResult = $state('');
 
   $effect(() => {
     if (open) {
       localTheme = $theme;
       localScale = $uiScale;
-      testResult = '';
       if (!loaded && window.aegis) {
-        window.aegis
-          .getSettings()
-          .then((s) => {
-            if (!s) return;
-            scanInterval = s.scanIntervalSec ?? 10;
-            notifications = s.notificationsEnabled ?? true;
-            apiKey = s.anthropicApiKey ?? '';
-            customPatterns = (s.customSensitivePatterns || []).join('\n');
-            loaded = true;
-          })
-          .catch(() => {});
+        window.aegis.getSettings().then((s) => {
+          if (!s) return;
+          scanInterval = s.scanIntervalSec ?? 10;
+          notifications = s.notificationsEnabled ?? true;
+          apiKey = s.anthropicApiKey ?? '';
+          customPatterns = (s.customSensitivePatterns || []).join('\n');
+          loaded = true;
+        }).catch(() => {});
       }
     }
   });
@@ -41,223 +40,53 @@
     localScale = parseFloat(e.target.value);
     document.documentElement.style.setProperty('--aegis-ui-scale', String(localScale));
   }
-
   function onThemeChange(e) {
     localTheme = e.target.value;
     document.documentElement.dataset.theme = localTheme;
   }
 
   async function handleSave() {
-    // Save appearance
     setTheme(localTheme);
     setUiScale(localScale);
-
-    // Save all settings
     if (window.aegis) {
-      const patterns = customPatterns
-        .split('\n')
-        .map((l) => l.trim())
-        .filter(Boolean);
+      const patterns = customPatterns.split('\n').map((l) => l.trim()).filter(Boolean);
       const current = await window.aegis.getSettings();
       await window.aegis.saveSettings({
-        ...current,
-        uiScale: localScale,
-        scanIntervalSec: scanInterval,
-        notificationsEnabled: notifications,
-        anthropicApiKey: apiKey.trim(),
+        ...current, uiScale: localScale, scanIntervalSec: scanInterval,
+        notificationsEnabled: notifications, anthropicApiKey: apiKey.trim(),
         customSensitivePatterns: patterns,
       });
     }
-    loaded = false;
-    open = false;
+    loaded = false; open = false;
   }
 
   function handleCancel() {
     document.documentElement.dataset.theme = $theme;
     document.documentElement.style.setProperty('--aegis-ui-scale', String($uiScale));
-    loaded = false;
-    open = false;
+    loaded = false; open = false;
   }
-
-  function handleBackdrop(e) {
-    if (e.target === e.currentTarget) handleCancel();
-  }
-
-  function handleKeydown(e) {
-    if (e.key === 'Escape') handleCancel();
-  }
-
-  async function testNotify() {
-    testResult = '';
-    if (!window.aegis?.testNotification) {
-      testResult = 'Not available';
-      return;
-    }
-    const r = await window.aegis.testNotification();
-    testResult = r.success ? 'Sent' : r.error || 'Failed';
-  }
-
-  let scalePercent = $derived(Math.round(localScale * 100));
+  function handleBackdrop(e) { if (e.target === e.currentTarget) handleCancel(); }
+  function handleKeydown(e) { if (e.key === 'Escape') handleCancel(); }
 </script>
 
 {#if open}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <div
-    class="overlay"
-    onclick={handleBackdrop}
-    onkeydown={handleKeydown}
-    role="dialog"
-    aria-modal="true"
-    tabindex="-1"
-  >
+  <div class="overlay" onclick={handleBackdrop} onkeydown={handleKeydown}
+    role="dialog" aria-modal="true" tabindex="-1">
     <div class="panel" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
       <h2 class="panel-title">Settings</h2>
 
-      <!-- ── Appearance ── -->
-      <div class="section-label">Appearance</div>
+      <SettingsAppearance bind:localTheme bind:localScale {onThemeChange} {onScaleInput} />
+      <SettingsMonitoring bind:scanInterval bind:notifications bind:apiKey bind:customPatterns />
 
-      <div class="option-group">
-        <span class="option-label">Theme</span>
-        <div class="theme-toggle">
-          <label class="radio-label">
-            <input
-              type="radio"
-              name="theme"
-              value="dark"
-              checked={localTheme === 'dark'}
-              onchange={onThemeChange}
-            />
-            Dark
-          </label>
-          <label class="radio-label">
-            <input
-              type="radio"
-              name="theme"
-              value="light"
-              checked={localTheme === 'light'}
-              onchange={onThemeChange}
-            />
-            Light
-          </label>
-          <label class="radio-label">
-            <input
-              type="radio"
-              name="theme"
-              value="dark-hc"
-              checked={localTheme === 'dark-hc'}
-              onchange={onThemeChange}
-            />
-            Dark HC
-          </label>
-          <label class="radio-label">
-            <input
-              type="radio"
-              name="theme"
-              value="light-hc"
-              checked={localTheme === 'light-hc'}
-              onchange={onThemeChange}
-            />
-            Light HC
-          </label>
-        </div>
-      </div>
-
-      <div class="option-group">
-        <label class="option-label" for="ui-scale-slider"
-          >Interface Scale <span class="scale-value">{scalePercent}%</span></label
-        >
-        <input
-          id="ui-scale-slider"
-          type="range"
-          min="0.8"
-          max="1.5"
-          step="0.1"
-          value={localScale}
-          oninput={onScaleInput}
-          class="scale-slider"
-        />
-        <div class="scale-labels">
-          <span>80%</span>
-          <span>100%</span>
-          <span>150%</span>
-        </div>
-      </div>
-
-      <!-- ── Monitoring ── -->
-      <div class="section-label">Monitoring</div>
-
-      <div class="option-group">
-        <span class="option-label">Scan Interval</span>
-        <div class="range-row">
-          <input type="range" min="3" max="60" step="1" bind:value={scanInterval} />
-          <span class="range-val">{scanInterval}s</span>
-        </div>
-      </div>
-
-      <div class="option-group row">
-        <span class="option-label">Notifications</span>
-        <div class="notif-row">
-          <button
-            class="toggle"
-            class:toggle-on={notifications}
-            aria-label="Toggle notifications"
-            onclick={() => {
-              notifications = !notifications;
-            }}
-          >
-            <span class="toggle-knob"></span>
-          </button>
-          <button class="btn btn-small" onclick={testNotify}>Test</button>
-          {#if testResult}
-            <span class="test-result">{testResult}</span>
-          {/if}
-        </div>
-      </div>
-
-      <!-- ── AI Analysis ── -->
-      <div class="section-label">AI Analysis</div>
-
-      <div class="option-group">
-        <span class="option-label">Anthropic API Key</span>
-        <div class="key-row">
-          {#if showKey}
-            <input type="text" bind:value={apiKey} placeholder="sk-ant-..." class="key-input" />
-          {:else}
-            <input type="password" bind:value={apiKey} placeholder="sk-ant-..." class="key-input" />
-          {/if}
-          <button
-            class="btn btn-small"
-            onclick={() => {
-              showKey = !showKey;
-            }}
-          >
-            {showKey ? 'Hide' : 'Show'}
-          </button>
-        </div>
-      </div>
-
-      <div class="option-group">
-        <span class="option-label">Custom Sensitive Patterns</span>
-        <span class="field-hint">One regex per line</span>
-        <textarea
-          rows="3"
-          bind:value={customPatterns}
-          placeholder="e.g. \.secret$&#10;passwords\.txt"
-        ></textarea>
-      </div>
-
-      <!-- ── Config ── -->
       <div class="config-actions">
         <button class="btn" onclick={() => window.aegis?.exportConfig()}>Export Config</button>
-        <button
-          class="btn"
-          onclick={async () => {
-            const r = await window.aegis?.importConfig();
-            if (r?.success) loaded = false;
-          }}>Import Config</button
-        >
+        <button class="btn" onclick={async () => {
+          const r = await window.aegis?.importConfig();
+          if (r?.success) loaded = false;
+        }}>Import Config</button>
       </div>
 
       <div class="panel-actions">
@@ -270,287 +99,50 @@
 
 <style>
   .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 200;
+    position: fixed; inset: 0; z-index: 200;
     background: var(--md-sys-color-scrim);
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: flex; align-items: center; justify-content: center;
     animation: fadeIn 150ms ease;
   }
-
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-
+  @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
   .panel {
     background: var(--md-sys-color-surface-container-high);
     backdrop-filter: blur(var(--glass-blur));
     -webkit-backdrop-filter: blur(var(--glass-blur));
-    border: var(--glass-border);
-    box-shadow: var(--glass-shadow);
+    border: var(--glass-border); box-shadow: var(--glass-shadow);
     border-radius: var(--md-sys-shape-corner-large);
     padding: var(--aegis-space-10);
-    min-width: var(--aegis-size-modal-min);
-    max-width: 460px;
-    width: 90vw;
-    max-height: 85vh;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-    gap: var(--aegis-space-7);
+    min-width: var(--aegis-size-modal-min); max-width: 460px; width: 90vw;
+    max-height: 85vh; overflow-y: auto;
+    display: flex; flex-direction: column; gap: var(--aegis-space-7);
     animation: scale-in var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
   }
-
-  @keyframes scale-in {
-    from {
-      opacity: 0;
-      transform: scale(0.96) translateY(8px);
-    }
-  }
-
+  @keyframes scale-in { from { opacity: 0; transform: scale(0.96) translateY(8px); } }
   .panel-title {
     font: var(--md-sys-typescale-headline-medium);
-    color: var(--md-sys-color-on-surface);
-    margin: 0;
+    color: var(--md-sys-color-on-surface); margin: 0;
   }
-
-  .section-label {
-    font: var(--md-sys-typescale-label-large);
-    color: var(--md-sys-color-primary);
-    text-transform: uppercase;
-    letter-spacing: 0.8px;
-    border-bottom: 1px solid var(--md-sys-color-outline-variant);
-    padding-bottom: var(--aegis-space-2);
-    margin-top: var(--aegis-space-2);
-  }
-
-  .option-group {
-    display: flex;
-    flex-direction: column;
-    gap: var(--aegis-space-3);
-  }
-
-  .option-group.row {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .option-label {
-    font: var(--md-sys-typescale-label-medium);
-    font-weight: 600;
-    color: var(--md-sys-color-on-surface-variant);
-  }
-
-  .field-hint {
-    font: var(--md-sys-typescale-label-medium);
-    color: var(--md-sys-color-on-surface-variant);
-    opacity: 0.6;
-    font-size: calc(10px * var(--aegis-ui-scale));
-  }
-
-  .scale-value {
-    font-family: 'DM Mono', monospace;
-    color: var(--md-sys-color-primary);
-    font-weight: 700;
-  }
-
-  .theme-toggle {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--aegis-space-4) var(--aegis-space-8);
-  }
-
-  .radio-label {
-    font: var(--md-sys-typescale-body-medium);
-    color: var(--md-sys-color-on-surface);
-    display: flex;
-    align-items: center;
-    gap: var(--aegis-space-3);
-    cursor: pointer;
-  }
-
-  .radio-label input[type='radio'] {
-    accent-color: var(--md-sys-color-primary);
-  }
-
-  .scale-slider {
-    width: 100%;
-    height: 4px;
-    -webkit-appearance: none;
-    appearance: none;
-    background: var(--md-sys-color-surface-container-highest);
-    border-radius: 2px;
-    outline: none;
-    cursor: pointer;
-  }
-
-  .scale-slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: var(--md-sys-color-primary);
-    cursor: pointer;
-  }
-
-  .scale-labels {
-    display: flex;
-    justify-content: space-between;
-    font: var(--md-sys-typescale-label-medium);
-    color: var(--md-sys-color-on-surface-variant);
-    opacity: 0.6;
-  }
-
-  /* Range row for scan interval */
-  .range-row {
-    display: flex;
-    align-items: center;
-    gap: var(--aegis-space-5);
-  }
-  .range-row input[type='range'] {
-    flex: 1;
-    accent-color: var(--md-sys-color-primary);
-  }
-  .range-val {
-    font: var(--md-sys-typescale-label-medium);
-    font-weight: 600;
-    font-family: 'DM Mono', monospace;
-    color: var(--md-sys-color-on-surface);
-    min-width: 32px;
-    text-align: right;
-  }
-
-  /* Toggle switch */
-  .toggle {
-    position: relative;
-    width: 40px;
-    height: 22px;
-    padding: 0;
-    cursor: pointer;
-    background: var(--md-sys-color-surface-container);
-    border: 1px solid var(--md-sys-color-outline);
-    border-radius: var(--md-sys-shape-corner-full);
-    transition: background var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
-    flex-shrink: 0;
-  }
-  .toggle-on {
-    background: var(--md-sys-color-primary-container);
-    border-color: var(--md-sys-color-primary);
-  }
-  .toggle-knob {
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: var(--md-sys-color-on-surface-variant);
-    transition: all var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
-  }
-  .toggle-on .toggle-knob {
-    left: 20px;
-    background: var(--md-sys-color-primary);
-  }
-
-  .notif-row {
-    display: flex;
-    align-items: center;
-    gap: var(--aegis-space-4);
-  }
-
-  .test-result {
-    font: var(--md-sys-typescale-label-medium);
-    font-family: 'DM Mono', monospace;
-    color: var(--md-sys-color-primary);
-  }
-
-  /* Key input */
-  .key-row {
-    display: flex;
-    gap: var(--aegis-space-4);
-  }
-  .key-input,
-  textarea {
-    font: var(--md-sys-typescale-body-medium);
-    font-family: 'DM Mono', monospace;
-    font-size: calc(12px * var(--aegis-ui-scale));
-    padding: var(--aegis-space-4) var(--aegis-space-5);
-    background: var(--md-sys-color-surface-container);
-    border: 1px solid var(--md-sys-color-outline);
-    border-radius: var(--md-sys-shape-corner-small);
-    color: var(--md-sys-color-on-surface);
-    outline: none;
-  }
-  .key-input {
-    flex: 1;
-  }
-  textarea {
-    resize: vertical;
-    width: 100%;
-    box-sizing: border-box;
-  }
-  .key-input:focus,
-  textarea:focus {
-    border-color: var(--md-sys-color-primary);
-  }
-
-  /* Config row */
   .config-actions {
-    display: flex;
-    gap: var(--aegis-space-4);
+    display: flex; gap: var(--aegis-space-4);
     border-top: 1px solid var(--md-sys-color-outline-variant);
-    padding-top: var(--aegis-space-6);
-    margin-top: 2px;
+    padding-top: var(--aegis-space-6); margin-top: 2px;
   }
-
   .panel-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: var(--aegis-space-4);
+    display: flex; justify-content: flex-end; gap: var(--aegis-space-4);
   }
-
   .btn {
-    font: var(--md-sys-typescale-label-medium);
-    font-weight: 600;
+    font: var(--md-sys-typescale-label-medium); font-weight: 600;
     padding: var(--aegis-space-4) var(--aegis-space-9);
-    border: none;
-    border-radius: var(--md-sys-shape-corner-full);
-    cursor: pointer;
-    transition: all 0.3s var(--ease-glass);
+    border: none; border-radius: var(--md-sys-shape-corner-full);
+    cursor: pointer; transition: all 0.3s var(--ease-glass);
   }
-  .btn:hover {
-    opacity: 0.85;
-  }
-  .btn:active {
-    transform: scale(0.97);
-  }
-
-  .btn-small {
-    padding: var(--aegis-space-3) var(--aegis-space-6);
-    border-radius: var(--md-sys-shape-corner-small);
-    background: var(--md-sys-color-surface-container);
-    border: 1px solid var(--md-sys-color-outline);
-    color: var(--md-sys-color-on-surface-variant);
-  }
-  .btn-small:hover {
-    color: var(--md-sys-color-on-surface);
-    background: var(--md-sys-color-surface-container-high);
-  }
-
+  .btn:hover { opacity: 0.85; }
+  .btn:active { transform: scale(0.97); }
   .btn-cancel {
     background: transparent;
     border: 1px solid var(--md-sys-color-outline);
     color: var(--md-sys-color-on-surface-variant);
   }
-
   .btn-save {
     background: var(--md-sys-color-primary);
     color: var(--md-sys-color-on-primary);

--- a/src/renderer/lib/components/SettingsAppearance.svelte
+++ b/src/renderer/lib/components/SettingsAppearance.svelte
@@ -1,0 +1,91 @@
+<script>
+  /**
+   * @file SettingsAppearance.svelte
+   * @description Theme toggle + UI scale slider for Settings panel.
+   *   Extracted from OptionsPanel.svelte.
+   * @since v0.3.0
+   */
+  let { localTheme = $bindable('dark'), localScale = $bindable(1), onThemeChange, onScaleInput } = $props();
+
+  let scalePercent = $derived(Math.round(localScale * 100));
+</script>
+
+<div class="section-label">Appearance</div>
+
+<div class="option-group">
+  <span class="option-label">Theme</span>
+  <div class="theme-toggle">
+    <label class="radio-label">
+      <input type="radio" name="theme" value="dark" checked={localTheme === 'dark'} onchange={onThemeChange} /> Dark
+    </label>
+    <label class="radio-label">
+      <input type="radio" name="theme" value="light" checked={localTheme === 'light'} onchange={onThemeChange} /> Light
+    </label>
+    <label class="radio-label">
+      <input type="radio" name="theme" value="dark-hc" checked={localTheme === 'dark-hc'} onchange={onThemeChange} /> Dark HC
+    </label>
+    <label class="radio-label">
+      <input type="radio" name="theme" value="light-hc" checked={localTheme === 'light-hc'} onchange={onThemeChange} /> Light HC
+    </label>
+  </div>
+</div>
+
+<div class="option-group">
+  <label class="option-label" for="ui-scale-slider">
+    Interface Scale <span class="scale-value">{scalePercent}%</span>
+  </label>
+  <input
+    id="ui-scale-slider" type="range" min="0.8" max="1.5" step="0.1"
+    value={localScale} oninput={onScaleInput} class="scale-slider"
+  />
+  <div class="scale-labels"><span>80%</span><span>100%</span><span>150%</span></div>
+</div>
+
+<style>
+  .section-label {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+    padding-bottom: var(--aegis-space-2);
+    margin-top: var(--aegis-space-2);
+  }
+  .option-group { display: flex; flex-direction: column; gap: var(--aegis-space-3); }
+  .option-label {
+    font: var(--md-sys-typescale-label-medium);
+    font-weight: 600;
+    color: var(--md-sys-color-on-surface-variant);
+  }
+  .scale-value {
+    font-family: 'DM Mono', monospace;
+    color: var(--md-sys-color-primary);
+    font-weight: 700;
+  }
+  .theme-toggle {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--aegis-space-4) var(--aegis-space-8);
+  }
+  .radio-label {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface);
+    display: flex; align-items: center; gap: var(--aegis-space-3); cursor: pointer;
+  }
+  .radio-label input[type='radio'] { accent-color: var(--md-sys-color-primary); }
+  .scale-slider {
+    width: 100%; height: 4px;
+    -webkit-appearance: none; appearance: none;
+    background: var(--md-sys-color-surface-container-highest);
+    border-radius: 2px; outline: none; cursor: pointer;
+  }
+  .scale-slider::-webkit-slider-thumb {
+    -webkit-appearance: none; width: 16px; height: 16px;
+    border-radius: 50%; background: var(--md-sys-color-primary); cursor: pointer;
+  }
+  .scale-labels {
+    display: flex; justify-content: space-between;
+    font: var(--md-sys-typescale-label-medium);
+    color: var(--md-sys-color-on-surface-variant); opacity: 0.6;
+  }
+</style>

--- a/src/renderer/lib/components/SettingsMonitoring.svelte
+++ b/src/renderer/lib/components/SettingsMonitoring.svelte
@@ -1,0 +1,155 @@
+<script>
+  /**
+   * @file SettingsMonitoring.svelte
+   * @description Scan interval, notifications, API key, and custom patterns
+   *   for Settings panel. Extracted from OptionsPanel.svelte.
+   * @since v0.3.0
+   */
+  let {
+    scanInterval = $bindable(10),
+    notifications = $bindable(true),
+    apiKey = $bindable(''),
+    customPatterns = $bindable(''),
+  } = $props();
+
+  let showKey = $state(false);
+  let testResult = $state('');
+
+  async function testNotify() {
+    testResult = '';
+    if (!window.aegis?.testNotification) { testResult = 'Not available'; return; }
+    const r = await window.aegis.testNotification();
+    testResult = r.success ? 'Sent' : r.error || 'Failed';
+  }
+</script>
+
+<!-- ── Monitoring ── -->
+<div class="section-label">Monitoring</div>
+
+<div class="option-group">
+  <span class="option-label">Scan Interval</span>
+  <div class="range-row">
+    <input type="range" min="3" max="60" step="1" bind:value={scanInterval} />
+    <span class="range-val">{scanInterval}s</span>
+  </div>
+</div>
+
+<div class="option-group row">
+  <span class="option-label">Notifications</span>
+  <div class="notif-row">
+    <button class="toggle" class:toggle-on={notifications} aria-label="Toggle notifications"
+      onclick={() => { notifications = !notifications; }}>
+      <span class="toggle-knob"></span>
+    </button>
+    <button class="btn btn-small" onclick={testNotify}>Test</button>
+    {#if testResult}<span class="test-result">{testResult}</span>{/if}
+  </div>
+</div>
+
+<!-- ── AI Analysis ── -->
+<div class="section-label">AI Analysis</div>
+
+<div class="option-group">
+  <span class="option-label">Anthropic API Key</span>
+  <div class="key-row">
+    {#if showKey}
+      <input type="text" bind:value={apiKey} placeholder="sk-ant-..." class="key-input" />
+    {:else}
+      <input type="password" bind:value={apiKey} placeholder="sk-ant-..." class="key-input" />
+    {/if}
+    <button class="btn btn-small" onclick={() => { showKey = !showKey; }}>
+      {showKey ? 'Hide' : 'Show'}
+    </button>
+  </div>
+</div>
+
+<div class="option-group">
+  <span class="option-label">Custom Sensitive Patterns</span>
+  <span class="field-hint">One regex per line</span>
+  <textarea rows="3" bind:value={customPatterns} placeholder="e.g. \.secret$&#10;passwords\.txt"></textarea>
+</div>
+
+<style>
+  .section-label {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+    padding-bottom: var(--aegis-space-2);
+    margin-top: var(--aegis-space-2);
+  }
+  .option-group { display: flex; flex-direction: column; gap: var(--aegis-space-3); }
+  .option-group.row {
+    flex-direction: row; align-items: center; justify-content: space-between;
+  }
+  .option-label {
+    font: var(--md-sys-typescale-label-medium);
+    font-weight: 600; color: var(--md-sys-color-on-surface-variant);
+  }
+  .field-hint {
+    font: var(--md-sys-typescale-label-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    opacity: 0.6; font-size: calc(10px * var(--aegis-ui-scale));
+  }
+  .range-row { display: flex; align-items: center; gap: var(--aegis-space-5); }
+  .range-row input[type='range'] { flex: 1; accent-color: var(--md-sys-color-primary); }
+  .range-val {
+    font: var(--md-sys-typescale-label-medium);
+    font-weight: 600; font-family: 'DM Mono', monospace;
+    color: var(--md-sys-color-on-surface); min-width: 32px; text-align: right;
+  }
+  .toggle {
+    position: relative; width: 40px; height: 22px; padding: 0; cursor: pointer;
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-full);
+    transition: background var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+    flex-shrink: 0;
+  }
+  .toggle-on { background: var(--md-sys-color-primary-container); border-color: var(--md-sys-color-primary); }
+  .toggle-knob {
+    position: absolute; top: 2px; left: 2px; width: 16px; height: 16px;
+    border-radius: 50%; background: var(--md-sys-color-on-surface-variant);
+    transition: all var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+  }
+  .toggle-on .toggle-knob { left: 20px; background: var(--md-sys-color-primary); }
+  .notif-row { display: flex; align-items: center; gap: var(--aegis-space-4); }
+  .test-result {
+    font: var(--md-sys-typescale-label-medium);
+    font-family: 'DM Mono', monospace; color: var(--md-sys-color-primary);
+  }
+  .key-row { display: flex; gap: var(--aegis-space-4); }
+  .key-input, textarea {
+    font: var(--md-sys-typescale-body-medium);
+    font-family: 'DM Mono', monospace;
+    font-size: calc(12px * var(--aegis-ui-scale));
+    padding: var(--aegis-space-4) var(--aegis-space-5);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-small);
+    color: var(--md-sys-color-on-surface); outline: none;
+  }
+  .key-input { flex: 1; }
+  textarea { resize: vertical; width: 100%; box-sizing: border-box; }
+  .key-input:focus, textarea:focus { border-color: var(--md-sys-color-primary); }
+  .btn {
+    font: var(--md-sys-typescale-label-medium); font-weight: 600;
+    padding: var(--aegis-space-4) var(--aegis-space-9);
+    border: none; border-radius: var(--md-sys-shape-corner-full);
+    cursor: pointer; transition: all 0.3s var(--ease-glass);
+  }
+  .btn:hover { opacity: 0.85; }
+  .btn:active { transform: scale(0.97); }
+  .btn-small {
+    padding: var(--aegis-space-3) var(--aegis-space-6);
+    border-radius: var(--md-sys-shape-corner-small);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+  .btn-small:hover {
+    color: var(--md-sys-color-on-surface);
+    background: var(--md-sys-color-surface-container-high);
+  }
+</style>

--- a/src/renderer/lib/components/Timeline.svelte
+++ b/src/renderer/lib/components/Timeline.svelte
@@ -1,7 +1,14 @@
 <script>
+  /**
+   * @file Timeline.svelte
+   * @description Horizontal event timeline with zoom, scroll, and history loading.
+   *   Canvas rendering in TimelineCanvas, scrub bar in TimelineControls.
+   * @since v0.1.0
+   */
   import { events, network, focusedAgentPid } from '../stores/ipc.js';
+  import TimelineCanvas from './TimelineCanvas.svelte';
+  import TimelineControls from './TimelineControls.svelte';
 
-  const DOT_R = 4;
   const SVG_H = 36;
   const MID = 14;
   const TICK_TOP = 24;
@@ -9,20 +16,14 @@
   const PX_PER_UNIT = 120;
   const PAD = 20;
   const MIN_TICK_PX = 64;
-
   const ZOOM_LEVELS = [
-    { ms: 3600000 }, // 1h per 120px
-    { ms: 1800000 }, // 30min
-    { ms: 600000 }, // 10min
-    { ms: 300000 }, // 5min
-    { ms: 60000 }, // 1min
-    { ms: 30000 }, // 30s
-    { ms: 10000 }, // 10s (default — most zoomed in)
+    { ms: 3600000 }, { ms: 1800000 }, { ms: 600000 }, { ms: 300000 },
+    { ms: 60000 }, { ms: 30000 }, { ms: 10000 },
   ];
-
   const NICE_INTERVALS = [
     5000, 10000, 15000, 30000, 60000, 120000, 300000, 600000, 900000, 1800000, 3600000, 7200000,
   ];
+  const HISTORY_BATCH = 25;
 
   function getSeverity(ev) {
     if (ev._type === 'network') return ev.flagged ? 'high' : 'low';
@@ -31,108 +32,71 @@
     if (ev.action === 'deleted') return 'medium';
     return 'low';
   }
-
   function sevColor(sev) {
     if (sev === 'critical') return 'var(--md-sys-color-error)';
     if (sev === 'high') return 'var(--md-sys-color-secondary)';
     if (sev === 'medium') return 'var(--md-sys-color-primary)';
     return 'var(--md-sys-color-on-surface-variant)';
   }
-
   function formatTime(ts) {
     const d = new Date(ts);
     return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
   }
-
   function formatTick(ts, subMinute) {
     const d = new Date(ts);
     const hh = String(d.getHours()).padStart(2, '0');
     const mm = String(d.getMinutes()).padStart(2, '0');
     if (!subMinute) return `${hh}:${mm}`;
-    const ss = String(d.getSeconds()).padStart(2, '0');
-    return `${hh}:${mm}:${ss}`;
+    return `${hh}:${mm}:${String(d.getSeconds()).padStart(2, '0')}`;
   }
 
   let viewportWidth = $state(600);
   let zoomIndex = $state(6);
   let scrollLeft = $state(0);
   let dragging = $state(false);
-  let thumbHover = $state(false);
   let following = $state(true);
 
-  // Load persisted zoom from settings
   if (window.aegis) {
     window.aegis.getSettings().then((s) => {
-      if (
-        typeof s.timelineZoom === 'number' &&
-        s.timelineZoom >= 0 &&
-        s.timelineZoom < ZOOM_LEVELS.length
-      ) {
+      if (typeof s.timelineZoom === 'number' && s.timelineZoom >= 0 && s.timelineZoom < ZOOM_LEVELS.length) {
         zoomIndex = s.timelineZoom;
       }
     });
   }
 
-  // ═══ HISTORICAL AUDIT ENTRIES (lazy-loaded on scroll-back) ═══
+  // ═══ HISTORICAL AUDIT ENTRIES ═══
   let historicalEvents = $state([]);
   let loadingHistory = $state(false);
   let historyExhausted = $state(false);
   let pendingScrollAdjust = $state(false);
   let prevMinT = $state(0);
-  const HISTORY_BATCH = 25;
 
   function auditToTimelineEvent(entry) {
     const ts = new Date(entry.timestamp).getTime();
     if (entry.type === 'network-connection') {
-      return {
-        agent: entry.agent,
-        timestamp: ts,
-        _type: 'network',
-        flagged: entry.severity === 'high',
-        _historical: true,
-      };
+      return { agent: entry.agent, timestamp: ts, _type: 'network', flagged: entry.severity === 'high', _historical: true };
     }
-    return {
-      agent: entry.agent,
-      timestamp: ts,
-      action: entry.action,
-      file: entry.path,
-      sensitive: entry.severity === 'sensitive',
-      _denied: entry.type === 'permission-deny',
-      _type: 'file',
-      _historical: true,
-    };
+    return { agent: entry.agent, timestamp: ts, action: entry.action, file: entry.path,
+      sensitive: entry.severity === 'sensitive', _denied: entry.type === 'permission-deny',
+      _type: 'file', _historical: true };
   }
 
   async function loadOlderHistory() {
     if (loadingHistory || historyExhausted || !window.aegis?.getAuditEntriesBefore) return;
     loadingHistory = true;
-    // Snapshot current timeline origin so we can compensate after load
     prevMinT = minT;
     try {
-      const oldest =
-        historicalEvents.length > 0
-          ? new Date(historicalEvents[0].timestamp).toISOString()
-          : allLiveEvents.length > 0
-            ? new Date(allLiveEvents[0].timestamp).toISOString()
-            : new Date().toISOString();
+      const oldest = historicalEvents.length > 0
+        ? new Date(historicalEvents[0].timestamp).toISOString()
+        : allLiveEvents.length > 0 ? new Date(allLiveEvents[0].timestamp).toISOString() : new Date().toISOString();
       const entries = await window.aegis.getAuditEntriesBefore(oldest, HISTORY_BATCH);
-      if (entries.length === 0) {
-        historyExhausted = true;
-      } else {
+      if (entries.length === 0) { historyExhausted = true; }
+      else {
         const mapped = entries
-          .filter((e) =>
-            ['file-access', 'config-access', 'network-connection', 'permission-deny'].includes(
-              e.type,
-            ),
-          )
+          .filter((e) => ['file-access', 'config-access', 'network-connection', 'permission-deny'].includes(e.type))
           .map(auditToTimelineEvent);
-        if (mapped.length === 0) {
-          historyExhausted = true;
-        } else {
-          pendingScrollAdjust = true;
-          historicalEvents = [...mapped, ...historicalEvents];
-        }
+        if (mapped.length === 0) { historyExhausted = true; }
+        else { pendingScrollAdjust = true; historicalEvents = [...mapped, ...historicalEvents]; }
       }
     } catch (_) {}
     loadingHistory = false;
@@ -147,51 +111,34 @@
   let allLiveEvents = $derived.by(() => {
     const fileEvs = $events.flat().map((ev) => ({ ...ev, _type: 'file' }));
     const netEvs = $network.map((conn) => ({
-      agent: conn.agent || 'Unknown',
-      timestamp: conn.timestamp || Date.now(),
-      _type: 'network',
-      flagged: !!conn.flagged,
+      agent: conn.agent || 'Unknown', timestamp: conn.timestamp || Date.now(),
+      _type: 'network', flagged: !!conn.flagged,
     }));
     return [...fileEvs, ...netEvs].sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
   });
 
   let allEvents = $derived.by(() => {
-    // Merge historical (from audit log) with live events, dedup by timestamp+agent
     const seen = new Set();
     const merged = [];
     for (const ev of [...historicalEvents, ...allLiveEvents]) {
       const key = `${ev.timestamp}|${ev.agent}|${ev._type}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        merged.push(ev);
-      }
+      if (!seen.has(key)) { seen.add(key); merged.push(ev); }
     }
     merged.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
     return merged.slice(-500);
   });
 
-  // Snap to nearest 10s boundary DOWN for a clean starting point
   let rawMinT = $derived(allEvents.length > 0 ? allEvents[0].timestamp || 0 : Date.now());
   let minT = $derived(Math.floor(rawMinT / 10000) * 10000);
-  let maxT = $derived(
-    allEvents.length > 0 ? allEvents[allEvents.length - 1].timestamp || 0 : Date.now(),
-  );
+  let maxT = $derived(allEvents.length > 0 ? allEvents[allEvents.length - 1].timestamp || 0 : Date.now());
   let eventRange = $derived(maxT - minT || 1);
-
   let msPerUnit = $derived(ZOOM_LEVELS[zoomIndex].ms);
-
-  // How many ms the viewport represents at this zoom
   let viewportMs = $derived((viewportWidth / PX_PER_UNIT) * msPerUnit);
-  // The full virtual canvas width in ms — at least the viewport, or the event span
   let displayRange = $derived(Math.max(eventRange, viewportMs));
-  // Time origin at left edge (snapped)
   let displayMinT = $derived(minT);
-
-  // Virtual total width (in px coords) — all positioning happens in this space
   let totalWidth = $derived(Math.max(viewportWidth, (displayRange / msPerUnit) * PX_PER_UNIT));
   let maxScroll = $derived(Math.max(0, totalWidth - viewportWidth));
 
-  // Adaptive tick interval
   let tickInterval = $derived.by(() => {
     const pxPerMs = (totalWidth - PAD * 2) / displayRange;
     for (const interval of NICE_INTERVALS) {
@@ -201,11 +148,8 @@
   });
 
   let clampedScroll = $derived(Math.min(scrollLeft, maxScroll));
-  $effect(() => {
-    if (scrollLeft > maxScroll) scrollLeft = maxScroll;
-  });
+  $effect(() => { if (scrollLeft > maxScroll) scrollLeft = maxScroll; });
 
-  // After history loads, shift scrollLeft to keep the viewport on the same time range
   $effect(() => {
     if (pendingScrollAdjust && prevMinT > 0 && minT < prevMinT) {
       const shiftMs = prevMinT - minT;
@@ -215,50 +159,30 @@
     }
   });
 
-  // Load next batch when thumb is at the left edge
   $effect(() => {
-    if (
-      !following &&
-      !historyExhausted &&
-      !loadingHistory &&
-      thumbOffset >= 0 &&
-      thumbOffset <= 2
-    ) {
+    if (!following && !historyExhausted && !loadingHistory && thumbOffset >= 0 && thumbOffset <= 2) {
       loadOlderHistory();
     }
   });
 
-  // Auto-scroll to latest when following
   $effect(() => {
-    // Re-run whenever events change or maxScroll changes
-    void allEvents.length;
-    void maxScroll;
-    if (following) {
-      scrollLeft = maxScroll;
-    }
+    void allEvents.length; void maxScroll;
+    if (following) scrollLeft = maxScroll;
   });
 
-  // Map timestamp → virtual x
   function tsToX(ts) {
     const usable = totalWidth - PAD * 2;
     return PAD + ((ts - displayMinT) / displayRange) * usable;
   }
 
-  // viewBox pans through the virtual space — SVG element stays at viewportWidth
   let viewBox = $derived(`${clampedScroll} 0 ${viewportWidth} ${SVG_H}`);
 
   let dots = $derived.by(() => {
     if (allEvents.length === 0) return [];
     return allEvents.map((ev, idx) => {
       const sev = getSeverity(ev);
-      return {
-        x: tsToX(ev.timestamp || 0),
-        color: sevColor(sev),
-        agent: ev.agent || 'Unknown',
-        pid: ev.pid || null,
-        time: formatTime(ev.timestamp),
-        idx,
-      };
+      return { x: tsToX(ev.timestamp || 0), color: sevColor(sev),
+        agent: ev.agent || 'Unknown', pid: ev.pid || null, time: formatTime(ev.timestamp), idx };
     });
   });
 
@@ -269,222 +193,105 @@
     const firstTick = Math.ceil(displayMinT / tickInterval) * tickInterval;
     let isFirst = true;
     for (let t = firstTick; t <= tickEnd; t += tickInterval) {
-      // Skip the very first tick — it sits at the left edge and gets cut off
-      if (isFirst) {
-        isFirst = false;
-        continue;
-      }
+      if (isFirst) { isFirst = false; continue; }
       result.push({ x: tsToX(t), label: formatTick(t, subMinute) });
     }
     return result;
   });
 
-  // Scrub bar — all sizes relative to viewportWidth (the actual container width)
+  // ═══ SCRUB BAR ═══
   let thumbRatio = $derived(totalWidth > 0 ? viewportWidth / totalWidth : 1);
-  let scrubPad = 12; // 6px margin each side on the track
+  let scrubPad = 12;
   let trackWidth = $derived(viewportWidth - scrubPad);
   let thumbWidth = $derived(Math.min(120, Math.max(30, thumbRatio * trackWidth)));
   let trackUsable = $derived(trackWidth - thumbWidth);
+  let thumbOffset = $state(-1);
 
-  // thumbOffset is the source of truth for thumb position (always draggable)
-  let thumbOffset = $state(-1); // -1 = uninitialized, will sync to right edge
-  // Sync thumbOffset from scrollLeft when there's scroll room and not dragging
   $effect(() => {
     if (!dragging) {
-      if (following) {
-        thumbOffset = trackUsable;
-      } else if (maxScroll > 0) {
-        thumbOffset = maxScroll > 0 ? (clampedScroll / maxScroll) * trackUsable : trackUsable;
-      }
+      if (following) { thumbOffset = trackUsable; }
+      else if (maxScroll > 0) { thumbOffset = (clampedScroll / maxScroll) * trackUsable; }
     }
   });
-  let thumbX = $derived(
-    thumbOffset < 0 ? trackUsable : Math.max(0, Math.min(trackUsable, thumbOffset)),
-  );
+
+  let thumbX = $derived(thumbOffset < 0 ? trackUsable : Math.max(0, Math.min(trackUsable, thumbOffset)));
 
   function handleWheel(e) {
     e.preventDefault();
     let changed = false;
-    if (e.deltaY < 0 && zoomIndex < ZOOM_LEVELS.length - 1) {
-      zoomIndex++;
-      changed = true;
-    } else if (e.deltaY > 0 && zoomIndex > 0) {
-      zoomIndex--;
-      changed = true;
-    }
+    if (e.deltaY < 0 && zoomIndex < ZOOM_LEVELS.length - 1) { zoomIndex++; changed = true; }
+    else if (e.deltaY > 0 && zoomIndex > 0) { zoomIndex--; changed = true; }
     if (changed && window.aegis) {
-      window.aegis.getSettings().then((s) => {
-        window.aegis.saveSettings({ ...s, timelineZoom: zoomIndex });
-      });
+      window.aegis.getSettings().then((s) => { window.aegis.saveSettings({ ...s, timelineZoom: zoomIndex }); });
     }
   }
 
-  // Dot hover/click — detect edge collision and flip tooltip side
   function positionTooltip(e) {
-    const text = tooltipText;
-    // Estimate tooltip width: ~7px per char + 16px padding
-    const estWidth = text.length * 7 + 16;
+    const estWidth = tooltipText.length * 7 + 16;
     const estHeight = 24;
     const margin = 12;
-
-    // Flip horizontally if tooltip would go past right edge
-    if (e.clientX + margin + estWidth > window.innerWidth) {
-      tooltipFixedX = e.clientX - margin - estWidth;
-    } else {
-      tooltipFixedX = e.clientX + margin;
-    }
-
-    // Flip vertically if tooltip would go above top edge
-    if (e.clientY - estHeight - 8 < 0) {
-      tooltipFixedY = e.clientY + margin;
-    } else {
-      tooltipFixedY = e.clientY - estHeight - 8;
-    }
+    tooltipFixedX = (e.clientX + margin + estWidth > window.innerWidth)
+      ? e.clientX - margin - estWidth : e.clientX + margin;
+    tooltipFixedY = (e.clientY - estHeight - 8 < 0) ? e.clientY + margin : e.clientY - estHeight - 8;
   }
-
   function handleDotEnter(e, dot) {
     tooltipText = `${dot.time}  ${dot.agent}` + (dot.pid ? ` [${dot.pid}]` : '');
-    tooltipVisible = true;
-    positionTooltip(e);
+    tooltipVisible = true; positionTooltip(e);
   }
-
-  function handleDotMove(e) {
-    positionTooltip(e);
-  }
-
-  function handleDotLeave() {
-    tooltipVisible = false;
-  }
-
+  function handleDotMove(e) { positionTooltip(e); }
+  function handleDotLeave() { tooltipVisible = false; }
   function handleDotClick(e, dot) {
     e.stopPropagation();
-    if (dot.pid) {
-      focusedAgentPid.set(dot.pid);
-    }
+    if (dot.pid) focusedAgentPid.set(dot.pid);
   }
 
-  // Scrub drag
   let dragStartX = 0;
-  let dragStartScroll = 0;
-
   let dragStartThumbOffset = 0;
-
   function handleThumbDown(e) {
-    e.preventDefault();
-    dragging = true;
-    following = false;
-    dragStartX = e.clientX;
-    dragStartThumbOffset = thumbX;
+    e.preventDefault(); dragging = true; following = false;
+    dragStartX = e.clientX; dragStartThumbOffset = thumbX;
     window.addEventListener('mousemove', handleDragMove);
     window.addEventListener('mouseup', handleDragEnd);
   }
-
   function handleDragMove(e) {
     if (!dragging) return;
     const dx = e.clientX - dragStartX;
     thumbOffset = Math.max(0, Math.min(trackUsable, dragStartThumbOffset + dx));
-    // Drive scrollLeft from thumb position when there's scroll room
-    if (maxScroll > 0 && trackUsable > 0) {
-      scrollLeft = (thumbOffset / trackUsable) * maxScroll;
-    }
+    if (maxScroll > 0 && trackUsable > 0) scrollLeft = (thumbOffset / trackUsable) * maxScroll;
   }
-
   function handleDragEnd() {
     dragging = false;
-    // Re-enable following if thumb is at the right edge
     if (thumbOffset >= trackUsable - 2) following = true;
-    // Trigger history load if thumb reached the left edge
-    if (thumbOffset <= 2 && !historyExhausted && !loadingHistory) {
-      loadOlderHistory();
-    }
+    if (thumbOffset <= 2 && !historyExhausted && !loadingHistory) loadOlderHistory();
     window.removeEventListener('mousemove', handleDragMove);
     window.removeEventListener('mouseup', handleDragEnd);
   }
-
   function handleTrackClick(e) {
     if (dragging) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const clickX = e.clientX - rect.left - scrubPad / 2;
     const newOffset = Math.max(0, Math.min(trackUsable, clickX - thumbWidth / 2));
-    following = false;
-    thumbOffset = newOffset;
-    if (maxScroll > 0 && trackUsable > 0) {
-      scrollLeft = (thumbOffset / trackUsable) * maxScroll;
-    }
+    following = false; thumbOffset = newOffset;
+    if (maxScroll > 0 && trackUsable > 0) scrollLeft = (thumbOffset / trackUsable) * maxScroll;
     if (newOffset >= trackUsable - 2) following = true;
-    if (newOffset <= 2 && !historyExhausted && !loadingHistory) {
-      loadOlderHistory();
-    }
+    if (newOffset <= 2 && !historyExhausted && !loadingHistory) loadOlderHistory();
   }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="timeline-wrap" onwheel={handleWheel} bind:clientWidth={viewportWidth}>
-  <div class="timeline-viewport" id="timeline-viewport">
-    <svg width={viewportWidth} height={SVG_H} {viewBox}>
-      <!-- baseline track -->
-      <line
-        x1={clampedScroll + PAD}
-        y1={MID}
-        x2={clampedScroll + viewportWidth - PAD}
-        y2={MID}
-        class="baseline"
-      />
-
-      <!-- ticks -->
-      {#each ticks as t (t.x)}
-        <line x1={t.x} y1={TICK_TOP} x2={t.x} y2={TICK_TOP + TICK_H} class="tick-line" />
-        <text x={t.x} y={TICK_TOP + TICK_H + 1} text-anchor="middle" class="tick-label"
-          >{t.label}</text
-        >
-      {/each}
-
-      <!-- dots -->
-      {#each dots as dot (dot.idx)}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <circle
-          cx={dot.x}
-          cy={MID}
-          r={DOT_R}
-          fill={dot.color}
-          opacity="0.85"
-          class="dot"
-          onmouseenter={(e) => handleDotEnter(e, dot)}
-          onmousemove={(e) => handleDotMove(e)}
-          onmouseleave={handleDotLeave}
-          onclick={(e) => handleDotClick(e, dot)}
-        />
-      {/each}
-    </svg>
-  </div>
-
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="scrub-track" onclick={handleTrackClick}>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="scrub-thumb"
-      class:hover={thumbHover}
-      class:dragging
-      style="width:{thumbWidth}px; left:{thumbX}px"
-      onmousedown={handleThumbDown}
-      onmouseenter={() => (thumbHover = true)}
-      onmouseleave={() => (thumbHover = false)}
-      role="scrollbar"
-      aria-controls="timeline-viewport"
-      aria-valuenow={clampedScroll}
-      aria-valuemin={0}
-      aria-valuemax={maxScroll}
-      aria-orientation="horizontal"
-      tabindex="0"
-    >
-      <div class="grip"><span></span><span></span><span></span></div>
-    </div>
-  </div>
+  <TimelineCanvas
+    {viewportWidth} svgH={SVG_H} {viewBox} {clampedScroll} pad={PAD} mid={MID}
+    tickTop={TICK_TOP} tickH={TICK_H} {ticks} {dots}
+    onDotEnter={handleDotEnter} onDotMove={handleDotMove}
+    onDotLeave={handleDotLeave} onDotClick={handleDotClick}
+  />
+  <TimelineControls
+    {thumbWidth} {thumbX} {trackUsable} {scrubPad} {maxScroll}
+    onTrackClick={handleTrackClick} onThumbDown={handleThumbDown} {dragging}
+  />
 </div>
 
-<!-- Tooltip via fixed positioning -->
 {#if tooltipVisible}
   <div class="timeline-tooltip" style="left:{tooltipFixedX}px; top:{tooltipFixedY}px">
     {tooltipText}
@@ -499,69 +306,11 @@
     backdrop-filter: blur(var(--glass-blur));
     -webkit-backdrop-filter: blur(var(--glass-blur));
     border: var(--aegis-card-border);
-    box-shadow:
-      0 2px 8px rgba(0, 0, 0, 0.12),
-      var(--glass-highlight);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12), var(--glass-highlight);
     border-radius: var(--md-sys-shape-corner-small);
     padding: 3px 0;
     overflow: hidden;
   }
-
-  .timeline-viewport {
-    width: 100%;
-    height: var(--aegis-size-timeline);
-    overflow: hidden;
-    -webkit-mask-image: linear-gradient(
-      to right,
-      transparent,
-      black 28px,
-      black calc(100% - 28px),
-      transparent
-    );
-    mask-image: linear-gradient(
-      to right,
-      transparent,
-      black 28px,
-      black calc(100% - 28px),
-      transparent
-    );
-  }
-
-  svg {
-    display: block;
-  }
-
-  .baseline {
-    stroke: var(--md-sys-color-on-surface-variant);
-    stroke-width: 1;
-    opacity: 0.2;
-  }
-
-  .tick-line {
-    stroke: var(--md-sys-color-on-surface-variant);
-    stroke-width: 1;
-    opacity: 0.3;
-  }
-
-  .tick-label {
-    fill: var(--md-sys-color-on-surface-variant);
-    opacity: 0.5;
-    font-family: 'DM Mono', monospace;
-    font-size: calc(9px * var(--aegis-ui-scale, 1));
-    font-weight: var(--md-sys-typescale-label-medium-weight, 500);
-  }
-
-  .dot {
-    cursor: pointer;
-    transition: opacity var(--md-sys-motion-duration-short, 100ms)
-      var(--md-sys-motion-easing-standard, ease);
-  }
-
-  .dot:hover {
-    opacity: 1;
-    filter: brightness(1.3);
-  }
-
   .timeline-tooltip {
     position: fixed;
     pointer-events: none;
@@ -575,68 +324,5 @@
     padding: calc(3px * var(--aegis-ui-scale)) var(--aegis-space-4);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     z-index: 9999;
-  }
-
-  .scrub-track {
-    height: 4px;
-    margin: 6px 6px 5px;
-    background: var(--aegis-scrub-track);
-    border-radius: 2px;
-    position: relative;
-    cursor: pointer;
-  }
-
-  .scrub-thumb {
-    position: absolute;
-    top: -5px;
-    height: 14px;
-    border-radius: 7px;
-    background: var(--aegis-scrub-thumb);
-    border: 1px solid var(--aegis-scrub-thumb-border);
-    box-shadow: var(--aegis-scrub-thumb-shadow);
-    transition:
-      box-shadow 150ms ease,
-      filter 150ms ease;
-    cursor: grab;
-  }
-
-  /* Grip lines — 3 vertical bars */
-  .grip {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    display: flex;
-    gap: 2px;
-    pointer-events: none;
-  }
-
-  .grip span {
-    display: block;
-    width: 1px;
-    height: 6px;
-    background: var(--aegis-scrub-grip);
-    border-radius: 0.5px;
-  }
-
-  .scrub-thumb.hover,
-  .scrub-thumb:focus-visible {
-    filter: brightness(1.15);
-    box-shadow:
-      var(--aegis-scrub-thumb-shadow),
-      0 0 0 1px var(--aegis-scrub-thumb-border);
-  }
-
-  .scrub-thumb.hover .grip span,
-  .scrub-thumb:focus-visible .grip span {
-    background: var(--md-sys-color-on-surface-variant);
-  }
-
-  .scrub-thumb.dragging {
-    filter: brightness(1.2);
-    cursor: grabbing;
-    box-shadow:
-      0 2px 6px rgba(0, 0, 0, 0.4),
-      0 0 0 1px var(--aegis-scrub-thumb-border);
   }
 </style>

--- a/src/renderer/lib/components/TimelineCanvas.svelte
+++ b/src/renderer/lib/components/TimelineCanvas.svelte
@@ -1,0 +1,105 @@
+<script>
+  /**
+   * @file TimelineCanvas.svelte
+   * @description SVG timeline rendering — baseline track, ticks, and event dots.
+   *   Extracted from Timeline.svelte. Receives all data via props.
+   * @since v0.3.0
+   */
+
+  let {
+    viewportWidth,
+    svgH,
+    viewBox,
+    clampedScroll,
+    pad,
+    mid,
+    tickTop,
+    tickH,
+    ticks,
+    dots,
+    onDotEnter,
+    onDotMove,
+    onDotLeave,
+    onDotClick,
+  } = $props();
+</script>
+
+<div class="timeline-viewport" id="timeline-viewport">
+  <svg width={viewportWidth} height={svgH} {viewBox}>
+    <!-- baseline track -->
+    <line
+      x1={clampedScroll + pad}
+      y1={mid}
+      x2={clampedScroll + viewportWidth - pad}
+      y2={mid}
+      class="baseline"
+    />
+
+    <!-- ticks -->
+    {#each ticks as t (t.x)}
+      <line x1={t.x} y1={tickTop} x2={t.x} y2={tickTop + tickH} class="tick-line" />
+      <text x={t.x} y={tickTop + tickH + 1} text-anchor="middle" class="tick-label"
+        >{t.label}</text
+      >
+    {/each}
+
+    <!-- dots -->
+    {#each dots as dot (dot.idx)}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <circle
+        cx={dot.x}
+        cy={mid}
+        r={4}
+        fill={dot.color}
+        opacity="0.85"
+        class="dot"
+        onmouseenter={(e) => onDotEnter(e, dot)}
+        onmousemove={(e) => onDotMove(e)}
+        onmouseleave={onDotLeave}
+        onclick={(e) => onDotClick(e, dot)}
+      />
+    {/each}
+  </svg>
+</div>
+
+<style>
+  .timeline-viewport {
+    width: 100%;
+    height: var(--aegis-size-timeline);
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(
+      to right, transparent, black 28px, black calc(100% - 28px), transparent
+    );
+    mask-image: linear-gradient(
+      to right, transparent, black 28px, black calc(100% - 28px), transparent
+    );
+  }
+  svg { display: block; }
+  .baseline {
+    stroke: var(--md-sys-color-on-surface-variant);
+    stroke-width: 1;
+    opacity: 0.2;
+  }
+  .tick-line {
+    stroke: var(--md-sys-color-on-surface-variant);
+    stroke-width: 1;
+    opacity: 0.3;
+  }
+  .tick-label {
+    fill: var(--md-sys-color-on-surface-variant);
+    opacity: 0.5;
+    font-family: 'DM Mono', monospace;
+    font-size: calc(9px * var(--aegis-ui-scale, 1));
+    font-weight: var(--md-sys-typescale-label-medium-weight, 500);
+  }
+  .dot {
+    cursor: pointer;
+    transition: opacity var(--md-sys-motion-duration-short, 100ms)
+      var(--md-sys-motion-easing-standard, ease);
+  }
+  .dot:hover {
+    opacity: 1;
+    filter: brightness(1.3);
+  }
+</style>

--- a/src/renderer/lib/components/TimelineControls.svelte
+++ b/src/renderer/lib/components/TimelineControls.svelte
@@ -1,0 +1,97 @@
+<script>
+  /**
+   * @file TimelineControls.svelte
+   * @description Scrub bar with draggable thumb for timeline scrolling.
+   *   Extracted from Timeline.svelte. Receives all data via props.
+   * @since v0.3.0
+   */
+
+  let {
+    thumbWidth,
+    thumbX,
+    trackUsable,
+    scrubPad,
+    maxScroll,
+    onTrackClick,
+    onThumbDown,
+    dragging,
+  } = $props();
+
+  let thumbHover = $state(false);
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div class="scrub-track" onclick={onTrackClick}>
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="scrub-thumb"
+    class:hover={thumbHover}
+    class:dragging
+    style="width:{thumbWidth}px; left:{thumbX}px"
+    onmousedown={onThumbDown}
+    onmouseenter={() => (thumbHover = true)}
+    onmouseleave={() => (thumbHover = false)}
+    role="scrollbar"
+    aria-controls="timeline-viewport"
+    aria-valuenow={0}
+    aria-valuemin={0}
+    aria-valuemax={maxScroll}
+    aria-orientation="horizontal"
+    tabindex="0"
+  >
+    <div class="grip"><span></span><span></span><span></span></div>
+  </div>
+</div>
+
+<style>
+  .scrub-track {
+    height: 4px;
+    margin: 6px 6px 5px;
+    background: var(--aegis-scrub-track);
+    border-radius: 2px;
+    position: relative;
+    cursor: pointer;
+  }
+  .scrub-thumb {
+    position: absolute;
+    top: -5px;
+    height: 14px;
+    border-radius: 7px;
+    background: var(--aegis-scrub-thumb);
+    border: 1px solid var(--aegis-scrub-thumb-border);
+    box-shadow: var(--aegis-scrub-thumb-shadow);
+    transition: box-shadow 150ms ease, filter 150ms ease;
+    cursor: grab;
+  }
+  .grip {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    gap: 2px;
+    pointer-events: none;
+  }
+  .grip span {
+    display: block;
+    width: 1px;
+    height: 6px;
+    background: var(--aegis-scrub-grip);
+    border-radius: 0.5px;
+  }
+  .scrub-thumb.hover,
+  .scrub-thumb:focus-visible {
+    filter: brightness(1.15);
+    box-shadow: var(--aegis-scrub-thumb-shadow), 0 0 0 1px var(--aegis-scrub-thumb-border);
+  }
+  .scrub-thumb.hover .grip span,
+  .scrub-thumb:focus-visible .grip span {
+    background: var(--md-sys-color-on-surface-variant);
+  }
+  .scrub-thumb.dragging {
+    filter: brightness(1.2);
+    cursor: grabbing;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--aegis-scrub-thumb-border);
+  }
+</style>


### PR DESCRIPTION
## Summary

Splits 4 files exceeding the 200-line limit into 10 focused modules.

## Changes

| Original | Lines | Split Into | Lines |
|----------|-------|-----------|-------|
| main.js | 451 | main.js + scan-loop.js | 278 + 170 |
| Timeline.svelte | 643 | Timeline + TimelineCanvas + TimelineControls | 328 + 105 + 97 |
| OptionsPanel.svelte | 559 | OptionsPanel + SettingsAppearance + SettingsMonitoring | 150 + 91 + 155 |
| AgentCard.svelte | 429 | AgentCard + AgentCardDetails | 149 + 149 |

**Patterns:**
- `scan-loop.js` uses DI via `init(deps)` — same as all other main process modules
- Svelte children receive data via `$props()`, `$bindable()` for two-way binds
- No direct store imports in child components

## Testing
- Full suite: 383 pass / 4 skip / 0 fail
- Build: PASS (876ms, 0 errors)
- No behavior changes

## Related
- PR #37 code review issue #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)