### PR TITLE
feat(win32): honest read-detect via Restart Manager

### DIFF
--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -56,13 +56,19 @@ const DEFAULT_IGNORED_DIRS = [
 const FILE_SCAN_CONCURRENCY = 5;
 
 let _getFileHandles = _platform.getFileHandles;
+// win32 exposes these (Restart Manager); darwin/linux do not → undefined, so the
+// RM branch is skipped and the legacy getFileHandles pool path runs unchanged.
+let _getSensitiveHolders = _platform.getSensitiveHolders;
+const _isRmAvailable = _platform.isRestartManagerAvailable;
 /** @internal Override dependencies (for tests). */
 function _setDepsForTest(overrides) {
   if (overrides.getFileHandles) _getFileHandles = overrides.getFileHandles;
+  if (overrides.getSensitiveHolders) _getSensitiveHolders = overrides.getSensitiveHolders;
 }
-/** @internal Reset debounce state (for tests). */
+/** @internal Reset debounce state + opt out of the RM path (for tests). */
 function _resetForTest() {
   watcherDebounce.clear();
+  _getSensitiveHolders = undefined; // tests opt into RM explicitly via _setDepsForTest
 }
 
 const watcherDebounce = new Map();
@@ -344,11 +350,102 @@ async function scanFileHandles(agent) {
 }
 
 /**
+ * Whether the Restart Manager read-detect path is usable: the platform exposes
+ * getSensitiveHolders (win32 only) AND, if it reports availability, RM is up. When
+ * RM is unavailable the caller falls back to the legacy getFileHandles pool path,
+ * preserving the PR-A handle.exe fallback.
+ * @returns {boolean}
+ */
+function rmEnabled() {
+  if (typeof _getSensitiveHolders !== 'function') return false;
+  if (typeof _isRmAvailable === 'function' && !_isRmAvailable()) return false;
+  return true;
+}
+
+/**
+ * Restart Manager scan path (win32 primary): ONE powershell spawn returns every
+ * process holding a handle to a registered sensitive directory group. Each holder
+ * PID is mapped to its OWNING agent (C-01 — resolved from the PID, never
+ * cross-wired); AEGIS's own PID and non-agent holders are dropped. Emits an
+ * `action:'holding'` event — a point-in-time handle HOLD at the scan tick, NOT a
+ * read/access. Dedups per-PID by group via knownHandles so a sustained hold fires
+ * once, not once-per-scan.
+ * @param {Array} agents
+ * @returns {Promise<Array>}
+ * @since v0.10.0
+ */
+async function scanViaRestartManager(agents) {
+  let holders;
+  try {
+    holders = await _getSensitiveHolders();
+  } catch (_) {
+    return [];
+  }
+  if (!Array.isArray(holders) || holders.length === 0) return [];
+  const toScan =
+    _state && _state.isOtherPanelExpanded() ? agents : agents.filter((a) => a.category === 'ai');
+  const pidToAgent = new Map();
+  for (const a of toScan) pidToAgent.set(a.pid, a);
+  const kh = _state.knownHandles;
+  const newAccess = [];
+  for (const h of holders) {
+    if (h.pid === process.pid) continue; // own-PID guard — never blame AEGIS itself
+    const agent = pidToAgent.get(h.pid);
+    if (!agent) continue; // holder is not a tracked (in-scope) agent — drop
+    const group = h.group;
+    if (!kh.has(h.pid)) kh.set(h.pid, new Set());
+    const known = kh.get(h.pid);
+    const dedupKey = 'holding|' + group;
+    if (known.has(dedupKey)) continue;
+    known.add(dedupKey);
+    if (known.size > 500) {
+      const iter = known.values();
+      for (let i = 0; i < known.size - 500; i++) known.delete(iter.next().value);
+    }
+    // Rule/self-config patterns anchor on a separator AFTER the dir name (e.g.
+    // `\.claude[\\/]`), but a group is a bare DIR path with no trailing separator.
+    // Match against a separator-normalized variant so dir groups resolve, while
+    // keeping event.file the clean dir. Single-file (env) groups still match
+    // as-is via the basename-anchored ($) patterns.
+    const groupSep = group.endsWith('/') || group.endsWith('\\') ? group : group + '/';
+    const reason = h.reason || classifySensitive(groupSep) || classifySensitive(group) || '';
+    const selfAccess =
+      reason !== '' && (isSelfAccess(agent.agent, groupSep) || isSelfAccess(agent.agent, group));
+    const event = {
+      agent: agent.agent,
+      pid: h.pid,
+      parentEditor: agent.parentEditor || null,
+      cwd: agent.cwd || null,
+      file: group,
+      sensitive: reason !== '' && !selfAccess,
+      selfAccess,
+      reason,
+      action: 'holding',
+      timestamp: Date.now(),
+      category: agent.category || 'other',
+    };
+    newAccess.push(event);
+    _state.activityLog.push(event);
+    if (_state.onActivityPush) _state.onActivityPush(event);
+    if (_state.activityLog.length > 10000) {
+      const evicted = _state.activityLog.shift();
+      if (_state.onActivityEvict) _state.onActivityEvict(evicted);
+    }
+    _state.recordFileAccess(agent.agent, group, event.sensitive, event.reason);
+  }
+  return newAccess;
+}
+
+/**
  * @param {Array} agents
  * @returns {Promise<Array>}
  * @since v0.1.0
  */
 async function scanAllFileHandles(agents) {
+  // win32 primary: honest read-detect via Restart Manager (no handle.exe needed).
+  // Falls through to the legacy per-PID handle pool on darwin/linux, or on win32
+  // when RM is unavailable (the PR-A getFileHandles→[] fallback still applies).
+  if (rmEnabled()) return scanViaRestartManager(agents);
   const toScan =
     _state && _state.isOtherPanelExpanded() ? agents : agents.filter((a) => a.category === 'ai');
   // Bounded-concurrency worker pool: at most FILE_SCAN_CONCURRENCY scanFileHandles()

--- a/src/main/platform/restart-manager.js
+++ b/src/main/platform/restart-manager.js
@@ -1,0 +1,295 @@
+/**
+ * @file platform/restart-manager.js
+ * @module main/platform/restart-manager
+ * @description Honest Windows read-detection via the Windows Restart Manager
+ *   (rstrtmgr.dll), the replacement for the absent handle.exe. Restart Manager
+ *   inverts the handle.exe model: instead of asking "what files does PID X hold?"
+ *   it asks "which processes hold these registered resources?" — exactly what we
+ *   need to attribute a held sensitive file to an agent PID, cross-process,
+ *   asInvoker, WITHOUT admin (spike-proven).
+ *
+ *   IMPORTANT — this catches a handle HELD AT THE SCAN TICK, never a transient
+ *   open→read→close. A `.env` that an agent opens, reads, and closes is already
+ *   closed by the next scan → missed. This is point-in-time "holding open",
+ *   exactly like handle.exe — NOT a read/access stream. Callers must label the
+ *   resulting events "holding", never "read"/"accessed".
+ *
+ *   Grouping: one Restart Manager SESSION per directory group, opened and CLOSED
+ *   before the next (so only one session is ever live — the 64-session/user cap is
+ *   never approached). All groups run inside ONE powershell.exe spawn per scan
+ *   (the spawn COUNT is the cost we cut, not the in-process RM session count).
+ *
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.10.0
+ */
+'use strict';
+
+const { execFile } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { getAllRules } = require('../rule-loader');
+const { AGENT_CONFIG_PATHS } = require('../../shared/constants');
+
+/**
+ * Secret credential directories watched for held handles (mirror of the roots in
+ * file-watcher.setupFileWatchers). Each existing dir becomes ONE registration
+ * group → dir-level honest attribution ("holding a file under ~/.ssh"), never a
+ * fabricated per-file claim RM cannot confirm.
+ * @type {string[]}
+ */
+const SECRET_DIRS = ['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.azure'];
+
+/**
+ * Whether Restart Manager P/Invoke is usable. Optimistic default (true);
+ * downgraded to false ONLY by probeRestartManager() failing — "can't tell" must
+ * fail honest, not optimistic. rstrtmgr.dll ships on every Windows Vista+, so the
+ * probe really tests "does Add-Type + RmStartSession succeed in this runtime".
+ * @type {boolean}
+ */
+let _rmAvailable = true;
+
+/**
+ * Max file paths registered per group — a defensive bound so a pathological dir
+ * (thousands of files) cannot bloat one RmRegisterResources call.
+ * @type {number}
+ */
+const MAX_FILES_PER_GROUP = 64;
+
+/**
+ * The C# Restart Manager wrapper compiled once per spawn via Add-Type. Exposes
+ * a single static GetHolders(string[] files) → int[] of holder PIDs. Uses the
+ * two-call RmGetList protocol and branches on pnProcInfoNeeded > 0 (the holder
+ * count) — NOT on a 234/ERROR_MORE_DATA return code, which does not arrive here.
+ * @type {string}
+ */
+const RM_CSHARP = [
+  'using System;',
+  'using System.Collections.Generic;',
+  'using System.Runtime.InteropServices;',
+  'using System.Text;',
+  'public static class AegisRm {',
+  '  [StructLayout(LayoutKind.Sequential)] struct RM_UNIQUE_PROCESS { public int dwProcessId; public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime; }',
+  '  const int RM_INVALID_SESSION = -1;',
+  '  const int CCH_RM_SESSION_KEY = 32;',
+  '  const int CCH_RM_MAX_APP_NAME = 255;',
+  '  const int CCH_RM_MAX_SVC_NAME = 63;',
+  '  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)] struct RM_PROCESS_INFO {',
+  '    public RM_UNIQUE_PROCESS Process;',
+  '    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_APP_NAME + 1)] public string strAppName;',
+  '    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_SVC_NAME + 1)] public string strServiceShortName;',
+  '    public int ApplicationType; public uint AppStatus; public uint TSSessionId;',
+  '    [MarshalAs(UnmanagedType.Bool)] public bool bRestartable;',
+  '  }',
+  '  [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)] static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, StringBuilder strSessionKey);',
+  '  [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)] static extern int RmRegisterResources(uint pSessionHandle, uint nFiles, string[] rgsFilenames, uint nApplications, IntPtr rgApplications, uint nServices, string[] rgsServiceNames);',
+  '  [DllImport("rstrtmgr.dll")] static extern int RmGetList(uint dwSessionHandle, out uint pnProcInfoNeeded, ref uint pnProcInfo, [In, Out] RM_PROCESS_INFO[] rgAffectedApps, out uint lpdwRebootReasons);',
+  '  [DllImport("rstrtmgr.dll")] static extern int RmEndSession(uint pSessionHandle);',
+  '  public static int[] GetHolders(string[] files) {',
+  '    var pids = new List<int>();',
+  '    if (files == null || files.Length == 0) return pids.ToArray();',
+  '    uint session; var key = new StringBuilder(CCH_RM_SESSION_KEY + 1);',
+  '    if (RmStartSession(out session, 0, key) != 0) return pids.ToArray();',
+  '    try {',
+  '      if (RmRegisterResources(session, (uint)files.Length, files, 0, IntPtr.Zero, 0, null) != 0) return pids.ToArray();',
+  '      uint needed = 0, count = 0, reason = 0;',
+  '      RmGetList(session, out needed, ref count, null, out reason);',
+  '      if (needed > 0) {',
+  '        var info = new RM_PROCESS_INFO[needed]; count = needed;',
+  '        if (RmGetList(session, out needed, ref count, info, out reason) == 0) {',
+  '          for (uint i = 0; i < count; i++) pids.Add(info[i].Process.dwProcessId);',
+  '        }',
+  '      }',
+  '    } finally { RmEndSession(session); }',
+  '    return pids.ToArray();',
+  '  }',
+  '}',
+].join('\n');
+
+/**
+ * Compile-and-run PowerShell body. Reads the group list (JSON) from an env var to
+ * dodge path-quoting/injection in the script, invokes AegisRm.GetHolders per group,
+ * and emits a compact JSON array of { group, reason, pids } back on stdout.
+ * @type {string}
+ */
+const PS_BODY = [
+  '$ErrorActionPreference="Stop"',
+  `Add-Type -TypeDefinition @'\n${RM_CSHARP}\n'@`,
+  '$groups = $env:AEGIS_RM_GROUPS | ConvertFrom-Json',
+  '$out = @()',
+  'foreach ($g in $groups) {',
+  '  try { $pids = [AegisRm]::GetHolders([string[]]$g.files) } catch { $pids = @() }',
+  '  $out += [pscustomobject]@{ group = $g.group; reason = $g.reason; pids = @($pids) }',
+  '}',
+  'if ($out.Count -gt 0) { $out | ConvertTo-Json -Compress -Depth 4 } else { "[]" }',
+].join('\n');
+
+/**
+ * Classify a path against the loaded rules; returns the first matching reason or
+ * null. A standalone copy of file-watcher.classifySensitive's built-in path —
+ * restart-manager must NOT require file-watcher (that would close a require cycle
+ * win32 → restart-manager → file-watcher → platform → win32).
+ * @param {string} filePath
+ * @returns {string|null}
+ */
+function classify(filePath) {
+  for (const rule of getAllRules().values()) {
+    if (rule.enabled !== false && rule.pattern.test(filePath)) return rule.reason;
+  }
+  return null;
+}
+
+/**
+ * Shallow-enumerate concrete sensitive files under the watched secret/config dirs
+ * plus home ~/.env* files, grouped for registration. A directory becomes one group
+ * keyed by the dir path (dir-level naming); each ~/.env* file is its own group
+ * keyed by the file path (single confirmed file → file-level naming is honest).
+ * @returns {Array<{group: string, reason: string, files: string[]}>}
+ */
+function buildSensitiveGroups() {
+  const home = os.homedir();
+  /** @type {Array<{group: string, reason: string, files: string[]}>} */
+  const groups = [];
+  const dirNames = [...SECRET_DIRS, ...AGENT_CONFIG_PATHS];
+  const seen = new Set();
+  for (const name of dirNames) {
+    const dir = path.join(home, name);
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (_) {
+      continue; // dir absent or unreadable
+    }
+    const files = [];
+    for (const e of entries) {
+      if (!e.isFile()) continue;
+      files.push(path.join(dir, e.name));
+      if (files.length >= MAX_FILES_PER_GROUP) break;
+    }
+    if (files.length === 0) continue;
+    const reason = classify(files[0]) || classify(dir + path.sep);
+    if (!reason) continue; // not rule-sensitive → skip
+    groups.push({ group: dir, reason, files });
+  }
+  // ~/.env* — each file its own single-file group (confirmed file-level naming).
+  try {
+    for (const e of fs.readdirSync(home, { withFileTypes: true })) {
+      if (!e.isFile() || !/^\.env(\.|$)/i.test(e.name)) continue;
+      const file = path.join(home, e.name);
+      const reason = classify(file);
+      if (reason) groups.push({ group: file, reason, files: [file] });
+    }
+  } catch (_) {
+    // home unreadable — skip env group
+  }
+  return groups;
+}
+
+/**
+ * Run the Restart Manager scan: ONE powershell.exe spawn, one RM session per
+ * group (sequentially opened/closed), returning every process holding a handle
+ * to a registered sensitive resource. Holders are returned RAW (including
+ * non-agent PIDs and possibly AEGIS itself) — the caller maps PIDs to agents and
+ * applies the own-PID guard.
+ * @returns {Promise<Array<{pid: number, group: string, reason: string}>>}
+ * @since v0.10.0
+ */
+function getSensitiveHolders() {
+  if (!_rmAvailable) return Promise.resolve([]);
+  const groups = buildSensitiveGroups();
+  if (groups.length === 0) return Promise.resolve([]);
+  return new Promise((resolve) => {
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', PS_BODY],
+      { timeout: 15000, env: { ...process.env, AEGIS_RM_GROUPS: JSON.stringify(groups) } },
+      (err, stdout) => {
+        if (err) {
+          resolve([]);
+          return;
+        }
+        resolve(parseHolders(stdout));
+      },
+    );
+  });
+}
+
+/**
+ * Parse the PowerShell JSON ({ group, reason, pids[] }[]) into a flat holder list.
+ * @param {string} stdout
+ * @returns {Array<{pid: number, group: string, reason: string}>}
+ */
+function parseHolders(stdout) {
+  const raw = (stdout || '').trim();
+  if (!raw || raw === '[]') return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_) {
+    return [];
+  }
+  if (!Array.isArray(parsed)) parsed = [parsed];
+  /** @type {Array<{pid: number, group: string, reason: string}>} */
+  const holders = [];
+  for (const g of parsed) {
+    if (!g || !g.group) continue;
+    let pids = g.pids;
+    if (pids == null) continue;
+    if (!Array.isArray(pids)) pids = [pids];
+    for (const p of pids) {
+      const pid = Number(p);
+      if (Number.isInteger(pid) && pid > 0) {
+        holders.push({ pid, group: g.group, reason: g.reason || '' });
+      }
+    }
+  }
+  return holders;
+}
+
+/**
+ * One-time startup probe: can this runtime Add-Type the RM wrapper and open a
+ * Restart Manager session? Sets _rmAvailable. Errors/timeouts → unavailable
+ * (fail honest). Result is consumed by win32.probeReadDetection to drive the
+ * combined read-detection capability flag.
+ * @returns {Promise<{available: boolean}>}
+ * @since v0.10.0
+ */
+function probeRestartManager() {
+  return new Promise((resolve) => {
+    const probeBody = [
+      '$ErrorActionPreference="Stop"',
+      `Add-Type -TypeDefinition @'\n${RM_CSHARP}\n'@`,
+      'try { [void][AegisRm]::GetHolders(@()); "OK" } catch { "FAIL" }',
+    ].join('\n');
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', probeBody],
+      { timeout: 8000 },
+      (err, stdout) => {
+        const ok = !err && /OK/.test(stdout || '');
+        _rmAvailable = ok;
+        resolve({ available: ok });
+      },
+    );
+  });
+}
+
+/**
+ * @returns {boolean} Whether Restart Manager read-detection is currently usable.
+ * @since v0.10.0
+ */
+function isRestartManagerAvailable() {
+  return _rmAvailable;
+}
+
+module.exports = {
+  getSensitiveHolders,
+  probeRestartManager,
+  isRestartManagerAvailable,
+  buildSensitiveGroups,
+  // Exposed for testing only
+  _parseHolders: parseHolders,
+};

