### PR TITLE
fix: polling-gap — eager enter, lazy exit

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -56,7 +56,6 @@ let isQuitting = false,
 let oomIntervalId = null;
 let latestNetConnections = [],
   otherPanelExpanded = false;
-let previousAgentPids = new Map();
 const fileWatchers = [];
 
 // ═══ RUNNING COUNTERS for getStats() — O(1) instead of O(n) ═══
@@ -260,10 +259,6 @@ function initDeferredSubsystems(userData) {
     },
     setLatestNetConnections: (c) => {
       latestNetConnections = c;
-    },
-    getPreviousPids: () => previousAgentPids,
-    setPreviousPids: (m) => {
-      previousAgentPids = m;
     },
   });
   config.init({

--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -74,6 +74,10 @@ function init(deps) {
 async function scanProcesses() {
   _ensureAgentDb();
   let processes;
+  // A scan is "reliable" only when the process list was actually enumerated.
+  // A permission-denied scan returns an empty list that must NOT be read as
+  // "all agents exited" — the session tracker uses this flag to ignore it.
+  let reliable = true;
   try {
     processes = await _listProcesses();
     permissionDeniedScans = 0;
@@ -83,6 +87,7 @@ async function scanProcesses() {
     if (code === 'EPERM' || code === 'EACCES' || msg.includes('access is denied')) {
       permissionDeniedScans++;
       processes = [];
+      reliable = false;
     } else {
       throw err;
     }
@@ -122,7 +127,7 @@ async function scanProcesses() {
     .join(',');
   const changed = pidSetKey !== lastProcessPidSet;
   lastProcessPidSet = pidSetKey;
-  return { agents: unique, changed };
+  return { agents: unique, changed, reliable };
 }
 
 module.exports = {

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -6,6 +6,8 @@
  */
 'use strict';
 
+const sessionTracker = require('./session-tracker');
+
 let scanInterval = null;
 let fileScanInterval = null;
 let netInterval = null;
@@ -133,38 +135,34 @@ async function doProcessScan() {
     getStats,
     getResourceUsage,
     setAgents,
-    getPreviousPids,
-    setPreviousPids,
   } = deps;
   updateScanStatus(true);
   try {
     const result = await scanner.scanProcesses();
     setAgents(result.agents);
     const agents = result.agents;
-    const curPids = new Map();
-    for (const a of agents) curPids.set(a.pid, a.agent);
-    const prevPids = getPreviousPids();
-    for (const [pid, name] of curPids) {
-      if (!prevPids.has(pid))
-        audit.log('agent-enter', {
-          agent: name,
-          action: 'started',
-          path: '',
-          severity: 'normal',
-          extra: { pid },
-        });
-    }
-    for (const [pid, name] of prevPids) {
-      if (!curPids.has(pid))
-        audit.log('agent-exit', {
-          agent: name,
-          action: 'exited',
-          path: '',
-          severity: 'normal',
-          extra: { pid },
-        });
-    }
-    setPreviousPids(curPids);
+    // Eager-enter / lazy-exit session reconciliation: an agent seen in even ONE
+    // scan logs session-start immediately, and a flickering or permission-denied
+    // scan never spawns a duplicate session. See session-tracker.js.
+    const { entered, exited } = sessionTracker.reconcile(agents, {
+      reliable: result.reliable !== false,
+    });
+    for (const s of entered)
+      audit.log('agent-enter', {
+        agent: s.agent,
+        action: 'started',
+        path: '',
+        severity: 'normal',
+        extra: { pid: s.pid, startTime: s.firstSeen },
+      });
+    for (const s of exited)
+      audit.log('agent-exit', {
+        agent: s.agent,
+        action: 'exited',
+        path: '',
+        severity: 'normal',
+        extra: { pid: s.pid },
+      });
     watcher.pruneKnownHandles(agents);
     await procUtil.enrichWithParentChains(agents);
     procUtil.annotateHostApps(agents);

--- a/src/main/session-tracker.js
+++ b/src/main/session-tracker.js
@@ -1,0 +1,154 @@
+/**
+ * @file session-tracker.js
+ * @module main/session-tracker
+ * @description Polling-gap-resistant agent session tracking. Reconciles each
+ *   process scan against the set of currently-active sessions using an
+ *   eager-enter / lazy-exit rule:
+ *
+ *   - A (pid + process) seen for the FIRST time starts a session and is reported
+ *     in `entered` immediately — so an agent visible in even ONE scan is recorded
+ *     before any dedup/grace logic can suppress it (single-tick safe).
+ *   - A session not seen in a scan is only reported in `exited` after `grace`
+ *     consecutive RELIABLE misses, so a one-tick disappearance (flicker, late
+ *     `tasklist`, or a permission-denied scan) does NOT end it and reappearance
+ *     does NOT create a duplicate session.
+ *
+ *   Identity is `pid + process name`. The OS process start-time is not available
+ *   from the snapshot scanner (`tasklist /FO CSV /NH` returns only name+pid), so
+ *   PID-reuse is disambiguated by the process name (a recycled PID belonging to a
+ *   different agent yields a different key → a new session); each session also
+ *   carries an AEGIS-observed `firstSeen` timestamp as its start-time field.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ */
+'use strict';
+
+/**
+ * Consecutive RELIABLE scans an active session may go unseen before it is
+ * considered ended. 2 tolerates a single dropped/late scan (flicker) without
+ * ending the session — the minimum that absorbs one-tick gaps.
+ * @type {number}
+ */
+const DEFAULT_EXIT_GRACE = 2;
+
+/**
+ * @typedef {Object} Session
+ * @property {number} pid
+ * @property {string} agent - display name (e.g. "Claude Code")
+ * @property {string} process - OS process name (e.g. "claude")
+ * @property {number} firstSeen - AEGIS-observed start time (ms epoch)
+ * @property {number} lastSeen - last scan (ms epoch) this session was seen
+ * @property {number} missed - consecutive reliable scans unseen
+ */
+
+/** @type {Map<string, Session>} Active sessions keyed by `pid|process`. */
+const activeSessions = new Map();
+
+/**
+ * Stable identity key for a detected agent: pid + lowercased process name.
+ * NOT keyed on firstSeen — keying on a timestamp would give every reappearance
+ * a fresh identity and re-create the session on each flicker.
+ * @param {{pid: number, agent?: string, process?: string}} agent
+ * @returns {string}
+ */
+function sessionKey(agent) {
+  const proc = String(agent.process || agent.agent || '').toLowerCase();
+  return `${agent.pid}|${proc}`;
+}
+
+/**
+ * Reconcile a process scan against the active-session set.
+ *
+ * @param {Array<{pid: number, agent: string, process?: string}>} agents
+ *   Agents detected in THIS scan (deduped by pid upstream).
+ * @param {Object} [opts]
+ * @param {boolean} [opts.reliable=true] - false when the scan could not
+ *   enumerate processes (e.g. permission-denied → empty list). An unreliable
+ *   scan tells us nothing about who left, so it neither starts, ends, nor ages
+ *   any session and returns no events.
+ * @param {number} [opts.now] - injectable timestamp (ms) for tests.
+ * @param {number} [opts.grace=DEFAULT_EXIT_GRACE] - consecutive reliable misses
+ *   before a session is reported as exited.
+ * @returns {{entered: Array<{pid: number, agent: string, process: string, firstSeen: number}>,
+ *            exited: Array<{pid: number, agent: string, process: string, firstSeen: number, lastSeen: number}>}}
+ * @since v0.10.0-alpha
+ */
+function reconcile(agents, opts = {}) {
+  const reliable = opts.reliable !== false;
+  const now = opts.now != null ? opts.now : Date.now();
+  const grace = opts.grace != null ? opts.grace : DEFAULT_EXIT_GRACE;
+
+  // Unreliable scan: do not start, end, or age sessions. This is what kills the
+  // EPERM false-positive storm — a transient access-denied no longer ages out
+  // every live session into a spurious exit + re-enter pair.
+  if (!reliable) return { entered: [], exited: [] };
+
+  const entered = [];
+  const seenKeys = new Set();
+
+  for (const a of agents) {
+    const key = sessionKey(a);
+    seenKeys.add(key);
+    const existing = activeSessions.get(key);
+    if (existing) {
+      existing.lastSeen = now;
+      existing.missed = 0;
+    } else {
+      const session = {
+        pid: a.pid,
+        agent: a.agent,
+        process: a.process || '',
+        firstSeen: now,
+        lastSeen: now,
+        missed: 0,
+      };
+      activeSessions.set(key, session);
+      entered.push({
+        pid: session.pid,
+        agent: session.agent,
+        process: session.process,
+        firstSeen: session.firstSeen,
+      });
+    }
+  }
+
+  const exited = [];
+  for (const [key, s] of activeSessions) {
+    if (seenKeys.has(key)) continue;
+    s.missed += 1;
+    if (s.missed >= grace) {
+      exited.push({
+        pid: s.pid,
+        agent: s.agent,
+        process: s.process,
+        firstSeen: s.firstSeen,
+        lastSeen: s.lastSeen,
+      });
+      activeSessions.delete(key);
+    }
+  }
+
+  return { entered, exited };
+}
+
+/**
+ * @returns {number} Count of currently-active sessions.
+ * @since v0.10.0-alpha
+ */
+function activeCount() {
+  return activeSessions.size;
+}
+
+/** @internal Reset module state (for tests). @returns {void} */
+function _resetForTest() {
+  activeSessions.clear();
+}
+
+module.exports = {
+  reconcile,
+  activeCount,
+  sessionKey,
+  DEFAULT_EXIT_GRACE,
+  _resetForTest,
+};

--- a/tests/main/session-tracker.test.js
+++ b/tests/main/session-tracker.test.js
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import tracker from '../../src/main/session-tracker.js';
+
+/**
+ * Helper: run a sequence of scans and collect every entered/exited event across
+ * the whole run, so tests can assert on totals (e.g. "exactly one session").
+ * @param {Array<{agents: Array, reliable?: boolean}>} scans
+ * @param {number} startNow
+ * @param {number} [grace]
+ */
+function runScans(scans, startNow, grace) {
+  const allEntered = [];
+  const allExited = [];
+  let now = startNow;
+  for (const scan of scans) {
+    const res = tracker.reconcile(scan.agents, {
+      reliable: scan.reliable !== false,
+      now,
+      grace,
+    });
+    allEntered.push(...res.entered);
+    allExited.push(...res.exited);
+    now += 10000; // simulate a 10s poll interval
+  }
+  return { allEntered, allExited };
+}
+
+const CURSOR = { pid: 100, agent: 'Cursor', process: 'cursor' };
+
+describe('session-tracker', () => {
+  beforeEach(() => {
+    tracker._resetForTest();
+  });
+
+  describe('reconcile — single-tick (the polling-gap case)', () => {
+    it('agent seen exactly once then gone → exactly one session + one enter + one exit', () => {
+      // Seen in ONE scan, then absent for the full grace window.
+      const { allEntered, allExited } = runScans(
+        [
+          { agents: [CURSOR] }, // sighting
+          { agents: [] }, // gone (miss 1)
+          { agents: [] }, // gone (miss 2 → exit)
+        ],
+        1_000_000,
+        2,
+      );
+      expect(allEntered).toHaveLength(1);
+      expect(allEntered[0].agent).toBe('Cursor');
+      expect(allEntered[0].pid).toBe(100);
+      expect(allExited).toHaveLength(1);
+      expect(allExited[0].pid).toBe(100);
+      expect(tracker.activeCount()).toBe(0);
+    });
+
+    it('records the enter on the FIRST sighting, before any miss', () => {
+      const res = tracker.reconcile([CURSOR], { now: 1_000_000, grace: 2 });
+      expect(res.entered).toHaveLength(1);
+      expect(res.exited).toHaveLength(0);
+      // session-start carries an AEGIS-observed start-time field
+      expect(res.entered[0].firstSeen).toBe(1_000_000);
+    });
+
+    it('does not exit before the grace window elapses', () => {
+      tracker.reconcile([CURSOR], { now: 0, grace: 2 });
+      const afterOneMiss = tracker.reconcile([], { now: 10000, grace: 2 });
+      expect(afterOneMiss.exited).toHaveLength(0);
+      expect(tracker.activeCount()).toBe(1);
+    });
+  });
+
+  describe('reconcile — flicker must NOT spawn a duplicate session', () => {
+    it('same pid+process reappears within grace → no second enter', () => {
+      const { allEntered, allExited } = runScans(
+        [
+          { agents: [CURSOR] }, // sighting
+          { agents: [] }, // one-tick gap (miss 1, < grace)
+          { agents: [CURSOR] }, // reappears — same session
+        ],
+        0,
+        2,
+      );
+      expect(allEntered).toHaveLength(1); // NOT two
+      expect(allExited).toHaveLength(0);
+      expect(tracker.activeCount()).toBe(1);
+    });
+
+    it('a permission-denied (unreliable) scan does not end or re-create a session', () => {
+      const { allEntered, allExited } = runScans(
+        [
+          { agents: [CURSOR] }, // sighting
+          { agents: [], reliable: false }, // EPERM → empty list, ignored
+          { agents: [], reliable: false }, // EPERM again, still ignored
+          { agents: [CURSOR] }, // still the same session
+        ],
+        0,
+        2,
+      );
+      expect(allEntered).toHaveLength(1);
+      expect(allExited).toHaveLength(0);
+      expect(tracker.activeCount()).toBe(1);
+    });
+
+    it('unreliable scans are not counted as misses', () => {
+      tracker.reconcile([CURSOR], { now: 0, grace: 2 });
+      // Two unreliable scans would exceed grace IF counted — they must not be.
+      tracker.reconcile([], { now: 10000, reliable: false, grace: 2 });
+      tracker.reconcile([], { now: 20000, reliable: false, grace: 2 });
+      const res = tracker.reconcile([], { now: 30000, reliable: false, grace: 2 });
+      expect(res.exited).toHaveLength(0);
+      expect(tracker.activeCount()).toBe(1);
+    });
+  });
+
+  describe('reconcile — PID reuse', () => {
+    it('a recycled PID belonging to a different agent starts a new session', () => {
+      // pid 100 is Cursor, then after Cursor exits the OS reuses 100 for Copilot.
+      const { allEntered } = runScans(
+        [
+          { agents: [{ pid: 100, agent: 'Cursor', process: 'cursor' }] },
+          { agents: [{ pid: 100, agent: 'Copilot', process: 'copilot' }] },
+        ],
+        0,
+        2,
+      );
+      const names = allEntered.map((e) => e.agent).sort();
+      expect(names).toEqual(['Copilot', 'Cursor']);
+      expect(allEntered).toHaveLength(2);
+    });
+  });
+
+  describe('reconcile — multiple concurrent agents', () => {
+    it('tracks distinct sessions independently', () => {
+      const res = tracker.reconcile(
+        [
+          { pid: 100, agent: 'Cursor', process: 'cursor' },
+          { pid: 200, agent: 'Claude Code', process: 'claude' },
+        ],
+        { now: 0, grace: 2 },
+      );
+      expect(res.entered).toHaveLength(2);
+      expect(tracker.activeCount()).toBe(2);
+    });
+
+    it('one agent exiting does not affect the other', () => {
+      tracker.reconcile(
+        [
+          { pid: 100, agent: 'Cursor', process: 'cursor' },
+          { pid: 200, agent: 'Claude Code', process: 'claude' },
+        ],
+        { now: 0, grace: 2 },
+      );
+      // Cursor gone, Claude stays.
+      tracker.reconcile([{ pid: 200, agent: 'Claude Code', process: 'claude' }], {
+        now: 10000,
+        grace: 2,
+      });
+      const res = tracker.reconcile([{ pid: 200, agent: 'Claude Code', process: 'claude' }], {
+        now: 20000,
+        grace: 2,
+      });
+      expect(res.exited).toHaveLength(1);
+      expect(res.exited[0].agent).toBe('Cursor');
+      expect(tracker.activeCount()).toBe(1);
+    });
+  });
+
+  describe('sessionKey', () => {
+    it('is identical for the same pid + process regardless of sighting time', () => {
+      expect(tracker.sessionKey({ pid: 100, process: 'cursor' })).toBe(
+        tracker.sessionKey({ pid: 100, process: 'Cursor' }),
+      );
+    });
+
+    it('differs when the process name differs for the same pid', () => {
+      expect(tracker.sessionKey({ pid: 100, process: 'cursor' })).not.toBe(
+        tracker.sessionKey({ pid: 100, process: 'copilot' }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## fix(detection): polling-gap session tracker — eager enter, lazy exit

Resolves the short-lived-agent flicker / false-session correctness gap in the
process-scan loop.

### Problem
The old enter/exit in scan-loop.js was a pure per-scan PID-set diff
(curPids vs prevPids). A single missed or unreliable scan — a late tasklist,
or critically an EPERM scan where the process-scanner returns an empty list —
made curPids momentarily empty. That emitted a false agent-exit, then a false
re-enter on recovery, logging one continuous process as TWO sessions.

### Fix — new pure module src/main/session-tracker.js
reconcile(agents, opts) returns entered / exited with three rules:

- **Eager enter** — first sighting of a pid+process-name starts a session and is
  returned immediately (single-tick safe; recorded before any grace can touch it).
- **Lazy exit** — a session unseen is only returned in exited after grace
  consecutive RELIABLE misses (default 2, absorbs one dropped scan). Reappearance
  within grace is the SAME session, no second enter.
- **Unreliable scans count for nothing** — an EPERM scan starts, ends, and ages
  no session and emits no events. This kills the EPERM false-positive storm.

### Identity
Session key is pid + process-name (name disambiguates realistic PID reuse).
Each session carries an AEGIS-observed firstSeen ms-epoch as a start-time FIELD
(stored, not keyed — keying on a timestamp would re-create the session every flicker),
surfaced on the agent-enter audit as extra.startTime.

### Wiring
- process-scanner.scanProcesses now also returns reliable (true normally; false on
  EPERM / EACCES / access-denied) — purely additive.
- scan-loop.js doProcessScan replaces the inline diff with sessionTracker.reconcile,
  keeping the SAME agent-enter / agent-exit audit shapes.
- Removed now-dead main.js previousAgentPids var and its get/set deps.

### Tests / verify
- NEW tests/main/session-tracker.test.js — 11 tests: seen-once equals exactly one
  session + one enter + one exit; flicker within grace equals no second enter;
  unreliable scans not counted as misses; recycled-pid-different-agent equals new
  session; multi-agent independence; sessionKey identity.
- npm test green, build:renderer green, tsc --noEmit 0 errors, eslint 0, prettier clean.

Branched from master per one-PR-one-task. Independently clean-merges to master
(verified via merge-tree). Note: a follow-up branch that also edits doProcessScan
will conflict on scan-loop.js by design — flagged for whoever merges it second.
