### PR TITLE
fix(win32): honest read-detection — probe handle.exe, drop .Modules false-positive

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -233,6 +233,10 @@ if (!gotLock) {
 /** Wires deferred modules and starts scanning. Called after ready-to-show. */
 function initDeferredSubsystems(userData) {
   loadDeferredModules();
+  // One-time read-detection capability probe (win32 only — darwin/linux don't
+  // define it, so optional chaining no-ops). Fire-and-forget: it sets the
+  // platform's degraded flag before the first staggered file-scan tick.
+  require('./platform').probeReadDetection?.();
   const network = require('./network-monitor');
   const analysis = require('./ai-analysis');
 

--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -6,6 +6,19 @@
 'use strict';
 
 const { execFile } = require('child_process');
+const logger = require('../logger');
+
+/**
+ * Whether open-file-handle detection is available — i.e. handle64.exe/handle.exe
+ * is on PATH. Optimistic default (true): downgraded to false ONLY by
+ * probeReadDetection() finding no binary or erroring. "Can't tell" must fail
+ * honest (false), never optimistic. When false, getFileHandles() short-circuits
+ * to [] (no spawn) rather than fabricating handles from loaded modules.
+ * @type {boolean}
+ */
+let _readDetectionAvailable = true;
+/** @type {boolean} One-shot guard so the degraded warning logs at most once. */
+let _readDetectionWarned = false;
 
 /** @type {RegExp[]} Windows-specific file-path patterns to ignore */
 const IGNORE_FILE_PATTERNS = [
@@ -131,6 +144,9 @@ function getRawTcpConnections(pids) {
 function getFileHandles(pid) {
   pid = Number(pid);
   if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve([]);
+  // Honest zero: when no handle binary exists we cannot read open file handles.
+  // Return [] without spawning rather than reporting loaded modules as handles.
+  if (!_readDetectionAvailable) return Promise.resolve([]);
   return new Promise((resolve) => {
     const psScript = [
       '$ErrorActionPreference="SilentlyContinue"',
@@ -142,13 +158,6 @@ function getFileHandles(pid) {
       '  foreach($l in $out){',
       '    if($l -match "File\\s+.*?\\s+([A-Z]:\\\\.+)$"){',
       '      [void]$files.Add($Matches[1].Trim())',
-      '    }',
-      '  }',
-      '}else{',
-      `  $p=Get-Process -Id ${pid} -EA SilentlyContinue`,
-      '  if($p -and $p.Modules){',
-      '    foreach($m in $p.Modules){',
-      '      if($m.FileName){[void]$files.Add($m.FileName)}',
       '    }',
       '  }',
       '}',
@@ -182,6 +191,53 @@ function getFileHandles(pid) {
       },
     );
   });
+}
+
+/**
+ * One-time startup probe: is a handle binary (handle64.exe/handle.exe) on PATH?
+ * Sets the module-level _readDetectionAvailable flag and warns (once) when
+ * degraded. Errors/timeouts resolve to unavailable — fail honest, not optimistic.
+ * darwin/linux do NOT define this method (their lsof//proc read-detection is
+ * always available), so main.js calls it via optional chaining.
+ * @returns {Promise<{available: boolean, path: string|null}>}
+ * @since v0.10.0
+ */
+function probeReadDetection() {
+  return new Promise((resolve) => {
+    const psScript = [
+      '$ErrorActionPreference="SilentlyContinue"',
+      '$h=Get-Command handle64.exe -EA SilentlyContinue',
+      'if(!$h){$h=Get-Command handle.exe -EA SilentlyContinue}',
+      'if($h){$h.Source}else{""}',
+    ].join('\n');
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', psScript],
+      { timeout: 8000 },
+      (err, stdout) => {
+        const sourcePath = !err && stdout ? stdout.trim() : '';
+        const available = sourcePath.length > 0;
+        _readDetectionAvailable = available;
+        if (!available && !_readDetectionWarned) {
+          _readDetectionWarned = true;
+          logger.warn(
+            'platform',
+            'File read-detection degraded: handle64.exe/handle.exe not found — ' +
+              'file-read (accessed) events disabled until a handle binary is installed',
+          );
+        }
+        resolve({ available, path: available ? sourcePath : null });
+      },
+    );
+  });
+}
+
+/**
+ * @returns {boolean} Whether open-file-handle detection is currently available.
+ * @since v0.10.0
+ */
+function isReadDetectionAvailable() {
+  return _readDetectionAvailable;
 }
 
 /**
@@ -326,6 +382,8 @@ module.exports = {
   getParentProcessMap,
   getRawTcpConnections,
   getFileHandles,
+  probeReadDetection,
+  isReadDetectionAvailable,
   getProcessCwd,
   getProcessCwds,
   killProcess,

--- a/tests/main/platform/win32.test.js
+++ b/tests/main/platform/win32.test.js
@@ -262,6 +262,53 @@ describe('platform/win32', () => {
 
       expect(await win32.getFileHandles(100)).toEqual([]);
     });
+
+    // PR-A honesty — A1: the PS script must not fall back to loaded modules.
+    // White-box (the execFile mock can't simulate a real "binary absent" PS run,
+    // so we assert the script itself no longer contains the .Modules branch).
+    it('PS script has no .Modules / Get-Process fallback (no false-positive handles)', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(null, '[]'));
+      await win32.getFileHandles(100);
+      expect(mockExecFile).toHaveBeenCalled();
+      const psScript = mockExecFile.mock.calls[0][1][3];
+      expect(psScript).not.toMatch(/Modules/);
+      expect(psScript).not.toMatch(/Get-Process/);
+    });
+
+    // PR-A honesty — A2: when read-detection is unavailable, getFileHandles must
+    // return [] WITHOUT spawning a powershell (honest zero + perf short-circuit).
+    it('returns [] without spawning when read-detection is unavailable', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(null, ''));
+      await win32.probeReadDetection();
+      expect(win32.isReadDetectionAvailable()).toBe(false);
+      const callsAfterProbe = mockExecFile.mock.calls.length;
+      const result = await win32.getFileHandles(100);
+      expect(result).toEqual([]);
+      expect(mockExecFile.mock.calls.length).toBe(callsAfterProbe);
+    });
+  });
+
+  // PR-A — B: one-time startup probe drives the degraded flag honestly.
+  describe('probeReadDetection', () => {
+    it('sets readDetectionAvailable=true when a handle binary is found', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) =>
+        cb(null, 'C:\\tools\\handle64.exe\n'),
+      );
+      await win32.probeReadDetection();
+      expect(win32.isReadDetectionAvailable()).toBe(true);
+    });
+
+    it('sets readDetectionAvailable=false when no handle binary is found', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(null, ''));
+      await win32.probeReadDetection();
+      expect(win32.isReadDetectionAvailable()).toBe(false);
+    });
+
+    it('sets readDetectionAvailable=false on probe error (fail honest, not optimistic)', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(new Error('powershell missing')));
+      await win32.probeReadDetection();
+      expect(win32.isReadDetectionAvailable()).toBe(false);
+    });
   });
 
   describe('killProcess', () => {
@@ -425,6 +472,8 @@ describe('platform/win32', () => {
       expect(typeof win32.killProcess).toBe('function');
       expect(typeof win32.suspendProcess).toBe('function');
       expect(typeof win32.resumeProcess).toBe('function');
+      expect(typeof win32.probeReadDetection).toBe('function');
+      expect(typeof win32.isReadDetectionAvailable).toBe('function');
       expect(Array.isArray(win32.IGNORE_FILE_PATTERNS)).toBe(true);
     });
   });


### PR DESCRIPTION
## Что

`handle64.exe`/`handle.exe` отсутствуют → `getFileHandles` молча падал в `.Modules` fallback (загруженные DLL, **НЕ** открытые хендлы), эмитил их как `accessed`-события. Fix: startup-проба (один раз, `initDeferredSubsystems`, optional-chain → darwin/linux no-op) ставит флаг `readDetectionAvailable`; два слоя честности:

1. удалить `.Modules`-ветку из PS-скрипта (честное пустое окно до пробы),
2. JS short-circuit `getFileHandles → []` когда бинаря нет (steady state + ноль лишних спавнов).

`win32.js` теперь импортит `logger`, `logger.warn` один раз про degraded.

## Зачем

False-confidence failure (доказано live UI — Cursor feed забит `.node`/`.exe` accessed, SENSITIVE FILES=0 при активной работе). Read-сенсор был мёртв, feed выглядел живым. Теперь честный `[]` вместо ламп-на-стене.

## Решение `[]`, не source-marking

`file-watcher` — единственный потребитель `getFileHandles`, `scanFileHandles:303` уже short-circuit на `[]`. Source-tag пришлось бы тянуть через event → IPC → renderer (запрещённые поверхности). `[]` и честный, и минимальный.

## Слой жив, дыра строго в file-READ

chokidar (write/create/delete) untouched, network-классификация untouched, C-01 untouched. Слепая зона = агент **ЧИТАЕТ** секрет без модификации.

## Тесты

+6 (A1 white-box: `.Modules` removed из скрипта; A2: флаг false → `[]` + ноль спавнов; B ×проба ставит флаг). win32 44 → 50. Full 785 pass. RED подтверждён до фикса.

## Граница

`main.js` однострочник проверен инспекцией, не тестом (Electron-entry вне скоупа) — честно отмечено.

## KNOWN

`win32.js` 336 → 393 строк — pre-existing 300-overflow (C-17), extraction отдельный scope.