--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -7,16 +7,22 @@
 
 const { execFile } = require('child_process');
 const logger = require('../logger');
+const restartManager = require('./restart-manager');
 
 /**
- * Whether open-file-handle detection is available — i.e. handle64.exe/handle.exe
- * is on PATH. Optimistic default (true): downgraded to false ONLY by
- * probeReadDetection() finding no binary or erroring. "Can't tell" must fail
- * honest (false), never optimistic. When false, getFileHandles() short-circuits
- * to [] (no spawn) rather than fabricating handles from loaded modules.
+ * Whether the handle.exe/handle64.exe binary is on PATH — the LEGACY read-detect
+ * mechanism (getFileHandles). Optimistic default (true): downgraded to false ONLY
+ * by probeReadDetection() finding no binary or erroring. "Can't tell" fails honest
+ * (false). When false, getFileHandles() short-circuits to [] (no spawn) rather
+ * than fabricating handles from loaded modules.
+ *
+ * NOTE: this is now only ONE of two read-detect capabilities. Restart Manager
+ * (restart-manager.js) is the PRIMARY mechanism and does NOT need this binary;
+ * its availability lives in restart-manager._rmAvailable. Overall read-detection
+ * is available when EITHER works — see isReadDetectionAvailable().
  * @type {boolean}
  */
