### PR TITLE
feat(integration): wire resource-monitor, token-tracker, blocklist + mount RiskIndex

### DIFF
--- a/src/main/config-manager.js
+++ b/src/main/config-manager.js
@@ -75,9 +75,22 @@ const DEFAULT_SETTINGS = {
   customAgents: [],
   hardwareAcceleration: true,
   falsePositivePatterns: [],
+  watchlist: [],
 };
 
-let settings = { ...DEFAULT_SETTINGS };
+/**
+ * Fresh deep copy of the defaults. A shallow `{ ...DEFAULT_SETTINGS }` would
+ * share the mutable array/object values (watchlist, seenAgents, customAgents,
+ * agentPermissions, …) by reference, so an in-place `push` by a caller would
+ * silently pollute DEFAULT_SETTINGS itself and leak across every later reset.
+ * @returns {Object} an independent copy of DEFAULT_SETTINGS
+ * @since v0.10.0-alpha
+ */
+function freshDefaults() {
+  return structuredClone(DEFAULT_SETTINGS);
+}
+
+let settings = freshDefaults();
 let customSensitiveRules = [];
 let _knownAgentNames = [];
 let _applyCallback = null;
@@ -147,7 +160,7 @@ function loadSettings() {
   try {
     if (fs.existsSync(settingsPath())) {
       const raw = JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'));
-      settings = { ...DEFAULT_SETTINGS, ...raw };
+      settings = { ...freshDefaults(), ...raw };
       // Decrypt API key into memory
       if (raw._encryptedApiKey) {
         settings.anthropicApiKey = safeStore.decrypt(raw._encryptedApiKey);
@@ -160,7 +173,7 @@ function loadSettings() {
       }
     }
   } catch (_) {
-    settings = { ...DEFAULT_SETTINGS };
+    settings = freshDefaults();
   }
   buildCustomRules();
 }
@@ -172,7 +185,7 @@ function loadSettings() {
  * @since v0.1.0
  */
 function saveSettings(newSettings) {
-  settings = { ...DEFAULT_SETTINGS, ...newSettings };
+  settings = { ...freshDefaults(), ...newSettings };
   _writeSettings();
   buildCustomRules();
 }

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -15,6 +15,7 @@ const audit = require('./audit-logger');
 const { killProcess, suspendProcess, resumeProcess } = require('./platform');
 const zipWriter = require('./zip-writer');
 const { getAllRules, reloadRules } = require('./rule-loader');
+const blocklist = require('./blocklist');
 const logger = require('./logger');
 
 /** @type {Set<string>} Whitelist of allowed settings keys */
@@ -35,6 +36,7 @@ const SETTINGS_WHITELIST = new Set([
   'customAgents',
   'hardwareAcceleration',
   'falsePositivePatterns',
+  'watchlist',
 ]);
 
 /** @type {string[]} Catch-all regex patterns to reject as false positives */
@@ -551,6 +553,25 @@ ${findingsHtml}${recsHtml}
     const rules = getAllRules();
     return { success: true, count: rules.size };
   });
