### PR TITLE
chore(security): dedup rm -rf deny rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,7 +37,6 @@
       "Bash(git push *)",
       "Bash(git merge *)",
       "Bash(git rebase *)",
-      "Bash(rm -rf *)",
       "Bash(npm publish *)",
       "Edit(.env*)",
       "Edit(*.pem)",


### PR DESCRIPTION
Removes one true duplicate from `.claude/settings.json` permissions.deny.

## Change
- Removed `Bash(rm -rf *)` (space-glob form)
- Kept `Bash(rm -rf:*)` (colon-prefix form, part of the 221e2ba hard-floor)
- deny rules 22 -> 21; allow list unchanged (31)

## Why it is safe (superset proof, not equivalence)
Both rules share the identical literal prefix `rm -rf`. `:*` matches `rm -rf` + ANYTHING (maximal); ` *` matches `rm -rf` + word-boundary + anything (a restriction of that set). So every command the removed rule blocked is necessarily still blocked by the kept rule. Regression is impossible under any matcher interpretation -- the exact equivalence detail is not even required, only the superset direction.

Still blocked by `Bash(rm -rf:*)`: `rm -rf /`, `rm -rf foo`, `rm -rf ./build --no-preserve-root`, bare `rm -rf`. Edge `rm -rfoo` is caught more aggressively by `:*` (stricter, not a hole).

## Intentionally NOT touched
- `Bash(git push *)` and the force-push variants (`--force` / `-f` / `--force-with-lease`) -- 221e2ba hard-floor; redundant but never removed.
- `Read(./.env)` vs `Read(**/.env)` and `Read(./.env.*)` vs `Read(**/.env.*)` -- anchored vs unanchored path-glob, equivalence unproven + secret-floor; both kept.

Verified: JSON parses (deny 21 / allow 31), build:renderer clean.
