### PR TITLE
security: deny .ssh/.aws reads + curl/wget exfil

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,12 +46,16 @@
       "Read(./.env.*)",
       "Read(**/.env)",
       "Read(**/.env.*)",
+      "Read(**/.ssh/**)",
+      "Read(**/.aws/**)",
       "Bash(rm -rf:*)",
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
       "Bash(git push --force-with-lease:*)",
       "Bash(find * -delete:*)",
-      "Bash(find * -exec:*)"
+      "Bash(find * -exec:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
Closes the remaining STEP 3 deny gap after #122 landed the .env / rm -rf / force-push / find -delete-exec hardening on master.

## What
Adds 4 rules to `.claude/settings.json` `permissions.deny` (deny > allow, so these clamp the broad `Read(**)` allow):

| Rule | Closes |
|------|--------|
| `Read(**/.ssh/**)` | agent reading private SSH keys (`id_rsa`, `config`, `known_hosts`) |
| `Read(**/.aws/**)` | agent reading `~/.aws/credentials` |
| `Bash(curl:*)` | outbound exfil via curl |
| `Bash(wget:*)` | outbound exfil via wget |

## Why
The merged list denied `.env` reads in both `./` and `**/` forms but had **no** `.ssh`/`.aws` read-deny — an asymmetry. This mirrors the existing `.env` `**/` convention. Note: this governs what **Claude Code itself** may do in-repo, a separate layer from AEGIS's own monitoring of those dirs.

## Verify
- JSON parses; deny 18 → 22; all 4 rules present.
- Read denies use the same `**/` glob form as the existing `.env` rules; Bash exfil uses the `:*` prefix form matching the recent find/force-push additions.