### PR TITLE
feat(protection): config-dir monitoring for kilo/opencode/grok

### DIFF
--- a/rules/ai-config.yaml
+++ b/rules/ai-config.yaml
@@ -282,3 +282,27 @@ rules:
     category: "ai-config"
     risk: critical
     enabled: true
+
+  - id: "AI036"
+    name: "Kilo Code config"
+    pattern: "[\\\\\/]\\.config[\\\\\/]kilo[\\\\\/]"
+    reason: "AI agent config — Kilo Code"
+    category: "ai-config"
+    risk: critical
+    enabled: true
+
+  - id: "AI037"
+    name: "opencode config"
+    pattern: "[\\\\\/]\\.opencode[\\\\\/]"
+    reason: "AI agent config — opencode"
+    category: "ai-config"
+    risk: critical
+    enabled: true
+
+  - id: "AI038"
+    name: "Grok config"
+    pattern: "[\\\\\/]\\.grok-build[\\\\\/]"
+    reason: "AI agent config — Grok"
+    category: "ai-config"
+    risk: critical
+    enabled: true

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -94,6 +94,11 @@ const AGENT_CONFIG_PATHS = [
   '.semgrep',
   '.config/zed',
   '.config/configstore',
+  // Kilo Code — VS Code extension (ide-extension-detector.js). Global config dir
+  // ~/.config/kilo/kilo.jsonc. NOTE: the API key is NOT here — Kilo stores it in
+  // the OS keychain (VS Code SecretStorage), outside file-watching reach; the
+  // JSON only holds a "<removed>" placeholder. This watches the config, not the key.
+  '.config/kilo',
   // Container / VM / Local LLM config paths
   '.ollama',
   '.jan',
@@ -132,6 +137,12 @@ const AGENT_SELF_CONFIG = {
   goose: /[\\\/]\.config[\\\/]goose[\\\/]/i,
   zed: /[\\\/]\.config[\\\/]zed[\\\/]/i,
   jetbrains: /[\\\/]\.config[\\\/]JetBrains[\\\/]/i,
+  // WSL-inner & extension agents (Gate ③). Keys match the names the detectors
+  // emit — wsl-detector.js → 'opencode'/'grok', ide-extension-detector.js →
+  // 'Kilo Code' — so isSelfAccess (agentName.includes(keyword)) resolves them.
+  kilo: /[\\\/]\.config[\\\/]kilo[\\\/]/i,
+  opencode: /[\\\/]\.opencode[\\\/]/i,
+  grok: /[\\\/]\.grok-build[\\\/]/i,
   // Container / VM / Local LLM self-config
   docker: /[\\\/]\.docker[\\\/]/i,
   ollama: /[\\\/]\.ollama[\\\/]/i,

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -50,6 +50,18 @@ describe('file-watcher', () => {
       expect(fileWatcher.classifySensitive('/home/user/Documents/readme.txt')).toBeNull();
     });
 
+    it('Gate ③ config dirs (.config/kilo/, .opencode/, .grok-build/)', () => {
+      expect(fileWatcher.classifySensitive('/home/user/.config/kilo/kilo.jsonc')).toBe(
+        'AI agent config — Kilo Code',
+      );
+      expect(fileWatcher.classifySensitive('/home/user/.opencode/auth.json')).toBe(
+        'AI agent config — opencode',
+      );
+      expect(fileWatcher.classifySensitive('/home/user/.grok-build/settings.json')).toBe(
+        'AI agent config — Grok',
+      );
+    });
+
     it('includes custom rules when state is initialized', () => {
       fileWatcher.init(
         makeState({
@@ -123,6 +135,23 @@ describe('file-watcher', () => {
 
     it('non-matching agent returns false', () => {
       expect(fileWatcher.isSelfAccess('SomeAgent', '/home/user/.ssh/id_rsa')).toBe(false);
+    });
+
+    it('Gate ③ agents self-accessing own config is true (suppresses FP)', () => {
+      // Names exactly as the detectors emit them (wsl/ide-extension detectors).
+      expect(fileWatcher.isSelfAccess('Kilo Code', '/home/user/.config/kilo/kilo.jsonc')).toBe(
+        true,
+      );
+      expect(fileWatcher.isSelfAccess('opencode', '/home/user/.opencode/auth.json')).toBe(true);
+      expect(fileWatcher.isSelfAccess('grok', '/home/user/.grok-build/settings.json')).toBe(true);
+    });
+
+    it('Gate ③ cross-agent access stays flagged (not self-access)', () => {
+      // opencode reading Kilo's config is NOT self-access — must remain a threat.
+      expect(fileWatcher.isSelfAccess('opencode', '/home/user/.config/kilo/kilo.jsonc')).toBe(
+        false,
+      );
+      expect(fileWatcher.isSelfAccess('grok', '/home/user/.opencode/auth.json')).toBe(false);
     });
   });
 });

--- a/tests/main/rule-loader.test.js
+++ b/tests/main/rule-loader.test.js
@@ -195,9 +195,9 @@ describe('rule-loader', () => {
       expect(rules.size).toBeGreaterThanOrEqual(50);
     });
 
-    it('loads exactly 70 rules (68 migrated + 2 OpenClaw additions)', () => {
+    it('loads exactly 73 rules (68 migrated + 2 OpenClaw + 3 kilo/opencode/grok)', () => {
       const rules = ruleLoader.reloadRules(PROD_RULES_DIR);
-      expect(rules.size).toBe(70);
+      expect(rules.size).toBe(73);
     });
 
     it('getRulesByCategory("secrets") returns only SC-prefixed IDs', () => {
@@ -240,6 +240,23 @@ describe('rule-loader', () => {
       expect(rule.pattern.test('/home/user/.claude/config.json')).toBe(true);
       expect(rule.pattern.test('C:\\Users\\me\\.claude\\settings')).toBe(true);
       expect(rule.reason).toBe('AI agent config — Claude Code');
+    });
+
+    it('Gate ③ rules classify kilo / opencode / grok config dirs', () => {
+      ruleLoader.reloadRules(PROD_RULES_DIR);
+      const kilo = ruleLoader.getRuleById('AI036', PROD_RULES_DIR);
+      expect(kilo).toBeDefined();
+      expect(kilo.pattern.test('/home/user/.config/kilo/kilo.jsonc')).toBe(true);
+      expect(kilo.pattern.test('C:\\Users\\me\\.config\\kilo\\kilo.jsonc')).toBe(true);
+      expect(kilo.reason).toBe('AI agent config — Kilo Code');
+
+      const opencode = ruleLoader.getRuleById('AI037', PROD_RULES_DIR);
+      expect(opencode).toBeDefined();
+      expect(opencode.pattern.test('/home/user/.opencode/auth.json')).toBe(true);
+
+      const grok = ruleLoader.getRuleById('AI038', PROD_RULES_DIR);
+      expect(grok).toBeDefined();
+      expect(grok.pattern.test('/home/user/.grok-build/settings.json')).toBe(true);
     });
   });
 });

--- a/tests/shared/constants.test.js
+++ b/tests/shared/constants.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   SENSITIVE_RULES,
   AGENT_SELF_CONFIG,
+  AGENT_CONFIG_PATHS,
   PERMISSION_CATEGORIES,
   EDITORS,
   IGNORE_PROCESS_PATTERNS,
@@ -43,6 +44,26 @@ describe('constants', () => {
       expect(AGENT_SELF_CONFIG.claude.test('/home/.cursor/settings')).toBe(false);
       expect(AGENT_SELF_CONFIG.cursor.test('/home/.claude/config')).toBe(false);
       expect(AGENT_SELF_CONFIG.copilot.test('/home/.claude/config')).toBe(false);
+    });
+
+    it('Gate ③ agents match their own config dirs', () => {
+      expect(AGENT_SELF_CONFIG.kilo.test('/home/.config/kilo/kilo.jsonc')).toBe(true);
+      expect(AGENT_SELF_CONFIG.opencode.test('/home/.opencode/auth.json')).toBe(true);
+      expect(AGENT_SELF_CONFIG.grok.test('/home/.grok-build/settings.json')).toBe(true);
+    });
+
+    it('Gate ③ agents do not cross-match each other', () => {
+      expect(AGENT_SELF_CONFIG.kilo.test('/home/.opencode/auth.json')).toBe(false);
+      expect(AGENT_SELF_CONFIG.opencode.test('/home/.grok-build/settings.json')).toBe(false);
+      expect(AGENT_SELF_CONFIG.grok.test('/home/.config/kilo/kilo.jsonc')).toBe(false);
+    });
+  });
+
+  describe('AGENT_CONFIG_PATHS', () => {
+    it('includes the watched config dirs for kilo / opencode / grok', () => {
+      expect(AGENT_CONFIG_PATHS).toContain('.config/kilo');
+      expect(AGENT_CONFIG_PATHS).toContain('.opencode');
+      expect(AGENT_CONFIG_PATHS).toContain('.grok-build');
     });
   });
 


### PR DESCRIPTION
Watches + classifies `.config/kilo`, `.opencode`, `.grok-build` as AI-config (critical) via rule-loader, with self-access exemptions so an agent reading its OWN config is not a false positive (opencode/grok were dead-watch before — watched but unclassified; symmetry closed).

Scope-corrected vs the original plan (recon-driven, advisor-verified):
- No DB rows — these three are detected as synthetic pid:0 agents (wsl-detector / ide-extension-detector) that bypass the agent-database name-match; a row would be cosmetic. Agent count stays 107.
- auth.json does not exist — target is the config dir (kilo.jsonc). The API key lives in the OS keychain (VS Code SecretStorage), outside file-watching reach; the rule is honest config-dir monitoring, not "auth-token protection".

Changes: constants.js AGENT_CONFIG_PATHS += .config/kilo; AGENT_SELF_CONFIG += kilo/opencode/grok; rules/ai-config.yaml += AI036/AI037/AI038 (dir-level, risk critical).

Verify: typecheck 0, lint 0, 763 tests pass / 4 skip (47 files), build:renderer clean.

Note: rule count moved 70 to 73 — in-repo assertion updated; README still cites "70" (separate doc-sync follow-up).
