### PR TITLE
feat(token): per-agent token + cost tracker (module only)

### DIFF
--- a/src/main/token-tracker.js
+++ b/src/main/token-tracker.js
@@ -1,0 +1,236 @@
+/**
+ * @file token-tracker.js
+ * @module main/token-tracker
+ * @description Per-agent (per-PID) token + cost accounting. A pure, isolated
+ *   accounting module with no I/O and no Electron dependency — callers feed it
+ *   usage events and read back accumulated token counts and a USD cost estimate.
+ *
+ *   HONESTY MODEL (this drives the whole design). AEGIS cannot observe a
+ *   monitored agent's real token usage: those counts live inside that agent's
+ *   own TLS session to the model API and never appear on any wire AEGIS sees.
+ *   The only place AEGIS ever holds a real `usage` block is its OWN analysis
+ *   call (`ai-analysis.js` → `parsed.usage`). Therefore:
+ *
+ *   - A caller that HAS real measured counts passes them as-is → `estimated:false`.
+ *   - A caller that only has a proxy computes counts itself and passes them with
+ *     `estimated:true`. This module never fabricates counts and never invents a
+ *     char→token conversion (chars are inside the same unobservable TLS session
+ *     as tokens, so a char proxy would imply a data source we do not have).
+ *
+ *   The `estimated` flag reports whether the TOKEN COUNTS are measured vs
+ *   guessed — the thing AEGIS actually observes. It does NOT claim the dollar
+ *   figure is audited: the price table below is explicitly unverified
+ *   (see `MODEL_PRICING` / `// TODO: verify pricing`).
+ *
+ *   Attribution is per-PID (C-01): every count is stamped from the `pid`
+ *   argument and stored under that pid only — concurrency or interleaved events
+ *   can never cross-wire one agent's usage onto another.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ */
+'use strict';
+
+/**
+ * Published per-model pricing, in USD per 1,000,000 tokens, split into input
+ * (prompt) and output (completion) rates.
+ *
+ * TODO: verify pricing — these are approximate published rates captured at
+ * authoring time and are NOT auto-refreshed. Confirm against the provider's
+ * current price sheet before presenting any dollar figure as authoritative.
+ * @type {Readonly<Record<string, { input: number, output: number }>>}
+ */
+const MODEL_PRICING = Object.freeze({
+  // Anthropic — Claude (USD / 1M tokens). TODO: verify pricing.
+  'claude-haiku-4-5-20251001': { input: 1.0, output: 5.0 },
+  'claude-sonnet-4-5': { input: 3.0, output: 15.0 },
+  'claude-opus-4-1': { input: 15.0, output: 75.0 },
+  // OpenAI — GPT (USD / 1M tokens). TODO: verify pricing.
+  'gpt-4o': { input: 2.5, output: 10.0 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  // Google — Gemini (USD / 1M tokens). TODO: verify pricing.
+  'gemini-1.5-pro': { input: 1.25, output: 5.0 },
+});
+
+/**
+ * Fallback price applied to a model id absent from {@link MODEL_PRICING}. Using
+ * it forces `estimated:true` on the resulting cost, because the rate itself is a
+ * guess for an unknown model.
+ *
+ * TODO: verify pricing — placeholder mid-range rate, not a real quote.
+ * @type {Readonly<{ input: number, output: number }>}
+ */
+const DEFAULT_PRICING = Object.freeze({ input: 3.0, output: 15.0 });
+
+/**
+ * Tokens per 1,000,000 — divisor turning a token count into the per-million
+ * units {@link MODEL_PRICING} is quoted in.
+ * @type {number}
+ */
+const TOKENS_PER_PRICED_UNIT = 1_000_000;
+
+/**
+ * @typedef {Object} CostRecord
+ * @property {number} pid - the process this usage is attributed to (C-01 key).
+ * @property {number} inputTokens - accumulated prompt/input tokens.
+ * @property {number} outputTokens - accumulated completion/output tokens.
+ * @property {number} totalTokens - `inputTokens + outputTokens`.
+ * @property {number} costUsd - accumulated cost in USD (raw float; round at the
+ *   display layer). Rests on the unverified {@link MODEL_PRICING} table.
+ * @property {boolean} estimated - true once ANY contributing event had estimated
+ *   counts or used an unknown-model fallback price (sticky — never flips back).
+ * @property {string[]} models - distinct model ids that contributed, in first-seen order.
+ */
+
+/**
+ * @typedef {Object} TokenEvent
+ * @property {string} [model] - model id; matched against {@link MODEL_PRICING}.
+ * @property {number} [inputTokens] - measured or caller-estimated input tokens.
+ * @property {number} [outputTokens] - measured or caller-estimated output tokens.
+ * @property {boolean} [estimated] - set true when the counts above are an
+ *   estimate the caller computed, not measured usage.
+ */
+
+/** @type {Map<number, CostRecord>} Accumulated cost records keyed by pid. */
+const records = new Map();
+
+/**
+ * True when `v` is a finite number greater than zero (valid pid).
+ * @param {*} v
+ * @returns {boolean}
+ */
+function isPositiveNumber(v) {
+  return typeof v === 'number' && Number.isFinite(v) && v > 0;
+}
+
+/**
+ * True when `v` is a finite number ≥ 0 (valid token count).
+ * @param {*} v
+ * @returns {boolean}
+ */
+function isNonNegativeNumber(v) {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0;
+}
+
+/**
+ * Compute the USD cost of a single (model, tokens) pair. Pure — no module state.
+ *
+ * @param {string} model - model id; unknown ids fall back to {@link DEFAULT_PRICING}.
+ * @param {number} inputTokens - input/prompt tokens (coerced to 0 if not finite ≥0).
+ * @param {number} outputTokens - output/completion tokens (coerced to 0 if not finite ≥0).
+ * @returns {{ costUsd: number, knownModel: boolean }} `knownModel:false` means the
+ *   price came from the fallback table and the dollar figure is itself a guess.
+ * @since v0.10.0-alpha
+ */
+function computeCost(model, inputTokens, outputTokens) {
+  const inTok = isNonNegativeNumber(inputTokens) ? inputTokens : 0;
+  const outTok = isNonNegativeNumber(outputTokens) ? outputTokens : 0;
+  const knownModel = typeof model === 'string' && model in MODEL_PRICING;
+  const price = knownModel ? MODEL_PRICING[model] : DEFAULT_PRICING;
+  const costUsd =
+    (inTok / TOKENS_PER_PRICED_UNIT) * price.input +
+    (outTok / TOKENS_PER_PRICED_UNIT) * price.output;
+  return { costUsd, knownModel };
+}
+
+/**
+ * Honest zero-state record for a pid with no tracked usage. `estimated:false`
+ * because an exact zero is a fact, not a guess.
+ * @param {number} pid
+ * @returns {CostRecord}
+ */
+function zeroRecord(pid) {
+  return {
+    pid,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    costUsd: 0,
+    estimated: false,
+    models: [],
+  };
+}
+
+/**
+ * Attribute one usage event to a pid and accumulate its tokens + cost (C-01).
+ *
+ * @param {number} pid - owning process id; must be a finite number > 0.
+ * @param {TokenEvent} event - usage to record.
+ * @returns {CostRecord|null} the updated record, or `null` when `pid` is invalid
+ *   or `event` carries no usable token counts (nothing is fabricated).
+ * @since v0.10.0-alpha
+ */
+function trackTokens(pid, event) {
+  if (!isPositiveNumber(pid)) return null;
+  if (!event || typeof event !== 'object') return null;
+
+  const hasInput = isNonNegativeNumber(event.inputTokens);
+  const hasOutput = isNonNegativeNumber(event.outputTokens);
+  // No usable counts → record nothing. You cannot estimate from nothing, and
+  // fabricating a number here is exactly the dishonesty this module forbids.
+  if (!hasInput && !hasOutput) return records.get(pid) || null;
+
+  const inTok = hasInput ? event.inputTokens : 0;
+  const outTok = hasOutput ? event.outputTokens : 0;
+  const model = typeof event.model === 'string' ? event.model : '';
+  const { costUsd, knownModel } = computeCost(model, inTok, outTok);
+
+  // estimated is sticky-true: caller-flagged estimate OR an unknown-model price.
+  const eventEstimated = event.estimated === true || !knownModel;
+
+  const record = records.get(pid) || zeroRecord(pid);
+  record.inputTokens += inTok;
+  record.outputTokens += outTok;
+  record.totalTokens = record.inputTokens + record.outputTokens;
+  record.costUsd += costUsd;
+  record.estimated = record.estimated || eventEstimated;
+  if (model && !record.models.includes(model)) record.models.push(model);
+
+  records.set(pid, record);
+  return record;
+}
+
+/**
+ * Read the accumulated cost record for a pid.
+ * @param {number} pid
+ * @returns {CostRecord} the tracked record, or an honest zero-state record when
+ *   the pid has no usage (never `null`).
+ * @since v0.10.0-alpha
+ */
+function getCostByPid(pid) {
+  return records.get(pid) || zeroRecord(pid);
+}
+
+/**
+ * @returns {CostRecord[]} every tracked per-pid record (excludes untracked pids).
+ * @since v0.10.0-alpha
+ */
+function getAllCosts() {
+  return Array.from(records.values());
+}
+
+/**
+ * Drop the record for one pid (e.g. when an agent process exits).
+ * @param {number} pid
+ * @returns {boolean} true if a record existed and was removed.
+ * @since v0.10.0-alpha
+ */
+function reset(pid) {
+  return records.delete(pid);
+}
+
+/** @internal Clear all module state (for tests). @returns {void} */
+function _resetForTest() {
+  records.clear();
+}
+
+module.exports = {
+  MODEL_PRICING,
+  DEFAULT_PRICING,
+  computeCost,
+  trackTokens,
+  getCostByPid,
+  getAllCosts,
+  reset,
+  _resetForTest,
+};

--- a/tests/main/token-tracker.test.js
+++ b/tests/main/token-tracker.test.js
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import tracker from '../../src/main/token-tracker.js';
+
+const {
+  MODEL_PRICING,
+  DEFAULT_PRICING,
+  computeCost,
+  trackTokens,
+  getCostByPid,
+  getAllCosts,
+  reset,
+  _resetForTest,
+} = tracker;
+
+const KNOWN_MODEL = 'claude-haiku-4-5-20251001';
+const OTHER_MODEL = 'gpt-4o';
+
+describe('token-tracker', () => {
+  beforeEach(() => {
+    _resetForTest();
+  });
+
+  describe('computeCost (cost calculation)', () => {
+    it('prices 1M input + 1M output at the model table rate', () => {
+      const price = MODEL_PRICING[KNOWN_MODEL];
+      const { costUsd, knownModel } = computeCost(KNOWN_MODEL, 1_000_000, 1_000_000);
+      // 1M tokens / 1M unit = 1.0 unit each → input + output rate.
+      expect(costUsd).toBeCloseTo(price.input + price.output, 10);
+      expect(knownModel).toBe(true);
+    });
+
+    it('applies a different known model at its own rate', () => {
+      const price = MODEL_PRICING[OTHER_MODEL];
+      const { costUsd } = computeCost(OTHER_MODEL, 2_000_000, 500_000);
+      expect(costUsd).toBeCloseTo(2 * price.input + 0.5 * price.output, 10);
+    });
+
+    it('falls back to DEFAULT_PRICING for an unknown model (knownModel=false)', () => {
+      const { costUsd, knownModel } = computeCost('made-up-model', 1_000_000, 0);
+      expect(knownModel).toBe(false);
+      expect(costUsd).toBeCloseTo(DEFAULT_PRICING.input, 10);
+    });
+  });
+
+  describe('zero-state', () => {
+    it('returns an honest all-zero record for an untracked pid', () => {
+      const rec = getCostByPid(9999);
+      expect(rec).toEqual({
+        pid: 9999,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        costUsd: 0,
+        estimated: false,
+        models: [],
+      });
+    });
+
+    it('reports no tracked records before any event', () => {
+      expect(getAllCosts()).toEqual([]);
+    });
+  });
+
+  describe('estimated flag', () => {
+    it('marks real measured counts on a known model as NOT estimated', () => {
+      const rec = trackTokens(100, {
+        model: KNOWN_MODEL,
+        inputTokens: 1000,
+        outputTokens: 200,
+      });
+      expect(rec.estimated).toBe(false);
+    });
+
+    it('honors a caller-supplied estimated:true flag', () => {
+      const rec = trackTokens(100, {
+        model: KNOWN_MODEL,
+        inputTokens: 1000,
+        outputTokens: 200,
+        estimated: true,
+      });
+      expect(rec.estimated).toBe(true);
+    });
+
+    it('forces estimated:true for an unknown model (the price itself is a guess)', () => {
+      const rec = trackTokens(100, {
+        model: 'unknown-model-xyz',
+        inputTokens: 1000,
+        outputTokens: 200,
+      });
+      expect(rec.estimated).toBe(true);
+    });
+  });
+
+  describe('per-PID attribution (C-01)', () => {
+    it('keeps two pids independent — no cross-wiring', () => {
+      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 1000, outputTokens: 100 });
+      trackTokens(200, { model: OTHER_MODEL, inputTokens: 5000, outputTokens: 500 });
+
+      const a = getCostByPid(100);
+      const b = getCostByPid(200);
+
+      expect(a.pid).toBe(100);
+      expect(a.inputTokens).toBe(1000);
+      expect(a.models).toEqual([KNOWN_MODEL]);
+
+      expect(b.pid).toBe(200);
+      expect(b.inputTokens).toBe(5000);
+      expect(b.models).toEqual([OTHER_MODEL]);
+    });
+  });
+
+  describe('accumulation', () => {
+    it('sums tokens and cost across events for one pid', () => {
+      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 1000, outputTokens: 200 });
+      const rec = trackTokens(100, { model: KNOWN_MODEL, inputTokens: 500, outputTokens: 50 });
+
+      expect(rec.inputTokens).toBe(1500);
+      expect(rec.outputTokens).toBe(250);
+      expect(rec.totalTokens).toBe(1750);
+
+      const expected =
+        computeCost(KNOWN_MODEL, 1000, 200).costUsd + computeCost(KNOWN_MODEL, 500, 50).costUsd;
+      expect(rec.costUsd).toBeCloseTo(expected, 10);
+    });
+
+    it('makes estimated sticky-true once any contributing event is estimated', () => {
+      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 1000, outputTokens: 200 });
+      expect(getCostByPid(100).estimated).toBe(false);
+
+      trackTokens(100, {
+        model: KNOWN_MODEL,
+        inputTokens: 100,
+        outputTokens: 10,
+        estimated: true,
+      });
+      expect(getCostByPid(100).estimated).toBe(true);
+    });
+
+    it('collects distinct models in first-seen order', () => {
+      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
+      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
+      trackTokens(100, { model: OTHER_MODEL, inputTokens: 10, outputTokens: 1 });
+      expect(getCostByPid(100).models).toEqual([KNOWN_MODEL, OTHER_MODEL]);
+    });
+  });
+
+  describe('input guards (no fabrication)', () => {
+    it('returns null for an invalid pid', () => {
+      expect(trackTokens(0, { model: KNOWN_MODEL, inputTokens: 1 })).toBeNull();
+      expect(trackTokens(-5, { model: KNOWN_MODEL, inputTokens: 1 })).toBeNull();
+      expect(trackTokens(NaN, { model: KNOWN_MODEL, inputTokens: 1 })).toBeNull();
+    });
+
+    it('records nothing when an event carries no usable token counts', () => {
+      expect(trackTokens(100, { model: KNOWN_MODEL })).toBeNull();
+      expect(getAllCosts()).toEqual([]);
+    });
+  });
+
+  describe('getAllCosts', () => {
+    it('returns one record per tracked pid', () => {
+      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
+      trackTokens(200, { model: KNOWN_MODEL, inputTokens: 20, outputTokens: 2 });
+      const all = getAllCosts();
+      expect(all).toHaveLength(2);
+      expect(all.map((r) => r.pid).sort((x, y) => x - y)).toEqual([100, 200]);
+    });
+  });
+
+  describe('reset(pid)', () => {
+    it('drops only the targeted pid and reverts it to zero-state', () => {
+      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
+      trackTokens(200, { model: KNOWN_MODEL, inputTokens: 20, outputTokens: 2 });
+
+      expect(reset(100)).toBe(true);
+      expect(reset(100)).toBe(false); // already gone
+
+      expect(getCostByPid(100).totalTokens).toBe(0);
+      expect(getCostByPid(100).inputTokens).toBe(0);
+      expect(getCostByPid(200).inputTokens).toBe(20); // survives
+      expect(getAllCosts()).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `src/main/token-tracker.js` — an isolated, pure CommonJS module for **per-agent (per-PID) token and cost ($) accounting**, plus its Vitest suite. **Module only — no integration** (IPC / preload / renderer / scan-loop wiring is deferred to a follow-up).

## Why

AEGIS already attributes process / file / network activity per agent; token burn and its dollar cost are the natural next signal. This lands the accounting core in isolation so it can be reviewed and tested on its own before any wiring.

## Honesty model (the key design decision)

AEGIS **cannot** observe a monitored agent's real token counts — they live inside that agent's own TLS session to the model API and never appear on any wire AEGIS sees. So:

- A caller with **real measured** counts passes them as-is → `estimated: false`.
- A caller with only a proxy computes counts itself and passes them with `estimated: true`.
- The module **never fabricates** counts and **never invents a char→token conversion** (chars ride the same unobservable TLS session as tokens).

`estimated` tracks **token-count provenance** (measured vs guessed) — it does not claim the dollar figure is audited. Pricing is an explicit `// TODO: verify pricing` constant table, so the cost tests assert the **formula**, not specific dollar values.

## API (named CJS exports)

- `trackTokens(pid, event)` — per-PID accumulation (C-01); returns the updated record or `null`
- `getCostByPid(pid)` — record, or honest zero-state for an untracked pid
- `getAllCosts()` / `reset(pid)` — aggregate read + per-PID cleanup on agent exit
- `computeCost(model, in, out)` — pure cost helper
- `MODEL_PRICING` / `DEFAULT_PRICING` — pricing constants (`// TODO: verify pricing`)
- `_resetForTest()`

## Verification

- `eslint` (both files): 0 errors
- `tsc --noEmit -p tsconfig.main.json`: 0 (JSDoc types clean under checkJs)
- `vitest` new suite: 16/16 pass
- `npm test` full suite: 801 pass / 4 skip (48 files) — no regression
- `build:renderer`: clean
- file size: 236 lines (≤ 300)

## Scope

Touches only `src/main/token-tracker.js` + `tests/main/token-tracker.test.js`. No shared files modified.
