### PR TITLE
feat(detect): WSL + IDE-extension process-invisible detection

### DIFF
--- a/src/main/ide-extension-detector.js
+++ b/src/main/ide-extension-detector.js
@@ -1,0 +1,200 @@
+/**
+ * @file ide-extension-detector.js
+ * @module main/ide-extension-detector
+ * @description Detects AI coding agents that ship as editor EXTENSIONS and have
+ *   no standalone OS process (Kilo Code, Cline). Process-name scanning cannot
+ *   see them — they run inside the editor's extension host. Instead we read the
+ *   editor's `extensions/` directory for the known extension folder, and — only
+ *   when the editor itself is running — surface a synthetic agent annotated
+ *   "via <Editor>", the same way Copilot is annotated when hosted in VS Code.
+ * @requires fs
+ * @requires os
+ * @requires path
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ * @since v0.11.0-alpha
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const _platform = require('./platform');
+
+let _listProcesses = _platform.listProcesses;
+let _readdir = (dir) => fs.promises.readdir(dir);
+let _homedir = () => os.homedir();
+
+/**
+ * @internal Override dependencies (for tests).
+ * @param {{ listProcesses?: Function, readdir?: Function, homedir?: Function }} overrides
+ */
+function _setDepsForTest(overrides) {
+  if (overrides.listProcesses) _listProcesses = overrides.listProcesses;
+  if (overrides.readdir) _readdir = overrides.readdir;
+  if (overrides.homedir) _homedir = overrides.homedir;
+}
+
+/** @internal Reset to real dependencies and clear the cache (for tests). */
+function _resetForTest() {
+  _listProcesses = _platform.listProcesses;
+  _readdir = (dir) => fs.promises.readdir(dir);
+  _homedir = () => os.homedir();
+  _cache = [];
+  _lastRefresh = 0;
+  _refreshing = false;
+}
+
+// ═══ SIGNATURES ═══
+
+/**
+ * @typedef {Object} EditorExtHost
+ * @property {string[]} procNames - lowercase process names that mean this editor is running
+ * @property {string} extDir - extensions dir relative to home (VS Code-family layout)
+ * @property {string} label - human-readable editor label for "via <label>"
+ */
+
+/**
+ * VS Code and its forks share the `<home>/<editorDir>/extensions/<publisher>.<name>-<ver>`
+ * layout. Cursor and Windsurf are VS Code forks with their own extensions dir.
+ * @type {readonly EditorExtHost[]}
+ */
+const EDITOR_EXT_HOSTS = [
+  { procNames: ['code.exe', 'code'], extDir: '.vscode/extensions', label: 'VS Code' },
+  {
+    procNames: ['code - insiders.exe', 'code-insiders'],
+    extDir: '.vscode-insiders/extensions',
+    label: 'VS Code Insiders',
+  },
+  { procNames: ['cursor.exe', 'cursor'], extDir: '.cursor/extensions', label: 'Cursor' },
+  { procNames: ['windsurf.exe', 'windsurf'], extDir: '.windsurf/extensions', label: 'Windsurf' },
+];
+
+/**
+ * @typedef {Object} ExtSignature
+ * @property {string} idPrefix - lowercase `publisher.name` prefix of the extension folder
+ * @property {string} agent - display name to surface for the detected agent
+ */
+
+/**
+ * AI coding agents distributed only as editor extensions (no standalone process).
+ * @type {readonly ExtSignature[]}
+ */
+const AI_EXTENSIONS = [
+  { idPrefix: 'kilocode.kilo-code', agent: 'Kilo Code' },
+  { idPrefix: 'saoudrizwan.claude-dev', agent: 'Cline' },
+];
+
+// ═══ CACHE ═══
+
+/** @type {number} How long a directory/process scan stays fresh (ms) */
+const REFRESH_TTL_MS = 30000;
+
+/** @type {Array<Object>} Last detected synthetic agents */
+let _cache = [];
+let _lastRefresh = 0;
+let _refreshing = false;
+
+// ═══ INTERNAL ═══
+
+/**
+ * Does an extensions-dir listing contain a folder for the given extension id?
+ * Extension folders are named `publisher.name-<version>[-<platform>]`, so we
+ * match the id prefix followed by a `-` boundary (or an exact, version-less id).
+ * @param {string[]} entries - directory entry names
+ * @param {string} idPrefix - lowercase `publisher.name`
+ * @returns {boolean}
+ */
+function hasExtension(entries, idPrefix) {
+  return entries.some((e) => {
+    const lower = e.toLowerCase();
+    return lower === idPrefix || lower.startsWith(idPrefix + '-');
+  });
+}
+
+// ═══ PUBLIC API ═══
+
+/**
+ * Scan running editors and their extension directories for AI-agent extensions.
+ * Only editors that are actually running yield agents — an installed-but-idle
+ * extension is not an active agent. Each match becomes a synthetic agent with
+ * `pid: 0` (it has no real OS process; pid 0 also keeps it inert for the
+ * file-handle and TCP scanners, which guard `pid > 0`).
+ * @returns {Promise<Array<Object>>} Synthetic agent objects
+ * @since v0.11.0-alpha
+ */
+async function detectExtensionAgents() {
+  let procs;
+  try {
+    procs = await _listProcesses();
+  } catch (_) {
+    return [];
+  }
+  const running = new Set(procs.map((p) => p.name.toLowerCase()));
+  const home = _homedir();
+  const detected = [];
+  const seenAgents = new Set();
+
+  for (const editor of EDITOR_EXT_HOSTS) {
+    if (!editor.procNames.some((n) => running.has(n))) continue;
+    let entries;
+    try {
+      entries = await _readdir(path.join(home, editor.extDir));
+    } catch (_) {
+      continue; // extensions dir absent for this editor
+    }
+    if (!Array.isArray(entries) || entries.length === 0) continue;
+    for (const ext of AI_EXTENSIONS) {
+      if (seenAgents.has(ext.agent)) continue;
+      if (!hasExtension(entries, ext.idPrefix)) continue;
+      seenAgents.add(ext.agent);
+      detected.push({
+        agent: ext.agent,
+        process: editor.procNames[0],
+        pid: 0,
+        status: 'running',
+        category: 'ai',
+        parentEditor: editor.label,
+        displayLabel: `${ext.agent} (via ${editor.label})`,
+        detectionMethod: 'ide-extension',
+        extensionId: ext.idPrefix,
+      });
+    }
+  }
+  return detected;
+}
+
+/**
+ * Return the most recent detection synchronously, kicking off a throttled
+ * background refresh when the cache is stale. Never blocks the caller — the hot
+ * scan path reads cached results so a directory/process scan never delays the
+ * batched IPC. First call returns `[]` until the first refresh completes.
+ * @returns {Array<Object>} Cached synthetic agents
+ * @since v0.11.0-alpha
+ */
+function getCachedExtensionAgents() {
+  const now = Date.now();
+  if (!_refreshing && (_lastRefresh === 0 || now - _lastRefresh > REFRESH_TTL_MS)) {
+    _refreshing = true;
+    detectExtensionAgents()
+      .then((agents) => {
+        _cache = agents;
+      })
+      .catch(() => {})
+      .finally(() => {
+        _lastRefresh = Date.now();
+        _refreshing = false;
+      });
+  }
+  return _cache;
+}
+
+module.exports = {
+  detectExtensionAgents,
+  getCachedExtensionAgents,
+  EDITOR_EXT_HOSTS,
+  AI_EXTENSIONS,
+  _setDepsForTest,
+  _resetForTest,
+};

