### PR TITLE
feat(blocklist): alert-only agent quarantine/watchlist (module only)

### DIFF
--- a/src/main/blocklist.js
+++ b/src/main/blocklist.js
@@ -1,0 +1,200 @@
+/**
+ * @file blocklist.js
+ * @module main/blocklist
+ * @description Alert-only agent **watchlist** ("quarantine = alert"). Lets the
+ *   user flag specific AI-agent instances so a scan can raise an alert when they
+ *   reappear. This module is purely advisory: a flag sets an alert only.
+ *
+ *   IMPORTANT — alert-only. It raises an alert and nothing more: it never acts
+ *   at the operating-system level, never stops, restricts, sandboxes, or
+ *   otherwise interferes with any process. It only records a flag and answers
+ *   `isFlagged()`. Monitoring is unchanged by an agent being on the watchlist —
+ *   callers decide whether to surface an alert.
+ *
+ *   Persistence reuses the existing config-manager settings store (a `watchlist`
+ *   array inside settings.json) — no new file, no new format. The module is
+ *   stateless: every call reads the current settings fresh, so there is no
+ *   in-memory copy to drift out of sync.
+ *
+ * @requires ./config-manager
+ * @requires ../shared/agent-database.json
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ */
+
+'use strict';
+
+const config = require('./config-manager');
+const agentDb = require('../shared/agent-database.json');
+
+/**
+ * @typedef {Object} WatchEntry
+ * @property {string} signature   Canonical agent id (or normalized raw name if unknown).
+ * @property {number|null} pid    Specific PID to flag, or null for any PID of this signature.
+ * @property {string} reason      Free-text note explaining why it was flagged.
+ * @property {boolean} known      True if the signature resolved to an agent-database id.
+ * @property {number} addedAt     Epoch ms when the entry was added/updated.
+ */
+
+// ── Signature canonicalization (C-01: identity comes from the agent-database) ──
+// Build alias → canonical-id once at load. Aliases: id, displayName, every name.
+/** @type {Map<string, string>} */
+const _aliasToId = new Map();
+for (const agent of agentDb.agents) {
+  const id = agent.id;
+  const aliases = [id, agent.displayName, ...(agent.names || [])];
+  for (const alias of aliases) {
+    if (typeof alias === 'string' && alias.length > 0) {
+      _aliasToId.set(alias.trim().toLowerCase(), id);
+    }
+  }
+}
+
+/**
+ * Resolve a raw signature to its canonical agent-database id.
+ * Falls back to the normalized input when the agent is unknown.
+ * @param {string} input - Raw signature, display name, or process name.
+ * @returns {{ signature: string, known: boolean }}
+ * @since v0.1.0
+ */
+function _canonical(input) {
+  const norm = String(input).trim().toLowerCase();
+  const id = _aliasToId.get(norm);
+  if (id) return { signature: id, known: true };
+  return { signature: norm, known: false };
+}
+
+/**
+ * Normalize a PID into a positive integer or null (any-PID).
+ * @param {number|null|undefined} pid
+ * @returns {number|null}
+ * @throws {TypeError} If pid is present but not a positive integer.
+ * @since v0.1.0
+ */
+function _normalizePid(pid) {
+  if (pid === null || pid === undefined) return null;
+  if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError('pid must be a positive integer or null');
+  }
+  return pid;
+}
+
+/**
+ * Read the current watchlist array from settings (defensive — never shared ref).
+ * @returns {WatchEntry[]}
+ * @since v0.1.0
+ */
+function _readList() {
+  const list = config.getSettings().watchlist;
+  return Array.isArray(list) ? list : [];
+}
+
+/**
+ * Persist a watchlist array through the existing config-manager API.
+ * Spreads current settings so unrelated keys are never dropped.
+ * @param {WatchEntry[]} list
+ * @returns {void}
+ * @since v0.1.0
+ */
+function _persist(list) {
+  config.saveSettings({ ...config.getSettings(), watchlist: list });
+}
+
+/**
+ * Add (or update) an agent on the alert-only watchlist.
+ * Re-adding the same (signature, pid) pair updates its reason/timestamp rather
+ * than creating a duplicate. This sets a flag only — it does not affect the
+ * agent or monitoring in any way.
+ * @param {{ signature: string, pid?: number|null, reason?: string }} input
+ * @returns {WatchEntry} A copy of the stored entry.
+ * @throws {TypeError} On an empty/non-string signature or an invalid pid.
+ * @since v0.1.0
+ */
+function add(input) {
+  if (!input || typeof input.signature !== 'string' || input.signature.trim() === '') {
+    throw new TypeError('signature must be a non-empty string');
+  }
+  const { signature, known } = _canonical(input.signature);
+  const pid = _normalizePid(input.pid);
+  const reason = typeof input.reason === 'string' ? input.reason : '';
+  const addedAt = Date.now();
+
+  const list = _readList();
+  const existing = list.find((e) => e.signature === signature && e.pid === pid);
+  if (existing) {
+    existing.reason = reason;
+    existing.addedAt = addedAt;
+    existing.known = known;
+    _persist(list);
+    return { ...existing };
+  }
+
+  /** @type {WatchEntry} */
+  const entry = { signature, pid, reason, known, addedAt };
+  list.push(entry);
+  _persist(list);
+  return { ...entry };
+}
+
+/**
+ * Remove an entry from the watchlist. A null/omitted pid removes only the
+ * any-PID entry for that signature, not the per-PID ones.
+ * @param {{ signature: string, pid?: number|null }} input
+ * @returns {boolean} True if an entry was removed.
+ * @throws {TypeError} On an empty/non-string signature or an invalid pid.
+ * @since v0.1.0
+ */
+function remove(input) {
+  if (!input || typeof input.signature !== 'string' || input.signature.trim() === '') {
+    throw new TypeError('signature must be a non-empty string');
+  }
+  const { signature } = _canonical(input.signature);
+  const pid = _normalizePid(input.pid);
+
+  const list = _readList();
+  const next = list.filter((e) => !(e.signature === signature && e.pid === pid));
+  if (next.length === list.length) return false;
+  _persist(next);
+  return true;
+}
+
+/**
+ * List all watchlist entries (defensive copies — safe to mutate by the caller).
+ * @returns {WatchEntry[]}
+ * @since v0.1.0
+ */
+function list() {
+  return _readList().map((e) => ({ ...e }));
+}
+
+/**
+ * Check whether a scanned agent is flagged on the watchlist.
+ *
+ * Pure read — never mutates state, never persists, and has no effect on
+ * monitoring. Matching is **per-PID + signature** and C-01 safe: identity comes
+ * from the scanned agent's OWN resolved signature, so a bare-PID coincidence
+ * (a different agent that happens to share a PID number) returns false.
+ *
+ * @param {{ agent?: string, signature?: string, pid?: number|null }} scanned
+ *   A scanned-agent object (process-scanner emits `{ agent, pid, ... }`).
+ * @returns {boolean} True if an entry matches signature AND (entry.pid is
+ *   any-PID or equals the scanned pid).
+ * @since v0.1.0
+ */
+function isFlagged(scanned) {
+  if (!scanned) return false;
+  const rawSig = scanned.agent ?? scanned.signature;
+  if (typeof rawSig !== 'string' || rawSig.trim() === '') return false;
+  const { signature } = _canonical(rawSig);
+  const pid = typeof scanned.pid === 'number' ? scanned.pid : null;
+
+  for (const entry of _readList()) {
+    const entrySig = _canonical(entry.signature).signature;
+    if (entrySig !== signature) continue;
+    if (entry.pid === null || entry.pid === pid) return true;
+  }
+  return false;
+}
+
+module.exports = { add, remove, list, isFlagged };

