### PR TITLE
refactor: extract RM_CSHARP to rm-csharp.js

### DIFF
--- a/src/main/platform/restart-manager.js
+++ b/src/main/platform/restart-manager.js
@@ -31,6 +31,7 @@ const os = require('os');
 const path = require('path');
 const { getAllRules } = require('../rule-loader');
 const { AGENT_CONFIG_PATHS } = require('../../shared/constants');
+const { RM_CSHARP } = require('./rm-csharp');
 
 /**
  * Secret credential directories watched for held handles (mirror of the roots in
@@ -56,56 +57,6 @@ let _rmAvailable = true;
  * @type {number}
  */
 const MAX_FILES_PER_GROUP = 64;
-
-/**
- * The C# Restart Manager wrapper compiled once per spawn via Add-Type. Exposes
- * a single static GetHolders(string[] files) → int[] of holder PIDs. Uses the
- * two-call RmGetList protocol and branches on pnProcInfoNeeded > 0 (the holder
- * count) — NOT on a 234/ERROR_MORE_DATA return code, which does not arrive here.
- * @type {string}
- */
-const RM_CSHARP = [
-  'using System;',
-  'using System.Collections.Generic;',
-  'using System.Runtime.InteropServices;',
-  'using System.Text;',
-  'public static class AegisRm {',
-  '  [StructLayout(LayoutKind.Sequential)] struct RM_UNIQUE_PROCESS { public int dwProcessId; public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime; }',
-  '  const int RM_INVALID_SESSION = -1;',
-  '  const int CCH_RM_SESSION_KEY = 32;',
-  '  const int CCH_RM_MAX_APP_NAME = 255;',
-  '  const int CCH_RM_MAX_SVC_NAME = 63;',
-  '  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)] struct RM_PROCESS_INFO {',
-  '    public RM_UNIQUE_PROCESS Process;',
-  '    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_APP_NAME + 1)] public string strAppName;',
-  '    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_SVC_NAME + 1)] public string strServiceShortName;',
-  '    public int ApplicationType; public uint AppStatus; public uint TSSessionId;',
-  '    [MarshalAs(UnmanagedType.Bool)] public bool bRestartable;',
-  '  }',
-  '  [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)] static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, StringBuilder strSessionKey);',
-  '  [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)] static extern int RmRegisterResources(uint pSessionHandle, uint nFiles, string[] rgsFilenames, uint nApplications, IntPtr rgApplications, uint nServices, string[] rgsServiceNames);',
-  '  [DllImport("rstrtmgr.dll")] static extern int RmGetList(uint dwSessionHandle, out uint pnProcInfoNeeded, ref uint pnProcInfo, [In, Out] RM_PROCESS_INFO[] rgAffectedApps, out uint lpdwRebootReasons);',
-  '  [DllImport("rstrtmgr.dll")] static extern int RmEndSession(uint pSessionHandle);',
-  '  public static int[] GetHolders(string[] files) {',
-  '    var pids = new List<int>();',
-  '    if (files == null || files.Length == 0) return pids.ToArray();',
-  '    uint session; var key = new StringBuilder(CCH_RM_SESSION_KEY + 1);',
-  '    if (RmStartSession(out session, 0, key) != 0) return pids.ToArray();',
-  '    try {',
-  '      if (RmRegisterResources(session, (uint)files.Length, files, 0, IntPtr.Zero, 0, null) != 0) return pids.ToArray();',
-  '      uint needed = 0, count = 0, reason = 0;',
-  '      RmGetList(session, out needed, ref count, null, out reason);',
-  '      if (needed > 0) {',
-  '        var info = new RM_PROCESS_INFO[needed]; count = needed;',
-  '        if (RmGetList(session, out needed, ref count, info, out reason) == 0) {',
-  '          for (uint i = 0; i < count; i++) pids.Add(info[i].Process.dwProcessId);',
-  '        }',
-  '      }',
-  '    } finally { RmEndSession(session); }',
-  '    return pids.ToArray();',
-  '  }',
-  '}',
-].join('\n');
 
 /**
  * Compile-and-run PowerShell body. Reads the group list (JSON) from an env var to

--- a/src/main/platform/rm-csharp.js
+++ b/src/main/platform/rm-csharp.js
@@ -1,0 +1,71 @@
+/**
+ * @file platform/rm-csharp.js
+ * @module main/platform/rm-csharp
+ * @description The C# Windows Restart Manager (rstrtmgr.dll) P/Invoke wrapper
+ *   source, compiled per spawn via Add-Type inside restart-manager.js. Extracted
+ *   to its own module to keep restart-manager.js under the 300-line limit; the
+ *   string is byte-for-byte the value restart-manager previously defined inline,
+ *   so behavior is unchanged.
+ *
+ *   The wrapper exposes a single static GetHolders(string[] files) → int[] of
+ *   holder PIDs. It uses the two-call RmGetList protocol and branches on
+ *   pnProcInfoNeeded > 0 (the holder count) — NOT on a 234/ERROR_MORE_DATA
+ *   return code, which does not arrive here.
+ *
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.10.0
+ */
+'use strict';
+
+/**
+ * The C# Restart Manager wrapper compiled once per spawn via Add-Type. Exposes
+ * a single static GetHolders(string[] files) → int[] of holder PIDs. Uses the
+ * two-call RmGetList protocol and branches on pnProcInfoNeeded > 0 (the holder
+ * count) — NOT on a 234/ERROR_MORE_DATA return code, which does not arrive here.
+ * @type {string}
+ */
+const RM_CSHARP = [
+  'using System;',
+  'using System.Collections.Generic;',
+  'using System.Runtime.InteropServices;',
+  'using System.Text;',
+  'public static class AegisRm {',
+  '  [StructLayout(LayoutKind.Sequential)] struct RM_UNIQUE_PROCESS { public int dwProcessId; public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime; }',
+  '  const int RM_INVALID_SESSION = -1;',
+  '  const int CCH_RM_SESSION_KEY = 32;',
+  '  const int CCH_RM_MAX_APP_NAME = 255;',
+  '  const int CCH_RM_MAX_SVC_NAME = 63;',
+  '  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)] struct RM_PROCESS_INFO {',
+  '    public RM_UNIQUE_PROCESS Process;',
+  '    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_APP_NAME + 1)] public string strAppName;',
+  '    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_SVC_NAME + 1)] public string strServiceShortName;',
+  '    public int ApplicationType; public uint AppStatus; public uint TSSessionId;',
+  '    [MarshalAs(UnmanagedType.Bool)] public bool bRestartable;',
+  '  }',
+  '  [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)] static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, StringBuilder strSessionKey);',
+  '  [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)] static extern int RmRegisterResources(uint pSessionHandle, uint nFiles, string[] rgsFilenames, uint nApplications, IntPtr rgApplications, uint nServices, string[] rgsServiceNames);',
+  '  [DllImport("rstrtmgr.dll")] static extern int RmGetList(uint dwSessionHandle, out uint pnProcInfoNeeded, ref uint pnProcInfo, [In, Out] RM_PROCESS_INFO[] rgAffectedApps, out uint lpdwRebootReasons);',
+  '  [DllImport("rstrtmgr.dll")] static extern int RmEndSession(uint pSessionHandle);',
+  '  public static int[] GetHolders(string[] files) {',
+  '    var pids = new List<int>();',
+  '    if (files == null || files.Length == 0) return pids.ToArray();',
+  '    uint session; var key = new StringBuilder(CCH_RM_SESSION_KEY + 1);',
+  '    if (RmStartSession(out session, 0, key) != 0) return pids.ToArray();',
+  '    try {',
+  '      if (RmRegisterResources(session, (uint)files.Length, files, 0, IntPtr.Zero, 0, null) != 0) return pids.ToArray();',
+  '      uint needed = 0, count = 0, reason = 0;',
+  '      RmGetList(session, out needed, ref count, null, out reason);',
+  '      if (needed > 0) {',
+  '        var info = new RM_PROCESS_INFO[needed]; count = needed;',
+  '        if (RmGetList(session, out needed, ref count, info, out reason) == 0) {',
+  '          for (uint i = 0; i < count; i++) pids.Add(info[i].Process.dwProcessId);',
+  '        }',
+  '      }',
+  '    } finally { RmEndSession(session); }',
+  '    return pids.ToArray();',
+  '  }',
+  '}',
+].join('\n');
+
+module.exports = { RM_CSHARP };