--- a/src/main/network-monitor.js
+++ b/src/main/network-monitor.js
@@ -63,6 +63,13 @@ const STATIC_DOMAINS = [
   /gstatic\.com$/i,
   /cursor\.sh$/i,
   /cursor\.com$/i,
+  // New AI-agent vendors (Kilo Code, opencode, grok/xAI). Short domains use a
+  // label boundary `(^|\.)` so e.g. `x.ai` does not match `netflix.ai`; the
+  // boundary form also covers subdomains like `api.x.ai`.
+  /(^|\.)kilo\.ai$/i,
+  /(^|\.)kilocode\.ai$/i,
+  /(^|\.)opencode\.ai$/i,
+  /(^|\.)x\.ai$/i,
   /tabnine\.com$/i,
   /sourcegraph\.com$/i,
   /cloudflare\.com$/i,

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -7,6 +7,8 @@
 'use strict';
 
 const sessionTracker = require('./session-tracker');
+const ideExtensionDetector = require('./ide-extension-detector');
+const wslDetector = require('./wsl-detector');
 
 let scanInterval = null;
 let fileScanInterval = null;
@@ -122,6 +124,24 @@ function doNetworkScan() {
     });
 }
 
+/**
+ * Append synthetic agents that have no Windows process and so are invisible to
+ * the process scanner: editor-extension agents (Kilo Code, Cline) and WSL-inner
+ * agents (grok, opencode). Reads each detector's throttled cache synchronously —
+ * the dir/WSL scans run in the background, never blocking this batch. Dedups by
+ * agent name so a real process (if any) already in the list wins.
+ * @param {Array} agents @returns {void} @since v0.11.0-alpha
+ */
+function injectDetectedExternalAgents(agents) {
+  const external = [
+    ...ideExtensionDetector.getCachedExtensionAgents(),
+    ...wslDetector.getCachedWslAgents(),
+  ];
+  for (const ext of external) {
+    if (!agents.some((a) => a.agent === ext.agent)) agents.push(ext);
+  }
+}
+
 async function doProcessScan() {
   const {
     scanner,
@@ -167,6 +187,9 @@ async function doProcessScan() {
     await procUtil.enrichWithParentChains(agents);
     procUtil.annotateHostApps(agents);
     await procUtil.annotateWorkingDirs(agents);
+    // Surface extension-only (Kilo/Cline) and WSL-inner (grok/opencode) agents
+    // before the batch so the renderer sees them; cache-backed, non-blocking.
+    injectDetectedExternalAgents(agents);
     tray.updateTrayIcon();
     const deviations = anomaly.checkDeviations();
     if (deviations.length > 0) {

--- a/src/main/wsl-detector.js
+++ b/src/main/wsl-detector.js
@@ -1,0 +1,205 @@
+/**
+ * @file wsl-detector.js
+ * @module main/wsl-detector
+ * @description Detects AI agents running INSIDE WSL (grok, opencode). These run
+ *   in a Linux PID namespace invisible to Windows `tasklist`, so the Windows
+ *   process scanner never sees them. Primary signal: enumerate WSL processes via
+ *   `wsl.exe -e ps` and match new signatures. When enumeration is unavailable
+ *   (no `ps`, distro error), the fallback is the passive config-path watch on
+ *   `~/.grok-build` / `~/.opencode` registered in AGENT_CONFIG_PATHS.
+ *
+ *   Detected WSL agents are surfaced with `pid: 0`: a WSL Linux PID is
+ *   namespace-local and would COLLIDE with an unrelated Windows PID, causing the
+ *   file-handle / TCP scanners to mis-attribute that Windows process's activity.
+ *   pid 0 keeps the synthetic agent inert for those scanners (they guard pid>0).
+ * @requires child_process
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ * @since v0.11.0-alpha
+ */
+'use strict';
+
+const { execFile } = require('child_process');
+
+/** @type {string} A single NUL byte (avoids a control char in a regex literal) */
+const NUL_CHAR = String.fromCharCode(0);
+
+let _execFile = execFile;
+let _getPlatform = () => process.platform;
+
+/**
+ * @internal Override dependencies (for tests).
+ * @param {{ execFile?: Function, platform?: string }} overrides
+ */
+function _setDepsForTest(overrides) {
+  if (overrides.execFile) _execFile = overrides.execFile;
+  if (overrides.platform) _getPlatform = () => overrides.platform;
+}
+
+/** @internal Reset to real dependencies and clear all caches (for tests). */
+function _resetForTest() {
+  _execFile = execFile;
+  _getPlatform = () => process.platform;
+  _wslAvailable = null;
+  _cache = [];
+  _lastRefresh = 0;
+  _refreshing = false;
+}
+
+// ═══ SIGNATURES ═══
+
+/**
+ * @typedef {Object} WslSignature
+ * @property {RegExp} pattern - tested against each `ps` command line
+ * @property {string} agent - display name to surface
+ */
+
+/**
+ * AI agents commonly run under WSL. Patterns require a path/word boundary so a
+ * substring inside an unrelated path does not false-match.
+ * @type {readonly WslSignature[]}
+ */
+const WSL_SIGNATURES = [
+  { pattern: /(?:^|\/|\s)opencode(?:\s|$)/i, agent: 'opencode' },
+  { pattern: /(?:^|\/|\s)grok(?:-cli)?(?:\s|$)/i, agent: 'grok' },
+];
+
+// ═══ CACHE ═══
+
+/** @type {number} How long an enumeration stays fresh (ms) — WSL spawn is heavy */
+const REFRESH_TTL_MS = 60000;
+
+/** @type {boolean|null} Cached WSL availability (null = not yet probed) */
+let _wslAvailable = null;
+/** @type {Array<Object>} Last detected synthetic agents */
+let _cache = [];
+let _lastRefresh = 0;
+let _refreshing = false;
+
+// ═══ INTERNAL ═══
+
+/**
+ * Run an executable, resolving `{ ok, stdout }`. Never rejects.
+ * @param {string} cmd
+ * @param {string[]} args
+ * @returns {Promise<{ ok: boolean, stdout: string }>}
+ */
+function run(cmd, args) {
+  return new Promise((resolve) => {
+    _execFile(cmd, args, { timeout: 5000, windowsHide: true }, (err, stdout) => {
+      if (err) {
+        resolve({ ok: false, stdout: '' });
+        return;
+      }
+      resolve({
+        ok: true,
+        stdout: typeof stdout === 'string' ? stdout : (stdout || '').toString(),
+      });
+    });
+  });
+}
+
+/**
+ * Parse `ps -eo pid=,args=` output into matched synthetic agents.
+ * @param {string} stdout
+ * @returns {Array<Object>}
+ */
+function parsePsOutput(stdout) {
+  const detected = [];
+  const seenAgents = new Set();
+  for (const line of stdout.split('\n')) {
+    const m = line.trim().match(/^(\d+)\s+(.+)$/);
+    if (!m) continue;
+    const wslPid = parseInt(m[1], 10);
+    const cmdline = m[2];
+    for (const sig of WSL_SIGNATURES) {
+      if (seenAgents.has(sig.agent)) continue;
+      if (!sig.pattern.test(cmdline)) continue;
+      seenAgents.add(sig.agent);
+      detected.push({
+        agent: sig.agent,
+        process: cmdline.split(/\s+/)[0],
+        pid: 0,
+        status: 'running',
+        category: 'ai',
+        parentEditor: 'WSL',
+        host: 'wsl',
+        wslPid,
+        detectionMethod: 'wsl-process',
+      });
+    }
+  }
+  return detected;
+}
+
+// ═══ PUBLIC API ═══
+
+/**
+ * Whether WSL is installed with at least one distro. Cached after first probe.
+ * `wsl.exe -l -q` emits UTF-16LE; decoded as UTF-8 it interleaves a null byte
+ * between characters, so we strip null bytes before the emptiness check (we only
+ * need existence, not exact distro names).
+ * @returns {Promise<boolean>}
+ * @since v0.11.0-alpha
+ */
+async function isWslAvailable() {
+  if (_wslAvailable !== null) return _wslAvailable;
+  if (_getPlatform() !== 'win32') {
+    _wslAvailable = false;
+    return false;
+  }
+  const { ok, stdout } = await run('wsl.exe', ['-l', '-q']);
+  _wslAvailable = ok && stdout.split(NUL_CHAR).join('').trim().length > 0;
+  return _wslAvailable;
+}
+
+/**
+ * Enumerate WSL processes and surface matching AI agents as synthetic agents.
+ * Windows-only; no-ops to `[]` on other platforms or when WSL is unavailable or
+ * `ps` cannot be run (the config-path watch is the documented fallback then).
+ * @returns {Promise<Array<Object>>} Synthetic agent objects
+ * @since v0.11.0-alpha
+ */
+async function detectWslAgents() {
+  if (_getPlatform() !== 'win32') return [];
+  if (!(await isWslAvailable())) return [];
+  const { ok, stdout } = await run('wsl.exe', ['-e', 'ps', '-eo', 'pid=,args=']);
+  if (!ok || !stdout.trim()) return [];
+  return parsePsOutput(stdout);
+}
+
+/**
+ * Return the most recent enumeration synchronously, kicking off a throttled
+ * background refresh when stale. Never blocks the hot scan path — spawning into
+ * the WSL VM never delays the batched IPC. First call returns `[]` until the
+ * first refresh completes.
+ * @returns {Array<Object>} Cached synthetic agents
+ * @since v0.11.0-alpha
+ */
+function getCachedWslAgents() {
+  const now = Date.now();
+  if (!_refreshing && (_lastRefresh === 0 || now - _lastRefresh > REFRESH_TTL_MS)) {
+    _refreshing = true;
+    detectWslAgents()
+      .then((agents) => {
+        _cache = agents;
+      })
+      .catch(() => {})
+      .finally(() => {
+        _lastRefresh = Date.now();
+        _refreshing = false;
+      });
+  }
+  return _cache;
+}
+
+module.exports = {
+  isWslAvailable,
+  detectWslAgents,
+  getCachedWslAgents,
+  parsePsOutput,
+  WSL_SIGNATURES,
+  _setDepsForTest,
+  _resetForTest,
+};

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -100,6 +100,12 @@ const AGENT_CONFIG_PATHS = [
   '.cache/lm-studio',
   '.cache/gpt4all',
   '.docker',
+  // WSL-inner agents (grok, opencode) — passive fallback signal when WSL process
+  // enumeration is unavailable. NOTE: resolved against the WINDOWS home dir, so
+  // this watches a NATIVE install (e.g. C:\Users\you\.opencode), NOT the
+  // WSL-inner ~/.opencode. The primary signal is wsl-detector.js enumeration.
+  '.grok-build',
+  '.opencode',
 ];
 
 /**

--- a/tests/main/ide-extension-detector.test.js
+++ b/tests/main/ide-extension-detector.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import detector from '../../src/main/ide-extension-detector.js';
+
+const HOME = '/home/dev';
+
+/** Build a readdir mock from a map of editor-dir-fragment -> entries. */
+function makeReaddir(map) {
+  return async (dir) => {
+    // Order matters: '.vscode-insiders' also contains '.vscode'.
+    if (dir.includes('.vscode-insiders')) return map.insiders || throwEnoent();
+    if (dir.includes('.vscode')) return map.vscode || throwEnoent();
+    if (dir.includes('.cursor')) return map.cursor || throwEnoent();
+    if (dir.includes('.windsurf')) return map.windsurf || throwEnoent();
+    return throwEnoent();
+  };
+}
+function throwEnoent() {
+  const e = new Error('ENOENT');
+  // @ts-ignore
+  e.code = 'ENOENT';
+  throw e;
+}
+
+/** Mock listProcesses returning the given lowercase-able names. */
+function procs(names) {
+  return async () => names.map((name, i) => ({ name, pid: 1000 + i }));
+}
+
+afterEach(() => {
+  detector._resetForTest();
+});
+
+describe('ide-extension-detector', () => {
+  describe('detectExtensionAgents()', () => {
+    it('detects Kilo Code when VS Code runs and the extension is installed', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Code.exe']),
+        readdir: makeReaddir({ vscode: ['kilocode.kilo-code-4.0.0', 'ms-python.python-2024.1'] }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        agent: 'Kilo Code',
+        pid: 0,
+        category: 'ai',
+        parentEditor: 'VS Code',
+        displayLabel: 'Kilo Code (via VS Code)',
+        detectionMethod: 'ide-extension',
+      });
+    });
+
+    it('detects Cline via saoudrizwan.claude-dev', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['code']),
+        readdir: makeReaddir({ vscode: ['saoudrizwan.claude-dev-3.1.0'] }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toHaveLength(1);
+      expect(result[0].agent).toBe('Cline');
+    });
+
+    it('returns nothing when the editor is NOT running (idle extension is not an active agent)', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['chrome.exe', 'explorer.exe']),
+        readdir: makeReaddir({ vscode: ['kilocode.kilo-code-4.0.0'] }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toEqual([]);
+    });
+
+    it('returns nothing when the editor runs but the extension is not installed', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Code.exe']),
+        readdir: makeReaddir({
+          vscode: ['ms-python.python-2024.1', 'esbenp.prettier-vscode-10.1.0'],
+        }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toEqual([]);
+    });
+
+    it('detects Cursor host with its own extensions dir', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Cursor.exe']),
+        readdir: makeReaddir({ cursor: ['kilocode.kilo-code-4.0.0'] }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toHaveLength(1);
+      expect(result[0].parentEditor).toBe('Cursor');
+    });
+
+    it('detects Windsurf host', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Windsurf.exe']),
+        readdir: makeReaddir({ windsurf: ['saoudrizwan.claude-dev-3.1.0'] }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result[0].parentEditor).toBe('Windsurf');
+    });
+
+    it('does not false-match a similarly named extension (boundary check)', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Code.exe']),
+        // "kilocode.kilo-coder" must NOT match "kilocode.kilo-code"
+        readdir: makeReaddir({ vscode: ['kilocode.kilo-coder-1.0.0'] }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toEqual([]);
+    });
+
+    it('matches an exact, version-less extension folder', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Code.exe']),
+        readdir: makeReaddir({ vscode: ['kilocode.kilo-code'] }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toHaveLength(1);
+    });
+
+    it('dedups the same agent across multiple running editors', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Code.exe', 'Cursor.exe']),
+        readdir: makeReaddir({
+          vscode: ['kilocode.kilo-code-4.0.0'],
+          cursor: ['kilocode.kilo-code-4.0.0'],
+        }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result.filter((a) => a.agent === 'Kilo Code')).toHaveLength(1);
+    });
+
+    it('returns [] when listProcesses throws', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: async () => {
+          throw new Error('EPERM');
+        },
+        readdir: makeReaddir({ vscode: ['kilocode.kilo-code-4.0.0'] }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toEqual([]);
+    });
+
+    it('skips an editor whose extensions dir is absent (readdir throws)', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Code.exe']),
+        readdir: async () => throwEnoent(),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result).toEqual([]);
+    });
+
+    it('detects both Kilo and Cline when both are installed', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Code.exe']),
+        readdir: makeReaddir({
+          vscode: ['kilocode.kilo-code-4.0.0', 'saoudrizwan.claude-dev-3.1.0'],
+        }),
+      });
+      const result = await detector.detectExtensionAgents();
+      expect(result.map((a) => a.agent).sort()).toEqual(['Cline', 'Kilo Code']);
+    });
+  });
+
+  describe('getCachedExtensionAgents()', () => {
+    it('returns [] immediately, then caches after the background refresh', async () => {
+      detector._setDepsForTest({
+        homedir: () => HOME,
+        listProcesses: procs(['Code.exe']),
+        readdir: makeReaddir({ vscode: ['kilocode.kilo-code-4.0.0'] }),
+      });
+      // Cold cache: synchronous read returns empty while refresh runs in bg.
+      expect(detector.getCachedExtensionAgents()).toEqual([]);
+      await new Promise((r) => setTimeout(r, 20));
+      const cached = detector.getCachedExtensionAgents();
+      expect(cached).toHaveLength(1);
+      expect(cached[0].agent).toBe('Kilo Code');
+    });
+  });
+});

