### PR TITLE
fix: add reentrancy guard to doProcessScan to prevent overlapping scans (C-02)

### DIFF
--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -24,6 +24,9 @@ let latestLocalModels = {
 const eventDedupMap = new Map();
 let activeScanCount = 0;
 let _lastTriggeredNetScan = 0;
+// C-02: reentrancy guard — block overlapping doProcessScan runs so a slow scan
+// can't be clobbered by the next interval tick (last-writer-wins on the snapshot).
+let processScanRunning = false;
 
 /** @param {boolean} entering — true when scan starts, false when ends @since v0.4.0 */
 function updateScanStatus(entering) {
@@ -156,6 +159,10 @@ async function doProcessScan() {
     getResourceUsage,
     setAgents,
   } = deps;
+  // Early-return BEFORE updateScanStatus(true): a blocked re-entrant call must not
+  // bump activeScanCount, whose only decrement lives in the finally below.
+  if (processScanRunning) return;
+  processScanRunning = true;
   updateScanStatus(true);
   try {
     const result = await scanner.scanProcesses();
@@ -221,6 +228,7 @@ async function doProcessScan() {
     logger.error('main', 'Process scan failed', { error: err.message });
   } finally {
     updateScanStatus(false);
+    processScanRunning = false;
   }
 }
 

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -266,4 +266,62 @@ describe('scan-loop', () => {
       expect(models.lmstudio).toEqual({ running: false, models: [] });
     });
   });
+
+  // ── reentrancy guard (doProcessScan) ──
+
+  describe('reentrancy guard (doProcessScan)', () => {
+    it('does not start an overlapping process scan while a previous scan is in-flight', async () => {
+      // First scanProcesses call hangs forever (pending) so scan N stays in-flight
+      // across the next interval tick; any later call resolves normally.
+      const firstScan = new Promise(() => {});
+      let scanCalls = 0;
+      const scanProcesses = vi.fn().mockImplementation(() => {
+        scanCalls += 1;
+        return scanCalls === 1 ? firstScan : Promise.resolve({ agents: [], changed: false });
+      });
+      const mockDeps = {
+        scanner: { scanProcesses },
+        procUtil: {
+          enrichWithParentChains: vi.fn().mockResolvedValue(),
+          annotateHostApps: vi.fn(),
+          annotateWorkingDirs: vi.fn().mockResolvedValue(),
+        },
+        watcher: {
+          pruneKnownHandles: vi.fn(),
+          scanAllFileHandles: vi.fn().mockResolvedValue([]),
+        },
+        network: {
+          isNetworkScanRunning: vi.fn().mockReturnValue(false),
+          setNetworkScanRunning: vi.fn(),
+          scanNetworkConnections: vi.fn().mockResolvedValue([]),
+        },
+        baselines: { recordNetworkEndpoint: vi.fn() },
+        anomaly: {
+          checkDeviations: vi.fn().mockReturnValue([]),
+          calculateAnomalyScore: vi.fn().mockReturnValue({ score: 0 }),
+        },
+        audit: { log: vi.fn() },
+        tray: { updateTrayIcon: vi.fn(), notifySensitive: vi.fn() },
+        logger: { error: vi.fn(), warn: vi.fn() },
+        sendToRenderer: vi.fn(),
+        fileAccessBatcher: { push: vi.fn() },
+        statsUpdateBatcher: { push: vi.fn() },
+        getStats: vi.fn().mockReturnValue({}),
+        getResourceUsage: vi.fn().mockReturnValue({}),
+        getLatestAgents: vi.fn().mockReturnValue([]),
+        setAgents: vi.fn(),
+        setLatestNetConnections: vi.fn(),
+      };
+      scanLoop.init(mockDeps);
+      scanLoop.startScanIntervals(5000);
+
+      await vi.advanceTimersByTimeAsync(5000); // tick 1 → scan starts, hangs on firstScan
+      await vi.advanceTimersByTimeAsync(5000); // tick 2 → fires while scan 1 is in-flight
+
+      // Assert inside the in-flight window (firstScan is never resolved). A guarded
+      // doProcessScan short-circuits the second tick → 1 call; the unguarded (buggy)
+      // version runs both overlapping bodies → 2 calls.
+      expect(scanProcesses).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## C-02 — Reentrancy guard for doProcessScan

### Problem
`doProcessScan` had no reentrancy guard. When a scan's async body (tasklist + parent-chain enrich + file-handle + network work) outran the scan interval, the next interval tick re-entered the function. Two overlapping scan bodies then raced on the shared agent snapshot (last-writer-wins via `setAgents`) and double-bumped `activeScanCount`, whose only decrement lives in the `finally` — so the busy-count drifted upward.

### Fix (module-level latch only)
- New module-level flag `processScanRunning = false` (scan-loop.js:27)
- Early `return` BEFORE `updateScanStatus(true)`: `if (processScanRunning) return` (scan-loop.js:164)
- Flag set right after the guard (:165); reset to `false` in the EXISTING `finally` beside `updateScanStatus(false)` — no new try/finally added

The early-return placement is load-bearing: `updateScanStatus` mutates `activeScanCount` and its only decrement lives in the `finally`, so a blocked re-entrant call must short-circuit ABOVE the counter or it would leak the count upward forever.

Drop-not-queue is deliberate (monitor-first): a skipped tick means slightly staler data next cycle; queuing slow scans would amplify the overload the guard prevents.

`doNetworkScan` and `doFileScan` are untouched (network already self-gates via `isNetworkScanRunning`).

### Test
+1 RED→GREEN reentrancy test in tests/main/scan-loop.test.js: the first `scanProcesses()` returns a never-resolving deferred promise so scan N stays in-flight across the next interval tick; the test asserts inside the in-flight window that `scanProcesses` was called exactly once. On unguarded code the second tick re-enters (2 calls) and the assertion fails — proving it pins real overlap, not sequencing.

### Verify
- typecheck: 0 errors
- lint: 0 errors / 23 pre-existing no-console warnings (none in changed files)
- test: 769 pass / 4 skip (47 files) = 768 prior + 1 new

### Scope
2 files: src/main/scan-loop.js (+8), tests/main/scan-loop.test.js (+58).

### Follow-up (not in this PR)
`doFileScan` (scan-loop.js:266) has the identical missing reentrancy guard — same root cause, same one-flag fix applies. Deliberately scoped out (one-PR-one-task).