-let _readDetectionAvailable = true;
+let _handleBinaryAvailable = true;
 /** @type {boolean} One-shot guard so the degraded warning logs at most once. */
 let _readDetectionWarned = false;
 
@@ -146,7 +152,9 @@ function getFileHandles(pid) {
   if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve([]);
   // Honest zero: when no handle binary exists we cannot read open file handles.
   // Return [] without spawning rather than reporting loaded modules as handles.
-  if (!_readDetectionAvailable) return Promise.resolve([]);
+  // (Restart Manager is the primary path; this legacy handle.exe path only runs
+  // when the binary is genuinely present.)
+  if (!_handleBinaryAvailable) return Promise.resolve([]);
   return new Promise((resolve) => {
     const psScript = [
       '$ErrorActionPreference="SilentlyContinue"',
@@ -194,15 +202,11 @@ function getFileHandles(pid) {
 }
 
 /**
- * One-time startup probe: is a handle binary (handle64.exe/handle.exe) on PATH?
- * Sets the module-level _readDetectionAvailable flag and warns (once) when
- * degraded. Errors/timeouts resolve to unavailable — fail honest, not optimistic.
- * darwin/linux do NOT define this method (their lsof//proc read-detection is
- * always available), so main.js calls it via optional chaining.
+ * Probe whether a handle binary (handle64.exe/handle.exe) is on PATH. Sets the
+ * module-level _handleBinaryAvailable flag. Errors/timeouts → false (fail honest).
  * @returns {Promise<{available: boolean, path: string|null}>}
- * @since v0.10.0
  */
-function probeReadDetection() {
+function _probeHandleBinary() {
   return new Promise((resolve) => {
     const psScript = [
       '$ErrorActionPreference="SilentlyContinue"',
@@ -216,28 +220,52 @@ function probeReadDetection() {
       { timeout: 8000 },
       (err, stdout) => {
         const sourcePath = !err && stdout ? stdout.trim() : '';
-        const available = sourcePath.length > 0;
-        _readDetectionAvailable = available;
-        if (!available && !_readDetectionWarned) {
-          _readDetectionWarned = true;
-          logger.warn(
-            'platform',
-            'File read-detection degraded: handle64.exe/handle.exe not found — ' +
-              'file-read (accessed) events disabled until a handle binary is installed',
-          );
-        }
-        resolve({ available, path: available ? sourcePath : null });
+        _handleBinaryAvailable = sourcePath.length > 0;
+        resolve({
+          available: _handleBinaryAvailable,
+          path: _handleBinaryAvailable ? sourcePath : null,
+        });
       },
     );
   });
 }
 
 /**
- * @returns {boolean} Whether open-file-handle detection is currently available.
+ * One-time startup probe for read-detection. Probes BOTH capabilities in
+ * parallel: the legacy handle.exe binary AND the Windows Restart Manager (the
+ * primary path, no binary needed). Read-detection is available when EITHER works.
+ * Warns (once) ONLY when BOTH are absent. Errors/timeouts → unavailable (fail
+ * honest, not optimistic). darwin/linux do NOT define this method (their
+ * lsof//proc read-detection is always available), so main.js calls it via
+ * optional chaining.
+ * @returns {Promise<{available: boolean, handle: string|null, rm: boolean}>}
+ * @since v0.10.0
+ */
+async function probeReadDetection() {
+  const [handle, rm] = await Promise.all([
+    _probeHandleBinary(),
+    restartManager.probeRestartManager(),
+  ]);
+  const available = handle.available || rm.available;
+  if (!available && !_readDetectionWarned) {
+    _readDetectionWarned = true;
+    logger.warn(
+      'platform',
+      'File read-detection degraded: neither a handle binary (handle64.exe/' +
+        'handle.exe) nor the Windows Restart Manager is available — file-hold ' +
+        '(holding) events disabled',
+    );
+  }
+  return { available, handle: handle.path, rm: rm.available };
+}
+
+/**
+ * @returns {boolean} Whether read-detection is available via EITHER mechanism
+ *   (handle.exe binary OR Restart Manager).
  * @since v0.10.0
  */
 function isReadDetectionAvailable() {
-  return _readDetectionAvailable;
+  return _handleBinaryAvailable || restartManager.isRestartManagerAvailable();
 }
 
 /**
@@ -382,6 +410,8 @@ module.exports = {
   getParentProcessMap,
   getRawTcpConnections,
   getFileHandles,
+  getSensitiveHolders: restartManager.getSensitiveHolders,
+  isRestartManagerAvailable: restartManager.isRestartManagerAvailable,
   probeReadDetection,
   isReadDetectionAvailable,
   getProcessCwd,

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -4,8 +4,15 @@
  * @description Types for file watcher events, network connections, and deviation warnings.
  */
 
-/** File watcher action types */
-export type FileAction = 'created' | 'modified' | 'deleted' | 'accessed';
+/**
+ * File watcher action types.
+ * - created/modified/deleted: chokidar write events.
+ * - accessed: open file handle read-detect (handle.exe / lsof / /proc).
+ * - holding: Windows Restart Manager — a process holds a handle to a sensitive
+ *   resource AT THE SCAN TICK (point-in-time hold, not a read). Distinct from
+ *   'accessed' so the source (rm-hold vs chokidar-write) is never conflated.
+ */
+export type FileAction = 'created' | 'modified' | 'deleted' | 'accessed' | 'holding';
 
 /** File access event from watcher or handle scan */
 export interface FileEvent {

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -489,3 +489,90 @@ describe('file-watcher scanFileHandles', () => {
     });
   });
 });
+
+// Restart Manager (RM) path — the win32 read-detect replacement for handle.exe.
+// RM inverts the model: register sensitive DIRECTORY groups, one RmGetList per
+// group returns the holder PIDs. file-watcher maps each holder PID → owning agent
+// and emits an `action:'holding'` event (point-in-time handle hold, NOT a read).
+// The whole RM mechanism is injected via _setDepsForTest({ getSensitiveHolders })
+// so these tests never spawn PowerShell. _resetForTest() clears the RM dep so the
+// getFileHandles-pool tests above stay on their own (non-RM) path.
+describe('file-watcher Restart Manager (RM) holder path', () => {
+  let state;
+  let mockGetSensitiveHolders;
+
+  beforeEach(() => {
+    mockGetSensitiveHolders = vi.fn();
+    state = makeState();
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+    fileWatcher._setDepsForTest({ getSensitiveHolders: mockGetSensitiveHolders });
+  });
+
+  // #1 (core proof, RED before the RM branch exists): a holder PID resolves to the
+  // OWNING agent by PID — never cross-wired (C-01) — and emits one holding event.
+  it('maps an RM holder PID to the owning agent and emits a holding event (C-01)', async () => {
+    mockGetSensitiveHolders.mockResolvedValue([
+      { pid: 105, group: '/home/user/.ssh', reason: 'SSH keys/config' },
+    ]);
+    const agents = [
+      { pid: 100, agent: 'Claude Code', category: 'ai' },
+      { pid: 105, agent: 'Agent5', category: 'ai' },
+    ];
+    const events = await fileWatcher.scanAllFileHandles(agents);
+    expect(events).toHaveLength(1);
+    expect(events[0].agent).toBe('Agent5'); // resolved from holder PID 105, not aiAgents[0]
+    expect(events[0].pid).toBe(105);
+    expect(events[0].action).toBe('holding'); // NOT 'accessed' / 'read' — it's a hold
+    expect(events[0].file).toBe('/home/user/.ssh'); // the DIRECTORY group, not a fabricated file
+    expect(events[0].sensitive).toBe(true);
+    expect(events[0].reason).toBe('SSH keys/config');
+  });
+
+  // #3 self-access exemption: an agent holding its OWN config dir is expected, not a
+  // threat — selfAccess true, sensitive false (must not regress under the RM path).
+  it('marks an agent holding its OWN config dir as self-access (not a threat)', async () => {
+    mockGetSensitiveHolders.mockResolvedValue([
+      { pid: 100, group: '/home/user/.claude', reason: 'AI agent config — Claude Code' },
+    ]);
+    const agents = [{ pid: 100, agent: 'Claude Code', category: 'ai' }];
+    const events = await fileWatcher.scanAllFileHandles(agents);
+    expect(events).toHaveLength(1);
+    expect(events[0].selfAccess).toBe(true);
+    expect(events[0].sensitive).toBe(false);
+  });
+
+  // #4 own-PID guard: AEGIS's own process holding a watched file must NEVER be
+  // attributed to an agent ("AEGIS is holding your SSH keys" would be a false alarm).
+  it('drops a holder whose PID is AEGIS itself (own-PID guard)', async () => {
+    mockGetSensitiveHolders.mockResolvedValue([
+      { pid: process.pid, group: '/home/user/.ssh', reason: 'SSH keys/config' },
+    ]);
+    const agents = [{ pid: process.pid, agent: 'Self', category: 'ai' }];
+    const events = await fileWatcher.scanAllFileHandles(agents);
+    expect(events).toEqual([]);
+  });
+
+  it('drops RM holders whose PID is not a tracked agent', async () => {
+    mockGetSensitiveHolders.mockResolvedValue([
+      { pid: 9999, group: '/home/user/.aws', reason: 'AWS credentials' },
+    ]);
+    const agents = [{ pid: 100, agent: 'Claude Code', category: 'ai' }];
+    const events = await fileWatcher.scanAllFileHandles(agents);
+    expect(events).toEqual([]);
+  });
+
+  // #5 scope honesty: RM catches a handle HELD across the scan tick, never a
+  // transient open→read→close. The same dir held two consecutive scans dedups to
+  // one event — proving we report a sustained hold, not a per-read stream.
+  it('detects a held handle at the scan tick (dedups a sustained hold, not reads)', async () => {
+    mockGetSensitiveHolders.mockResolvedValue([
+      { pid: 105, group: '/home/user/.ssh', reason: 'SSH keys/config' },
+    ]);
+    const agents = [{ pid: 105, agent: 'Agent5', category: 'ai' }];
+    const first = await fileWatcher.scanAllFileHandles(agents);
+    const second = await fileWatcher.scanAllFileHandles(agents); // still holding
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(0); // sustained hold → one event, not one-per-scan
+  });
+});

--- a/tests/main/platform/restart-manager.test.js
+++ b/tests/main/platform/restart-manager.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import Module from 'module';
+
+// Intercept child_process so restart-manager never spawns a real powershell.exe.
+const mockExecFile = vi.fn();
+const originalLoad = Module._load;
+Module._load = function (request, _parent, _isMain) {
+  if (request === 'child_process') return { execFile: mockExecFile };
+  return originalLoad.apply(this, arguments);
+};
+
+afterAll(() => {
+  Module._load = originalLoad;
+});
+
+describe('platform/restart-manager', () => {
+  let rm;
+
+  beforeEach(async () => {
+    mockExecFile.mockReset();
+    vi.resetModules();
+    const mod = await import('../../../src/main/platform/restart-manager.js');
+    rm = mod.default;
+  });
+
+  describe('_parseHolders', () => {
+    it('flattens { group, reason, pids[] } groups into per-PID holders', () => {
+      const json = JSON.stringify([
+        { group: '/home/u/.ssh', reason: 'SSH keys/config', pids: [105, 200] },
+        { group: '/home/u/.aws', reason: 'AWS credentials', pids: [105] },
+      ]);
+      expect(rm._parseHolders(json)).toEqual([
+        { pid: 105, group: '/home/u/.ssh', reason: 'SSH keys/config' },
+        { pid: 200, group: '/home/u/.ssh', reason: 'SSH keys/config' },
+        { pid: 105, group: '/home/u/.aws', reason: 'AWS credentials' },
+      ]);
+    });
+
+    it('returns [] for "[]" / empty / unparseable output', () => {
+      expect(rm._parseHolders('[]')).toEqual([]);
+      expect(rm._parseHolders('')).toEqual([]);
+      expect(rm._parseHolders('not json')).toEqual([]);
+    });
+
+    it('wraps a single (non-array) group object', () => {
+      const json = JSON.stringify({ group: '/home/u/.ssh', reason: 'SSH', pids: 105 });
+      expect(rm._parseHolders(json)).toEqual([{ pid: 105, group: '/home/u/.ssh', reason: 'SSH' }]);
+    });
+
+    it('drops invalid PIDs and group-less entries', () => {
+      const json = JSON.stringify([
+        { group: '/home/u/.ssh', reason: 'SSH', pids: [0, -1, 'x', 105] },
+        { reason: 'no group', pids: [300] },
+      ]);
+      expect(rm._parseHolders(json)).toEqual([{ pid: 105, group: '/home/u/.ssh', reason: 'SSH' }]);
+    });
+  });
+
+  describe('probeRestartManager', () => {
+    it('marks RM available when the Add-Type probe prints OK', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(null, 'OK\n'));
+      const result = await rm.probeRestartManager();
+      expect(result.available).toBe(true);
+      expect(rm.isRestartManagerAvailable()).toBe(true);
+    });
+
+    it('marks RM unavailable when the probe prints FAIL', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(null, 'FAIL\n'));
+      const result = await rm.probeRestartManager();
+      expect(result.available).toBe(false);
+      expect(rm.isRestartManagerAvailable()).toBe(false);
+    });
+
+    it('marks RM unavailable on probe error (fail honest, not optimistic)', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(new Error('no powershell')));
+      const result = await rm.probeRestartManager();
+      expect(result.available).toBe(false);
+      expect(rm.isRestartManagerAvailable()).toBe(false);
+    });
+
+    // White-box honesty: the P/Invoke branches on the holder COUNT (pnProcInfoNeeded
+    // > 0), NOT on a 234/ERROR_MORE_DATA return code (which does not arrive here),
+    // and the RM source carries no "read"/"accessed" wording — it is a hold.
+    it('compiles a P/Invoke that branches on needed>0 and never says read/accessed', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(null, 'OK'));
+      await rm.probeRestartManager();
+      const script = mockExecFile.mock.calls[0][1][3];
+      expect(script).toMatch(/RmStartSession/);
+      expect(script).toMatch(/RmGetList/);
+      expect(script).toMatch(/needed > 0/);
+      expect(script).not.toMatch(/234/);
+      expect(script).not.toMatch(/accessed|read/i);
+    });
+  });
+
+  describe('getSensitiveHolders', () => {
+    // PR-A honesty: when RM is unavailable, return [] WITHOUT spawning powershell —
+    // the same honest-zero contract getFileHandles holds when no handle binary exists.
+    it('returns [] without spawning when RM is unavailable', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => cb(null, 'FAIL'));
+      await rm.probeRestartManager(); // → unavailable
+      const callsAfterProbe = mockExecFile.mock.calls.length;
+      const holders = await rm.getSensitiveHolders();
+      expect(holders).toEqual([]);
+      expect(mockExecFile.mock.calls.length).toBe(callsAfterProbe); // no extra spawn
+    });
+  });
+
+  describe('buildSensitiveGroups', () => {
+    it('returns an array and never throws (shallow enumeration of secret dirs)', () => {
+      const groups = rm.buildSensitiveGroups();
+      expect(Array.isArray(groups)).toBe(true);
+      for (const g of groups) {
+        expect(typeof g.group).toBe('string');
+        expect(Array.isArray(g.files)).toBe(true);
+      }
+    });
+  });
+
+  describe('exports', () => {
+    it('exports the RM contract', () => {
+      expect(typeof rm.getSensitiveHolders).toBe('function');
+      expect(typeof rm.probeRestartManager).toBe('function');
+      expect(typeof rm.isRestartManagerAvailable).toBe('function');
+      expect(typeof rm.buildSensitiveGroups).toBe('function');
+    });
+  });
+});

