### PR TITLE
fix(a11y): keyboard-accessible kill/suspend + palette commands

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -12,7 +12,8 @@
   import CommandPalette from './lib/components/CommandPalette.svelte';
   import { commandPalette } from './lib/stores/command-palette.svelte.ts';
   import { addToast } from './lib/stores/toast.js';
-  import { agents, anomalies, isDemoMode } from './lib/stores/ipc.js';
+  import { agents, anomalies, isDemoMode, selectedAgentPid } from './lib/stores/ipc.js';
+  import { get } from 'svelte/store';
   import DemoBanner from './lib/components/DemoBanner.svelte';
   import {
     getSlideDirection,
@@ -141,6 +142,29 @@
     prevAnomalyKeys = currentKeys;
   });
 
+  /**
+   * Run a kill/suspend intervention on the currently selected (expanded) agent
+   * via the existing IPC bridge. Reads the selection non-reactively so the
+   * dispatch effect is not re-triggered when the selection changes.
+   * @param {'killProcess'|'suspendProcess'} method
+   * @param {string} doneLabel  Success toast label, e.g. "Killed agent"
+   * @param {string} failLabel  Failure toast label, e.g. "Failed to kill agent"
+   */
+  async function runSelectedAgentAction(method, doneLabel, failLabel) {
+    const pid = get(selectedAgentPid);
+    if (pid == null) {
+      addToast('No agent selected — open an agent card first', 'warning');
+      return;
+    }
+    if (!window.aegis) return;
+    const result = await window.aegis[method](pid);
+    if (result?.success) {
+      addToast(`${doneLabel} (PID ${pid})`, 'success');
+    } else {
+      addToast(`${failLabel}: ${result?.error ?? 'unknown error'}`, 'error');
+    }
+  }
+
   // ── Command palette: execute actions ──
   $effect(() => {
     const cmd = commandPalette.lastExecuted;
@@ -187,6 +211,13 @@
         break;
       case 'theme:light-hc':
         setTheme('light-hc');
+        break;
+      // Agent actions — operate on the currently selected (expanded) agent
+      case 'agent:kill':
+        runSelectedAgentAction('killProcess', 'Killed agent', 'Failed to kill agent');
+        break;
+      case 'agent:suspend':
+        runSelectedAgentAction('suspendProcess', 'Suspended agent', 'Failed to suspend agent');
         break;
       // Actions
       case 'action:test-notification':

--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -98,6 +98,22 @@
     expandedPid = expanded ? null : agent.pid;
   }
 
+  /**
+   * Keyboard activation for the card (role="button"). Enter/Space toggle the
+   * card, mirroring the click handler. Guarded to the article itself so that
+   * Enter/Space on inner buttons (copy PID, kill/suspend/resume) does not
+   * bubble up and collapse the card — those buttons stopPropagation on click,
+   * not on keydown.
+   * @param {KeyboardEvent} e
+   */
+  function handleKeydown(e) {
+    if (e.target !== e.currentTarget) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggle();
+    }
+  }
+
   async function pidAction(e, method) {
     e.stopPropagation();
     if (window.aegis) await window.aegis[method](agent.pid);
@@ -119,16 +135,18 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<article
+<div
   class="agent-card"
   class:expanded
   class:blinking
   class:threat-flash={threatFlash}
   class:danger={isDanger}
   bind:this={cardEl}
+  role="button"
+  tabindex="0"
+  aria-expanded={expanded}
   onclick={toggle}
+  onkeydown={handleKeydown}
   onmousemove={handleMouseMove}
 >
   <div class="header-row">
@@ -181,7 +199,7 @@
       />
     </div>
   </div>
-</article>
+</div>
 
 <style>
   .agent-card {

--- a/src/renderer/lib/components/AgentPanel.svelte
+++ b/src/renderer/lib/components/AgentPanel.svelte
@@ -1,12 +1,12 @@
 <script>
   import { enrichedAgents } from '../stores/risk.js';
+  import { selectedAgentPid } from '../stores/ipc.js';
   import AgentCard from './AgentCard.svelte';
   import { t } from '../i18n/index.js';
 
   /** @type {{ active?: boolean }} */
   let { active = true } = $props();
 
-  let expandedPid = $state(null);
   let localAgents = $state([]);
 
   $effect(() => {
@@ -52,7 +52,7 @@
   {:else}
     <div class="agent-list">
       {#each grouped as agent (agent.name)}
-        <AgentCard {agent} bind:expandedPid />
+        <AgentCard {agent} bind:expandedPid={$selectedAgentPid} />
       {/each}
     </div>
   {/if}

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -22,6 +22,12 @@ interface ScanStatusData {
   readonly scanning?: boolean;
 }
 
+/** Result of a process intervention (kill/suspend/resume) from the main process */
+interface ProcessActionResult {
+  readonly success: boolean;
+  readonly error?: string;
+}
+
 /** Minimal type for the window.aegis IPC bridge exposed by preload.js */
 interface AegisIpcBridge {
   onScanBatch(cb: (data: ScanBatchData) => void): void;
@@ -32,6 +38,9 @@ interface AegisIpcBridge {
   getStats(): Promise<Record<string, unknown>>;
   getResourceUsage(): Promise<Record<string, unknown>>;
   getFalsePositives(): Promise<FalsePositiveEntry[]>;
+  killProcess(pid: number): Promise<ProcessActionResult>;
+  suspendProcess(pid: number): Promise<ProcessActionResult>;
+  resumeProcess(pid: number): Promise<ProcessActionResult>;
 }
 
 declare global {
@@ -51,6 +60,13 @@ export const scanActive: Writable<boolean> = writable(false);
 
 /** PID of agent to highlight in AgentPanel (set by Timeline dot click) */
 export const focusedAgentPid: Writable<number | null> = writable(null);
+
+/**
+ * PID of the currently selected (expanded) agent card. Persistent across the
+ * session — the target for Command Palette kill/suspend actions. Distinct from
+ * {@link focusedAgentPid}, which auto-clears after a scroll-into-view.
+ */
+export const selectedAgentPid: Writable<number | null> = writable(null);
 
 /** True when running in a browser without Electron IPC. */
 export const isDemoMode: boolean = import.meta.env.VITE_DEMO_MODE === 'true' || !window.aegis;

--- a/src/renderer/lib/utils/command-registry.ts
+++ b/src/renderer/lib/utils/command-registry.ts
@@ -2,7 +2,9 @@
  * @file command-registry.ts — Static command definitions for Command Palette
  * @module renderer/lib/utils/command-registry
  * @description Provides all static commands grouped by category.
- * Agent commands (107) are excluded — loaded dynamically via fuzzy search.
+ * Per-agent commands (107 signatures) are excluded — loaded dynamically via
+ * fuzzy search. Agent *action* commands (kill/suspend the selected agent) are
+ * static and live here under the `agent` category.
  */
 
 import type { CommandItem } from '../../../shared/types/command-palette';
@@ -160,6 +162,26 @@ export function getExportCommands(): CommandItem[] {
   ];
 }
 
+/** Agent action commands — operate on the currently selected (expanded) agent */
+export function getAgentActionCommands(): CommandItem[] {
+  return [
+    {
+      id: 'agent:kill',
+      label: 'Kill agent',
+      category: 'agent',
+      icon: '🛑',
+      keywords: ['terminate', 'stop', 'end', 'selected', 'process'],
+    },
+    {
+      id: 'agent:suspend',
+      label: 'Suspend agent',
+      category: 'agent',
+      icon: '⏸️',
+      keywords: ['pause', 'freeze', 'halt', 'selected', 'process'],
+    },
+  ];
+}
+
 /** Miscellaneous action commands */
 export function getActionCommands(): CommandItem[] {
   return [
@@ -193,6 +215,7 @@ export function getAllCommands(): CommandItem[] {
     ...getNavigationCommands(),
     ...getThemeCommands(),
     ...getExportCommands(),
+    ...getAgentActionCommands(),
     ...getActionCommands(),
   ];
 }

--- a/tests/renderer/command-registry.test.ts
+++ b/tests/renderer/command-registry.test.ts
@@ -7,16 +7,17 @@ import {
   getNavigationCommands,
   getThemeCommands,
   getExportCommands,
+  getAgentActionCommands,
   getActionCommands,
 } from '../../src/renderer/lib/utils/command-registry';
 import type { CommandCategory } from '../../src/shared/types';
 
-const VALID_CATEGORIES: CommandCategory[] = ['navigate', 'theme', 'export', 'action'];
+const VALID_CATEGORIES: CommandCategory[] = ['navigate', 'agent', 'theme', 'export', 'action'];
 
 describe('command-registry', () => {
   describe('getAllCommands', () => {
-    it('returns 22 commands total', () => {
-      expect(getAllCommands()).toHaveLength(22);
+    it('returns 24 commands total', () => {
+      expect(getAllCommands()).toHaveLength(24);
     });
 
     it('every command has id, label, and category', () => {
@@ -72,6 +73,23 @@ describe('command-registry', () => {
       for (const cmd of getExportCommands()) {
         expect(cmd.category).toBe('export');
       }
+    });
+  });
+
+  describe('getAgentActionCommands', () => {
+    it('returns 2 items (kill + suspend)', () => {
+      expect(getAgentActionCommands()).toHaveLength(2);
+    });
+
+    it('all have category "agent"', () => {
+      for (const cmd of getAgentActionCommands()) {
+        expect(cmd.category).toBe('agent');
+      }
+    });
+
+    it('exposes agent:kill and agent:suspend ids', () => {
+      const ids = getAgentActionCommands().map((c) => c.id);
+      expect(ids).toEqual(['agent:kill', 'agent:suspend']);
     });
   });
 


### PR DESCRIPTION
Resolves **U1 (P0)** from the UX audit: the agent Kill/Suspend/Resume intervention was keyboard-inaccessible and mouse-only.

## Changes

**AgentCard a11y**
- Card is now keyboard-operable: `role="button"` + `tabindex="0"` + `aria-expanded` + `onkeydown` (Enter/Space → `toggle`, `preventDefault` on Space).
- Keydown guard `e.target !== e.currentTarget` so Enter/Space on the inner Copy/Kill/Suspend/Resume buttons does not bubble up and collapse the card (those `stopPropagation` on click, not on keydown).
- Removed both `svelte-ignore` a11y suppressions. Host `<article>` → `<div>` so `role="button"` lints clean (the Svelte autofixer flagged role-on-`<article>` via `a11y_no_noninteractive_element_to_interactive_role`). Visually identical — all CSS is class-based (`.agent-card`).

**Command Palette**
- New `agent:kill` / `agent:suspend` commands (new `agent` category) that act on the currently selected (expanded) agent.
- Introduced a `selectedAgentPid` shared store (AgentPanel's local `expandedPid` lifted into it). Dispatch reads it **non-reactively** via `get()` so the dispatch `$effect` isn't re-triggered (re-firing the last command) when selection changes, then calls the **existing** `window.aegis.killProcess` / `suspendProcess` IPC — no logic duplicated.
- Null-PID guard ("No agent selected" toast) + success/failure toast from the IPC result.
- Added `killProcess`/`suspendProcess`/`resumeProcess` to the `AegisIpcBridge` interface (latent gap the Vite transpile wouldn't catch).

## Scope

Deliberately did **not** pull in U3 (card-side try/catch + disabled-during-call) — that's a separate finding.

## Verification
- `npm run build:renderer` — 0 errors
- `npx tsc --noEmit` — clean
- `npx eslint` (touched files) — 0 errors (1 pre-existing `no-console` warning)
- `npm test` — 710 pass / 4 skip (44 files); `command-registry` tests updated 22 → 24 + new `agent` category coverage
- Svelte MCP autofixer — 0 issues on AgentCard
