### PR TITLE
docs: sync remaining agent count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npm run dist              # Electron-builder NSIS installer
 ## Key Paths
 - src/main/ — 23 CommonJS modules (scanners, watchers, IPC, scoring, zip-writer)
 - src/renderer/ — 43 Svelte 5 components + 9 stores + 15 utils + tokens.css/global.css
-- src/shared/ — agent-database.json (107 agents), constants.js (68 rules), types/ (8 TS files)
+- src/shared/ — agent-database.json (110 agents), constants.js (68 rules), types/ (8 TS files)
 - memory-bank/ — ai-mistakes.md (READ FIRST), progress.md, architecture.md
 - .claude/skills/ — 9 skills: context, design-system, electron-main, svelte-patterns, testing, ship, pr-monitor, ci-monitor, prompt-craft
 - IPC: preload.js — 43 invoke + 6 push channels via contextBridge


### PR DESCRIPTION
Sync the two remaining stale agent-count references 107 to 110, follow-up to PR #138.

- CLAUDE.md:30 — "107 agents" to "110 agents" [committed]
- memory-bank/architecture.md:67 — fixed locally, gitignored so not in this PR

Left as-is: CLAUDE.md:53 (consistency-reviewer row describing its verification targets), scoped out per request.
