### PR TITLE
docs: update all metadata to v0.10.0-alpha

### DIFF
--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -14,22 +14,22 @@ description: >-
 
 ## Project
 AEGIS — Independent AI Oversight Layer (Electron desktop)
-Repo: github.com/antropos17/Aegis | Version: 0.9.0-alpha
-Current Focus: Post-release polish, tech debt cleanup
+Repo: github.com/antropos17/Aegis | Version: 0.10.0-alpha
+Current Focus: Launch preparation (GIF, Dev.to, Reddit, HN)
 
 ## Stack
 Read package.json for exact versions. NEVER hardcode.
 Electron 33, Svelte 5, Vite 7, TypeScript (incremental, allowJs:true, checkJs:true), chokidar.
 
 ## Architecture
-- Main process (Node.js): src/main/ — 26 CJS modules (scanners, watchers, IPC, scoring, logging)
-- Renderer (Svelte 5): src/renderer/ — 40 components + 6 stores + 11 utils via IPC bridge
-- Bridge: src/main/preload.js — contextBridge, 43 invoke + 11 push channels
+- Main process (Node.js): src/main/ — 23 CJS modules (scanners, watchers, IPC, scoring, logging)
+- Renderer (Svelte 5): src/renderer/ — 43 components + 9 stores + 15 utils via IPC bridge
+- Bridge: src/main/preload.js — contextBridge, 43 invoke + 6 push channels
 - Data: src/shared/agent-database.json (107 agent signatures)
-- Config: src/shared/constants.js (70+ sensitive patterns)
+- Config: src/shared/constants.js (68 rules across 8 categories)
 - Rules: src/main/rule-loader.js — loadRules() + categoryIndex Map for O(1) lookup by category
-- Types: src/shared/types/ — 7 .ts files, 39 type definitions
-- Tests: 595 pass, 4 skip across 35 files (Vitest, all ESM)
+- Types: src/shared/types/ — 8 .ts files
+- Tests: 707 pass, 4 skip across 44 files (Vitest, all ESM)
 
 ## Key Components (Fancy UI — complete)
 - ShieldTab: bento grid with SummaryCards, RiskRing, ActivityFeed
