### PR TITLE
feat: show unique agent count vs process count in header and reports

### DIFF
--- a/src/renderer/lib/components/Header.svelte
+++ b/src/renderer/lib/components/Header.svelte
@@ -12,7 +12,8 @@
     return Math.max(0, Math.round(100 - avg));
   });
 
-  let agentCount = $derived($enrichedAgents.length);
+  let processCount = $derived($enrichedAgents.length);
+  let uniqueAgentCount = $derived(new Set($enrichedAgents.map((a) => a.name)).size);
   let filesMonitored = $derived($stats.totalFiles ?? '--');
 
   function getScoreClass(score) {
@@ -31,7 +32,11 @@
   <div class="header-stats">
     <span class="shield-score {scoreClass}">{shieldScore}</span>
     <span class="stat-sep">&middot;</span>
-    <span class="stat-text">{agentCount} {agentCount === 1 ? 'agent' : 'agents'}</span>
+    <span class="stat-text">{uniqueAgentCount} {uniqueAgentCount === 1 ? 'agent' : 'agents'}</span>
+    <span class="stat-sep">&middot;</span>
+    <span class="stat-text stat-dim"
+      >{processCount} {processCount === 1 ? 'process' : 'processes'}</span
+    >
     <span class="stat-sep">&middot;</span>
     <span class="stat-text">{filesMonitored} files</span>
   </div>
@@ -115,6 +120,10 @@
     font: var(--md-sys-typescale-label-medium);
     color: var(--md-sys-color-on-surface-variant);
     font-variant-numeric: tabular-nums;
+  }
+
+  .stat-dim {
+    opacity: 0.6;
   }
 
   .icon-btn {

--- a/src/renderer/lib/components/Reports.svelte
+++ b/src/renderer/lib/components/Reports.svelte
@@ -38,7 +38,7 @@
       <span class="stat-label">Sensitive</span>
     </div>
     <div class="stat-card">
-      <span class="stat-value">{$enrichedAgents.length}</span>
+      <span class="stat-value">{new Set($enrichedAgents.map((a) => a.name)).size}</span>
       <span class="stat-label">Agents</span>
     </div>
     <div class="stat-card">


### PR DESCRIPTION
Header now displays unique agent names (e.g. `5 agents`) separately from total process count (e.g. `51 processes`). Previously all processes were counted as individual agents, which was misleading when multiple instances of the same agent (e.g. Claude Code) were running.

Reports summary card also updated to show unique agent count.

Closes #54

## Changes
- `Header.svelte`: Replace single `agentCount` with `uniqueAgentCount` (by name) + `processCount` (by PID)
- - `Reports.svelte`: Summary card "Agents" now uses `new Set(agents.map(a => a.name)).size`
- - Process count shown with reduced opacity to de-emphasize
## Testing
- [x] All 436 tests pass (0 fail, 4 skipped)
- [ ] - [x] Prettier formatted
- [ ] - [x] No console.log in production code
- [ ] - [x] Files under 200 lines
- [ ] - [x] Tested locally with `npm start`