--- a/tests/main/network-monitor.test.js
+++ b/tests/main/network-monitor.test.js
@@ -43,6 +43,20 @@ describe('network-monitor', () => {
       expect(networkMonitor.isKnownDomain('registry.npmjs.org')).toBe(true);
       expect(networkMonitor.isKnownDomain('nodejs.org')).toBe(true);
     });
+
+    it('recognizes new AI-agent vendor domains (Kilo, opencode, grok/xAI)', () => {
+      expect(networkMonitor.isKnownDomain('kilo.ai')).toBe(true);
+      expect(networkMonitor.isKnownDomain('kilocode.ai')).toBe(true);
+      expect(networkMonitor.isKnownDomain('api.kilocode.ai')).toBe(true);
+      expect(networkMonitor.isKnownDomain('opencode.ai')).toBe(true);
+      expect(networkMonitor.isKnownDomain('x.ai')).toBe(true);
+      expect(networkMonitor.isKnownDomain('api.x.ai')).toBe(true);
+    });
+
+    it('does not let the short x.ai pattern match unrelated .ai domains', () => {
+      expect(networkMonitor.isKnownDomain('netflix.ai')).toBe(false);
+      expect(networkMonitor.isKnownDomain('phoenix.ai')).toBe(false);
+    });
   });
 
   describe('isPrivateIp()', () => {

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -186,6 +186,77 @@ describe('scan-loop', () => {
     });
   });
 