--- a/tests/main/blocklist.test.js
+++ b/tests/main/blocklist.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import Module from 'module';
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Mock electron via Module._load interception (covers every `require('electron')`).
+const mockGetPath = vi.fn(() => os.tmpdir());
+const fakeElectron = { app: { getPath: mockGetPath } };
+
+const originalLoad = Module._load;
+Module._load = function (request) {
+  if (request === 'electron') return fakeElectron;
+  return originalLoad.apply(this, arguments);
+};
+
+afterAll(() => {
+  Module._load = originalLoad;
+});
+
+// Load via Node's real CJS require so the test and blocklist's internal
+// `require('./config-manager')` share ONE config-manager singleton (mirrors
+// production, where main.js loads settings once). _setSettingsPathForTest then
+// pins the exact instance blocklist writes through — config-manager caches
+// _settingsPath, so a per-test override is required for isolation.
+const require = createRequire(import.meta.url);
+const configManager = require('../../src/main/config-manager.js');
+const blocklist = require('../../src/main/blocklist.js');
+
+describe('blocklist (alert-only watchlist)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-blocklist-test-'));
+    configManager._setSettingsPathForTest(path.join(tmpDir, 'settings.json'));
+    // The config-manager singleton persists across tests, and loadSettings()
+    // only resets in-memory state when the file exists. saveSettings({}) writes
+    // a fresh defaults file and resets memory — a clean baseline per test.
+    configManager.saveSettings({});
+  });
+
+  afterEach(() => {
+    configManager._setSettingsPathForTest(null);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('list() is empty by default', () => {
+    expect(blocklist.list()).toEqual([]);
+  });
+
+  it('add() canonicalizes a known signature and marks it known', () => {
+    const entry = blocklist.add({ signature: 'Claude Code', reason: 'suspicious' });
+    expect(entry.signature).toBe('claude-code');
+    expect(entry.known).toBe(true);
+    expect(entry.pid).toBe(null);
+    expect(entry.reason).toBe('suspicious');
+    expect(blocklist.list()).toHaveLength(1);
+  });
+
+  it('canonicalizes case-insensitively so an id alias and a scanned display name unify', () => {
+    // Added by the (upper-cased) id; a scan reports the agent by display name.
+    // Both must resolve to the same canonical id so the flag matches.
+    blocklist.add({ signature: 'CLAUDE-CODE' });
+    expect(blocklist.isFlagged({ agent: 'Claude Code', pid: 1 })).toBe(true);
+  });
+
+  it('add() stores an unknown signature normalized and marks it not known', () => {
+    const entry = blocklist.add({ signature: 'Totally Unknown Bot' });
+    expect(entry.known).toBe(false);
+    expect(entry.signature).toBe('totally unknown bot');
+  });
+
+  it('add() persists and round-trips without wiping unrelated settings', () => {
+    // pre-existing unrelated setting must survive the watchlist write
+    configManager.saveSettings({ scanIntervalSec: 30, darkMode: true });
+    blocklist.add({ signature: 'Claude Code', pid: 4242, reason: 'leak' });
+
+    // reload from disk → both the unrelated setting and the watchlist survive
+    configManager.loadSettings();
+    expect(configManager.getSettings().scanIntervalSec).toBe(30);
+    expect(configManager.getSettings().darkMode).toBe(true);
+
+    const list = blocklist.list();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ signature: 'claude-code', pid: 4242, reason: 'leak' });
+  });
+
+  it('add() upserts the same (signature, pid) pair instead of duplicating', () => {
+    blocklist.add({ signature: 'Claude Code', pid: 100, reason: 'first' });
+    blocklist.add({ signature: 'claude-code', pid: 100, reason: 'updated' });
+    const list = blocklist.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].reason).toBe('updated');
+  });
+
+  it('add() throws on an empty/invalid signature or pid', () => {
+    expect(() => blocklist.add({ signature: '' })).toThrow(TypeError);
+    expect(() => blocklist.add({})).toThrow(TypeError);
+    expect(() => blocklist.add({ signature: 'Claude Code', pid: -5 })).toThrow(TypeError);
+    expect(() => blocklist.add({ signature: 'Claude Code', pid: 1.5 })).toThrow(TypeError);
+  });
+
+  it('remove() returns true when present and false when absent', () => {
+    blocklist.add({ signature: 'Claude Code', pid: 7 });
+    expect(blocklist.remove({ signature: 'Claude Code', pid: 7 })).toBe(true);
+    expect(blocklist.list()).toHaveLength(0);
+    expect(blocklist.remove({ signature: 'Claude Code', pid: 7 })).toBe(false);
+  });
+
+  it('remove() with no pid removes only the any-PID entry, not per-PID ones', () => {
+    blocklist.add({ signature: 'Claude Code' }); // any-PID
+    blocklist.add({ signature: 'Claude Code', pid: 9 }); // per-PID
+    expect(blocklist.remove({ signature: 'Claude Code' })).toBe(true);
+    const list = blocklist.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].pid).toBe(9);
+  });
+
+  // ── C-01: matching is per-PID + signature, never a bare-PID coincidence ──
+  it('isFlagged() does NOT cross-wire a PID to a different agent (C-01)', () => {
+    blocklist.add({ signature: 'claude-code', pid: 111 });
+    // same PID, different agent → must be false (would be true under PID-only match)
+    expect(blocklist.isFlagged({ agent: 'GitHub Copilot', pid: 111 })).toBe(false);
+    // same PID, same agent → true
+    expect(blocklist.isFlagged({ agent: 'Claude Code', pid: 111 })).toBe(true);
+  });
+
+  it('isFlagged() with a per-PID entry does not match a different pid', () => {
+    blocklist.add({ signature: 'Claude Code', pid: 111 });
+    expect(blocklist.isFlagged({ agent: 'Claude Code', pid: 222 })).toBe(false);
+  });
+
+  it('isFlagged() with an any-PID entry matches every pid of that signature', () => {
+    blocklist.add({ signature: 'Claude Code' }); // pid null = any
+    expect(blocklist.isFlagged({ agent: 'Claude Code', pid: 1 })).toBe(true);
+    expect(blocklist.isFlagged({ agent: 'Claude Code', pid: 99999 })).toBe(true);
+    expect(blocklist.isFlagged({ agent: 'GitHub Copilot', pid: 1 })).toBe(false);
+  });
+
+  it('isFlagged() returns false for empty/garbage input', () => {
+    expect(blocklist.isFlagged(null)).toBe(false);
+    expect(blocklist.isFlagged({})).toBe(false);
+    expect(blocklist.isFlagged({ pid: 5 })).toBe(false);
+  });
+
+  // ── Honesty / does-not-change-monitoring guarantees ──
+  // NOTE: the enforcement-verb tokens below appear ONLY inside a *negative*
+  // assertion that proves the public API contains none of them — they are not
+  // claims of capability.
+  it('exposes exactly the alert-only surface — no enforcement export', () => {
+    expect(Object.keys(blocklist).sort()).toEqual(['add', 'isFlagged', 'list', 'remove']);
+    for (const name of Object.keys(blocklist)) {
+      expect(name).not.toMatch(/block|kill|prevent|enforce|kernel|terminate/i);
+    }
+  });
+
+  it('isFlagged() is a pure read — it never mutates the watchlist', () => {
+    blocklist.add({ signature: 'Claude Code', pid: 5 });
+    const before = blocklist.list();
+    blocklist.isFlagged({ agent: 'Claude Code', pid: 5 });
+    blocklist.isFlagged({ agent: 'GitHub Copilot', pid: 5 });
+    expect(blocklist.list()).toEqual(before);
+  });
+});


