### PR TITLE
fix(rules): anchor SC003/SC004/SC007 to basename (C-05)

### DIFF
--- a/rules/secrets.yaml
+++ b/rules/secrets.yaml
@@ -21,7 +21,7 @@ rules:
 
   - id: "SC003"
     name: "Password file"
-    pattern: "password"
+    pattern: "[\\\\\/][^\\\\\\/]*password[^\\\\\\/]*$"
     reason: "Password file"
     category: "secrets"
     risk: critical
@@ -29,7 +29,7 @@ rules:
 
   - id: "SC004"
     name: "Credentials"
-    pattern: "credential"
+    pattern: "[\\\\\/][^\\\\\\/]*credential[^\\\\\\/]*$"
     reason: "Credentials"
     category: "secrets"
     risk: critical
@@ -53,7 +53,7 @@ rules:
 
   - id: "SC007"
     name: "API key file"
-    pattern: "api_key"
+    pattern: "[\\\\\/][^\\\\\\/]*api_key[^\\\\\\/]*$"
     reason: "API key file"
     category: "secrets"
     risk: critical

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -62,6 +62,42 @@ describe('file-watcher', () => {
       );
     });
 
+    // C-05: SC003/SC004/SC007 anchored to basename (like SC006) — word in a
+    // DIRECTORY name must NOT flag; word in the basename still flags.
+    it('SC003: password in dir name → null (basename-anchored)', () => {
+      expect(
+        fileWatcher.classifySensitive('/home/user/projects/password-manager/README.md'),
+      ).toBeNull();
+    });
+
+    it('SC004: credential in dir name → null (basename-anchored)', () => {
+      expect(
+        fileWatcher.classifySensitive('/home/user/code/credential-helper/index.js'),
+      ).toBeNull();
+    });
+
+    it('SC007: api_key in dir name → null (basename-anchored)', () => {
+      expect(fileWatcher.classifySensitive('/home/user/src/api_key_validator/test.js')).toBeNull();
+    });
+
+    it('SC003: password in basename → "Password file"', () => {
+      expect(fileWatcher.classifySensitive('/home/user/myproj/password.json')).toBe(
+        'Password file',
+      );
+    });
+
+    it('SC004: credentials in basename → "Credentials"', () => {
+      expect(fileWatcher.classifySensitive('/home/user/myproj/credentials.json')).toBe(
+        'Credentials',
+      );
+    });
+
+    it('SC007: api_key in basename → "API key file"', () => {
+      expect(fileWatcher.classifySensitive('/home/user/myproj/my_api_key.txt')).toBe(
+        'API key file',
+      );
+    });
+
     it('includes custom rules when state is initialized', () => {
       fileWatcher.init(
         makeState({


### PR DESCRIPTION
## C-05 — anchor SC003/SC004/SC007 to basename (last Phase-1 P0)

### Root cause
`rule-loader.js` compiles every YAML `pattern` via `new RegExp(str, 'i')` with **no anchoring**, and `file-watcher.js` `classifySensitive` runs `rule.pattern.test(filePath)` against the **full resolved absolute path**. SC003/SC004/SC007 were the bare substrings `password` / `credential` / `api_key`, so they matched **anywhere** in the path — including **directory names**:

- `/home/user/projects/password-manager/README.md` → false `"Password file"`
- `/home/user/code/credential-helper/index.js` → false `"Credentials"`
- `/home/user/src/api_key_validator/test.js` → false `"API key file"`

SC006 already solved this for `token` with a basename-anchored class.

### Fix — 3 `pattern:` strings in `rules/secrets.yaml` only
Each rewritten to SC006's exact on-disk byte form, swapping only the word:

```
[\\\\\/][^\\\\\\/]*WORD[^\\\\\\/]*$
```

which double-decodes YAML→regex to `/[\\/][^\\\/]*WORD[^\\\/]*$/i` — a separator (`\` or `/`), then non-separators containing the word, then non-separators to end ⇒ the word must be in the **last path segment** (basename). The engine, schema (`additionalProperties: false`), and SC001/002/005/006/008 are **untouched**.

### RED → GREEN
**3 FP cases (RED → GREEN)** — word in a *directory* name, innocuous basename → `toBeNull()`. On unpatched code each returned its reason instead of `null` (3 failures at the FP assert line, proving the test pins the real false positive).

**3 TP cases (green → green regression guards)** — word in basename → must still flag. Reasons cited byte-for-byte from `secrets.yaml`:
- `/home/user/myproj/password.json` → `"Password file"`
- `/home/user/myproj/credentials.json` → `"Credentials"`
- `/home/user/myproj/my_api_key.txt` → `"API key file"`

A full cross-rule simulation (all 8 YAML files in real Map-insertion order) confirmed each TP fires **only** its target rule — `SC008` `.git-credentials$` does not catch `credentials.json`, and no earlier rule shadows.

### Compile-equality gate (Windows-regression guard)
A hand-typed patch can silently collapse the leading class to slash-only `[\/]` (matches `/` but **not** Windows `\`) while still passing every forward-slash test. Defense: the patch was generated by a node script that `.replace('token', word)` on SC006's **real on-disk bytes** (no hand-typed backslashes), then a gate asserts each compiled `.source === SC006.source` with the word swapped **and** functionally matches both `\`- and `/`-path basenames while rejecting word-in-dir paths on both separators. Gate **PASS**.

### Out of scope (named, deliberately not done)
1. **Word-boundary tightening** — partial fix: a file literally named `password-utils.js` still matches by basename. Separate task.
2. **Deliberate FN tradeoff** — a real secret in a `passwords/` folder whose filename lacks the word is now missed (folder name is a weak signal; accepted in exchange for killing the dir-name FP storm).
3. **Dead duplicate in `constants.js`** — the deprecated `SENSITIVE_RULES` array (`:367` `/password/i`, `:371` `/api_key/i`) carries the identical bug but is **unused** by `classifySensitive` (grep-confirmed dead) → no-op for this fix; flagged for eventual removal.

### Verify
- `npm run typecheck` → 0 errors
- `npm run lint` → 0 errors (23 pre-existing `no-console` warnings, none in changed files)
- `npm test` → **775 pass / 4 skip (47 files)** = 769 prior + 6 new C-05

### Scope
`rules/secrets.yaml` (3 lines) + `tests/main/file-watcher.test.js` (+6 tests).

---

**Phase 1 P0 CLOSED — C-01 … C-05 all DONE.**
