### PR TITLE
perf: virtualize NetworkPanel (content-visibility), stable list keys, cap GroupedFeed

### DIFF
--- a/src/renderer/lib/components/ActivityFeed.svelte
+++ b/src/renderer/lib/components/ActivityFeed.svelte
@@ -103,7 +103,13 @@
   }
 
   let unified = $derived.by(() => {
-    const fileEvs = cachedEvents.flat().map((ev) => ({ ...ev, _type: 'file' }));
+    const fileEvs = cachedEvents.flat().map((ev) => ({
+      ...ev,
+      _type: 'file',
+      // Position-independent identity (no loop index) so prepending a new
+      // event doesn't re-key — and thus destroy/recreate — every row.
+      _key: `f-${ev.timestamp}-${ev.pid}-${ev.file}-${ev.action}`,
+    }));
     const netEvs = cachedNetwork.map((conn) => ({
       agent: conn.agent || 'Unknown',
       timestamp: conn.timestamp || Date.now(),
@@ -115,8 +121,24 @@
       _type: 'network',
       userAgent: conn.userAgent || null,
       httpUnencrypted: !!conn.httpUnencrypted,
+      // No timestamp in the key: network is re-set wholesale each poll and the
+      // ts fallback (Date.now) would churn. pid+endpoint+state is stable.
+      _key: `n-${conn.pid}-${conn.remoteIp}-${conn.remotePort}-${conn.state}`,
     }));
-    return [...fileEvs, ...netEvs].sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+    const merged = [...fileEvs, ...netEvs].sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+    // Crash guard: Svelte 5 throws on duplicate keyed-each keys. There is no
+    // unique id in the source data, so collapse any exact key collisions —
+    // keep-first keeps the newest (list is sorted desc). No-op when the
+    // upstream 30s dedup invariant holds; safety net if it ever doesn't.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient dedup helper inside a derived, not reactive state
+    const seen = new Set();
+    const deduped = [];
+    for (const ev of merged) {
+      if (seen.has(ev._key)) continue;
+      seen.add(ev._key);
+      deduped.push(ev);
+    }
+    return deduped;
   });
 
   let filtered = $derived.by(() => {
@@ -180,7 +202,7 @@
     {#if filtered.length === 0}
       <div class="feed-empty">{$t('activity.feed.no_events')}</div>
     {:else}
-      {#each filtered as ev, i (`${ev.timestamp}-${ev.agent}-${i}`)}
+      {#each filtered as ev, i (ev._key)}
         {@const sev = getSeverity(ev)}
         {@const label = badgeLabel(ev, sev)}
         {@const isNew = i < newItemCount}

--- a/src/renderer/lib/components/GroupedFeed.svelte
+++ b/src/renderer/lib/components/GroupedFeed.svelte
@@ -15,6 +15,19 @@
   let expandedGroups = new SvelteSet();
   let expandedEvent = $state(null);
 
+  /**
+   * Max events rendered per sub-list before a "show more" toggle. Without this,
+   * a single agent can absorb the whole 200-event cap and an expanded group
+   * renders up to ~200 items x ~5 nodes = ~1000 DOM nodes (perf-audit P4).
+   */
+  const SUB_CAP = 50;
+  /** Keys (`${group.name}-${sub.label}`) of sub-lists the user expanded fully. */
+  let expandedSubs = new SvelteSet();
+
+  function toggleSub(key) {
+    expandedSubs.has(key) ? expandedSubs.delete(key) : expandedSubs.add(key);
+  }
+
   /** @type {any[][]} */
   let cachedEvents = $state([]);
   /** @type {any[]} */
@@ -77,8 +90,11 @@
         <div class="group-body">
           {#each [{ label: $t('activity.groups.file_access'), evs: group.fileEvents }, { label: $t('activity.groups.config_access'), evs: group.configEvents }, { label: $t('activity.groups.network'), evs: group.networkEvents }] as sub (sub.label)}
             {#if sub.evs.length > 0}
+              {@const subKey = `${group.name}-${sub.label}`}
+              {@const showAll = expandedSubs.has(subKey)}
+              {@const shown = showAll ? sub.evs : sub.evs.slice(0, SUB_CAP)}
               <div class="sub-label">{sub.label} ({sub.evs.length})</div>
-              {#each sub.evs as ev, i (`${ev.timestamp}-${i}`)}
+              {#each shown as ev, i (`${ev.timestamp}-${i}`)}
                 <GroupedFeedItem
                   {ev}
                   index={i}
@@ -87,6 +103,13 @@
                   onToggle={toggleEvent}
                 />
               {/each}
+              {#if sub.evs.length > SUB_CAP}
+                <button class="show-more" onclick={() => toggleSub(subKey)}>
+                  {showAll
+                    ? $t('activity.groups.show_less')
+                    : $t('activity.groups.show_more', { count: sub.evs.length - SUB_CAP })}
+                </button>
+              {/if}
             {/if}
           {/each}
         </div>
@@ -184,5 +207,24 @@
     color: var(--fancy-text-2);
     padding: var(--aegis-space-3) var(--aegis-space-6) var(--aegis-space-1);
     text-transform: uppercase;
+  }
+
+  .show-more {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: var(--aegis-space-2) var(--aegis-space-6);
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: calc(10px * var(--aegis-ui-scale));
+    font-family: var(--fancy-font-mono);
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    color: var(--md-sys-color-primary);
+    transition: color var(--fancy-transition-micro) var(--fancy-ease);
+  }
+  .show-more:hover {
+    color: var(--md-sys-color-on-surface);
   }
 </style>

--- a/src/renderer/lib/components/NetworkPanel.svelte
+++ b/src/renderer/lib/components/NetworkPanel.svelte
@@ -55,7 +55,20 @@
     else if (sortBy === 'domain')
       copy.sort((a, b) => (a.domain || a.remoteIp).localeCompare(b.domain || b.remoteIp));
     else if (sortBy === 'class') copy.sort((a, b) => classify(a).localeCompare(classify(b)));
-    return copy;
+    // Crash guard: the each-key (pid-ip-port-state) must be unique — Svelte 5
+    // throws on duplicate keys. No unique id exists in the source, so drop any
+    // exact collisions (keep first). Lets us key by stable identity instead of
+    // the volatile loop index, so rows are reused across polls, not recreated.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient dedup helper inside a derived, not reactive state
+    const seen = new Set();
+    const out = [];
+    for (const c of copy) {
+      const k = `${c.pid}-${c.remoteIp}-${c.remotePort}-${c.state}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(c);
+    }
+    return out;
   });
 
   let counts = $derived.by(() => {
@@ -99,7 +112,7 @@
   {#if sorted.length === 0}
     <div class="net-empty">{$t('network.no_connections')}</div>
   {:else}
-    {#each sorted as conn, i (`${conn.pid}-${conn.remoteIp}-${conn.remotePort}-${i}`)}
+    {#each sorted as conn (`${conn.pid}-${conn.remoteIp}-${conn.remotePort}-${conn.state}`)}
       {@const cls = classify(conn)}
       <div class="net-row">
         <span class="net-agent">{conn.agent}</span>
@@ -206,6 +219,12 @@
     padding: var(--aegis-space-3) var(--aegis-space-6);
     font-size: calc(11px * var(--aegis-ui-scale));
     transition: background 0.15s ease;
+    /* Browser-native virtualization: skip layout/paint for off-screen rows
+       (the list can reach 500). Rows stay in the DOM, so :nth-child striping,
+       scroll position, and filters are preserved automatically. The `auto`
+       keyword lets the estimate self-correct after a row renders once. */
+    content-visibility: auto;
+    contain-intrinsic-size: auto 30px;
   }
   .net-row:nth-child(odd) {
     background: var(--md-sys-color-surface-container-low);

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -103,7 +103,9 @@
       "events_plural": "{count} events",
       "unresolved": "unresolved",
       "domain_prefix": "Domain:",
-      "ip_prefix": "IP:"
+      "ip_prefix": "IP:",
+      "show_more": "Show {count} more",
+      "show_less": "Show less"
     }
   },
   "agents": {


### PR DESCRIPTION
## What

Long-list rendering perf (ui-perf-audit P2 / P3 / P4). Two approach divergences from the literal task brief, both deliberate (documented below) — flagging so you can veto.

### Step 1 — stable list keys (the dominant win, P2)
Both feeds keyed `{#each}` by a string **containing the loop index `i`**. The lists are newest-first (prepend), so every new row shifted every index → every key changed → Svelte destroyed + recreated all ≤200 / ≤500 rows per update. Fixed by keying on a **position-independent content composite**:
- file events: `f-${ts}-${pid}-${file}-${action}`
- network: `n-${pid}-${ip}-${port}-${state}` (no timestamp — network is re-`set` wholesale each poll and the `ts || Date.now()` fallback would churn)

Verified from `src/shared/types/events.ts`: **no unique id exists** (no id / localPort / fd / socket id), so distinct sockets to the same endpoint are genuinely indistinguishable. Svelte 5 throws (hard error, not a warning) on duplicate keys → added a **keep-first dedup-by-key** in the derived as a crash-guard. It collapses only rows identical in *every displayed field*; for an EDR that means two indistinguishable connections to the same endpoint render as one row — strictly better than a crash. (Flagging this collapse explicitly.)

### Step 2 — NetworkPanel `content-visibility` (P3), **not** manual windowing
Used `content-visibility: auto; contain-intrinsic-size: auto 30px` on `.net-row` instead of slice-windowing. It skips layout/paint of off-screen rows (the real cost at 500 rows) while keeping all rows in the DOM — so `:nth-child` striping, scroll position, filters, and severity all keep working with **zero JS**. Manual windowing would have needed row-height measurement at variable `--aegis-ui-scale`, spacer math, filter-shrink clamping, blank-row handling, and a striping rewrite — all regression risk for no benefit here (the JS cost it *doesn't* skip is already cheap after the Step-1 key fix). Pure CSS, no dependency (respects "NO UI libraries" + avoids the npm-10.8.2 lockfile-drift footgun).

### Step 3 — GroupedFeed per-group cap (P4)
An expanded group could render the whole 200-event cap for one agent × ~5 nodes ≈ 1000 nodes. Capped each sub-list to **50** rendered items with a "Show N more" / "Show less" toggle (new i18n keys; per-(group,sub) state).

### ActivityFeed windowing — deferred to the runtime check
Per the audit's own note (and the advisor): ActivityFeed is capped at 200 and after the key fix only changed rows touch the DOM — 200 keyed rows is fine. Windowing there fights its auto-scroll-to-bottom, Follow button, and per-item slide-in animation. **Decision:** add `content-visibility` to ActivityFeed *only if* the runtime check shows jank — evidence over guessing.

## Preserved
Filters, click-to-filter, scroll position, severity bars, and the **RH-1 by-design `$effect`+`if(!active)return` tab-gate** (not converted to `$derived` — that's the audit's explicit do-not-touch regression).

## Verify
- Svelte autofixer: 0 issues on all 3 components
- `npm run lint` ✓ 0 errors (suppressed 2 `prefer-svelte-reactivity` on transient dedup Sets — computation helpers, not reactive state; same call as the radar P1 fix)
- `npm run build:renderer` ✓ 0 errors
- `npm test` ✓ 711 pass / 4 skip (44 files)
- **Pending:** runtime check via the app — scroll both feeds with many rows (smooth, no row jump/dup, filters + click-to-filter work, scroll not reset, NetworkPanel scrollbar not jumpy).