+  // ── external-agent injection (IDE-extension + WSL) ──
+
+  describe('external-agent injection into scan-batch', () => {
+    it('injects cached detector agents into the scan-batch payload before sending', async () => {
+      const ide = require_('../../src/main/ide-extension-detector.js');
+      const wsl = require_('../../src/main/wsl-detector.js');
+      const origIde = ide.getCachedExtensionAgents;
+      const origWsl = wsl.getCachedWslAgents;
+      const synthetic = {
+        agent: 'Kilo Code',
+        process: 'code.exe',
+        pid: 0,
+        status: 'running',
+        category: 'ai',
+        parentEditor: 'VS Code',
+        detectionMethod: 'ide-extension',
+      };
+      ide.getCachedExtensionAgents = () => [synthetic];
+      wsl.getCachedWslAgents = () => [];
+      try {
+        const sendToRenderer = vi.fn();
+        const mockDeps = {
+          scanner: { scanProcesses: vi.fn().mockResolvedValue({ agents: [], changed: false }) },
+          procUtil: {
+            enrichWithParentChains: vi.fn().mockResolvedValue(),
+            annotateHostApps: vi.fn(),
+            annotateWorkingDirs: vi.fn().mockResolvedValue(),
+          },
+          watcher: {
+            pruneKnownHandles: vi.fn(),
+            scanAllFileHandles: vi.fn().mockResolvedValue([]),
+          },
+          network: {
+            isNetworkScanRunning: vi.fn().mockReturnValue(false),
+            setNetworkScanRunning: vi.fn(),
+            scanNetworkConnections: vi.fn().mockResolvedValue([]),
+          },
+          baselines: { recordNetworkEndpoint: vi.fn() },
+          anomaly: {
+            checkDeviations: vi.fn().mockReturnValue([]),
+            calculateAnomalyScore: vi.fn().mockReturnValue({ score: 0 }),
+          },
+          audit: { log: vi.fn() },
+          tray: { updateTrayIcon: vi.fn(), notifySensitive: vi.fn() },
+          logger: { error: vi.fn(), warn: vi.fn() },
+          sendToRenderer,
+          fileAccessBatcher: { push: vi.fn() },
+          statsUpdateBatcher: { push: vi.fn() },
+          getStats: vi.fn().mockReturnValue({}),
+          getResourceUsage: vi.fn().mockReturnValue({}),
+          getLatestAgents: vi.fn().mockReturnValue([]),
+          setAgents: vi.fn(),
+          setLatestNetConnections: vi.fn(),
+          getPreviousPids: vi.fn().mockReturnValue(new Map()),
+          setPreviousPids: vi.fn(),
+        };
+        scanLoop.init(mockDeps);
+        scanLoop.startScanIntervals(5000);
+        await vi.advanceTimersByTimeAsync(5000);
+
+        const batchCall = sendToRenderer.mock.calls.find((c) => c[0] === 'scan-batch');
+        expect(batchCall).toBeTruthy();
+        const names = batchCall[1].agents.map((a) => a.agent);
+        expect(names).toContain('Kilo Code');
+      } finally {
+        ide.getCachedExtensionAgents = origIde;
+        wsl.getCachedWslAgents = origWsl;
+      }
+    });
+  });
+
   // ── getLatestLocalModels ──
 
   describe('getLatestLocalModels', () => {

--- a/tests/main/wsl-detector.test.js
+++ b/tests/main/wsl-detector.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import detector from '../../src/main/wsl-detector.js';
+
+/**
+ * Build an execFile mock keyed by joined args.
+ * @param {Record<string, {stdout?: string, err?: string}>} responses
+ */
+function mockExec(responses) {
+  return (cmd, args, _opts, cb) => {
+    const key = args.join(' ');
+    const r = responses[key];
+    if (!r || r.err) {
+      cb(new Error(r ? r.err : 'unexpected: ' + key), '');
+      return;
+    }
+    cb(null, r.stdout || '');
+  };
+}
+
+const PS_KEY = '-e ps -eo pid=,args=';
+const LIST_KEY = '-l -q';
+
+afterEach(() => {
+  detector._resetForTest();
+});
+
+describe('wsl-detector', () => {
+  describe('parsePsOutput() (pure)', () => {
+    it('detects opencode and grok with correct fields', () => {
+      const out = ['  123 /usr/bin/opencode serve', '  456 /usr/bin/bash', '  789 grok chat'].join(
+        '\n',
+      );
+      const result = detector.parsePsOutput(out);
+      expect(result).toHaveLength(2);
+      const oc = result.find((a) => a.agent === 'opencode');
+      expect(oc).toMatchObject({
+        agent: 'opencode',
+        pid: 0,
+        category: 'ai',
+        parentEditor: 'WSL',
+        host: 'wsl',
+        wslPid: 123,
+        detectionMethod: 'wsl-process',
+      });
+      const gr = result.find((a) => a.agent === 'grok');
+      expect(gr.wslPid).toBe(789);
+    });
+
+    it('matches opencode invoked via node by path', () => {
+      const result = detector.parsePsOutput('  10 node /home/u/.local/bin/opencode');
+      expect(result).toHaveLength(1);
+      expect(result[0].agent).toBe('opencode');
+    });
+
+    it('matches grok-cli', () => {
+      const result = detector.parsePsOutput('  11 grok-cli --model grok-2');
+      expect(result.map((a) => a.agent)).toContain('grok');
+    });
+
+    it('does not false-match notopencode or grokuser (boundary)', () => {
+      const out = ['  1 /usr/bin/notopencode', '  2 /home/grokuser/app'].join('\n');
+      expect(detector.parsePsOutput(out)).toEqual([]);
+    });
+
+    it('dedups repeated agents to a single entry', () => {
+      const out = ['  1 /usr/bin/opencode', '  2 /opt/opencode/bin/opencode'].join('\n');
+      const result = detector.parsePsOutput(out);
+      expect(result.filter((a) => a.agent === 'opencode')).toHaveLength(1);
+    });
+
+    it('ignores malformed lines', () => {
+      expect(detector.parsePsOutput('garbage\n\n   \nPID ARGS')).toEqual([]);
+    });
+  });
+
+  describe('isWslAvailable()', () => {
+    it('returns false on non-win32 platforms', async () => {
+      detector._setDepsForTest({ platform: 'linux', execFile: mockExec({}) });
+      expect(await detector.isWslAvailable()).toBe(false);
+    });
+
+    it('returns true on win32 when a distro is listed', async () => {
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({ [LIST_KEY]: { stdout: 'Ubuntu\n' } }),
+      });
+      expect(await detector.isWslAvailable()).toBe(true);
+    });
+
+    it('strips UTF-16LE null bytes before the emptiness check', async () => {
+      // Real NUL bytes interleaved, as `wsl -l -q` UTF-16LE decodes under UTF-8.
+      const NUL = String.fromCharCode(0);
+      const utf16ish = NUL + 'U' + NUL + 'b' + NUL + 'u' + NUL + 'n' + NUL + 't' + NUL + 'u' + NUL;
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({ [LIST_KEY]: { stdout: utf16ish } }),
+      });
+      expect(await detector.isWslAvailable()).toBe(true);
+    });
+
+    it('treats an all-null distro list as unavailable', async () => {
+      const NUL = String.fromCharCode(0);
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({ [LIST_KEY]: { stdout: NUL + NUL + '\n' } }),
+      });
+      expect(await detector.isWslAvailable()).toBe(false);
+    });
+
+    it('returns false when wsl.exe errors (not installed)', async () => {
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({ [LIST_KEY]: { err: 'ENOENT' } }),
+      });
+      expect(await detector.isWslAvailable()).toBe(false);
+    });
+
+    it('returns false when the distro list is empty/whitespace', async () => {
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({ [LIST_KEY]: { stdout: ' \n' } }),
+      });
+      expect(await detector.isWslAvailable()).toBe(false);
+    });
+  });
+
+  describe('detectWslAgents()', () => {
+    it('returns [] on non-win32', async () => {
+      detector._setDepsForTest({ platform: 'linux', execFile: mockExec({}) });
+      expect(await detector.detectWslAgents()).toEqual([]);
+    });
+
+    it('returns [] on win32 when WSL is unavailable', async () => {
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({ [LIST_KEY]: { err: 'ENOENT' } }),
+      });
+      expect(await detector.detectWslAgents()).toEqual([]);
+    });
+
+    it('enumerates and surfaces opencode/grok when available', async () => {
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({
+          [LIST_KEY]: { stdout: 'Ubuntu\n' },
+          [PS_KEY]: { stdout: '  42 /usr/bin/opencode serve\n  99 grok chat' },
+        }),
+      });
+      const result = await detector.detectWslAgents();
+      expect(result.map((a) => a.agent).sort()).toEqual(['grok', 'opencode']);
+      expect(result.every((a) => a.pid === 0)).toBe(true);
+    });
+
+    it('returns [] when ps yields no matching processes', async () => {
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({
+          [LIST_KEY]: { stdout: 'Ubuntu\n' },
+          [PS_KEY]: { stdout: '  1 /sbin/init\n  2 /usr/bin/bash' },
+        }),
+      });
+      expect(await detector.detectWslAgents()).toEqual([]);
+    });
+
+    it('returns [] when ps itself errors (enumeration unavailable → fallback)', async () => {
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({
+          [LIST_KEY]: { stdout: 'Ubuntu\n' },
+          [PS_KEY]: { err: 'ps: not found' },
+        }),
+      });
+      expect(await detector.detectWslAgents()).toEqual([]);
+    });
+  });
+
+  describe('getCachedWslAgents()', () => {
+    it('returns [] immediately, then caches after the background refresh', async () => {
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec({
+          [LIST_KEY]: { stdout: 'Ubuntu\n' },
+          [PS_KEY]: { stdout: '  42 /usr/bin/opencode' },
+        }),
+      });
+      expect(detector.getCachedWslAgents()).toEqual([]);
+      await new Promise((r) => setTimeout(r, 20));
+      const cached = detector.getCachedWslAgents();
+      expect(cached).toHaveLength(1);
+      expect(cached[0].agent).toBe('opencode');
+    });
+  });
+});


### PR DESCRIPTION
Adds wsl-detector + ide-extension-detector to surface process-invisible agents (WSL-inner: grok/opencode; editor extensions: Kilo Code/Cline) that have no Windows process and are missed by the process scanner.

Rebased on master post-#135 (polling-gap). Conflict in scan-loop.js resolved as a clean union: sessionTracker.reconcile (session stage) + injectDetectedExternalAgents (inject stage) coexist; dead PID deps removed.

- typecheck: 0 errors
- lint: 0 errors
- test: 756 passed / 4 skipped (incl. scan-loop 11, wsl-detector 18, ide-extension-detector 13, network-monitor 33)
