### PR TITLE
feat(ui): compact muted per-PID list in agent card

### DIFF
--- a/src/renderer/lib/components/AgentCardDetails.svelte
+++ b/src/renderer/lib/components/AgentCardDetails.svelte
@@ -11,15 +11,9 @@
   import { addToast } from '../stores/toast.js';
   import { formatTime } from '../utils/timeline-utils';
   import { shortenPath } from '../utils/path-utils';
+  import PidList from './PidList.svelte';
 
   let { agent, gradeColor, agentEvents, sessionDuration, onPidAction } = $props();
-
-  /**
-   * Per-PID list for a grouped agent. Falls back to the single agent when the
-   * card is not a group (no `_instances`), so non-grouped cards are unchanged.
-   * @type {Array<{ pid: number, process?: string }>}
-   */
-  let instances = $derived(agent._instances?.length ? agent._instances : [agent]);
 
   async function markFalsePositive(ev) {
     const entry = { agentName: agent.name || agent.agent, pattern: ev.file, timestamp: Date.now() };
@@ -88,25 +82,7 @@
   </div>
 {/if}
 
-<div class="pid-list">
-  {#each instances as inst (inst.pid)}
-    <div class="pid-actions-row">
-      <span class="pid-info">PID {inst.pid}{inst.process ? ` \u2014 ${inst.process}` : ''}</span>
-      <div class="pid-actions">
-        <button class="action-btn kill" onclick={(e) => onPidAction(e, 'killProcess', inst.pid)}
-          >Kill</button
-        >
-        <button
-          class="action-btn suspend"
-          onclick={(e) => onPidAction(e, 'suspendProcess', inst.pid)}>Suspend</button
-        >
-        <button class="action-btn resume" onclick={(e) => onPidAction(e, 'resumeProcess', inst.pid)}
-          >Resume</button
-        >
-      </div>
-    </div>
-  {/each}
-</div>
+<PidList {agent} {onPidAction} />
 
 <style>
   .risk-bar-row {
@@ -224,59 +200,5 @@
   .fp-btn:focus-visible {
     opacity: 1;
     background: var(--md-sys-color-surface-container);
-  }
-  .pid-list {
-    display: flex;
-    flex-direction: column;
-  }
-  .pid-actions-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--aegis-space-4);
-    margin-top: var(--aegis-space-2);
-    border-top: 1px solid var(--md-sys-color-outline);
-    padding-top: var(--aegis-space-3);
-  }
-  .pid-info {
-    font: var(--md-sys-typescale-label-medium);
-    font-family: var(--fancy-font-mono);
-    color: var(--md-sys-color-on-surface-variant);
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .pid-actions {
-    display: flex;
-    gap: var(--aegis-space-3);
-    flex-shrink: 0;
-  }
-  .action-btn {
-    font: var(--md-sys-typescale-label-medium);
-    font-weight: 600;
-    padding: var(--aegis-space-2) var(--aegis-space-6);
-    border: none;
-    border-radius: var(--md-sys-shape-corner-full);
-    cursor: pointer;
-    transition: all 0.3s var(--ease-glass);
-  }
-  .action-btn:hover {
-    opacity: 0.8;
-  }
-  .action-btn:active {
-    transform: scale(0.97);
-  }
-  .action-btn.kill {
-    background: var(--md-sys-color-error);
-    color: var(--md-sys-color-on-error);
-  }
-  .action-btn.suspend {
-    background: var(--md-sys-color-secondary);
-    color: var(--md-sys-color-surface);
-  }
-  .action-btn.resume {
-    background: var(--md-sys-color-tertiary);
-    color: var(--md-sys-color-surface);
   }
 </style>

--- a/src/renderer/lib/components/PidList.svelte
+++ b/src/renderer/lib/components/PidList.svelte
@@ -1,0 +1,151 @@
+<script>
+  /**
+   * @file PidList.svelte
+   * @description Compact, dense per-PID list for a grouped agent card. Each row
+   *   shows PID + process with a hover tooltip (process / cwd / parent / risk)
+   *   and muted Kill / Suspend / Resume buttons revealed on row hover — instead
+   *   of three saturated full-width buttons per row.
+   * @since v0.10.0-alpha
+   */
+
+  /**
+   * @type {{
+   *   agent: { _instances?: Array<object>, pid: number, process?: string, name?: string },
+   *   onPidAction: (e: MouseEvent, method: string, pid: number) => void,
+   * }}
+   */
+  let { agent, onPidAction } = $props();
+
+  /**
+   * Per-PID list for a grouped agent. Falls back to the single agent when the
+   * card is not a group (no `_instances`), so non-grouped cards are unchanged.
+   * @type {Array<{ pid: number, process?: string, cwd?: string, parentChain?: string, parentEditor?: string, riskScore?: number }>}
+   */
+  let instances = $derived(agent._instances?.length ? agent._instances : [agent]);
+
+  /** Compact per-PID intervention buttons — muted, revealed on row hover. */
+  const PID_ACTIONS = [
+    { method: 'killProcess', glyph: '✕', label: 'Kill', cls: 'kill' },
+    { method: 'suspendProcess', glyph: '⏸', label: 'Suspend', cls: 'suspend' },
+    { method: 'resumeProcess', glyph: '▶', label: 'Resume', cls: 'resume' },
+  ];
+
+  /**
+   * Build a multi-line hover tooltip for a PID row; absent fields are omitted
+   * so the tooltip never renders the string "undefined".
+   * @param {{ pid: number, process?: string, cwd?: string, parentChain?: string, parentEditor?: string, riskScore?: number }} inst
+   * @returns {string}
+   */
+  function pidTooltip(inst) {
+    const lines = [`PID ${inst.pid}`];
+    if (inst.process) lines.push(`Process: ${inst.process}`);
+    if (inst.cwd) lines.push(`CWD: ${inst.cwd}`);
+    if (inst.parentChain) lines.push(`Parent: ${inst.parentChain}`);
+    else if (inst.parentEditor) lines.push(`Parent: ${inst.parentEditor}`);
+    if (typeof inst.riskScore === 'number') lines.push(`Risk: ${Math.round(inst.riskScore)}`);
+    return lines.join('\n');
+  }
+</script>
+
+<div class="pid-list">
+  {#each instances as inst (inst.pid)}
+    <div class="pid-row" title={pidTooltip(inst)}>
+      <span class="pid-num">{inst.pid}</span>
+      <span class="pid-proc">{inst.process || inst.name || ''}</span>
+      <div class="pid-acts">
+        {#each PID_ACTIONS as act (act.method)}
+          <button
+            class="pid-act {act.cls}"
+            title={act.label}
+            aria-label="{act.label} PID {inst.pid}"
+            onclick={(e) => onPidAction(e, act.method, inst.pid)}>{act.glyph}</button
+          >
+        {/each}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  /* ── Per-PID list — dense rows, muted actions revealed on hover ── */
+  .pid-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--aegis-space-1);
+    max-height: calc(160px * var(--aegis-ui-scale));
+    overflow-y: auto;
+    margin-top: var(--aegis-space-2);
+    border-top: 1px solid var(--md-sys-color-outline);
+    padding-top: var(--aegis-space-3);
+  }
+  .pid-row {
+    display: flex;
+    align-items: center;
+    gap: var(--aegis-space-3);
+    padding: var(--aegis-space-1) var(--aegis-space-2);
+    border-radius: var(--md-sys-shape-corner-small);
+    font: var(--md-sys-typescale-label-medium);
+    font-family: var(--fancy-font-mono);
+    color: var(--md-sys-color-on-surface-variant);
+    transition: background var(--fancy-transition-micro) var(--fancy-ease);
+  }
+  .pid-row:hover {
+    background: var(--md-sys-color-surface-container);
+  }
+  .pid-num {
+    flex-shrink: 0;
+    font-weight: 600;
+    color: var(--md-sys-color-on-surface);
+  }
+  .pid-proc {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    opacity: 0.7;
+  }
+  .pid-acts {
+    display: flex;
+    gap: var(--aegis-space-1);
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity var(--fancy-transition-micro) var(--fancy-ease);
+  }
+  .pid-row:hover .pid-acts,
+  .pid-row:focus-within .pid-acts {
+    opacity: 1;
+  }
+  .pid-act {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: calc(20px * var(--aegis-ui-scale));
+    height: calc(20px * var(--aegis-ui-scale));
+    font-size: calc(10px * var(--aegis-ui-scale));
+    line-height: 1;
+    border-radius: var(--md-sys-shape-corner-small);
+    border: 1px solid currentColor;
+    background: transparent;
+    cursor: pointer;
+    opacity: 0.7;
+    transition: all var(--fancy-transition-micro) var(--fancy-ease);
+  }
+  .pid-act:hover,
+  .pid-act:focus-visible {
+    opacity: 1;
+    background: var(--md-sys-color-surface-container-high);
+  }
+  .pid-act:active {
+    transform: scale(0.9);
+  }
+  .pid-act.kill {
+    color: var(--md-sys-color-error);
+  }
+  .pid-act.suspend {
+    color: var(--md-sys-color-secondary);
+  }
+  .pid-act.resume {
+    color: var(--md-sys-color-tertiary);
+  }
+</style>


### PR DESCRIPTION
## What

Polishes the expanded per-PID list in `AgentCardDetails` — previously a sheet of full-width rows, each with three saturated Kill/Suspend/Resume pills always visible.

## Changes
- **Compact rows**: dense PID list, row height **30.7px → 24px**.
- **Muted colors**: actions carried via text + thin border (`error` / `secondary` / `tertiary`) with a neutral `surface-container-high` hover lift — no new color tokens.
- **Tooltip (mandatory)**: each row has a multi-line `title` — process / cwd / parent / risk — absent fields omitted (never renders "undefined").
- **Hover-revealed actions**: three compact icon buttons (✕ ⏸ ▶) appear only on row hover/focus, so resting rows are clean.
- Extracted the list into a new `PidList.svelte` to keep `AgentCardDetails` under the 300-line cap.

## Not touched
scan-results format, risk/self-access/dedup, `AgentPanel`/`AgentCard` data threading (`_instances` + per-PID `onPidAction` already existed on master).

## Verification
- `npm run build:renderer` clean · `npx tsc --noEmit` clean · eslint clean · Svelte autofixer clean.
- Playwright `_electron`: launched the real app, injected a 3-PID grouped agent, expanded the card, captured before/after.
  - Before: `.pid-actions-row` height **30.7px**, 3 always-visible filled buttons/row.
  - After: `.pid-row` height **24px**, tooltip `PID 3421\nProcess: claude\nCWD: ~/code/myapp\nParent: ...\nRisk: 0`, 3 hover-revealed buttons/row.