### PR TITLE
fix(ux): empty state when no agents detected

### DIFF
--- a/src/renderer/lib/components/ShieldTab.svelte
+++ b/src/renderer/lib/components/ShieldTab.svelte
@@ -1,6 +1,7 @@
 <script>
   import { fade } from 'svelte/transition';
-  import { agents } from '../stores/ipc.js';
+  import { agents, firstScanDone } from '../stores/ipc.js';
+  import { t } from '../i18n/index.js';
   import Radar from './Radar.svelte';
   import AgentPanel from './AgentPanel.svelte';
   import FeedFilters from './FeedFilters.svelte';
@@ -15,15 +16,19 @@
   let severityFilter = $state('all');
   let typeFilter = $state('all');
 
-  /** True once first scan batch arrives with agent data */
-  let dataReady = $state(false);
-  $effect(() => {
-    if ($agents.length > 0) dataReady = true;
-  });
+  // Three render states, derived live from the stores (no latch):
+  //   populated → at least one agent detected → show the bento dashboard
+  //   empty     → first scan landed but found nothing → show an empty state
+  //   loading   → first scan hasn't arrived yet → show skeletons
+  // Deriving `populated` from the live store (rather than a one-way latch)
+  // means a machine whose last agent exits correctly falls back to the empty
+  // state instead of being stuck showing a populated dashboard.
+  let populated = $derived($agents.length > 0);
+  let empty = $derived(!populated && $firstScanDone);
 </script>
 
 <div class="bento">
-  {#if dataReady}
+  {#if populated}
     <div class="bento-radar panel" transition:fade={{ duration: 300 }}>
       <Radar {active} />
     </div>
@@ -36,6 +41,13 @@
     </div>
     <div class="bento-agents panel" transition:fade={{ duration: 300 }}>
       <AgentPanel {active} />
+    </div>
+  {:else if empty}
+    <div class="bento-empty panel" transition:fade={{ duration: 300 }}>
+      <div class="empty-card">
+        <h2 class="empty-title">{$t('agents.no_agents')}</h2>
+        <p class="empty-hint">{$t('agents.no_agents_hint')}</p>
+      </div>
     </div>
   {:else}
     <div class="bento-radar panel">
@@ -118,6 +130,33 @@
     grid-row: 1 / span 2;
     overflow-y: auto;
     min-height: 0;
+  }
+
+  /* ── Empty state: spans the whole grid when no agents are detected ── */
+  .bento-empty {
+    grid-column: 1 / -1;
+    grid-row: 1 / -1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--fancy-space-md);
+  }
+
+  .empty-card {
+    max-width: 420px;
+    text-align: center;
+  }
+
+  .empty-title {
+    margin: 0 0 var(--fancy-space-sm);
+    font: var(--md-sys-typescale-title-medium);
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .empty-hint {
+    margin: 0;
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
   }
 
   /* ── Responsive: 2-col at medium ── */

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -108,6 +108,7 @@
   },
   "agents": {
     "no_agents": "No AI agents detected",
+    "no_agents_hint": "AEGIS is monitoring your system — detected AI agents will appear here automatically.",
     "pid": "PID {pid}",
     "last_file": "Last: {file}",
     "session_hours": "{h}h {m}m",

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -111,7 +111,9 @@ if (!isDemoMode) {
   window.aegis!.getResourceUsage().then((data) => resourceUsage.set(data));
   window.aegis!.getFalsePositives().then((data) => falsePositives.set(data || []));
 } else {
-  firstScanDone.set(true);
+  // Demo mode seeds agents synchronously (≥2 every scenario), so the live
+  // `populated` check drives the dashboard — no `firstScanDone` latch needed,
+  // and the original skeleton→populated flow is preserved.
   const cleanupDemo = startDemoMode({ agents, events, stats, network, anomalies, resourceUsage });
   if (import.meta.hot) {
     import.meta.hot.dispose(() => cleanupDemo());

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -58,6 +58,15 @@ export const resourceUsage: Writable<Record<string, unknown>> = writable({});
 export const falsePositives: Writable<FalsePositiveEntry[]> = writable([]);
 export const scanActive: Writable<boolean> = writable(false);
 
+/**
+ * True once the first scan batch has arrived from the main process. Monotonic
+ * (only ever flips false→true). Lets the UI distinguish "first scan hasn't
+ * landed yet" (show skeletons) from "scan ran and found zero agents" (show an
+ * empty state) instead of latching on agent count, which left quiet machines
+ * stuck on skeletons forever.
+ */
+export const firstScanDone: Writable<boolean> = writable(false);
+
 /** PID of agent to highlight in AgentPanel (set by Timeline dot click) */
 export const focusedAgentPid: Writable<number | null> = writable(null);
 
@@ -80,6 +89,8 @@ if (!isDemoMode) {
       if (data.stats) stats.set(data.stats);
       if (data.resourceUsage) resourceUsage.set(data.resourceUsage);
       if (data.anomalyScores) anomalies.set(data.anomalyScores);
+      // A batch landed — the first scan has completed, even if it found nothing.
+      firstScanDone.set(true);
     });
   });
 
@@ -100,6 +111,7 @@ if (!isDemoMode) {
   window.aegis!.getResourceUsage().then((data) => resourceUsage.set(data));
   window.aegis!.getFalsePositives().then((data) => falsePositives.set(data || []));
 } else {
+  firstScanDone.set(true);
   const cleanupDemo = startDemoMode({ agents, events, stats, network, anomalies, resourceUsage });
   if (import.meta.hot) {
     import.meta.hot.dispose(() => cleanupDemo());


### PR DESCRIPTION
## What & why

On a quiet machine with **no AI agents running**, the Shield tab showed skeleton loaders **forever** (UX audit finding U5 / perf-audit P11). Root cause: `dataReady` latched to `true` only when `agents.length > 0` and never reset, so a scan that finds nothing never clears the skeletons.

## Fix

- **`ipc.ts`** — new `firstScanDone` store, latched `true` on the first `scan-batch` arrival (and in demo mode). This is the missing "a scan has completed" signal, independent of agent count.
- **`ShieldTab.svelte`** — replaced the `dataReady` latch with three live-derived states:
  - `populated` (`agents > 0`) → bento dashboard
  - `empty` (scan done, 0 agents) → new empty state
  - else → skeletons (loading)
- Deriving `populated` live from the store means the latch bug cannot recur, and a machine whose last agent exits now correctly falls back to the empty state.
- **`en.json`** — added `agents.no_agents_hint`; reused existing `agents.no_agents` ("No AI agents detected") for the heading.

Empty-state UI: heading + one-line hint, tokens-only CSS (theme-aware), `transition:fade` to match the populated panels. No new dependencies.

## Verification

- `npm run build:renderer` — pass
- `npx tsc --noEmit` — pass
- `npx eslint` (changed files) — pass · Svelte autofixer — clean
- `npm test` — 710 passed, 4 skipped (44 files)
