### PR TITLE
fix(ui): show unique agent count in Total Agents card

### DIFF
--- a/src/renderer/lib/components/SummaryCards.svelte
+++ b/src/renderer/lib/components/SummaryCards.svelte
@@ -19,7 +19,7 @@
   });
 
   /* ── Derived metrics ── */
-  let agentCount = $derived(localAgents.length);
+  let agentCount = $derived(new Set(localAgents.map((a) => a.name)).size);
 
   let avgRiskScore = $derived.by(() => {
     const scores = Object.values(localAnomalies).filter((s) => typeof s === 'number');


### PR DESCRIPTION
## Summary
- **Total Agents** card in SummaryCards showed process count (e.g. 19) instead of unique agent count (e.g. 3)
- Header already showed the correct unique count via `new Set(...names).size`
- Applied the same deduplication logic to SummaryCards

## Change
```diff
- let agentCount = $derived(localAgents.length);
+ let agentCount = $derived(new Set(localAgents.map((a) => a.name)).size);
```

## Test plan
- [x] `npm test` — 707 passed
- [x] `npm run build:renderer` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Visual: Total Agents card now matches header agent count