### PR TITLE
feat: expand agent database with Qwen-Agent, CodeWhisperer aliases, Gemini CLI patterns

### DIFF
--- a/src/shared/agent-database.json
+++ b/src/shared/agent-database.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "lastUpdated": "2026-02-16",
+  "lastUpdated": "2026-02-28",
   "agents": [
 
     {
@@ -192,7 +192,7 @@
     },
     {
       "id": "amazon-q",
-      "names": ["q", "q.exe", "codewhisperer", "amazon-q", "aws-q"],
+      "names": ["q", "q.exe", "codewhisperer", "codewhisperer.exe", "aws-codewhisperer", "amazon-q", "aws-q"],
       "displayName": "Amazon Q Developer",
       "vendor": "Amazon Web Services",
       "category": "coding-assistant",
@@ -260,7 +260,7 @@
     },
     {
       "id": "gemini-code-assist",
-      "names": ["gemini", "gemini-code", "google-cloud-code"],
+      "names": ["gemini", "gemini-code", "gemini-cli", "google-cloud-code"],
       "displayName": "Gemini Code Assist",
       "vendor": "Google",
       "category": "coding-assistant",
@@ -495,6 +495,23 @@
       "configPaths": [],
       "parentEditors": ["Code.exe", "code", "idea64.exe"],
       "riskProfile": "low"
+    },
+    {
+      "id": "qwen-agent",
+      "names": ["qwen-agent", "qwen-agent.exe", "qwen-cli", "qwen-cli.exe"],
+      "displayName": "Qwen-Agent",
+      "vendor": "Alibaba Cloud",
+      "category": "coding-assistant",
+      "icon": "\ud83e\udd16",
+      "color": "#615EFF",
+      "defaultTrust": 55,
+      "website": "https://github.com/QwenLM/Qwen-Agent",
+      "description": "AI agent framework powered by Qwen models",
+      "knownDomains": ["dashscope.aliyuncs.com", "qwen.ai", "modelscope.cn"],
+      "knownPorts": [443],
+      "configPaths": [],
+      "parentEditors": [],
+      "riskProfile": "medium"
     },
 
     {


### PR DESCRIPTION
## Summary
- Adds **Qwen-Agent** entry (qwen-agent, qwen-cli) — Alibaba Cloud AI agent framework
- Adds **CodeWhisperer legacy aliases** to Amazon Q (codewhisperer.exe, aws-codewhisperer)
- Adds **gemini-cli** pattern to Gemini Code Assist entry
- Agents from #28 (Aider, Continue, Tabby, Cline, Windsurf) were already present in DB

**Total: 95 agents** (was 94)

Closes #28, #31, #32, #33

## Test plan
- [x] `npm test` — 383 passed, 4 skipped
- [x] `npx prettier --check` — all clean
- [x] `npm run build:renderer` — builds successfully
- [x] No duplicate IDs in agent-database.json
- [x] JSON valid, all entries have required fields