### PR TITLE
fix: attribute file events to owning agent (C-01)

### DIFF
--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -108,6 +108,31 @@ function isSelfAccess(agentName, filePath) {
 }
 
 /**
+ * Find the AI agent that owns a file path so the event is attributed to it
+ * (and the self-access exemption is checked against the right agent). An
+ * agent's OWN config dir wins first — a cwd may contain another agent's config
+ * dir, so self-config must outrank cwd containment. Returns null if none match,
+ * letting the caller fall back to its prior default.
+ * @param {string} filePath - Resolved file path from the watcher event.
+ * @param {Array<{agent:string,cwd?:string}>} aiAgents - Candidate AI agents.
+ * @returns {Object|null} The owning agent, or null when no agent matches.
+ * @since v0.10.0
+ */
+function findOwningAgent(filePath, aiAgents) {
+  for (const a of aiAgents) {
+    if (isSelfAccess(a.agent, filePath)) return a;
+  }
+  const target = process.platform === 'win32' ? filePath.toLowerCase() : filePath;
+  for (const a of aiAgents) {
+    if (!a.cwd) continue;
+    let base = path.resolve(a.cwd);
+    if (process.platform === 'win32') base = base.toLowerCase();
+    if (target === base || target.startsWith(base + path.sep)) return a;
+  }
+  return null;
+}
+
+/**
  * Build an ignore-filter function for chokidar's `ignored` option.
  * Uses function form (not glob) to avoid chokidar issue #773.
  * Handles both `/` and `\` separators for Windows compatibility.
@@ -152,7 +177,8 @@ function handleWatcherEvent(action, filePath) {
   }
   const reason = classifySensitive(filePath);
   const aiAgents = _state.getLatestAiAgents();
-  const agent = aiAgents.length > 0 ? aiAgents[0] : agents[0];
+  const owner = aiAgents.length > 0 ? findOwningAgent(filePath, aiAgents) : null;
+  const agent = owner || (aiAgents.length > 0 ? aiAgents[0] : agents[0]);
   const selfAccess = reason !== null && isSelfAccess(agent.agent, filePath);
   const event = {
     agent: agent.agent,

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -251,6 +251,36 @@ describe('file-watcher event handling', () => {
       fileWatcher.handleWatcherEvent('modified', '/home/user/file.js');
       expect(state.activityLog[0].agent).toBe('Claude Code');
     });
+
+    it('attributes a self-config event to the owning agent, not aiAgents[0] (C-01)', () => {
+      // Two AI agents online; the event is opencode accessing its OWN config.
+      // Old code blamed aiAgents[0] (Claude Code) → wrong agent AND a false
+      // sensitive flag, because the self-access check ran against Claude.
+      state.getLatestAiAgents = () => [
+        { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user/claude-proj' },
+        { pid: 200, agent: 'opencode', category: 'ai', cwd: '/home/user/project' },
+      ];
+      fileWatcher.handleWatcherEvent('modified', '/home/user/.opencode/auth.json');
+      const event = state.activityLog[0];
+      expect(event.agent).toBe('opencode');
+      expect(event.pid).toBe(200);
+      expect(event.selfAccess).toBe(true);
+      expect(event.sensitive).toBe(false);
+    });
+
+    it('attributes a non-config event to the agent whose cwd contains it (C-01)', () => {
+      // A plain (non-sensitive) file inside the SECOND agent's working dir must
+      // attribute to that agent, not aiAgents[0]. Exercises the cwd-ownership
+      // branch (no self-config match is possible for an ordinary source file).
+      state.getLatestAiAgents = () => [
+        { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user/claude-proj' },
+        { pid: 200, agent: 'opencode', category: 'ai', cwd: '/home/user/project' },
+      ];
+      fileWatcher.handleWatcherEvent('modified', '/home/user/project/src/index.js');
+      const event = state.activityLog[0];
+      expect(event.agent).toBe('opencode');
+      expect(event.pid).toBe(200);
+    });
   });
 
   describe('pruneKnownHandles()', () => {


### PR DESCRIPTION
C-01 (P0). handleWatcherEvent attributed every file event to aiAgents[0]; with >=2 AI agents this mis-attributed events and broke self-access exemption (agent #2's own-config flagged sensitive, pinned on agent #1).

Fix: findOwningAgent(filePath, aiAgents) - self-config match (isSelfAccess) wins, then cwd containment, else fallback to prior aiAgents[0] behavior. scanFileHandles untouched (already per-PID).

Tests: +2 regression (attribution branch + cwd branch), RED before fix -> GREEN after. Full suite 765 pass / 4 skip, typecheck/lint clean (23 pre-existing warnings).

Phase 1 DoD: regression test fails without fix. PREREQ for per-agent baselines + correlation (Phase 6).
