### PR TITLE
feat(renderer): honest agent-card actions — watchlist, view details, acknowledge

### DIFF
--- a/src/renderer/lib/components/AgentActions.svelte
+++ b/src/renderer/lib/components/AgentActions.svelte
@@ -1,0 +1,122 @@
+<script>
+  /**
+   * @file AgentActions.svelte
+   * @description Always-visible per-agent action row on AgentCard. Three advisory,
+   *   UI-only actions — none stop, restrict, sandbox, or interfere with any
+   *   process:
+   *     • Add to watchlist — flags the agent so a future scan raises an alert when
+   *       it reappears (alert-only; never acts at the OS level).
+   *     • View details — expands the card's detail panel.
+   *     • Acknowledge — a session-only "I have seen this" triage mark.
+   * @since v0.10.0-alpha
+   */
+  import { addToast } from '../stores/toast.js';
+  import { acknowledgedAgents, toggleAcknowledged } from '../stores/acknowledged.js';
+
+  /**
+   * @type {{
+   *   agent: { name?: string, agent?: string, pid?: number },
+   *   onViewDetails: () => void,
+   * }}
+   */
+  let { agent, onViewDetails } = $props();
+
+  /** Stable key for this agent — its display name (falls back to pid). */
+  let agentKey = $derived(agent.name || agent.agent || String(agent.pid ?? ''));
+
+  /** Reactive: is this agent currently acknowledged? */
+  let acknowledged = $derived($acknowledgedAgents.has(agentKey));
+
+  /**
+   * Add this agent to the alert-only watchlist via the existing IPC bridge.
+   * Passes `pid: null` so the signature (every instance of the agent) is flagged.
+   * Alert-only — this raises an alert if the agent reappears and nothing more.
+   * @param {MouseEvent} e
+   */
+  async function addToWatchlist(e) {
+    e.stopPropagation();
+    if (!agentKey) return;
+    if (!window.aegis?.blocklistAdd) return;
+    const res = await window.aegis.blocklistAdd({
+      signature: agentKey,
+      pid: null,
+      reason: 'Flagged from agent card',
+    });
+    if (res?.success) {
+      addToast(`Added ${agentKey} to watchlist — alert only`, 'success');
+    } else {
+      addToast(`Could not add to watchlist: ${res?.error ?? 'unknown error'}`, 'error');
+    }
+  }
+
+  /**
+   * View the agent's details — expands the card's detail panel via the parent.
+   * @param {MouseEvent} e
+   */
+  function viewDetails(e) {
+    e.stopPropagation();
+    onViewDetails();
+  }
+
+  /**
+   * Acknowledge (or clear) this agent — a session-only renderer-side triage mark.
+   * @param {MouseEvent} e
+   */
+  function acknowledge(e) {
+    e.stopPropagation();
+    const now = toggleAcknowledged(agentKey);
+    addToast(
+      now ? `Acknowledged ${agentKey}` : `Acknowledgement cleared for ${agentKey}`,
+      'success',
+      3000,
+    );
+  }
+</script>
+
+<div class="agent-actions">
+  <button class="action-btn" type="button" onclick={addToWatchlist}>Add to watchlist</button>
+  <button class="action-btn" type="button" onclick={viewDetails}>View details</button>
+  <button
+    class="action-btn"
+    class:active={acknowledged}
+    type="button"
+    aria-pressed={acknowledged}
+    onclick={acknowledge}
+  >
+    {acknowledged ? 'Acknowledged' : 'Acknowledge'}
+  </button>
+</div>
+
+<style>
+  .agent-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--fancy-space-sm);
+    margin-top: var(--fancy-space-sm);
+  }
+  .action-btn {
+    font-family: var(--fancy-font-body);
+    font-size: calc(11px * var(--aegis-ui-scale));
+    font-weight: 600;
+    padding: var(--fancy-space-xs) var(--fancy-space-md);
+    border-radius: var(--md-sys-shape-corner-full);
+    border: 1px solid var(--fancy-border);
+    background: transparent;
+    color: var(--fancy-text-2);
+    cursor: pointer;
+    transition:
+      border-color var(--fancy-transition-micro) var(--fancy-ease),
+      background var(--fancy-transition-micro) var(--fancy-ease),
+      color var(--fancy-transition-micro) var(--fancy-ease);
+  }
+  .action-btn:hover,
+  .action-btn:focus-visible {
+    border-color: var(--fancy-border-highlight);
+    color: var(--fancy-text-1);
+    background: var(--fancy-surface-hover);
+  }
+  .action-btn.active {
+    border-color: var(--fancy-info);
+    color: var(--fancy-info);
+  }
+</style>

