### PR TITLE
feat: add kilo/opencode/grok agents + doc-count sync

### DIFF
--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -25,7 +25,7 @@ Electron 33, Svelte 5, Vite 7, TypeScript (incremental, allowJs:true, checkJs:tr
 - Main process (Node.js): src/main/ — 23 CJS modules (scanners, watchers, IPC, scoring, logging)
 - Renderer (Svelte 5): src/renderer/ — 43 components + 9 stores + 15 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 43 invoke + 6 push channels
-- Data: src/shared/agent-database.json (107 agent signatures)
+- Data: src/shared/agent-database.json (110 agent signatures)
 - Config: src/shared/constants.js (68 rules across 8 categories)
 - Rules: src/main/rule-loader.js — loadRules() + categoryIndex Map for O(1) lookup by category
 - Types: src/shared/types/ — 8 .ts files

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - **Process Monitoring** — Tracks 107 known AI agent signatures with parent-child tree resolution and IDE host detection.
 - **File System Access** — Watches sensitive directories (`.ssh`, `.aws`, `.gnupg`, `.env`, cloud configs) and 27 AI agent config paths for unauthorized access.
 - **Network Activity** — Logs outbound TCP connections per agent PID with reverse DNS and known-vs-unknown API endpoint classification.
-- **Behavioral Analysis** — Applies 70 detection rules across 8 categories with rolling 10-session baselines and 4-axis anomaly scoring.
+- **Behavioral Analysis** — Applies 73 detection rules across 8 categories with rolling 10-session baselines and 4-axis anomaly scoring.
 - **Trust Scoring** — Assigns real-time risk scores with trust grades (A+ through F) using time-decay algorithms and multi-dimensional threat assessment.
 - **Multi-Agent Dashboard** — Displays all 107 agents in a bento-grid dashboard with sparklines, risk rings, activity feeds, and expandable agent cards.
 
@@ -46,7 +46,7 @@
 | **512** | vulnerabilities found in OpenClaw by Kaspersky — autonomous agents ship with real security risks |
 | **0** | open-source EDR tools existed for AI agents before Aegis |
 | **107** | AI agent signatures in the detection database, from Claude Code to AutoGPT |
-| **70** | behavioral detection rules across 8 categories, with hot-reload and custom overrides |
+| **73** | behavioral detection rules across 8 categories, with hot-reload and custom overrides |
 | **707** | tests passing, 0 failures — the monitoring engine is verified on every commit |
 | **<2s** | cold boot to full dashboard — lightweight enough to run alongside the agents it monitors |
 
@@ -146,7 +146,7 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
 
 ## YAML Rulesets
 
-- 70 detection rules across 8 categories (AI config, secrets, SSH, cloud, browser, devtools, crypto, certificates)
+- 73 detection rules across 8 categories (AI config, secrets, SSH, cloud, browser, devtools, crypto, certificates)
 - JSON Schema validated, hot-reload without restart
 - Extend or override via `rules/custom/` directory
 
@@ -248,7 +248,7 @@ Autonomous AI agents like OpenClaw, AutoGPT, and Devin have deep access to local
 
 ### How is Aegis different from traditional EDR?
 
-Traditional EDR tools (CrowdStrike, Sentinel One) monitor human-driven threats — malware, ransomware, phishing. Aegis is built specifically for AI agent behavior: it ships with 107 agent profiles, 70 detection rules tuned for agent-specific patterns, and behavioral baselines that track how each agent's activity changes over time.
+Traditional EDR tools (CrowdStrike, Sentinel One) monitor human-driven threats — malware, ransomware, phishing. Aegis is built specifically for AI agent behavior: it ships with 107 agent profiles, 73 detection rules tuned for agent-specific patterns, and behavioral baselines that track how each agent's activity changes over time.
 
 ### Does Aegis work with MCP tools?
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@
 
 ## What Does Aegis Monitor?
 
-- **Process Monitoring** — Tracks 107 known AI agent signatures with parent-child tree resolution and IDE host detection.
+- **Process Monitoring** — Tracks 110 known AI agent signatures with parent-child tree resolution and IDE host detection.
 - **File System Access** — Watches sensitive directories (`.ssh`, `.aws`, `.gnupg`, `.env`, cloud configs) and 27 AI agent config paths for unauthorized access.
 - **Network Activity** — Logs outbound TCP connections per agent PID with reverse DNS and known-vs-unknown API endpoint classification.
 - **Behavioral Analysis** — Applies 73 detection rules across 8 categories with rolling 10-session baselines and 4-axis anomaly scoring.
 - **Trust Scoring** — Assigns real-time risk scores with trust grades (A+ through F) using time-decay algorithms and multi-dimensional threat assessment.
-- **Multi-Agent Dashboard** — Displays all 107 agents in a bento-grid dashboard with sparklines, risk rings, activity feeds, and expandable agent cards.
+- **Multi-Agent Dashboard** — Displays all 110 agents in a bento-grid dashboard with sparklines, risk rings, activity feeds, and expandable agent cards.
 
 ## Why Aegis?
 
@@ -45,7 +45,7 @@
 |---|---|
 | **512** | vulnerabilities found in OpenClaw by Kaspersky — autonomous agents ship with real security risks |
 | **0** | open-source EDR tools existed for AI agents before Aegis |
-| **107** | AI agent signatures in the detection database, from Claude Code to AutoGPT |
+| **110** | AI agent signatures in the detection database, from Claude Code to AutoGPT |
 | **73** | behavioral detection rules across 8 categories, with hot-reload and custom overrides |
 | **707** | tests passing, 0 failures — the monitoring engine is verified on every commit |
 | **<2s** | cold boot to full dashboard — lightweight enough to run alongside the agents it monitors |
@@ -66,7 +66,7 @@ AEGIS sits at a different layer. It is an **independent, OS-level observer**: it
 
 | Layer | How |
 |-------|-----|
-| **Processes** | 107 known AI agent signatures, parent-child tree resolution, IDE host detection |
+| **Processes** | 110 known AI agent signatures, parent-child tree resolution, IDE host detection |
 | **Files** | Watches `.ssh`, `.aws`, `.gnupg`, `.env*`, cloud configs, 27 AI agent config dirs |
 | **Network** | Outbound TCP per agent PID, reverse DNS, known API endpoints vs unknown |
 | **Behavior** | Rolling 10-session baselines, 4-axis anomaly scoring (Network/FS/Process/Baseline) |
@@ -132,7 +132,7 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
 
 ## Features
 
-**Detection** — 107 agent signatures, parent chain resolution, config dir protection, per-agent risk scoring with trust grades (A+ through F), HTTP/User-Agent scoring, local LLM detection, false positive marking
+**Detection** — 110 agent signatures, parent chain resolution, config dir protection, per-agent risk scoring with trust grades (A+ through F), HTTP/User-Agent scoring, local LLM detection, false positive marking
 
 **Analysis** — Behavioral baselines with rolling averages, multi-dimensional anomaly detection, AI threat assessment via Anthropic API (opt-in), printable HTML threat reports
 
@@ -209,7 +209,7 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
 
 ## Agent Database
 
-107 agents in [`src/shared/agent-database.json`](src/shared/agent-database.json):
+110 agents in [`src/shared/agent-database.json`](src/shared/agent-database.json):
 
 **Coding** — Claude Code, GitHub Copilot, Cursor, Windsurf, Tabnine, Amazon Q, Cody, Aider
 **Autonomous** — OpenClaw, Devin, Manus AI, OpenHands, SWE-Agent, AutoGPT, BabyAGI, CrewAI
@@ -248,7 +248,7 @@ Autonomous AI agents like OpenClaw, AutoGPT, and Devin have deep access to local
 
 ### How is Aegis different from traditional EDR?
 
-Traditional EDR tools (CrowdStrike, Sentinel One) monitor human-driven threats — malware, ransomware, phishing. Aegis is built specifically for AI agent behavior: it ships with 107 agent profiles, 73 detection rules tuned for agent-specific patterns, and behavioral baselines that track how each agent's activity changes over time.
+Traditional EDR tools (CrowdStrike, Sentinel One) monitor human-driven threats — malware, ransomware, phishing. Aegis is built specifically for AI agent behavior: it ships with 110 agent profiles, 73 detection rules tuned for agent-specific patterns, and behavioral baselines that track how each agent's activity changes over time.
 
 ### Does Aegis work with MCP tools?
 
@@ -260,7 +260,7 @@ No. Aegis is an observability layer, not a restriction layer. Sandboxes limit wh
 
 ### What agents does Aegis support?
 
-Aegis ships with 107 agent signatures across five categories: coding assistants (Claude Code, Copilot, Cursor), autonomous agents (OpenClaw, AutoGPT, CrewAI, Devin), desktop AI (Gemini, Apple Intelligence), frameworks (LangChain, AutoGen, MetaGPT), and local LLMs (Ollama, LM Studio, llama.cpp). You can add custom agents via the UI or JSON config.
+Aegis ships with 110 agent signatures across five categories: coding assistants (Claude Code, Copilot, Cursor), autonomous agents (OpenClaw, AutoGPT, CrewAI, Devin), desktop AI (Gemini, Apple Intelligence), frameworks (LangChain, AutoGen, MetaGPT), and local LLMs (Ollama, LM Studio, llama.cpp). You can add custom agents via the UI or JSON config.
 
 ### Can I use Aegis in production?
 

--- a/docs/social-preview-animated.html
+++ b/docs/social-preview-animated.html
@@ -143,7 +143,7 @@
     </div>
     <div class="pills" id="pills">
       <span class="pill">568 tests</span>
-      <span class="pill">107 agents</span>
+      <span class="pill">110 agents</span>
       <span class="pill">70 rules</span>
       <span class="pill">MIT Licensed</span>
     </div>

--- a/docs/social-preview.html
+++ b/docs/social-preview.html
@@ -91,7 +91,7 @@
     <div class="tagline">Agents execute code. We execute oversight.</div>
     <div class="pills">
       <span class="pill">568 tests</span>
-      <span class="pill">107 agents</span>
+      <span class="pill">110 agents</span>
       <span class="pill">70 rules</span>
       <span class="pill">MIT Licensed</span>
     </div>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24,7 +24,7 @@ Requires Node.js 18+ and npm 9+. Windows 10/11 recommended. macOS/Linux experime
 ## Features
 
 ### Process Monitoring
-Tracks 107 known AI agent signatures with parent-child tree resolution and IDE host detection. Covers coding assistants (Claude Code, Copilot, Cursor), autonomous agents (OpenClaw, AutoGPT, CrewAI, Devin), desktop AI (Gemini, Apple Intelligence), frameworks (LangChain, AutoGen, MetaGPT), and local LLMs (Ollama, LM Studio, llama.cpp).
+Tracks 110 known AI agent signatures with parent-child tree resolution and IDE host detection. Covers coding assistants (Claude Code, Copilot, Cursor), autonomous agents (OpenClaw, AutoGPT, CrewAI, Devin), desktop AI (Gemini, Apple Intelligence), frameworks (LangChain, AutoGen, MetaGPT), and local LLMs (Ollama, LM Studio, llama.cpp).
 
 ### File System Access
 Watches sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs) and 27 AI agent config paths for unauthorized access.

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@
 
 ## Key Features
 
