### PR TITLE
feat(a11y): add keyboard shortcuts and accessibility improvements

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -8,7 +8,10 @@
   import ReportsTab from './lib/components/ReportsTab.svelte';
   import { theme, uiScale, toggleTheme } from './lib/stores/theme.js';
 
+  const TAB_IDS = ['shield', 'activity', 'rules', 'reports'];
+
   let activeTab = $state('shield');
+  let optionsOpen = $state(false);
 
   $effect(() => {
     document.documentElement.dataset.theme = $theme;
@@ -22,9 +25,50 @@
   $effect(() => {
     document.documentElement.style.setProperty('--aegis-ui-scale', String($uiScale));
   });
+
+  $effect(() => {
+    /** @param {KeyboardEvent} e */
+    function handleKeydown(e) {
+      const tag = document.activeElement?.tagName;
+      const isInput =
+        tag === 'INPUT' || tag === 'TEXTAREA' || document.activeElement?.isContentEditable;
+
+      if (isInput && e.key !== 'Escape') return;
+
+      switch (e.key) {
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+          activeTab = TAB_IDS[parseInt(e.key) - 1];
+          break;
+        case 's':
+        case 'S':
+          optionsOpen = true;
+          break;
+        case 't':
+        case 'T':
+          toggleTheme();
+          break;
+        case 'Escape':
+          optionsOpen = false;
+          break;
+        case '/': {
+          e.preventDefault();
+          /** @type {HTMLInputElement | null} */
+          const input = document.querySelector('input[type="search"], input[type="text"]');
+          input?.focus();
+          break;
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  });
 </script>
 
-<Header />
+<Header bind:optionsOpen />
 
 <div class="app-shell">
   <nav class="app-nav">
@@ -33,7 +77,12 @@
 
   <main class="app-content">
     {#key activeTab}
-      <div class="tab-content">
+      <div
+        class="tab-content"
+        id="tabpanel-{activeTab}"
+        role="tabpanel"
+        aria-labelledby="tab-{activeTab}"
+      >
         {#if activeTab === 'shield'}
           <ShieldTab />
         {:else if activeTab === 'activity'}
@@ -87,6 +136,12 @@
     to {
       opacity: 1;
       transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .tab-content {
+      animation: none;
     }
   }
 </style>

--- a/src/renderer/lib/components/Header.svelte
+++ b/src/renderer/lib/components/Header.svelte
@@ -3,7 +3,7 @@
   import { enrichedAgents } from '../stores/risk.js';
   import OptionsPanel from './OptionsPanel.svelte';
 
-  let optionsOpen = $state(false);
+  let { optionsOpen = $bindable(false) } = $props();
 
   let shieldScore = $derived.by(() => {
     const list = $enrichedAgents;
@@ -39,6 +39,7 @@
   <button
     class="icon-btn"
     aria-label="Settings"
+    aria-keyshortcuts="s"
     onclick={() => {
       optionsOpen = true;
     }}

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -9,11 +9,16 @@
   ];
 </script>
 
-<nav class="tab-bar">
-  {#each tabs as tab (tab.id)}
+<nav class="tab-bar" role="tablist" aria-label="Main navigation">
+  {#each tabs as tab, i (tab.id)}
     <button
+      id="tab-{tab.id}"
       class="tab-pill"
       class:active={activeTab === tab.id}
+      role="tab"
+      aria-selected={activeTab === tab.id}
+      aria-controls="tabpanel-{tab.id}"
+      aria-keyshortcuts={String(i + 1)}
       onclick={() => (activeTab = tab.id)}
     >
       {tab.label}

--- a/src/renderer/lib/styles/global.css
+++ b/src/renderer/lib/styles/global.css
@@ -75,3 +75,14 @@ body::before {
 button:active {
   transform: scale(0.97);
 }
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

Implements keyboard shortcuts and accessibility improvements, addressing #17.

**Keyboard shortcuts (global, ignored when focus is in an input):**
- `1` / `2` / `3` / `4` -- switch to Shield / Activity / Rules / Reports tab
- `S` -- open Settings panel
- `T` -- cycle theme (dark, light, dark-hc, light-hc)
- `Esc` -- close Settings panel
- `/` -- focus first search/text input in current view

**Accessibility:**
- `TabBar`: `role="tablist"` on nav, `role="tab"` + `aria-selected` + `aria-controls` + `aria-keyshortcuts` on each button
- Tab panels: `role="tabpanel"` + `aria-labelledby` referencing the active tab id
- Settings button: `aria-keyshortcuts="s"`
- `global.css`: `@media (prefers-reduced-motion: reduce)` block suppresses all animations and transitions

**State lifting:**
- `optionsOpen` moved from `Header.svelte` local state to `App.svelte` and passed down as a `$bindable` prop, so the keyboard handler can open and close the settings panel without a store

Closes #17