--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -8,6 +8,7 @@
   import { focusedAgentPid } from '../stores/ipc.js';
   import { eventsByPid } from '../stores/events-index.ts';
   import AgentCardDetails from './AgentCardDetails.svelte';
+  import AgentActions from './AgentActions.svelte';
   import Sparkline from './Sparkline.svelte';
   import TrustBadge from './TrustBadge.svelte';
   import { getRiskInfo } from '../utils/trust-badge-utils';
@@ -179,6 +180,8 @@
   </div>
 
   {#if lastFile}<div class="activity-hint">{$t('agents.last_file', { file: lastFile })}</div>{/if}
+
+  <AgentActions {agent} onViewDetails={() => (expandedPid = agent.pid)} />
 
   <div class="expand-body">
     <div class="expand-inner">

--- a/src/renderer/lib/stores/acknowledged.ts
+++ b/src/renderer/lib/stores/acknowledged.ts
@@ -1,0 +1,59 @@
+/**
+ * @file acknowledged.ts — session-local "acknowledged agents" triage marks.
+ * @module renderer/stores/acknowledged
+ * @description In-memory only. Acknowledging an agent is a cheap, renderer-side
+ *   triage flag ("I have seen this") — it never persists, never touches the main
+ *   process, and never changes monitoring in any way. Marks are keyed by the
+ *   agent's display name and live only for the current session.
+ */
+
+import { writable, get } from 'svelte/store';
+import type { Writable } from 'svelte/store';
+
+/**
+ * Reactive set of acknowledged agent keys (agent display name). In-memory and
+ * session-only — never serialized, never sent to the main process.
+ */
+export const acknowledgedAgents: Writable<Set<string>> = writable(new Set());
+
+/**
+ * Toggle the acknowledged state for an agent key. Replaces the backing Set with
+ * a fresh reference so the store notifies subscribers (reactivity).
+ * @param key - Agent key (display name).
+ * @returns The resulting acknowledged state (true = now acknowledged).
+ * @since v0.10.0-alpha
+ */
+export function toggleAcknowledged(key: string): boolean {
+  let result = false;
+  acknowledgedAgents.update((set) => {
+    const next = new Set(set);
+    if (next.has(key)) {
+      next.delete(key);
+      result = false;
+    } else {
+      next.add(key);
+      result = true;
+    }
+    return next;
+  });
+  return result;
+}
+
+/**
+ * Read whether an agent key is currently acknowledged (non-reactive snapshot).
+ * Components should prefer the reactive `$acknowledgedAgents.has(key)`.
+ * @param key - Agent key (display name).
+ * @returns True when acknowledged.
+ * @since v0.10.0-alpha
+ */
+export function isAcknowledged(key: string): boolean {
+  return get(acknowledgedAgents).has(key);
+}
+
+/**
+ * Clear all acknowledged marks (full reset; also used by tests).
+ * @since v0.10.0-alpha
+ */
+export function clearAcknowledged(): void {
+  acknowledgedAgents.set(new Set());
+}

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -28,6 +28,13 @@ interface ProcessActionResult {
   readonly error?: string;
 }
 
+/** Result of an alert-only watchlist add from the main process */
+interface WatchlistAddResult {
+  readonly success: boolean;
+  readonly entry?: unknown;
+  readonly error?: string;
+}
+
 /** Minimal type for the window.aegis IPC bridge exposed by preload.js */
 interface AegisIpcBridge {
   onScanBatch(cb: (data: ScanBatchData) => void): void;
@@ -41,6 +48,11 @@ interface AegisIpcBridge {
   killProcess(pid: number): Promise<ProcessActionResult>;
   suspendProcess(pid: number): Promise<ProcessActionResult>;
   resumeProcess(pid: number): Promise<ProcessActionResult>;
+  blocklistAdd(entry: {
+    signature: string;
+    pid?: number | null;
+    reason?: string;
+  }): Promise<WatchlistAddResult>;
 }
 
 declare global {

--- a/tests/renderer/acknowledged.test.js
+++ b/tests/renderer/acknowledged.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  acknowledgedAgents,
+  toggleAcknowledged,
+  isAcknowledged,
+  clearAcknowledged,
+} from '../../src/renderer/lib/stores/acknowledged.js';
+
+describe('acknowledged store', () => {
+  beforeEach(() => clearAcknowledged());
+  afterEach(() => clearAcknowledged());
+
+  it('starts empty', () => {
+    expect(get(acknowledgedAgents).size).toBe(0);
+    expect(isAcknowledged('Claude Code')).toBe(false);
+  });
+
+  describe('toggleAcknowledged()', () => {
+    it('marks an agent acknowledged and returns true', () => {
+      const result = toggleAcknowledged('Claude Code');
+      expect(result).toBe(true);
+      expect(isAcknowledged('Claude Code')).toBe(true);
+      expect(get(acknowledgedAgents).has('Claude Code')).toBe(true);
+    });
+
+    it('un-marks on second toggle and returns false', () => {
+      toggleAcknowledged('Cursor');
+      const result = toggleAcknowledged('Cursor');
+      expect(result).toBe(false);
+      expect(isAcknowledged('Cursor')).toBe(false);
+    });
+
+    it('tracks multiple agents independently', () => {
+      toggleAcknowledged('A');
+      toggleAcknowledged('B');
+      expect(isAcknowledged('A')).toBe(true);
+      expect(isAcknowledged('B')).toBe(true);
+      toggleAcknowledged('A');
+      expect(isAcknowledged('A')).toBe(false);
+      expect(isAcknowledged('B')).toBe(true);
+    });
+
+    it('emits a new Set reference for reactivity', () => {
+      const before = get(acknowledgedAgents);
+      toggleAcknowledged('X');
+      const after = get(acknowledgedAgents);
+      expect(after).not.toBe(before);
+    });
+  });
+
+  describe('clearAcknowledged()', () => {
+    it('removes all marks', () => {
+      toggleAcknowledged('A');
+      toggleAcknowledged('B');
+      expect(get(acknowledgedAgents).size).toBe(2);
+      clearAcknowledged();
+      expect(get(acknowledgedAgents).size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds an always-visible **action row** to each `AgentCard` via a new `AgentActions.svelte` component. Three advisory, UI-only actions — none stop, restrict, sandbox, or interfere with any process:

| Button | Action | Backend |
|---|---|---|
| **Add to watchlist** | Existing alert-only `blocklistAdd` IPC. `pid:null` flags the agent **signature** (every instance). Toast: "Added <name> to watchlist — alert only". | None new (PR #158) |
| **View details** | Expands the existing card detail panel (`expandedPid = agent.pid`). | None |
| **Acknowledge** | Session-only in-memory triage mark (toggle). | None |

## Honesty

- **No new IPC channel.** `preload.js`, `ipc-handlers.js`, `blocklist.js`, `App.svelte` are **untouched**.
- The watchlist is **alert-only** — it raises an alert if the agent reappears and never acts at the OS level (per `blocklist.js` contract).
- No `block`/`kernel`/`blocked`/`prevent` wording in any new line (grep-verified).

## Design notes

- **Acknowledge is agent-level, in-memory** (new `acknowledged.ts` store, `writable<Set>`). FileEvents have no stable id and churn at cap 500, so per-event persistence would need a new IPC + settings schema — out of scope. Not persisted; not wired to suppress anomaly toasts (would refactor App.svelte).
- `ipc.ts` (not frozen) gains the `blocklistAdd` type on the hand-maintained `AegisIpcBridge` interface so `typecheck:svelte` passes.
- `AgentCard.svelte` change is append-only (+3 lines: import + render).

## Verify

`build:renderer` ✓ · `typecheck:svelte` 0/0 · `eslint` 0 · `prettier --check` clean · Svelte MCP autofixer 0 issues · `npm test` **851 pass / 4 skip (52 files)** (+6 new `acknowledged.test.js`).