### PR TITLE
fix: re-queue audit events on flush failure so write errors don't lose logs (C-03)

### DIFF
--- a/src/main/audit-logger.js
+++ b/src/main/audit-logger.js
@@ -141,6 +141,11 @@ function flush() {
     fs.appendFileSync(fp, lines, 'utf-8');
   } catch (err) {
     if (_onFlushError) _onFlushError(err);
+    // TODO(C-03-followup): unbounded buffer growth — if the disk is permanently
+    // broken (full / no perms), re-queuing on every failed flush grows _buffer
+    // without bound (OOM). Add a cap (drop-oldest beyond a limit) in a follow-up;
+    // out of scope for this PR.
+    _buffer = entries.concat(_buffer);
   }
 }
 

--- a/tests/main/audit-logger.test.js
+++ b/tests/main/audit-logger.test.js
@@ -155,4 +155,25 @@ describe('audit-logger', () => {
     expect(errorCb).toHaveBeenCalledTimes(1);
     expect(errorCb.mock.calls[0][0]).toBeInstanceOf(Error);
   });
+
+  it('re-queues events on write failure so a later flush persists them', () => {
+    auditLogger.init({ userDataPath: tmpDir, onFlushError: vi.fn() });
+    const auditDir = path.join(tmpDir, 'audit-logs');
+
+    auditLogger.log('test', { agent: 'requeue-me' });
+
+    // Force the first flush to fail: remove the dir so appendFileSync throws ENOENT.
+    fs.rmSync(auditDir, { recursive: true, force: true });
+    auditLogger.flush();
+
+    // Restore writability and flush again — a re-queue fix must persist the event
+    // that the failed flush had drained from the buffer.
+    fs.mkdirSync(auditDir, { recursive: true });
+    auditLogger.flush();
+
+    const files = fs.readdirSync(auditDir).filter((f) => f.endsWith('.json'));
+    expect(files).toHaveLength(1);
+    const content = fs.readFileSync(path.join(auditDir, files[0]), 'utf-8');
+    expect(content).toContain('requeue-me');
+  });
 });


### PR DESCRIPTION
## C-03 — re-queue audit events on flush failure (no silent log loss)

**Problem.** `audit-logger.js` `flush()` drained the buffer with
`_buffer.splice(0)` **before** `fs.appendFileSync`. On a write error
(disk full / no perms / ENOENT) the `catch` only called `_onFlushError`
and never restored the drained events — so they were lost permanently.
This is the foundation for Phase 3 (hash-chained audit): you can't chain
entries that silently vanished.

**Fix (catch-block only).** After `_onFlushError(err)`, re-queue:
```js
_buffer = entries.concat(_buffer);
```
- `concat` restores **front-of-buffer** chronological order, and avoids
  the `unshift(...entries)` argument-spread `RangeError` on a huge buffer.
- The **success path** (`splice` -> `append`) is **byte-identical** — the
  re-queue runs only inside the `catch`, the branch that previously lost data.
- `TODO(C-03-followup)` marks the unbounded-buffer-growth / OOM cap
  (drop-oldest beyond a limit) as a deliberate out-of-scope follow-up.

**Test (+1, RED->GREEN, black-box).** No `_buffer` getter — asserts the
*contract*, not internal state: log an event, delete the dir to force the
first flush to fail, restore the dir, flush again, assert the event is on
disk. Without the fix the second flush early-returns (empty buffer) and the
file is missing — RED on the data-loss assert (not teardown). With the fix — GREEN.

### Verify
- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors (23 pre-existing `no-console` warnings, untouched)
- `npm test` — 768 passed / 4 skipped (47 files) = 767 prior + 1 new

### Out of scope (flagged, not in this PR)
- `logger.js` has the **byte-identical** bug (`splice` -> `append` -> `catch`
  console.error only) — separate sibling follow-up.
- `_totalEntries` counter desync — self-heals via re-queue for the
  recoverable case.

Scope: 2 files, +26.