+
+  // ── Alert-only agent watchlist (advisory flag only — never affects monitoring) ──
+  ipcMain.handle('blocklist-add', (_e, entry) => {
+    try {
+      return { success: true, entry: blocklist.add(entry) };
+    } catch (error) {
+      logger.warn(`IPC blocklist-add rejected: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+  ipcMain.handle('blocklist-remove', (_e, entry) => {
+    try {
+      return { success: true, removed: blocklist.remove(entry) };
+    } catch (error) {
+      logger.warn(`IPC blocklist-remove rejected: ${error.message}`);
+      return { success: false, error: error.message };
+    }
+  });
+  ipcMain.handle('blocklist-list', () => blocklist.list());
 }
 
 module.exports = { init, register };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -83,4 +83,19 @@ contextBridge.exposeInMainWorld('aegis', {
     ipcRenderer.on('scan-status', handler);
     return () => ipcRenderer.removeListener('scan-status', handler);
   },
+  // ── Per-PID resource usage + token costs (main → renderer push) ──
+  onResourceUsage: (cb) => {
+    const handler = (_e, data) => cb(data);
+    ipcRenderer.on('resource-usage', handler);
+    return () => ipcRenderer.removeListener('resource-usage', handler);
+  },
+  onTokenCosts: (cb) => {
+    const handler = (_e, data) => cb(data);
+    ipcRenderer.on('token-costs', handler);
+    return () => ipcRenderer.removeListener('token-costs', handler);
+  },
+  // ── Alert-only agent watchlist (renderer → main invoke) ──
+  blocklistAdd: (entry) => ipcRenderer.invoke('blocklist-add', entry),
+  blocklistRemove: (entry) => ipcRenderer.invoke('blocklist-remove', entry),
+  blocklistList: () => ipcRenderer.invoke('blocklist-list'),
 });

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -9,6 +9,9 @@
 const sessionTracker = require('./session-tracker');
 const ideExtensionDetector = require('./ide-extension-detector');
 const wslDetector = require('./wsl-detector');
+const resourceMonitor = require('./resource-monitor');
+const tokenTracker = require('./token-tracker');
+const blocklist = require('./blocklist');
 
 let scanInterval = null;
 let fileScanInterval = null;
@@ -218,6 +221,11 @@ async function doProcessScan() {
     const scores = {};
     for (const a of agents) scores[a.agent] = anomaly.calculateAnomalyScore(a.agent).score;
 
+    // Alert-only watchlist flag (synchronous): set agent.flagged so it rides the
+    // scan-batch below. Advisory only — never stops or restricts any process (C-01:
+    // isFlagged matches the scanned agent's OWN signature + pid).
+    for (const a of agents) a.flagged = blocklist.isFlagged(a);
+
     // Single batched IPC — renderer updates all stores at once
     sendToRenderer('scan-batch', {
       agents,
@@ -225,6 +233,20 @@ async function doProcessScan() {
       resourceUsage: getResourceUsage(),
       anomalyScores: scores,
     });
+
+    // Token costs ride a separate channel. With no usage feed wired this is an
+    // empty array (honest zero) — the tracker never fabricates counts.
+    sendToRenderer('token-costs', tokenTracker.getAllCosts());
+
+    // Per-PID CPU/RAM/GPU is fetched fire-and-forget AFTER the batch so its
+    // spawn (~0.4–8s, 5s-cached) never delays getting agents on screen. The
+    // result is pushed on its own `resource-usage` channel, keyed by pid (C-01).
+    const resourcePids = agents.map((a) => a.pid).filter((p) => Number.isInteger(p) && p > 0);
+    resourceMonitor
+      .getResourcesForPids(resourcePids)
+      .then((resourceMap) => sendToRenderer('resource-usage', [...resourceMap.values()]))
+      .catch((err) => logger.error('main', 'Resource usage scan failed', { error: err.message }));
+
     if (result.changed && Date.now() - _lastTriggeredNetScan > 15000) {
       _lastTriggeredNetScan = Date.now();
       doNetworkScan();

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -7,6 +7,8 @@
   import RulesTab from './lib/components/RulesTab.svelte';
   import ReportsTab from './lib/components/ReportsTab.svelte';
   import AgentStatsPanel from './lib/components/AgentStatsPanel.svelte';
+  import RiskIndex from './lib/components/RiskIndex.svelte';
+  import { enrichedAgents } from './lib/stores/risk.js';
   import { theme, uiScale, toggleTheme, setTheme } from './lib/stores/theme.js';
   import Toast from './lib/components/Toast.svelte';
   import CommandPalette from './lib/components/CommandPalette.svelte';
@@ -301,7 +303,24 @@
 <Toast />
 <CommandPalette />
 
+<!-- Fleet-wide risk index — fixed dock, fed the risk-enriched agents (riskScore
+     lives on enrichedAgents, never on the raw `agents` store). Append-only. -->
+<aside class="risk-index-dock">
+  <RiskIndex agents={$enrichedAgents} />
+</aside>
+
 <style>
+  /* Fixed dock for the fleet risk index — pinned bottom-left above the footer,
+     below modals (CommandPalette z-index 100, Toast 9000). */
+  .risk-index-dock {
+    position: fixed;
+    left: var(--aegis-space-9);
+    bottom: calc(var(--aegis-size-footer) + var(--aegis-space-6));
+    width: 240px;
+    max-width: calc(100vw - var(--aegis-space-9) * 2);
+    z-index: 50;
+  }
+
   .app-shell {
     height: 100vh;
     display: flex;


### PR DESCRIPTION
## Summary

Integration-only wiring of four already-shipped, previously-deferred modules into the running app. **No change to the modules' own logic, the risk-scoring calibration, or file-watcher.**

| Module | Wiring |
|---|---|
| `resource-monitor` | per-PID CPU/RAM/GPU fetched **fire-and-forget after** scan-batch → pushed on new `resource-usage` channel |
| `token-tracker` | `getAllCosts()` pushed on new `token-costs` channel (honest empty array — no usage feed is wired) |
| `blocklist` | `agent.flagged = isFlagged(a)` set synchronously, rides scan-batch (alert-only); `blocklist-add/-remove/-list` IPC |
| `RiskIndex.svelte` | mounted in a fixed bottom-left dock in `App.svelte`, fed `$enrichedAgents` |

## Details

- **scan-loop.js** — direct `require` of the three pure main modules (same pattern as `sessionTracker`/`ide`/`wsl`). `flagged` is computed synchronously and rides the existing `scan-batch`. Per the agreed reorder, the resource metrics spawn (~0.4–8s, 5s-cached) is **fire-and-forget after** the batch so it never delays getting agents on screen. All per-PID (C-01). No `block`/`kernel`/`blocked` wording — watchlist is advisory only.
- **preload.js** — append-only: 2 push channels + 3 invoke channels, kebab-case. No new renderer stores (a preload channel is the deliverable; an unrendered store would be unrequested code, and a per-agent `resourceUsage` store would collide with the existing one that holds AEGIS's *own* process usage).
- **Decision B** — `'watchlist'` added to `SETTINGS_WHITELIST` (ipc-handlers) + `watchlist: []` to `DEFAULT_SETTINGS` (config-manager), so the Settings panel save round-trip doesn't reject the key.
- **config-manager deep-clone fix (why it's here)** — adding the `watchlist` default exposed a latent aliasing bug: the shallow `{...DEFAULT_SETTINGS}` shared the `watchlist` array **by reference**, and `blocklist.add`'s in-place `push` permanently polluted the module-level default, leaking across every settings reset (caught 5 `blocklist.test` failures, reproduced in isolation). Because `blocklist` is a frozen module for this task, the correct fix lives in shared infra: `freshDefaults() = structuredClone(DEFAULT_SETTINGS)` at each reset. This also hardens the other mutable array defaults (`seenAgents`, `customAgents`, …) against the same aliasing.
- **App.svelte** — `RiskIndex` is fed **`$enrichedAgents`, not `$agents`**: `riskScore` lives only on the `enrichedAgents` derived store (`risk.ts`); the raw `agents` store has none, so passing it would silently render index 0 / all-Low *and* still pass `typecheck:svelte`. Mount is append-only; tabs untouched; dock sits at `z-index: 50`, below CommandPalette (100) and Toast (9000).

## Verification

Full gate chain green on the committed (post lint-staged) state:

- `typecheck` — 0 errors
- `lint` — 0 errors (23 pre-existing `no-console` warnings)
- `test` — **845 pass / 4 skip (51 files)**
- `build:renderer` — clean
- `typecheck:svelte` — 213 files, 0 errors / 0 warnings

**Test coverage note:** the new wiring is *gate-verified* — the scan-loop paths execute (flagged loop + both `sendToRenderer` calls) without error, and the `blocklist-*` handlers register cleanly — but no dedicated assertion tests were added (out of the task's scope, which defined verification as the gate chain). Happy to add scan-loop emit tests + a `blocklist-add` round-trip as a follow-up if wanted.
