### PR TITLE
fix(a11y): Esc closes modals, keyboard fixes

### DIFF
--- a/src/renderer/lib/components/ActivityFeed.svelte
+++ b/src/renderer/lib/components/ActivityFeed.svelte
@@ -429,7 +429,8 @@
   .feed-entry:hover .feed-reveal {
     opacity: 0.7;
   }
-  .feed-reveal:hover {
+  .feed-reveal:hover,
+  .feed-reveal:focus-visible {
     opacity: 1;
   }
 
@@ -461,7 +462,8 @@
   .feed-entry:hover .fp-btn {
     opacity: 0.7;
   }
-  .fp-btn:hover {
+  .fp-btn:hover,
+  .fp-btn:focus-visible {
     opacity: 1;
     background: var(--md-sys-color-surface-container);
   }

--- a/src/renderer/lib/components/AgentCardDetails.svelte
+++ b/src/renderer/lib/components/AgentCardDetails.svelte
@@ -206,7 +206,8 @@
   .log-row:hover .fp-btn {
     opacity: 0.7;
   }
-  .fp-btn:hover {
+  .fp-btn:hover,
+  .fp-btn:focus-visible {
     opacity: 1;
     background: var(--md-sys-color-surface-container);
   }

--- a/src/renderer/lib/components/AgentDatabase.svelte
+++ b/src/renderer/lib/components/AgentDatabase.svelte
@@ -144,8 +144,11 @@
     border: var(--glass-border);
     border-radius: var(--md-sys-shape-corner-small);
     color: var(--md-sys-color-on-surface);
-    outline: none;
     transition: border-color 0.2s ease;
+  }
+  /* Keep the global :focus-visible ring for keyboard users; drop it on mouse. */
+  .db-search:focus:not(:focus-visible) {
+    outline: none;
   }
   .db-search:focus {
     border-color: var(--md-sys-color-primary);

--- a/src/renderer/lib/components/AgentFormModal.svelte
+++ b/src/renderer/lib/components/AgentFormModal.svelte
@@ -6,6 +6,16 @@
    * @type {{ mode: 'add' | 'edit' | 'delete', form: import('../utils/agent-crud-utils.ts').AgentFormData, agentName: string, onclose: () => void, onsave: () => void, ondelete: () => void }}
    */
   let { mode, form, agentName, onclose, onsave, ondelete } = $props();
+
+  /** @type {HTMLDivElement | undefined} */
+  let modalRef = $state(undefined);
+
+  // Autofocus the dialog on open so the overlay/dialog subtree is in the
+  // keyboard event path immediately — without this, focus stays on the
+  // trigger button outside the overlay and Esc never reaches our handler.
+  $effect(() => {
+    modalRef?.focus();
+  });
 </script>
 
 <div
@@ -18,11 +28,15 @@
   }}
 >
   <div
+    bind:this={modalRef}
     class="modal"
     role="dialog"
     tabindex="-1"
     onclick={(e) => e.stopPropagation()}
-    onkeydown={(e) => e.stopPropagation()}
+    onkeydown={(e) => {
+      if (e.key === 'Escape') onclose();
+      e.stopPropagation();
+    }}
   >
     {#if mode === 'delete'}
       <h3 class="modal-title">{$t('rules.database.crud.delete_title')}</h3>
@@ -147,6 +161,11 @@
     border: 1px solid var(--md-sys-color-outline);
     border-radius: var(--md-sys-shape-corner-small);
     color: var(--md-sys-color-on-surface);
+  }
+  /* Suppress the outline only for mouse focus; keyboard focus keeps the
+     global :focus-visible ring (global.css). */
+  .field input:focus:not(:focus-visible),
+  .field select:focus:not(:focus-visible) {
     outline: none;
   }
   .field input:focus,

--- a/src/renderer/lib/components/CommandPalette.svelte
+++ b/src/renderer/lib/components/CommandPalette.svelte
@@ -208,12 +208,16 @@
     flex: 1;
     background: transparent;
     border: none;
-    outline: none;
     color: var(--fancy-text-1);
     font-family: var(--fancy-font-body);
     font-size: 14px;
     padding: var(--fancy-space-md) 0;
     line-height: 1.4;
+  }
+
+  /* Keep the global :focus-visible ring for keyboard users; drop it on mouse. */
+  .cp-input:focus:not(:focus-visible) {
+    outline: none;
   }
 
   .cp-input::placeholder {

--- a/src/renderer/lib/components/SettingsAppearance.svelte
+++ b/src/renderer/lib/components/SettingsAppearance.svelte
@@ -144,8 +144,12 @@
     appearance: none;
     background: var(--md-sys-color-surface-container-highest);
     border-radius: 2px;
-    outline: none;
     cursor: pointer;
+  }
+  /* Slider is arrow-key operable — keep the global :focus-visible ring for
+     keyboard users; drop the outline only on mouse focus. */
+  .scale-slider:focus:not(:focus-visible) {
+    outline: none;
   }
   .scale-slider::-webkit-slider-thumb {
     -webkit-appearance: none;

--- a/src/renderer/lib/components/SettingsMonitoring.svelte
+++ b/src/renderer/lib/components/SettingsMonitoring.svelte
@@ -228,7 +228,6 @@
     border: 1px solid var(--md-sys-color-outline);
     border-radius: var(--md-sys-shape-corner-small);
     color: var(--md-sys-color-on-surface);
-    outline: none;
   }
   .key-input {
     flex: 1;
@@ -237,6 +236,11 @@
     resize: vertical;
     width: 100%;
     box-sizing: border-box;
+  }
+  /* Keep the global :focus-visible ring for keyboard users; drop it on mouse. */
+  .key-input:focus:not(:focus-visible),
+  textarea:focus:not(:focus-visible) {
+    outline: none;
   }
   .key-input:focus,
   textarea:focus {


### PR DESCRIPTION
## What

a11y / keyboard pass on modals and inputs (ux-audit F5: U6 + U7/U11 + U9).

### U6 — AgentFormModal Esc now closes (P1)
The `.modal` keydown handler calls `e.stopPropagation()`, which the audit observed swallows Esc; a `<svelte:window>` handler (the audit's suggested fix) would sit **above** `.modal` in the bubble path and never see the key once focus is in a field — and removing the stopPropagation would leak bare hotkeys (1-5/s/t) to App and switch tabs behind the modal (no open-guard like the palette has). **Fix:** handle Escape *inside* the existing `.modal` handler — the one node the event is guaranteed to reach — plus autofocus the dialog (`bind:this` + `$effect`, same pattern as CommandPalette) so focus starts inside the overlay. No `<form>`, so Enter is untouched.

### U7 / U11 — keyboard focus rings restored on 5 inputs (P1/P2)
A scoped `outline: none` was unconditionally beating the global `:focus-visible` ring. Scoped the reset to `:focus:not(:focus-visible)` so mouse focus stays ring-less (unchanged look) while keyboard focus shows the ring. Files: AgentFormModal, AgentDatabase, SettingsMonitoring, CommandPalette, and **SettingsAppearance `.scale-slider`** (audit called it a "form input" — it is a range slider; arrow-key operable, so the ring matters).

### U9 — hidden tab-order buttons revealed on keyboard focus (P2)
`.feed-reveal` / `.fp-btn` are `opacity:0` buttons revealed only on hover but still in the tab order. Added `:focus-visible { opacity: 1 }` so keyboard users see them on focus. No resting/hover change.

## Out of scope (noted, not fixed)
- **U12** (palette item `onmousedown`→`onclick`): mouse press-vs-release, not keyboard.
- Other modals' Esc (CommandPalette/OptionsPanel/App-settings): re-confirmed working, no change.
- Visual-coupled fixes (e.g. always-reduced-opacity for U9) intentionally avoided per the no-visual-change brief.

## Verify
- Svelte MCP autofixer: 0 issues on all 7 touched files
- `npm run build:renderer` ✓ 0 errors (220 modules)
- `npm run lint` ✓ 0 errors (pre-existing no-console warnings only)
- `npm test` ✓ 711 pass / 4 skip (44 files)
