### PR TITLE
chore: update README demo GIF to v0.10.0 Fancy UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/antropos17/Aegis/releases/download/v0.3.0-alpha/demo-trimmed.gif" alt="AEGIS Demo" width="800">
+  <img src="https://github.com/antropos17/Aegis/releases/download/aegis-v0.10.0-alpha/demo.gif" alt="AEGIS Demo" width="800">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Updated demo GIF in README from old v0.3.0-alpha recording to new v0.10.0 Fancy UI demo
- Uploaded `demo.gif` to GitHub Release `aegis-v0.10.0-alpha`
- Single-line URL change in README.md line 19

## Test plan
- [x] `npm test` — 707 passed
- [x] `npm run build:renderer` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Verify GIF loads from new release URL