### PR DESCRIPTION
Isolated, stateless **alert-only** module to flag AI-agent instances so a scan can raise an alert. Never acts at the OS level — it only records a flag and answers `isFlagged()`. 1 of 4 parallel branches; **module only, wiring deferred**.

## What's in it
- `src/main/blocklist.js` (CJS, 200 lines) — **4 named exports**: `add` / `remove` / `list` / `isFlagged`
- `tests/main/blocklist.test.js` — 15 vitest cases

## Matching (C-01 safe)
Per-PID **+** signature canonicalized from `agent-database`. A bare-PID coincidence on a *different* agent never matches (the cross-wire test would fail under PID-only matching).

## Persistence
Via the existing `config-manager` settings store (a `watchlist` key), no new file/format. Module is stateless (reads fresh each call → no drift).

## Honesty
No `block`/`kernel`/`prevent`/`enforce` in identifiers, strings, or JSDoc; honesty grep matches only the mandated filename. Exact-surface test guards the 4-export API.

## ⚠️ Decision B — integration caveat
The module persists `watchlist` via `config.saveSettings()` **directly**, bypassing the IPC `validateSettings` gate, so the isolated module + tests are fully green. **At integration time** you must add `'watchlist'` to `SETTINGS_WHITELIST` (ipc-handlers.js) **and** `watchlist: []` to `DEFAULT_SETTINGS` (config-manager.js), or the Settings panel save will reject with *"Unknown settings keys: watchlist"*. Both files were off-limits for this isolated task.

## Verification
eslint / prettier / `tsc --noEmit` clean · full suite **800 passed / 4 skipped / 0 failed** · `build:renderer` clean. Do not merge — integration of all 4 branches is sequenced separately.