### PR DESCRIPTION
## What

Prep refactor (PR 1 of 2) for the read-detect-strengthen hot-cycle work.

Extracts the inline `RM_CSHARP` C# Restart Manager P/Invoke wrapper string out of `src/main/platform/restart-manager.js` into a dedicated module `src/main/platform/rm-csharp.js`, re-`require`d back. The string is byte-for-byte identical — **behavior unchanged**.

## Why

`restart-manager.js` sat at 295/300 lines and would blow the 300-line limit on the first line of the upcoming hot-cycle change (which adds hot-dir scoping + `getHotSensitiveHolders`). Extracting the ~45-line C# constant first restores headroom:

- `restart-manager.js`: 295 -> 246 lines
- `rm-csharp.js`: 71 lines (new)

`RM_CSHARP` was never exported, so no consumer imported it directly — this is a pure internal move.

## Verify

- `npm test` -> 845 passed, 4 skipped (restart-manager.test.js 11/11 green)
- `npm run build:renderer` -> clean
- `npx eslint src/` -> 0 errors
- `npx tsc --noEmit -p tsconfig.main.json` -> 0 errors
- prettier: changed files content-clean (format:check noise = known CRLF false-positive)

## Scope

Refactor only. The hot-cycle feature (10s -TypeDefinition poll on .ssh/.aws/.gnupg/.env) lands in a separate follow-up PR.