### PR TITLE
fix(ux): remove dead palette commands, wire working export

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -223,21 +223,29 @@
       case 'action:test-notification':
         addToast('Test notification', 'success');
         break;
-      case 'action:toggle-demo':
-        addToast('Coming soon', 'info');
-        break;
-      case 'action:analyze-session':
-        addToast('Coming soon', 'info');
-        break;
-      // Export
+      // Export — each triggers a native save dialog via the existing IPC bridge
+      // (same handlers Reports/AuditLog/Settings/AgentDatabase already use).
+      // Optional chaining no-ops in demo/web mode where window.aegis is absent.
       case 'export:json':
+        window.aegis?.exportLog();
+        break;
       case 'export:csv':
+        window.aegis?.exportCsv();
+        break;
       case 'export:html':
+        window.aegis?.generateReport();
+        break;
       case 'export:zip':
+        window.aegis?.exportZip();
+        break;
       case 'export:audit':
+        window.aegis?.exportFullAudit();
+        break;
       case 'export:config':
+        window.aegis?.exportConfig();
+        break;
       case 'export:agent-db':
-        addToast('Coming soon', 'info');
+        window.aegis?.exportAgentDatabase();
         break;
       default:
         console.warn('Unknown command:', cmd.id);

--- a/src/renderer/lib/utils/command-registry.ts
+++ b/src/renderer/lib/utils/command-registry.ts
@@ -182,7 +182,14 @@ export function getAgentActionCommands(): CommandItem[] {
   ];
 }
 
-/** Miscellaneous action commands */
+/**
+ * Miscellaneous action commands.
+ * Only commands with a real, palette-appropriate effect live here.
+ * `analyze-session` was removed — it returns data that must be rendered, and
+ * its proper home is the ThreatAnalysis view (Reports → Threat); firing it from
+ * the palette would discard the result. `toggle-demo` was removed — demo mode is
+ * a build-time constant (`isDemoMode` in stores/ipc.ts), not runtime-togglable.
+ */
 export function getActionCommands(): CommandItem[] {
   return [
     {
@@ -191,20 +198,6 @@ export function getActionCommands(): CommandItem[] {
       category: 'action',
       icon: '🔔',
       keywords: ['alert', 'toast'],
-    },
-    {
-      id: 'action:analyze-session',
-      label: 'Analyze Session',
-      category: 'action',
-      icon: '🔬',
-      keywords: ['scan', 'inspect', 'review'],
-    },
-    {
-      id: 'action:toggle-demo',
-      label: 'Toggle Demo Mode',
-      category: 'action',
-      icon: '🎭',
-      keywords: ['sample', 'fake', 'mock'],
     },
   ];
 }

--- a/tests/renderer/command-registry.test.ts
+++ b/tests/renderer/command-registry.test.ts
@@ -16,8 +16,8 @@ const VALID_CATEGORIES: CommandCategory[] = ['navigate', 'agent', 'theme', 'expo
 
 describe('command-registry', () => {
   describe('getAllCommands', () => {
-    it('returns 24 commands total', () => {
-      expect(getAllCommands()).toHaveLength(24);
+    it('returns 22 commands total', () => {
+      expect(getAllCommands()).toHaveLength(22);
     });
 
     it('every command has id, label, and category', () => {
@@ -94,14 +94,19 @@ describe('command-registry', () => {
   });
 
   describe('getActionCommands', () => {
-    it('returns 3 items', () => {
-      expect(getActionCommands()).toHaveLength(3);
+    it('returns 1 item (test-notification only)', () => {
+      expect(getActionCommands()).toHaveLength(1);
     });
 
     it('all have category "action"', () => {
       for (const cmd of getActionCommands()) {
         expect(cmd.category).toBe('action');
       }
+    });
+
+    it('exposes only action:test-notification (no dead stubs)', () => {
+      const ids = getActionCommands().map((c) => c.id);
+      expect(ids).toEqual(['action:test-notification']);
     });
   });
 });


### PR DESCRIPTION
## F3 — Honesty: remove dead Command Palette commands, wire working export

Addresses UX audit finding **U4**: the Command Palette shipped commands with real labels ("Export JSON", "Full Audit", "Analyze Session", "Toggle Demo Mode") that all routed to `addToast('Coming soon')`. Trust-code-over-docs revealed the audit's premise was only half right.

### What the code actually showed
The audit assumed all 7 `export:*` were dead stubs. They are **not** — every one is backed by a real `ipcMain.handle(...)` in `src/main/ipc-handlers.js` that opens a native save dialog and writes a file. They were dead **only** in `App.svelte`'s dispatch switch. So this is a *wiring* fix, not a deletion.

### Removed (2) — genuinely no palette-appropriate effect
| Command | Why removed |
|---------|-------------|
| `action:toggle-demo` | `isDemoMode` is a **build-time constant** (`import.meta.env.VITE_DEMO_MODE \|\| !window.aegis`, `stores/ipc.ts:81`). There is no runtime toggle — structurally impossible without a rebuild. |
| `action:analyze-session` | Handler exists (`analyze-session`, Anthropic-powered) **but returns data that must be rendered**. Its proper home is the ThreatAnalysis view (Reports -> Threat), which already exposes it via a button. Firing it from the palette would run a cost-bearing API call and discard the result. **The IPC handler / preload / channel are left untouched** — only the palette command + dispatch case are removed. |

### Wired (7) — all backed by real, already-exposed handlers
| Command | IPC method | Handler |
|---------|-----------|---------|
| `export:json` | `exportLog()` | `export-log` |
| `export:csv` | `exportCsv()` | `export-csv` |
| `export:html` | `generateReport()` | `generate-report` |
| `export:zip` | `exportZip()` | `export-zip` |
| `export:audit` | `exportFullAudit()` | `export-full-audit` |
| `export:config` | `exportConfig()` | `export-config` |
| `export:agent-db` | `exportAgentDatabase()` | `export-agent-database` |

No logic is duplicated — each case calls the existing bridge method (`window.aegis?.method()`, mirroring `Reports.svelte`). Optional chaining no-ops safely in demo/web mode (same pattern as `agent:kill`/`agent:suspend`).

### Disclosure for review (past the literal brief)
The task named the export "from Reports". Reports surfaces exactly **4**: JSON/CSV/HTML (`Reports.svelte`) + ZIP (ReportsTab "Export All"). The other **3** — `export:audit`, `export:config`, `export:agent-db` — are real and already reachable, but from **AuditLog / Settings / AgentDatabaseCrud**, not Reports. They were wired (rather than removed) because each is handler-backed + already exposed, so wiring preserves capability while satisfying "palette = only what works" and "no new Coming soon". **If you'd prefer those three removed instead, say so and I'll drop them.**

### Result
All 22 remaining palette commands now work (7 nav + 5 theme + 2 agent + 1 action + 7 export). Zero "Coming soon" stubs remain.

### Verification
- `npm run build:renderer` — 0 errors
- `npm test` — 711 passed, 4 skipped (44 files)
- `npm run lint` — 0 errors (pre-existing no-console warnings only)
- `npx svelte-check` — 0 errors
