### PR TITLE
ci: bump GitHub Actions to latest major (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -21,8 +21,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -35,8 +35,8 @@ jobs:
   svelte-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -46,8 +46,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
       - run: npm run test:coverage
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/
@@ -63,8 +63,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,9 +11,9 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
All GitHub Actions were on the deprecating **Node 20** runtime (GitHub deadline **2026-06-16**). Bumped each to its latest major, verified live against each tag's `action.yml` `runs.using`:

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | @v4 | @v6 | node20 → node24 |
| `actions/setup-node` | @v4 | @v6 | node20 → node24 |
| `actions/upload-artifact` | @v4 | @v7 | node20 → node24 |
| `googleapis/release-please-action` | @v4 | @v5 | node20 → node24 |

**Why upload-artifact jumps to v7, not v5:** `upload-artifact@v5` is *still* node20 — a +1-major bump would not clear the deprecation. v6 is the first node24 release; v7 is latest.

**Unchanged by design:** `node-version: '20'` (the build/test runtime, distinct from the action's embedded runtime) stays at 20 in all 6 jobs. No npm pin exists in the workflows.

**Verification scope:** only `ci.yml` runs on this PR, so green CI + a clean deprecation log proves the checkout/setup-node/upload-artifact bumps. `release-please.yml` (push→master) and `release-build.yml` (release-published) don't fire on the PR — verified-by-inspection (action.yml → node24) until a real push/release.