### PR TITLE
chore: add audit/fancy-ui/research/ship slash-commands

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,5 @@
+---
+description: Full codebase health check. Usage: /audit
+---
+Delegate to the auditor agent.
+Run full health check and output status table.

--- a/.claude/commands/fancy-ui.md
+++ b/.claude/commands/fancy-ui.md
@@ -1,0 +1,9 @@
+---
+description: Run Fancy UI phase. Usage: /fancy-ui F1.1 or /fancy-ui F2.3
+---
+Delegate to the ui-designer agent:
+
+Task: Execute phase $ARGUMENTS from FANCY-AEGIS-MASTER-PLAN.md.
+Read the plan, find the section for $ARGUMENTS, implement exactly what it says.
+Run verify loop (see code-quality rule)
+Commit with conventional message: feat(ui): description [$ARGUMENTS]

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -1,0 +1,8 @@
+---
+description: Explore codebase. Usage: /research "how does risk scoring work"
+context: fork
+agent: Explore
+---
+Research $ARGUMENTS thoroughly in the Aegis codebase.
+Find relevant files, analyze code, report findings.
+Never edit files.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,6 @@
+---
+description: Release workflow. Usage: /ship v0.5.0-alpha
+---
+Delegate to the shipper agent.
+Target version: $ARGUMENTS
+Run pre-flight checks, show what ships, wait for confirmation.


### PR DESCRIPTION
Track the four operational slash-commands that were visible-but-untracked after un-ignoring `.claude/commands/` (e156975).

Closes the long-open "track 4 sibling commands" follow-up.

- `audit.md` → delegates to the auditor agent
- `fancy-ui.md` → delegates to ui-designer (takes `$ARGUMENTS` phase id)
- `research.md` → `context: fork` + `agent: Explore`
- `ship.md` → delegates to the shipper agent

Each re-verified as valid (frontmatter `description:` + agent-delegation body) before staging. Stray 0-byte redirect artifact removed; `aegis_landing.html` deliberately left untracked (separate landing task).