-- Process monitoring with 107 known AI agent signatures and parent-child tree resolution
+- Process monitoring with 110 known AI agent signatures and parent-child tree resolution
 - File system watching for sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs)
 - Network activity logging with per-agent PID tracking and reverse DNS
 - Behavioral analysis with 68 detection rules across 8 categories

--- a/src/renderer/lib/components/DemoBanner.svelte
+++ b/src/renderer/lib/components/DemoBanner.svelte
@@ -1,7 +1,7 @@
 <div class="demo-banner" role="status" aria-live="polite">
   <span class="demo-badge">DEMO</span>
   <span class="demo-text">
-    Monitoring <strong>107</strong> AI agents across <strong>11</strong> categories
+    Monitoring <strong>110</strong> AI agents across <strong>11</strong> categories
     <span class="demo-sep">&middot;</span>
     Simulated scenario data
   </span>

--- a/src/renderer/lib/utils/command-registry.ts
+++ b/src/renderer/lib/utils/command-registry.ts
@@ -2,7 +2,7 @@
  * @file command-registry.ts — Static command definitions for Command Palette
  * @module renderer/lib/utils/command-registry
  * @description Provides all static commands grouped by category.
- * Per-agent commands (107 signatures) are excluded — loaded dynamically via
+ * Per-agent commands (110 signatures) are excluded — loaded dynamically via
  * fuzzy search. Agent *action* commands (kill/suspend the selected agent) are
  * static and live here under the `agent` category.
  */

