### PR TITLE
feat(ui): material icon PID buttons, more contrast, drop card glow

### DIFF
--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -126,14 +126,6 @@
     await navigator.clipboard.writeText(String(agent.pid));
     addToast($t('agents.pid_copied'), 'success', 3000);
   }
-
-  /** Spotlight hover — track mouse position relative to card */
-  function handleMouseMove(e) {
-    if (!cardEl) return;
-    const rect = cardEl.getBoundingClientRect();
-    cardEl.style.setProperty('--mouse-x', `${e.clientX - rect.left}px`);
-    cardEl.style.setProperty('--mouse-y', `${e.clientY - rect.top}px`);
-  }
 </script>
 
 <div
@@ -148,7 +140,6 @@
   aria-expanded={expanded}
   onclick={toggle}
   onkeydown={handleKeydown}
-  onmousemove={handleMouseMove}
 >
   <div class="header-row">
     <span class="agent-name">{displayName}</span>
@@ -216,24 +207,6 @@
       box-shadow var(--fancy-transition-normal) var(--fancy-ease),
       border-color var(--fancy-transition-normal) var(--fancy-ease),
       background var(--fancy-transition-normal) var(--fancy-ease);
-  }
-
-  /* Spotlight hover pseudo-element */
-  .agent-card::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(
-      circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-      rgba(255, 255, 255, 0.06),
-      transparent 40%
-    );
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity var(--fancy-transition-micro) var(--fancy-ease);
-  }
-  .agent-card:hover::before {
-    opacity: 1;
   }
 
   .agent-card:hover {

--- a/src/renderer/lib/components/PidList.svelte
+++ b/src/renderer/lib/components/PidList.svelte
@@ -23,11 +23,27 @@
    */
   let instances = $derived(agent._instances?.length ? agent._instances : [agent]);
 
-  /** Compact per-PID intervention buttons — muted, revealed on row hover. */
+  /**
+   * Compact per-PID intervention buttons — muted, revealed on row hover.
+   * Icons are inlined Google Material Icons (Apache-2.0) path data so they
+   * render crisply and inherit `currentColor`, with no CDN or font dependency
+   * (the app CSP forbids both). `path` is the `d` of a 24×24 Material glyph:
+   * close / pause / play_arrow.
+   */
   const PID_ACTIONS = [
-    { method: 'killProcess', glyph: '✕', label: 'Kill', cls: 'kill' },
-    { method: 'suspendProcess', glyph: '⏸', label: 'Suspend', cls: 'suspend' },
-    { method: 'resumeProcess', glyph: '▶', label: 'Resume', cls: 'resume' },
+    {
+      method: 'killProcess',
+      label: 'Kill',
+      cls: 'kill',
+      path: 'M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z',
+    },
+    {
+      method: 'suspendProcess',
+      label: 'Suspend',
+      cls: 'suspend',
+      path: 'M6 19h4V5H6v14zm8-14v14h4V5h-4z',
+    },
+    { method: 'resumeProcess', label: 'Resume', cls: 'resume', path: 'M8 5v14l11-7z' },
   ];
 
   /**
@@ -58,8 +74,12 @@
             class="pid-act {act.cls}"
             title={act.label}
             aria-label="{act.label} PID {inst.pid}"
-            onclick={(e) => onPidAction(e, act.method, inst.pid)}>{act.glyph}</button
+            onclick={(e) => onPidAction(e, act.method, inst.pid)}
           >
+            <svg class="pid-act-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d={act.path} />
+            </svg>
+          </button>
         {/each}
       </div>
     </div>
@@ -103,7 +123,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    opacity: 0.7;
+    opacity: 0.85;
   }
   .pid-acts {
     display: flex;
@@ -120,16 +140,22 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: calc(20px * var(--aegis-ui-scale));
-    height: calc(20px * var(--aegis-ui-scale));
-    font-size: calc(10px * var(--aegis-ui-scale));
+    width: calc(24px * var(--aegis-ui-scale));
+    height: calc(24px * var(--aegis-ui-scale));
+    padding: 0;
     line-height: 1;
     border-radius: var(--md-sys-shape-corner-small);
     border: 1px solid currentColor;
     background: transparent;
     cursor: pointer;
-    opacity: 0.7;
+    opacity: 0.9;
     transition: all var(--fancy-transition-micro) var(--fancy-ease);
+  }
+  .pid-act-icon {
+    width: calc(15px * var(--aegis-ui-scale));
+    height: calc(15px * var(--aegis-ui-scale));
+    fill: currentColor;
+    display: block;
   }
   .pid-act:hover,
   .pid-act:focus-visible {


### PR DESCRIPTION
Follow-up polish to the per-PID list (PR #141), from live review feedback.

## Changes
- **Material Icons**: replaced the unicode glyphs (✕ ⏸ ▶) with inlined **Google Material Icons** SVG path data — `close` / `pause` / `play_arrow` (Apache-2.0). Crisp at any DPI/scale, inherit `currentColor` so the muted red/gold/green palette is preserved. **No CDN, no icon font, no UI-lib dependency** — required by the app CSP (`font-src 'self'`, `connect-src 'self'`) and the project's no-Google-CDN rule.
- **Bigger + higher contrast**: action buttons `20px → 24px`; process-name opacity `0.7 → 0.85`, icon opacity `0.7 → 0.9`.
- **Removed the cursor glow**: deleted the `.agent-card::before` spotlight pseudo-element and its `onmousemove` mouse-tracker in `AgentCard.svelte` — no dead code left.

## Verification
`npm run build:renderer` clean · `npx tsc --noEmit` clean · eslint clean · Svelte autofixer clean. Verified live in the Electron app (Playwright `_electron` with an injected 3-PID agent): icons render as crisp Material SVGs, glow gone.