@@ -57,6 +57,7 @@ Electron 33, Svelte 5, Vite 7, TypeScript (incremental, allowJs:true, checkJs:tr
 - electron-main — CJS modules, platform abstraction, IPC, file watchers
 - svelte-patterns — Svelte 5 runes, component patterns, template directives
 - testing — Vitest patterns, ESM imports, mocking, test structure
+- prompt-craft — prompt formula for Claude Code and Antigravity
 - pr-monitor — PR triage, contributor management, /loop monitoring
 - ci-monitor — CI watching, repo health, post-launch metrics
 

--- a/.claude/skills/electron-main/SKILL.md
+++ b/.claude/skills/electron-main/SKILL.md
@@ -5,9 +5,9 @@ description: Electron main process patterns for Aegis. CJS modules, platform abs
 # Electron Main Process
 
 ## Architecture
-- 21 CJS modules loaded directly by Node.js (NO build step)
+- 23 CJS modules loaded directly by Node.js (NO build step)
 - Platform dispatcher: src/main/platform/index.js → win32|darwin|linux
-- IPC: 43 invoke + 10 push channels, scan-batch consolidation
+- IPC: 43 invoke + 6 push channels, scan-batch consolidation
 - File watcher: chokidar 3.6, function-form ignored (NOT glob)
 
 ## Rules

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -6,7 +6,7 @@ description: Vitest testing patterns for Aegis. ESM imports, mocking, test struc
 
 ## Stack
 - Vitest 4 + esbuild transform
-- 34 test files, 568 tests, 4 skip
+- 44 test files, 707 tests, 4 skip
 
 ## Structure
 - tests/ directory mirrors src/ structure

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,6 @@ How was this tested?
 ## Checklist
 - [ ] Follows code style guidelines (CommonJS main, Svelte 5 renderer)
 - [ ] No console.log in production code
-- [ ] Files under 200 lines
+- [ ] Files under 300 lines
 - [ ] I have tested this locally with `npm start`
 - [ ] This code has been reviewed by a human (not solely AI-generated)

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - run: npm ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # AEGIS — Independent AI Oversight Layer
-Electron 33 + Svelte 5 (runes) + Vite 7. Privacy-first AI agent monitor. v0.9.0-alpha
+Electron 33 + Svelte 5 (runes) + Vite 7. Privacy-first AI agent monitor. v0.10.0-alpha
 Landing: aegisprotect.vercel.app | Demo: aegis-demo-ten.vercel.app
 
 ## Commands
 npm run build:renderer    # Vite build (MUST pass before commit)
 npm run lint              # ESLint
 npm run format            # Prettier
-npm test                  # Vitest (595 tests, 35 files)
+npm test                  # Vitest (707 tests, 44 files)
 npm run dist              # Electron-builder NSIS installer
 
 ## Background Tasks (/loop)
@@ -17,7 +17,7 @@ npm run dist              # Electron-builder NSIS installer
 ## Critical Rules
 1. Read memory-bank/ai-mistakes.md before ANY code change
 2. Do ONLY what the prompt says — no extra features, no unrequested changes
-3. Main = CJS (require). Renderer = ESM (import). Max 200 lines/file
+3. Main = CJS (require). Renderer = ESM (import). Max 300 lines/file
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
@@ -25,12 +25,12 @@ npm run dist              # Electron-builder NSIS installer
 8. TypeScript: new files in .ts, `npx eslint` + `npx tsc --noEmit` before commit, zero `any`
 
 ## Key Paths
-- src/main/ — 26 CommonJS modules (scanners, watchers, IPC, scoring, zip-writer)
-- src/renderer/ — 40 Svelte 5 components + 6 stores + 11 utils + tokens.css/global.css
-- src/shared/ — agent-database.json (107 agents), constants.js (70+ rules), types/ (7 TS files)
+- src/main/ — 23 CommonJS modules (scanners, watchers, IPC, scoring, zip-writer)
+- src/renderer/ — 43 Svelte 5 components + 9 stores + 15 utils + tokens.css/global.css
+- src/shared/ — agent-database.json (107 agents), constants.js (68 rules), types/ (8 TS files)
 - memory-bank/ — ai-mistakes.md (READ FIRST), progress.md, architecture.md
-- .claude/skills/ — 8 skills: context, design-system, electron-main, svelte-patterns, testing, ship, pr-monitor, ci-monitor
-- IPC: preload.js — 43 invoke + 11 push channels via contextBridge
+- .claude/skills/ — 9 skills: context, design-system, electron-main, svelte-patterns, testing, ship, pr-monitor, ci-monitor, prompt-craft
+- IPC: preload.js — 43 invoke + 6 push channels via contextBridge
 
 ## MCP & Skills
 - Context7 MCP: проверяй доку ПЕРЕД решениями | Svelte MCP: autofixer на .svelte

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Requires Node.js 18+ and Windows 10/11 for full monitoring functionality. The El
 1. **Fork** the repository
 2. **Branch** from `master`: `git checkout -b feature/your-feature`
 3. **Implement** your changes following the code standards below
-4. **Test**: run `npm test` (568 tests across 34 files) and `npm start` — verify no console errors, all tabs render, existing features work
+4. **Test**: run `npm test` (707 tests across 44 files) and `npm start` — verify no console errors, all tabs render, existing features work
 5. **Commit** with [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 6. **Push** your branch and open a **Pull Request** with a clear description of what changed and why
 
@@ -41,7 +41,7 @@ When maintainers merge the Release PR → version bump + CHANGELOG + GitHub Rele
 - **Svelte 5 + Vite for renderer** — component-based architecture with `$state`/`$derived`/`$effect` runes. Main process remains CommonJS.
 - **CommonJS in main process** — `require`/`module.exports` with `init()` dependency injection pattern. Each module receives only the state it needs.
 - **JSDoc headers on all exported functions** — `@param`, `@returns`, `@since` tags required. Include `@file`, `@module`, `@description` at top of every file.
-- **200 line soft limit per file** — split into focused, single-responsibility modules when exceeding.
+- **300 line soft limit per file** — split into focused, single-responsibility modules when exceeding.
 - **`const` over `let`** when the binding doesn't change. Never use `var`.
 - **No external dependencies** without discussion — the project intentionally has only 1 runtime dependency (`chokidar`; `electron` is a devDependency). Adding a dependency requires justification.
 
@@ -57,7 +57,7 @@ When maintainers merge the Release PR → version bump + CHANGELOG + GitHub Rele
 - **New files should be written in TypeScript** (`.ts`) — existing `.js` files will be migrated incrementally
 - **Main process** (`.js`): uses JSDoc annotations + `checkJs: true` for type safety without converting to `.ts`
 - **Renderer** (`.ts`/`.svelte`): native TypeScript with ES modules
-- Shared type definitions live in `src/shared/types/` (34 types across 7 files)
+- Shared type definitions live in `src/shared/types/` (types across 8 files)
 - Run `npx tsc --noEmit` (typecheck) before opening a PR — zero type errors required
 - **Zero `any`** — use proper types, generics, or `unknown` instead. ESLint warns on `any`
 - Explicit return types on exported functions (`@typescript-eslint/explicit-function-return-type`)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/antropos17/Aegis/releases/latest"><img src="https://img.shields.io/github/v/release/antropos17/Aegis?include_prereleases&style=flat-square&label=Release" alt="Release"></a>
   <img src="https://img.shields.io/github/actions/workflow/status/antropos17/Aegis/ci.yml?style=flat-square&label=CI" alt="CI">
-  <img src="https://img.shields.io/badge/Tests-593%20passing-brightgreen?style=flat-square" alt="Tests">
+  <img src="https://img.shields.io/badge/Tests-707%20passing-brightgreen?style=flat-square" alt="Tests">
   <img src="https://img.shields.io/badge/License-MIT-blue?style=flat-square" alt="MIT License">
   <img src="https://img.shields.io/badge/Platform-Win%20%7C%20macOS%20%7C%20Linux-lightgrey?style=flat-square" alt="Platform">
 </p>
@@ -92,6 +92,9 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v0.10.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.10.0-alpha) | 2026-03-09 | Code cleanup, security hardening, command palette |
+| [v0.9.1-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.9.1-alpha) | 2026-03-08 | Dropdown dedup, skill paths, aegis-context optimized |
+| [v0.9.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.9.0-alpha) | 2026-03-08 | categoryIndex, prompt-craft skill, TS migration stores |
 | [v0.8.2-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.8.2-alpha) | 2026-03-08 | formatBytes TS extraction, meaningful tests, branch cleanup |
 | [v0.8.1-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.8.1-alpha) | 2026-03-07 | Patch release |
 | [v0.8.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.8.0-alpha) | 2026-03-05 | Launch readiness: CSP hardened, OpenClaw integration, README overhaul |
@@ -174,7 +177,7 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
             └─────────────┘    └─────────────┘
 ```
 
-**Stack**: Electron 33, Svelte 5, Vite 7, TypeScript, Vitest (593 tests across 35 files)
+**Stack**: Electron 33, Svelte 5, Vite 7, TypeScript, Vitest (707 tests across 44 files)
 
 ## Agent Database
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,7 @@ AEGIS follows Electron security best practices:
 
 - **Context isolation:** Enabled. The renderer process cannot access Node.js APIs.
 - **Node integration:** Disabled in the renderer.
-- **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (54 channels). No arbitrary IPC.
+- **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (49 channels: 43 invoke + 6 push). No arbitrary IPC.
 - **Content Security Policy:** Strict `default-src 'self'` policy, no external font loading.
 - **No remote content:** The app loads only local files. No external URLs in the renderer.
 - **Input sanitization:** All user-visible strings pass through `escapeHtml()` before DOM insertion. Template literals are used for HTML generation, not `innerHTML` with raw strings.
@@ -79,7 +79,7 @@ AEGIS follows Electron security best practices:
 - **All data stays local.** No telemetry, no cloud sync, no analytics, no tracking.
 - **AI analysis is opt-in.** API calls to Anthropic only happen when the user explicitly clicks "Run AI Threat Analysis." No background API calls.
 - **Audit logs contain metadata, not content.** File paths and agent names are logged, but file contents are never read or stored.
-- **API key is stored locally** in `settings.json` in Electron's userData directory. It is not encrypted at rest — this is a known limitation.
+- **API key is stored locally** in Electron's userData directory, encrypted via Electron safeStorage (added v0.9.0).
 
 ### Known Limitations
 
@@ -92,9 +92,9 @@ AEGIS follows Electron security best practices:
 
 | Version     | Supported                          |
 |-------------|------------------------------------|
-| 0.8.x       | Current release — actively supported |
-| 0.5.x–0.7.x | Security fixes only                |
-| < 0.5.x     | End of life                        |
+| 0.10.x      | Current release — actively supported |
+| 0.7.x–0.9.x | Security fixes only                |
+| < 0.7.x     | End of life                        |
 
 ## Credit
 


### PR DESCRIPTION
## Summary
Update all stale metadata across 13 files to match v0.10.0-alpha reality.

### Key changes
- Tests: 593/595/568 → 707 (44 files)
- Modules: 26 → 23, Components: 40 → 43
- IPC: 54/11 push → 49 total (43 invoke + 6 push)
- SECURITY.md: safeStorage encryption documented, versions table updated
- Node: release-build.yml 18 → 20
- CLAUDE.md: max lines 200 → 300 (aligned with code-quality.md)
- Deleted stale memory-bank/v16.md

All numbers verified via live audit. 707 pass, 0 fail.