--- a/tests/main/platform/win32.test.js
+++ b/tests/main/platform/win32.test.js
@@ -309,6 +309,37 @@ describe('platform/win32', () => {
       await win32.probeReadDetection();
       expect(win32.isReadDetectionAvailable()).toBe(false);
     });
+
+    // #2 two-flag honesty: read-detection has TWO capabilities now — the legacy
+    // handle.exe binary AND the Restart Manager. When handle.exe is ABSENT but RM
+    // is PRESENT, read-detection is AVAILABLE (via RM) and the degraded warning
+    // must NOT fire. The warning is gated by the SAME `!available` condition as
+    // this flag, so available===true proves no degraded warning was logged.
+    it('reports available (no degraded warning) when handle.exe is absent but RM works', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => {
+        const script = args[3]; // the -Command body
+        if (/AegisRm|GetHolders/.test(script))
+          cb(null, 'OK'); // RM probe succeeds
+        else cb(null, ''); // handle-binary probe: not found
+      });
+      const result = await win32.probeReadDetection();
+      expect(result.available).toBe(true);
+      expect(result.rm).toBe(true);
+      expect(result.handle).toBeNull();
+      expect(win32.isReadDetectionAvailable()).toBe(true);
+    });
+
+    it('reports unavailable (degraded) only when BOTH handle.exe and RM are absent', async () => {
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => {
+        const script = args[3];
+        if (/AegisRm|GetHolders/.test(script))
+          cb(null, 'FAIL'); // RM probe fails
+        else cb(null, ''); // handle-binary probe: not found
+      });
+      const result = await win32.probeReadDetection();
+      expect(result.available).toBe(false);
+      expect(win32.isReadDetectionAvailable()).toBe(false);
+    });
   });
 
   describe('killProcess', () => {
@@ -474,6 +505,8 @@ describe('platform/win32', () => {
       expect(typeof win32.resumeProcess).toBe('function');
       expect(typeof win32.probeReadDetection).toBe('function');
       expect(typeof win32.isReadDetectionAvailable).toBe('function');
+      expect(typeof win32.getSensitiveHolders).toBe('function');
+      expect(typeof win32.isRestartManagerAvailable).toBe('function');
       expect(Array.isArray(win32.IGNORE_FILE_PATTERNS)).toBe(true);
     });
   });


### PR DESCRIPTION
Restore Windows read-detection without handle.exe via rstrtmgr.dll P/Invoke. RM answers which process holds a registered sensitive resource (cross-process, asInvoker, no admin), inverting handle.exe's PID->files model. One powershell spawn/scan registers sensitive dir GROUPS (sequential RM sessions), maps holder PID->owning agent (C-01), and emits action:'holding' (point-in-time hold, not a read). Own-PID guard, self-access exemption, and PR-A getFileHandles->[] fallback preserved. Two capability flags: read-detect available via handle.exe OR RM; degraded only when both absent.
