### PR TITLE
fix: dedup process-names so each name maps to one agent (C-04)

### DIFF
--- a/src/shared/agent-database.json
+++ b/src/shared/agent-database.json
@@ -21,7 +21,7 @@
     },
     {
       "id": "github-copilot",
-      "names": ["copilot-agent", "copilot", "github-copilot", "copilot-language-server"],
+      "names": ["copilot-agent", "copilot", "github-copilot"],
       "displayName": "GitHub Copilot",
       "vendor": "GitHub / Microsoft",
       "category": "coding-assistant",
@@ -69,7 +69,7 @@
     },
     {
       "id": "windsurf",
-      "names": ["Windsurf.exe", "windsurf", "Windsurf"],
+      "names": ["Windsurf.exe", "windsurf"],
       "displayName": "Windsurf",
       "vendor": "Cognition / Codeium",
       "category": "ai-ide",
@@ -150,7 +150,7 @@
     },
     {
       "id": "pearai",
-      "names": ["pearai", "pearai.exe", "PearAI.exe"],
+      "names": ["pearai", "pearai.exe"],
       "displayName": "PearAI",
       "vendor": "PearAI",
       "category": "ai-ide",
@@ -201,7 +201,7 @@
     },
     {
       "id": "tabnine",
-      "names": ["TabNine.exe", "TabNine", "tabnine", "TabNine-deep-local", "WD-TabNine"],
+      "names": ["TabNine.exe", "tabnine", "TabNine-deep-local", "WD-TabNine"],
       "displayName": "Tabnine",
       "vendor": "Tabnine",
       "category": "coding-assistant",
@@ -402,7 +402,7 @@
     },
     {
       "id": "supermaven",
-      "names": ["sm-agent", "supermaven"],
+      "names": ["supermaven"],
       "displayName": "Supermaven",
       "vendor": "Supermaven Inc.",
       "category": "coding-assistant",
@@ -1168,7 +1168,7 @@
     },
     {
       "id": "perplexity-desktop",
-      "names": ["Perplexity.exe", "perplexity", "Perplexity"],
+      "names": ["Perplexity.exe", "perplexity"],
       "displayName": "Perplexity Desktop",
       "vendor": "Perplexity AI",
       "category": "desktop-agent",
@@ -1751,7 +1751,7 @@
     },
     {
       "id": "jan",
-      "names": ["jan.exe", "jan", "Jan.exe"],
+      "names": ["jan.exe", "jan"],
       "displayName": "Jan",
       "vendor": "Jan AI",
       "category": "local-llm-runtime",
@@ -1876,7 +1876,7 @@
     },
     {
       "id": "anythingllm",
-      "names": ["AnythingLLM", "anything-llm", "anythingllm"],
+      "names": ["anything-llm", "anythingllm"],
       "displayName": "AnythingLLM",
       "vendor": "Mintplex Labs",
       "category": "local-llm-runtime",

--- a/tests/main/process-scanner.test.js
+++ b/tests/main/process-scanner.test.js
@@ -76,4 +76,21 @@ describe('process-scanner', () => {
     const result = await scanner.scanProcesses();
     expect(result.agents.some((a) => a.agent === 'Claude Code')).toBe(true);
   });
+
+  // C-04: each process name belongs to exactly one agent (umbrella no longer
+  // steals a name from its rightful owner). Asserts the SPECIFIC owner is
+  // present AND the umbrella is absent — not tied to agents[0].
+  it('routes "copilot-language-server" to Copilot Language Server, not GitHub Copilot', async () => {
+    mockListProcesses.mockResolvedValue([{ name: 'copilot-language-server', pid: 4242 }]);
+    const { agents } = await scanner.scanProcesses();
+    expect(agents.some((a) => a.agent === 'Copilot Language Server')).toBe(true);
+    expect(agents.some((a) => a.agent === 'GitHub Copilot')).toBe(false);
+  });
+
+  it('routes bare "sm-agent" to Supermaven Agent, not Supermaven', async () => {
+    mockListProcesses.mockResolvedValue([{ name: 'sm-agent', pid: 4243 }]);
+    const { agents } = await scanner.scanProcesses();
+    expect(agents.some((a) => a.agent === 'Supermaven Agent')).toBe(true);
+    expect(agents.some((a) => a.agent === 'Supermaven')).toBe(false);
+  });
 });


### PR DESCRIPTION
## C-04 — dedup process-names so each name maps to exactly one agent

**Problem.** Some process names appeared in more than one agent's `names`
array in `agent-database.json`, so a single OS process name could resolve
to two different agents. Two flavours:

- **Cross-agent name-steal (Class B):** umbrella agents had grabbed a name
  owned by a more specific agent.
  - `copilot-language-server` → routes to **Copilot Language Server** (was also claimed by GitHub Copilot)
  - `sm-agent` → routes to **Supermaven Agent** (was also claimed by Supermaven)
- **Case-duplicate names (6):** redundant case variants within a single
  agent's array (the matcher is case-insensitive), removed for hygiene:
  `Windsurf`, `PearAI.exe`, `TabNine`, `Perplexity`, `Jan.exe`, `AnythingLLM`.

**Fix.** Data-only edit to `src/shared/agent-database.json`. The matcher in
`process-scanner.js` is **untouched** — only the lookup table changed.

**Tests.** +2 RED->GREEN tests in `tests/main/process-scanner.test.js` that
assert the *specific* owner is present AND the umbrella agent is absent
(not tied to `agents[0]`).

### Verify
- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors (23 pre-existing `no-console` warnings, untouched)
- `npm test` — 767 passed / 4 skipped (47 files)

Scope: 2 files, +25 / -8.
