### PR TITLE
fix(hooks): branch-guard skips out-of-repo and gitignored paths

### DIFF
--- a/.claude/hooks/branch-guard.js
+++ b/.claude/hooks/branch-guard.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// PreToolUse(Edit|Write) branch-guard for AEGIS.
+//
+// Blocks edits to TRACKED, in-repo files while the project repo is on `master`,
+// so all work goes through a feature branch (GitHub-Flow rule).
+//
+// Two skips run BEFORE the block (the bug this hook fixes):
+//   1. OUT-OF-REPO  — the edited path is not under the project repo root
+//                     (e.g. ~/.claude/settings.json). The master-branch guard
+//                     has no business gating files outside the repo.
+//   2. GITIGNORED   — the path is under the repo root but git-ignored
+//                     (e.g. memory-bank/ working notes). Ignored files are not
+//                     part of the tracked tree, so editing them on master is fine.
+//
+// Input: a PreToolUse event as JSON on stdin (the only supported mechanism —
+//        there are no $TOOL_INPUT_* env vars). Shape:
+//        { "tool_input": { "file_path": "..." }, "cwd": "..." }
+// Block: exit code 2 + a plain-language message on stderr (the canonical form).
+// Allow: exit code 0.
+//
+// Run as a hook:  node "${CLAUDE_PROJECT_DIR}/.claude/hooks/branch-guard.js"
+// Test the logic: require this module and call decide() with mock rows, OR pipe
+//                 a mock event:  echo '{...}' | node .claude/hooks/branch-guard.js
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+
+/**
+ * Normalize a filesystem path for cross-platform prefix comparison.
+ * Backslashes -> forward slashes; the drive letter is lower-cased (Windows is
+ * case-insensitive on the drive). Per spec, only the drive letter is folded —
+ * the rest of the path keeps its original case.
+ * @param {string} p
+ * @returns {string}
+ */
+function normPath(p) {
+  return String(p)
+    .replace(/\\/g, '/')
+    .replace(/^([a-zA-Z]):/, (_m, drive) => drive.toLowerCase() + ':');
+}
+
+/**
+ * Run a git subcommand in `dir`. Returns trimmed stdout, or null if git exits
+ * non-zero / errors (used both for "not a repo" and for check-ignore's exit 1).
+ * @param {string} dir
+ * @param {string[]} args
+ * @returns {string|null}
+ */
+function git(dir, args) {
+  try {
+    return execFileSync('git', ['-C', dir, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether an Edit/Write should be blocked.
+ *
+ * Order: not-master -> allow; out-of-repo -> allow; gitignored -> allow;
+ * otherwise (tracked/in-repo on master) -> block.
+ *
+ * `branch` is injectable so the decision can be unit-tested for both master and
+ * feature-branch states without checking out master. When omitted, the live
+ * branch of the repo at `cwd` is used.
+ *
+ * @param {string} filePath - absolute path of the file being edited
+ * @param {string} cwd - working directory of the session (the project repo)
+ * @param {string} [branch] - current branch override (for tests)
+ * @returns {{ block: boolean, reason: string }}
+ */
+function decide(filePath, cwd, branch) {
+  if (!filePath || !cwd) return { block: false, reason: 'no path/cwd' };
+
+  const currentBranch = branch != null ? branch : git(cwd, ['branch', '--show-current']);
+  if (currentBranch !== 'master') {
+    return { block: false, reason: `branch '${currentBranch}' is not master` };
+  }
+
+  // Resolve the PROJECT repo root from cwd (not from the edited file's dir —
+  // that dir may belong to a different repo or none at all).
+  const topLevel = git(cwd, ['rev-parse', '--show-toplevel']);
+  if (!topLevel) return { block: false, reason: 'cwd is not a git repo' };
+
+  const root = normPath(topLevel);
+  const edited = normPath(filePath);
+
+  // Skip 1: out-of-repo. Trailing-slash boundary so AEGIS != AEGIS-other.
+  if (edited !== root && !edited.startsWith(root + '/')) {
+    return { block: false, reason: 'path is outside the repo root' };
+  }
+
+  // Skip 2: gitignored inside the repo. check-ignore exits 0 when ignored.
+  const rel = edited.slice(root.length + 1);
+  const ignored = git(root, ['check-ignore', '-q', '--', rel]) !== null;
+  if (ignored) {
+    return { block: false, reason: 'path is gitignored' };
+  }
+
+  return { block: true, reason: 'tracked file under repo root on master' };
+}
+
+/**
+ * Hook entry point: read the PreToolUse event from stdin, decide, and signal
+ * via exit code (0 allow, 2 block + stderr message).
+ */
+function main() {
+  let raw = '';
+  try {
+    raw = require('fs').readFileSync(0, 'utf8');
+  } catch {
+    process.exit(0); // no stdin -> nothing to guard
+  }
+
+  let event;
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    process.exit(0); // unparseable -> fail open (never block on malformed input)
+  }
+
+  const filePath = event && event.tool_input && event.tool_input.file_path;
+  const cwd = (event && event.cwd) || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+  const { block } = decide(filePath, cwd);
+  if (block) {
+    process.stderr.write(
+      `Cannot edit on master: ${filePath}\nCreate a feature branch first (feat/* | fix/* | chore/* | docs/*).`,
+    );
+    process.exit(2);
+  }
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { decide, normPath };

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"$(git branch --show-current)\" != \"master\" ] || { echo '{\"block\": true, \"message\": \"Cannot edit on master. Create feature branch first.\"}' >&2; exit 2; }",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/branch-guard.js\"",
             "timeout": 5
           }
         ]

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ cdp_*.js
 !.claude/skills/
 !.claude/agents/
 !.claude/commands/
+!.claude/hooks/
 !.claude/settings.json
 !.mcp.json
 memory-bank/


### PR DESCRIPTION
## What

The `PreToolUse(Edit|Write)` branch-guard blocked edits on `master` **regardless of path** — including files **outside the repo** (e.g. `~/.claude/settings.json`) and **gitignored working notes** (`memory-bank/`). This forced edits to unrelated/global files through Bash workarounds.

## Change

Reworked the inline shell one-liner into a shell-agnostic Node script (`.claude/hooks/branch-guard.js`, tracked via `!.claude/hooks/`). It reads the PreToolUse event from **stdin** (`tool_input.file_path` + `cwd` — the only supported mechanism; `$TOOL_INPUT_*` env vars do not exist), resolves the **project repo root from cwd**, and adds two skips before the block:

1. path **outside repo root** → allow
2. path **gitignored inside repo** → allow

Otherwise (tracked file under root on `master`) → **block** (exit 2 + plain stderr message).

Why a Node script: the Windows hook shell is Git Bash with a **PowerShell fallback** where POSIX `[ ... ]` breaks; `node` is shell-agnostic and always present.

## Scope

- Single hook only. The `.md`-specific guard described in older notes does **not** exist in code (verified across `settings.json`, `settings.local.json`, global `~/.claude`, and full tracked history) and was **not** resurrected — an always-on version would wrongly block tracked `.md` edits (README) on `docs/*` branches.
- The broken `PostToolUse` `$TOOL_INPUT_path` svelte hook is left untouched (out of scope).

## Verification (all green)

| Case | Verdict |
|---|---|
| `C:\…\.claude\settings.json` (out of repo) | allow |
| `memory-bank/progress.md` (gitignored, both slashes) | allow |
| `.claude/commands/ship.md` (in-repo, master) | block |
| `src/main/main.js` (master) | block |
| `README.md` (master) | block |
| `README.md` (docs/* branch) | allow |

- 7/7 `decide()` logic matrix against the real AEGIS repo
- End-to-end on an isolated `master` repo: tracked → `exit 2` + stderr; gitignored → `exit 0`; out-of-repo → `exit 0`
- `npm run build:renderer` ✓ (0 errors)