### PR TITLE
perf(file-watcher): bounded-concurrency file handle scan

### DIFF
--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -46,6 +46,15 @@ const DEFAULT_IGNORED_DIRS = [
   '.turbo',
 ];
 
+/**
+ * Max concurrent per-PID handle scans in scanAllFileHandles. Each scan spawns
+ * one powershell.exe + handle.exe (~500ms cold) on win32 — an uncapped fan-out
+ * over ~12 agents would saturate CPU and spike resources. Fixed at 5 (the
+ * bottleneck is per-PID I/O, not core count) so the cap stays deterministic.
+ * @type {number}
+ */
+const FILE_SCAN_CONCURRENCY = 5;
+
 let _getFileHandles = _platform.getFileHandles;
 /** @internal Override dependencies (for tests). */
 function _setDepsForTest(overrides) {
@@ -342,11 +351,28 @@ async function scanFileHandles(agent) {
 async function scanAllFileHandles(agents) {
   const toScan =
     _state && _state.isOtherPanelExpanded() ? agents : agents.filter((a) => a.category === 'ai');
-  const allNew = [];
-  for (const agent of toScan) {
-    const events = await scanFileHandles(agent);
-    allNew.push(...events);
+  // Bounded-concurrency worker pool: at most FILE_SCAN_CONCURRENCY scanFileHandles()
+  // run at once (each spawns one powershell/handle.exe). Results are stored by
+  // original index, so the returned array stays in agent order — per-event agent
+  // attribution (C-01) is stamped inside scanFileHandles and never cross-wired.
+  const results = new Array(toScan.length);
+  let next = 0;
+  async function worker() {
+    while (next < toScan.length) {
+      const i = next++;
+      try {
+        results[i] = await scanFileHandles(toScan[i]);
+      } catch (_) {
+        // One agent's scan throwing (e.g. unguarded recordFileAccess) must not
+        // abort the batch — drop just this agent's events and pull the next.
+        results[i] = [];
+      }
+    }
   }
+  const poolSize = Math.min(FILE_SCAN_CONCURRENCY, toScan.length);
+  await Promise.all(Array.from({ length: poolSize }, worker));
+  const allNew = [];
+  for (const r of results) allNew.push(...r);
   return allNew;
 }
 
@@ -397,6 +423,7 @@ module.exports = {
   handleWatcherEvent,
   getIgnoredDirFilter,
   DEFAULT_IGNORED_DIRS,
+  FILE_SCAN_CONCURRENCY,
   _setDepsForTest,
   _resetForTest,
 };

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -438,5 +438,54 @@ describe('file-watcher scanFileHandles', () => {
       await fileWatcher.scanAllFileHandles(agents);
       expect(state.recordFileAccess).toHaveBeenCalledTimes(2);
     });
+
+    it('runs at most FILE_SCAN_CONCURRENCY (5) handle scans concurrently, preserving attribution', async () => {
+      let inFlight = 0;
+      let maxInFlight = 0;
+      mockGetFileHandles.mockImplementation((pid) => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            inFlight--;
+            resolve([`/home/user/file-${pid}.js`]);
+          }, 10);
+        });
+      });
+      state.isOtherPanelExpanded = () => true; // scan every agent
+      const agents = Array.from({ length: 12 }, (_, i) => ({
+        pid: 100 + i,
+        agent: `Agent${i}`,
+        category: 'ai',
+      }));
+      const events = await fileWatcher.scanAllFileHandles(agents);
+
+      // Caps AND saturates: a serial loop gives 1, an uncapped Promise.all gives 12.
+      expect(fileWatcher.FILE_SCAN_CONCURRENCY).toBe(5);
+      expect(maxInFlight).toBe(fileWatcher.FILE_SCAN_CONCURRENCY);
+      expect(mockGetFileHandles).toHaveBeenCalledTimes(12); // all still scanned
+      // C-01: each event carries the agent name matching its pid — no cross-wiring.
+      expect(events.filter((e) => e.pid === 105).every((e) => e.agent === 'Agent5')).toBe(true);
+    });
+
+    it('one agent throwing on an unguarded path does not abort the rest of the batch', async () => {
+      mockGetFileHandles.mockResolvedValue(['/home/user/x.js']);
+      state.isOtherPanelExpanded = () => true;
+      // recordFileAccess (file-watcher.js:332) is NOT inside scanFileHandles' try/catch,
+      // so a throw here propagates — the worker pool's try/catch must contain it.
+      state.recordFileAccess = vi.fn((agentName) => {
+        if (agentName === 'B') throw new Error('downstream blew up');
+      });
+      const agents = [
+        { pid: 100, agent: 'A', category: 'ai' },
+        { pid: 101, agent: 'B', category: 'ai' }, // throws mid-scan
+        { pid: 102, agent: 'C', category: 'ai' },
+      ];
+      const events = await fileWatcher.scanAllFileHandles(agents);
+      const pids = events.map((e) => e.pid);
+      expect(pids).toContain(100); // A survived
+      expect(pids).toContain(102); // C survived
+      expect(pids).not.toContain(101); // B's events dropped, batch intact
+    });
   });
 });


### PR DESCRIPTION
## What

Replaced the serial `for…await` loop in `scanAllFileHandles` with a **bounded-concurrency worker pool** — `Promise.all` over **5 workers** (an index cursor), not over N agents — capped by a named, exported const `FILE_SCAN_CONCURRENCY = 5`.

## Why

Measured target. File scan is the fattest stage: median **6188 ms** (scan-timing-baseline, 2026-06-04), ~64% cumulative, ~10× the process scan. Root cause: each agent's `scanFileHandles` awaited one `getFileHandles(pid)` = a per-PID `powershell.exe` + `handle.exe` spawn (~500 ms cold); 12 agents serially ≈ 6.2 s. Overlapping 5 spawns targets **6.2 s → ~1.5 s**. This is **not** a UI freeze (`execFile` is async) — it's detection latency + a wider busy window.

## Why fixed 5, not adaptive (`os.cpus`)

The bottleneck is per-PID **I/O, not CPU**, so core count is the wrong knob. A fixed cap also keeps the test deterministic (`maxInFlight === 5`).

## Correctness

- **C-01 attribution preserved.** Results are stored by **original index**, so the returned array stays in agent order; per-event attribution is stamped *inside* `scanFileHandles` from the agent argument — concurrency cannot cross-wire it.
- **Isolation.** A per-agent `try/catch` lives *inside* the worker loop: one agent throwing (e.g. the unguarded `recordFileAccess` path) drops only its events (`results[i] = []`); the batch survives.

## Tests (+2, 70 → 72)

- **A — limit + attribution:** in-flight counter asserts `maxInFlight === FILE_SCAN_CONCURRENCY` (caps *and* saturates), all 12 agents still scanned, C-01 attribution intact.
- **B — isolation:** forces a throw from the unguarded `recordFileAccess` for one agent; asserts the others survive and only the failing one is dropped.

## Known / out of scope

- `file-watcher.js` is 402 lines — a **pre-existing** 300-line overflow (C-17), not introduced here. The `audit` CI job reports line count as a *finding*, not a hard-fail.
- **Not touched:** `scan-loop.js` timing instrumentation (just merged), and `win32.getFileHandles` internals (PowerShell cold-start = optional follow-up PR-3).