--- a/src/shared/agent-database.json
+++ b/src/shared/agent-database.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0",
-  "lastUpdated": "2026-02-28",
+  "version": "2.1.0",
+  "lastUpdated": "2026-06-03",
   "agents": [
     {
       "id": "claude-code",
@@ -384,6 +384,23 @@
       "riskProfile": "medium"
     },
     {
+      "id": "kilo-code",
+      "names": ["kilo-code", "kilocode"],
+      "displayName": "Kilo Code",
+      "vendor": "Kilo Code",
+      "category": "coding-assistant",
+      "icon": "\ud83e\udd8e",
+      "color": "#A855F7",
+      "defaultTrust": 58,
+      "website": "https://kilocode.ai",
+      "description": "AI coding agent (Cline/Roo lineage) for VS Code",
+      "knownDomains": ["kilocode.ai", "kilo.ai", "api.kilocode.ai"],
+      "knownPorts": [443],
+      "configPaths": ["~/.config/kilo/kilo.jsonc"],
+      "parentEditors": ["Code.exe", "code"],
+      "riskProfile": "medium"
+    },
+    {
       "id": "supermaven",
       "names": ["sm-agent", "supermaven"],
       "displayName": "Supermaven",
@@ -687,6 +704,40 @@
       "knownDomains": [],
       "knownPorts": [443],
       "configPaths": ["~/.mentat/.mentat_config.json", ".mentat_config.json"],
+      "parentEditors": [],
+      "riskProfile": "medium"
+    },
+    {
+      "id": "opencode",
+      "names": ["opencode", "opencode.exe"],
+      "displayName": "opencode",
+      "vendor": "SST",
+      "category": "cli-tool",
+      "icon": "\u2328\ufe0f",
+      "color": "#38BDF8",
+      "defaultTrust": 60,
+      "website": "https://opencode.ai",
+      "description": "Open-source terminal coding agent",
+      "knownDomains": ["opencode.ai"],
+      "knownPorts": [443],
+      "configPaths": ["~/.opencode/", ".opencode/"],
+      "parentEditors": [],
+      "riskProfile": "medium"
+    },
+    {
+      "id": "grok-cli",
+      "names": ["grok-cli", "grok", "grok-cli.exe"],
+      "displayName": "Grok CLI",
+      "vendor": "xAI",
+      "category": "cli-tool",
+      "icon": "\u2716\ufe0f",
+      "color": "#000000",
+      "defaultTrust": 58,
+      "website": "https://x.ai",
+      "description": "Grok terminal coding agent by xAI",
+      "knownDomains": ["api.x.ai"],
+      "knownPorts": [443],
+      "configPaths": ["~/.grok-build/"],
       "parentEditors": [],
       "riskProfile": "medium"
     },


### PR DESCRIPTION
## What

Two commits on `docs/rule-count-73`:

**`69bb19d` feat: add opencode/grok/kilo to agent catalog** — 3 new signatures in `src/shared/agent-database.json`, embedded in their category blocks (not appended to the end):
- **kilo-code** → `coding-assistant` after `roo-code` (extension-only, no standalone process — same distribution model as Cline/Roo)
- **opencode** → `cli-tool` after `mentat`
- **grok-cli** → `cli-tool` before `tabby`
- version `2.0.0 → 2.1.0`, `lastUpdated → 2026-06-03`, agent count `107 → 110`
- configPaths mirror the `AGENT_SELF_CONFIG` keys in `constants.js` (kilo/opencode/grok) so self-access exemption resolves
- **fix:** grok `knownDomains` uses `api.x.ai` only — bare `x.ai` was matched as `/x\.ai$/` by the DB-domain path (no leading boundary) and collided with `netflix.ai`/`phoenix.ai`; the apex is already covered by the static boundary pattern in `network-monitor.js`

**`caad4e2` docs: sync agent count 107 → 110** — live agent counter only:
- README.md (×8), llms.txt, llms-full.txt, aegis-context/SKILL.md, DemoBanner.svelte, command-registry.ts comment, 2× social-preview HTML
- skipped: `e.g. 107` reviewer examples, audit records discussing the claim, coverage `L107` anchors

## Verify
- `npm run typecheck` → 0 errors
- `npm test` → 763 pass / 4 skip (47 files)
- `npm run build:renderer` → clean
- both commits GPG-signed

## Follow-up (not in this PR)
`CLAUDE.md:30` and `memory-bank/architecture.md:67` still read `107` — separate doc-sync.
