### PR TITLE
feat: agent card PID list (#56)

### DIFF
--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -114,9 +114,10 @@
     }
   }
 
-  async function pidAction(e, method) {
+  /** Run a process action against a specific PID (defaults to the representative). */
+  async function pidAction(e, method, pid = agent.pid) {
     e.stopPropagation();
-    if (window.aegis) await window.aegis[method](agent.pid);
+    if (window.aegis) await window.aegis[method](pid);
   }
 
   /** Copy PID to clipboard and show toast. */

--- a/src/renderer/lib/components/AgentCardDetails.svelte
+++ b/src/renderer/lib/components/AgentCardDetails.svelte
@@ -14,6 +14,13 @@
 
   let { agent, gradeColor, agentEvents, sessionDuration, onPidAction } = $props();
 
+  /**
+   * Per-PID list for a grouped agent. Falls back to the single agent when the
+   * card is not a group (no `_instances`), so non-grouped cards are unchanged.
+   * @type {Array<{ pid: number, process?: string }>}
+   */
+  let instances = $derived(agent._instances?.length ? agent._instances : [agent]);
+
   async function markFalsePositive(ev) {
     const entry = { agentName: agent.name || agent.agent, pattern: ev.file, timestamp: Date.now() };
     if (window.aegis?.addFalsePositive) {
@@ -81,17 +88,24 @@
   </div>
 {/if}
 
-<div class="pid-actions-row">
-  <span class="pid-info">PID {agent.pid}{agent.process ? ` \u2014 ${agent.process}` : ''}</span>
-  <div class="pid-actions">
-    <button class="action-btn kill" onclick={(e) => onPidAction(e, 'killProcess')}>Kill</button>
-    <button class="action-btn suspend" onclick={(e) => onPidAction(e, 'suspendProcess')}
-      >Suspend</button
-    >
-    <button class="action-btn resume" onclick={(e) => onPidAction(e, 'resumeProcess')}
-      >Resume</button
-    >
-  </div>
+<div class="pid-list">
+  {#each instances as inst (inst.pid)}
+    <div class="pid-actions-row">
+      <span class="pid-info">PID {inst.pid}{inst.process ? ` \u2014 ${inst.process}` : ''}</span>
+      <div class="pid-actions">
+        <button class="action-btn kill" onclick={(e) => onPidAction(e, 'killProcess', inst.pid)}
+          >Kill</button
+        >
+        <button
+          class="action-btn suspend"
+          onclick={(e) => onPidAction(e, 'suspendProcess', inst.pid)}>Suspend</button
+        >
+        <button class="action-btn resume" onclick={(e) => onPidAction(e, 'resumeProcess', inst.pid)}
+          >Resume</button
+        >
+      </div>
+    </div>
+  {/each}
 </div>
 
 <style>
@@ -210,6 +224,10 @@
   .fp-btn:focus-visible {
     opacity: 1;
     background: var(--md-sys-color-surface-container);
+  }
+  .pid-list {
+    display: flex;
+    flex-direction: column;
   }
   .pid-actions-row {
     display: flex;

--- a/src/renderer/lib/components/AgentPanel.svelte
+++ b/src/renderer/lib/components/AgentPanel.svelte
@@ -39,6 +39,9 @@
         fileCount: instances.reduce((s, a) => s + (a.fileCount || 0), 0),
         networkCount: instances.reduce((s, a) => s + (a.networkCount || 0), 0),
         _processCount: instances.length,
+        // Full per-PID list (riskiest first) — rendered on expand. The rep is
+        // included; the collapsed card's count badge already shows the total.
+        _instances: [...instances].sort((a, b) => (b.riskScore || 0) - (a.riskScore || 0)),
       };
     });
   });


### PR DESCRIPTION
Closes #56. Expand now lists all PIDs of a grouped agent; count badge unchanged.