### PR TITLE
feat(file-watcher): hot read-detect cycle on crown-jewel secret dirs (10s RM poll)

### DIFF
--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -59,16 +59,26 @@ let _getFileHandles = _platform.getFileHandles;
 // win32 exposes these (Restart Manager); darwin/linux do not → undefined, so the
 // RM branch is skipped and the legacy getFileHandles pool path runs unchanged.
 let _getSensitiveHolders = _platform.getSensitiveHolders;
+// Fast hot-cycle holder source (HOT_DIRS only); win32 only, undefined elsewhere.
+let _getHotSensitiveHolders = _platform.getHotSensitiveHolders;
 const _isRmAvailable = _platform.isRestartManagerAvailable;
+// Cost guard: ensure only ONE RM powershell spawn is in flight at a time across
+// the full (30s) and hot (~10s) cycles. NOT a correctness guard — the shared
+// knownHandles dedup already prevents double-emit (JS is single-threaded); this
+// only avoids a redundant concurrent spawn when both ticks coincide.
+let _rmScanInFlight = false;
 /** @internal Override dependencies (for tests). */
 function _setDepsForTest(overrides) {
   if (overrides.getFileHandles) _getFileHandles = overrides.getFileHandles;
   if (overrides.getSensitiveHolders) _getSensitiveHolders = overrides.getSensitiveHolders;
+  if (overrides.getHotSensitiveHolders) _getHotSensitiveHolders = overrides.getHotSensitiveHolders;
 }
 /** @internal Reset debounce state + opt out of the RM path (for tests). */
 function _resetForTest() {
   watcherDebounce.clear();
   _getSensitiveHolders = undefined; // tests opt into RM explicitly via _setDepsForTest
+  _getHotSensitiveHolders = undefined;
+  _rmScanInFlight = false;
 }
 
 const watcherDebounce = new Map();
@@ -370,14 +380,39 @@ function rmEnabled() {
  * `action:'holding'` event — a point-in-time handle HOLD at the scan tick, NOT a
  * read/access. Dedups per-PID by group via knownHandles so a sustained hold fires
  * once, not once-per-scan.
+ *
+ * Used by BOTH the full (30s) and the hot (~10s) cycles via `fetchHolders`; both
+ * share `_state.knownHandles`, so a hold caught by one cycle is deduped against
+ * the other (cross-cycle dedup). A single-flight guard keeps the two cycles from
+ * spawning two powershells at once (cost only — the shared dedup already prevents
+ * any double-emit since JS is single-threaded).
  * @param {Array} agents
+ * @param {Function} [fetchHolders] - Holder source (full or hot); defaults to full.
  * @returns {Promise<Array>}
  * @since v0.10.0
  */
-async function scanViaRestartManager(agents) {
+async function scanViaRestartManager(agents, fetchHolders = _getSensitiveHolders) {
+  if (_rmScanInFlight) return []; // a full/hot RM scan is already running — skip
+  _rmScanInFlight = true;
+  try {
+    return await _scanRmHolders(agents, fetchHolders);
+  } finally {
+    _rmScanInFlight = false;
+  }
+}
+
+/**
+ * Core RM holder→agent mapping + holding-event emission (C-01: agent resolved from
+ * the holder PID, never cross-wired). Split out so scanViaRestartManager can wrap
+ * it with the single-flight guard.
+ * @param {Array} agents
+ * @param {Function} fetchHolders - Holder source (full or hot).
+ * @returns {Promise<Array>}
+ */
+async function _scanRmHolders(agents, fetchHolders) {
   let holders;
   try {
-    holders = await _getSensitiveHolders();
+    holders = await fetchHolders();
   } catch (_) {
     return [];
   }
@@ -434,6 +469,34 @@ async function scanViaRestartManager(agents) {
     _state.recordFileAccess(agent.agent, group, event.sensitive, event.reason);
   }
   return newAccess;
+}
+
+/**
+ * Whether the fast hot read-detect cycle is usable: the platform exposes
+ * getHotSensitiveHolders (win32 only) AND, if it reports availability, RM is up.
+ * scan-loop checks this to avoid creating the hot timer on darwin/linux (no RM).
+ * @returns {boolean}
+ */
+function isHotReadScanActive() {
+  if (typeof _getHotSensitiveHolders !== 'function') return false;
+  if (typeof _isRmAvailable === 'function' && !_isRmAvailable()) return false;
+  return true;
+}
+
+/**
+ * Fast hot read-detect scan (win32 only): the same RM holder→agent path as the
+ * full scan but sourced from getHotSensitiveHolders (HOT_DIRS + ~/.env* only),
+ * driven at ~10s to shrink the 30s read-blind window on the crown-jewel secret
+ * dirs. Shares _state.knownHandles with the full scan → cross-cycle dedup (a hold
+ * caught here will NOT re-fire from the 30s scan, and vice versa). Emits
+ * `action:'holding'` — a HOLD at the tick, NEVER a transient open→read→close.
+ * @param {Array} agents
+ * @returns {Promise<Array>}
+ * @since v0.11.0-alpha
+ */
+async function scanHotFileHolders(agents) {
+  if (!isHotReadScanActive()) return [];
+  return scanViaRestartManager(agents, _getHotSensitiveHolders);
 }
 
 /**
@@ -513,6 +576,8 @@ module.exports = {
   setupFileWatchers,
   setupRulesWatcher,
   scanAllFileHandles,
+  scanHotFileHolders,
+  isHotReadScanActive,
   pruneKnownHandles,
   classifySensitive,
   shouldIgnore,

--- a/src/main/platform/restart-manager.js
+++ b/src/main/platform/restart-manager.js
@@ -43,6 +43,16 @@ const { RM_CSHARP } = require('./rm-csharp');
 const SECRET_DIRS = ['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.azure'];
 
 /**
+ * The crown-jewel credential roots scanned by the FAST hot read-detect cycle
+ * (file-watcher.scanHotFileHolders, ~10s) — a strict subset of SECRET_DIRS, kept
+ * small so each frequent spawn registers few files and stays cheap. `~/.env*` is
+ * folded in via the includeEnv branch of buildSensitiveGroups, not listed here.
+ * The full 30s scan still covers the broader SECRET_DIRS ∪ AGENT_CONFIG_PATHS set.
+ * @type {string[]}
+ */
+const HOT_DIRS = ['.ssh', '.aws', '.gnupg'];
+
+/**
  * Whether Restart Manager P/Invoke is usable. Optimistic default (true);
  * downgraded to false ONLY by probeRestartManager() failing — "can't tell" must
  * fail honest, not optimistic. rstrtmgr.dll ships on every Windows Vista+, so the
@@ -96,13 +106,21 @@ function classify(filePath) {
  * plus home ~/.env* files, grouped for registration. A directory becomes one group
  * keyed by the dir path (dir-level naming); each ~/.env* file is its own group
  * keyed by the file path (single confirmed file → file-level naming is honest).
+ *
+ * Parametrized so the FAST hot cycle can register a small subset. Defaults
+ * reproduce the original full-scan behavior exactly (SECRET_DIRS ∪
+ * AGENT_CONFIG_PATHS, env included) — existing callers are unaffected.
+ * @param {string[]} [dirNames] - Directory basenames (under home) to enumerate.
+ * @param {boolean} [includeEnv=true] - Whether to add ~/.env* single-file groups.
  * @returns {Array<{group: string, reason: string, files: string[]}>}
  */
-function buildSensitiveGroups() {
+function buildSensitiveGroups(
+  dirNames = [...SECRET_DIRS, ...AGENT_CONFIG_PATHS],
+  includeEnv = true,
+) {
   const home = os.homedir();
   /** @type {Array<{group: string, reason: string, files: string[]}>} */
   const groups = [];
-  const dirNames = [...SECRET_DIRS, ...AGENT_CONFIG_PATHS];
   const seen = new Set();
   for (const name of dirNames) {
     const dir = path.join(home, name);
@@ -126,15 +144,17 @@ function buildSensitiveGroups() {
     groups.push({ group: dir, reason, files });
   }
   // ~/.env* — each file its own single-file group (confirmed file-level naming).
-  try {
-    for (const e of fs.readdirSync(home, { withFileTypes: true })) {
-      if (!e.isFile() || !/^\.env(\.|$)/i.test(e.name)) continue;
-      const file = path.join(home, e.name);
-      const reason = classify(file);
-      if (reason) groups.push({ group: file, reason, files: [file] });
+  if (includeEnv) {
+    try {
+      for (const e of fs.readdirSync(home, { withFileTypes: true })) {
+        if (!e.isFile() || !/^\.env(\.|$)/i.test(e.name)) continue;
+        const file = path.join(home, e.name);
+        const reason = classify(file);
+        if (reason) groups.push({ group: file, reason, files: [file] });
+      }
+    } catch (_) {
+      // home unreadable — skip env group
     }
-  } catch (_) {
-    // home unreadable — skip env group
   }
   return groups;
 }
@@ -145,18 +165,28 @@ function buildSensitiveGroups() {
  * to a registered sensitive resource. Holders are returned RAW (including
  * non-agent PIDs and possibly AEGIS itself) — the caller maps PIDs to agents and
  * applies the own-PID guard.
+ *
+ * Parametrized so the fast hot cycle can scan a small subset; default args
+ * reproduce the original full scan exactly. `windowsHide:true` keeps the
+ * frequent spawn from flashing a console window every ~10s.
+ * @param {string[]} [dirNames] - Directory basenames to scan (see buildSensitiveGroups).
+ * @param {boolean} [includeEnv=true] - Whether to include ~/.env* groups.
  * @returns {Promise<Array<{pid: number, group: string, reason: string}>>}
  * @since v0.10.0
  */
-function getSensitiveHolders() {
+function getSensitiveHolders(dirNames, includeEnv) {
   if (!_rmAvailable) return Promise.resolve([]);
-  const groups = buildSensitiveGroups();
+  const groups = buildSensitiveGroups(dirNames, includeEnv);
   if (groups.length === 0) return Promise.resolve([]);
   return new Promise((resolve) => {
     execFile(
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', PS_BODY],
-      { timeout: 15000, env: { ...process.env, AEGIS_RM_GROUPS: JSON.stringify(groups) } },
+      {
+        timeout: 15000,
+        windowsHide: true,
+        env: { ...process.env, AEGIS_RM_GROUPS: JSON.stringify(groups) },
+      },
       (err, stdout) => {
         if (err) {
           resolve([]);
@@ -166,6 +196,18 @@ function getSensitiveHolders() {
       },
     );
   });
+}
+
+/**
+ * Fast hot-cycle variant: scans ONLY the crown-jewel credential roots (HOT_DIRS)
+ * plus ~/.env*, for the ~10s read-detect poll that shrinks the 30s read-blind
+ * window. Same RM mechanism and same HOLDS-AT-TICK honesty as getSensitiveHolders
+ * — it catches a handle held at the tick, NEVER a transient open→read→close.
+ * @returns {Promise<Array<{pid: number, group: string, reason: string}>>}
+ * @since v0.11.0-alpha
+ */
+function getHotSensitiveHolders() {
+  return getSensitiveHolders(HOT_DIRS, true);
 }
 
 /**
@@ -238,6 +280,7 @@ function isRestartManagerAvailable() {
 
 module.exports = {
   getSensitiveHolders,
+  getHotSensitiveHolders,
   probeRestartManager,
   isRestartManagerAvailable,
   buildSensitiveGroups,

--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -411,6 +411,7 @@ module.exports = {
   getRawTcpConnections,
   getFileHandles,
   getSensitiveHolders: restartManager.getSensitiveHolders,
+  getHotSensitiveHolders: restartManager.getHotSensitiveHolders,
   isRestartManagerAvailable: restartManager.isRestartManagerAvailable,
   probeReadDetection,
   isReadDetectionAvailable,

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -16,6 +16,14 @@ const blocklist = require('./blocklist');
 let scanInterval = null;
 let fileScanInterval = null;
 let netInterval = null;
+let hotReadInterval = null;
+/**
+ * Fast hot read-detect cadence (win32 RM only): ~10s, vs the 30s full file scan.
+ * Shrinks the read-blind window on the crown-jewel secret dirs (HOT_DIRS). 10s is
+ * the safe `-TypeDefinition` cadence (no precompiled-DLL spawn optimization).
+ * @type {number}
+ */
+const HOT_READ_INTERVAL_MS = 10000;
 /** @type {Object} Injected dependencies */
 let deps = {};
 /** @type {{ollama: {running: boolean, models: string[]}, lmstudio: {running: boolean, models: string[]}}} */
@@ -92,6 +100,10 @@ function stopScanIntervals() {
   if (netInterval) {
     clearInterval(netInterval);
     netInterval = null;
+  }
+  if (hotReadInterval) {
+    clearInterval(hotReadInterval);
+    hotReadInterval = null;
   }
 }
 
@@ -319,12 +331,50 @@ async function doFileScan() {
   }
 }
 
+/**
+ * Fast hot read-detect cycle (win32 RM only, ~10s): a faster RM poll over the
+ * crown-jewel secret dirs (HOT_DIRS + ~/.env*) that shrinks the 30s read-blind
+ * window. Events ride the SAME dedup→batch→audit→tray pipeline as doFileScan and
+ * share knownHandles, so a hold caught here will not re-fire from the 30s scan.
+ * Deliberately does NOT toggle updateScanStatus — a 10s background poll must not
+ * flicker the global "scanning" indicator (process/file scans drive that). RM
+ * catches a HOLD at the tick, never a transient open→read→close.
+ * @since v0.11.0-alpha
+ */
+async function doHotReadScan() {
+  const { watcher, tray, logger, getStats, getLatestAgents } = deps;
+  const agents = getLatestAgents();
+  if (agents.length === 0) return;
+  const t0 = performance.now();
+  try {
+    const rawEvents = await watcher.scanHotFileHolders(agents);
+    const events = rawEvents.map(dedupFileEvent).filter(Boolean);
+    if (events.length > 0) {
+      for (const ev of events) deps.fileAccessBatcher.push(ev);
+      tray.notifySensitive(events.filter((e) => e.sensitive && e.category === 'ai'));
+      for (const ev of events) logAuditForFile(ev);
+      deps.statsUpdateBatcher.push(getStats());
+      tray.updateTrayIcon();
+    }
+  } catch (err) {
+    logger.error('main', 'Hot read scan failed', { error: err.message });
+  } finally {
+    logger.debug('scan', 'hot-read', { ms: Math.round(performance.now() - t0) });
+  }
+}
+
 /** @param {number} intervalMs @since v0.3.0 */
 function startScanIntervals(intervalMs) {
   const ms = intervalMs || 10000;
   scanInterval = setInterval(doProcessScan, ms);
   netInterval = setInterval(doNetworkScan, 30000);
   fileScanInterval = setInterval(doFileScan, Math.max(ms * 3, 30000));
+  // Hot read-detect cycle: win32 + RM only. Not created on darwin/linux (no RM)
+  // so we never run a pointless no-op timer. Started here (post-warmup) only —
+  // never during startWarmup — to keep the heavy boot window quiet.
+  if (deps.watcher && deps.watcher.isHotReadScanActive && deps.watcher.isHotReadScanActive()) {
+    hotReadInterval = setInterval(doHotReadScan, HOT_READ_INTERVAL_MS);
+  }
 }
 
 let warmupTimer = null;

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -576,3 +576,73 @@ describe('file-watcher Restart Manager (RM) holder path', () => {
     expect(second).toHaveLength(0); // sustained hold → one event, not one-per-scan
   });
 });
+
+// Hot read-detect cycle (~10s) — the fast RM poll over HOT_DIRS. Its whole point
+// is shared dedup: a hold caught by EITHER the hot cycle or the full (30s) scan
+// must fire ONCE, because both cycles write the same key into the shared
+// knownHandles. These RED before scanHotFileHolders exists, and stay RED for the
+// wrong implementation (a hot cycle that keeps its OWN dedup state → 2 events).
+describe('file-watcher hot read-detect cycle (cross-cycle dedup)', () => {
+  let state;
+  let mockFull;
+  let mockHot;
+  const HOLDER = [{ pid: 105, group: '/home/user/.ssh', reason: 'SSH keys/config' }];
+  const AGENTS = [{ pid: 105, agent: 'Agent5', category: 'ai' }];
+
+  beforeEach(() => {
+    mockFull = vi.fn().mockResolvedValue(HOLDER);
+    mockHot = vi.fn().mockResolvedValue(HOLDER);
+    state = makeState();
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+    fileWatcher._setDepsForTest({
+      getSensitiveHolders: mockFull,
+      getHotSensitiveHolders: mockHot,
+    });
+  });
+
+  // Core proof + C-01: the hot scan resolves the holder PID to its OWNING agent
+  // and emits a `holding` (never read/accessed) event.
+  it('hot scan emits a holding event attributed by PID (C-01)', async () => {
+    const events = await fileWatcher.scanHotFileHolders(AGENTS);
+    expect(events).toHaveLength(1);
+    expect(events[0].agent).toBe('Agent5');
+    expect(events[0].pid).toBe(105);
+    expect(events[0].action).toBe('holding');
+    expect(events[0].file).toBe('/home/user/.ssh');
+  });
+
+  // Hot then full: full must see the shared dedup key and emit nothing.
+  it('hot scan then full scan of the same holder → ONE event total', async () => {
+    const hot = await fileWatcher.scanHotFileHolders(AGENTS);
+    const full = await fileWatcher.scanAllFileHandles(AGENTS);
+    expect(hot).toHaveLength(1);
+    expect(full).toHaveLength(0);
+  });
+
+  // Reverse order (full first, e.g. agent already held at process start): the hot
+  // cycle must then dedup against the full scan.
+  it('full scan then hot scan of the same holder → ONE event total (reverse order)', async () => {
+    const full = await fileWatcher.scanAllFileHandles(AGENTS);
+    const hot = await fileWatcher.scanHotFileHolders(AGENTS);
+    expect(full).toHaveLength(1);
+    expect(hot).toHaveLength(0);
+  });
+
+  // A sustained hold sampled repeatedly by the FAST cycle still fires once.
+  it('repeated hot scans of a sustained hold → one event, not one-per-tick', async () => {
+    const first = await fileWatcher.scanHotFileHolders(AGENTS);
+    const second = await fileWatcher.scanHotFileHolders(AGENTS);
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(0);
+  });
+
+  // Capability gate: with no hot holder source wired (darwin/linux), the hot scan
+  // is a cheap no-op — never throws, returns [].
+  it('returns [] when no hot holder source is available (darwin/linux)', async () => {
+    fileWatcher._resetForTest(); // clears the injected hot dep
+    const events = await fileWatcher.scanHotFileHolders(AGENTS);
+    expect(events).toEqual([]);
+    expect(fileWatcher.isHotReadScanActive()).toBe(false);
+  });
+});

--- a/tests/main/platform/restart-manager.test.js
+++ b/tests/main/platform/restart-manager.test.js
@@ -115,11 +115,28 @@ describe('platform/restart-manager', () => {
         expect(Array.isArray(g.files)).toBe(true);
       }
     });
+
+    // Hot-scoping: when given a subset + includeEnv=false, the params must be
+    // honored — no .aws/.gnupg groups, no ~/.env* single-file groups. Fails if
+    // the function ignored its args and used the hardcoded full set. (On a host
+    // with no ~/.ssh the list is empty and the loop is vacuously clean.)
+    it('honors dirNames subset and includeEnv=false (hot scoping)', () => {
+      const path = require('path');
+      const groups = rm.buildSensitiveGroups(['.ssh'], false);
+      expect(Array.isArray(groups)).toBe(true);
+      for (const g of groups) {
+        const lower = g.group.toLowerCase();
+        expect(lower).not.toContain(`${path.sep}.aws`);
+        expect(lower).not.toContain(`${path.sep}.gnupg`);
+        expect(/^\.env(\.|$)/i.test(path.basename(g.group))).toBe(false);
+      }
+    });
   });
 
   describe('exports', () => {
     it('exports the RM contract', () => {
       expect(typeof rm.getSensitiveHolders).toBe('function');
+      expect(typeof rm.getHotSensitiveHolders).toBe('function');
       expect(typeof rm.probeRestartManager).toBe('function');
       expect(typeof rm.isRestartManagerAvailable).toBe('function');
       expect(typeof rm.buildSensitiveGroups).toBe('function');


### PR DESCRIPTION
## What

PR 2 of 2 for read-detect-strengthen (PR 1 = #159, the `rm-csharp.js` extraction, already merged). Adds a **fast (~10s) Restart Manager poll** over the crown-jewel credential roots — `HOT_DIRS = ['.ssh','.aws','.gnupg']` plus `~/.env*` — running alongside the existing 30s full file scan.

## Why

The RM read-detect runs inside `doFileScan` at `Math.max(ms*3, 30000)` = **30s**. That 30s is the read-blind window (MASTER-PLAN §2): RM only sees a handle **held at the scan tick**, so a hold that starts and ends between two 30s ticks is missed. The hot cycle samples the most sensitive dirs **3× more often (10s)**, lowering detection latency for sustained holds and raising P(catch) for medium/repeated holds — without widening the broad set (the 30s scan still covers `SECRET_DIRS ∪ AGENT_CONFIG_PATHS`).

## Honesty (unchanged posture)

RM is **HOLDS-AT-TICK**, not a read stream. A faster poll does **not** catch a transient ~ms `open→read→close` (P≈1e-3 at 10s) — **no polling approach can**; only event-driven facilities (ETW, or Windows SACL object-access auditing) can, and those are separate later mechanisms. Event label stays **`holding`** — never `read`/`accessed`/`blocked`/`kernel`/`prevent`.

## How

- **restart-manager.js**: `HOT_DIRS` const; `buildSensitiveGroups(dirNames, includeEnv)` and `getSensitiveHolders(dirNames, includeEnv)` parametrized with **defaults = current full-scan behavior** (existing callers unaffected); `getHotSensitiveHolders()` = `getSensitiveHolders(HOT_DIRS, true)`; `windowsHide: true` on the spawn (no console flash at 10s). Still 286 lines (≤300, thanks to #159).
- **win32.js**: exports `getHotSensitiveHolders`. darwin/linux do not → `undefined` → hot cycle disabled there.
- **file-watcher.js**: `scanViaRestartManager(agents, fetchHolders)` (core split into `_scanRmHolders` so the wrapper can hold a guard); `scanHotFileHolders()` reuses that core via the hot source → **shares `_state.knownHandles` + the `'holding|'+group` dedup key = cross-cycle dedup**. `isHotReadScanActive()` gates win32+RM. `_rmScanInFlight` single-flight guard.
- **scan-loop.js**: `doHotReadScan()` (10s, `HOT_READ_INTERVAL_MS`) rides the **same** dedup→batch→audit→tray pipeline as `doFileScan`; started **only in `startScanIntervals` (post-warmup)**, gated on `watcher.isHotReadScanActive()` (no timer on darwin/linux). Cleared in `stopScanIntervals`. Deliberately does **not** toggle `updateScanStatus` (a 10s background poll must not flicker the global scanning indicator).

## Guarantees

- **No risk-scoring change** — hot events flow through the same `recordFileAccess`/baselines path; self-access exemption / dedup / diminishing-returns untouched.
- **C-01 preserved** — holder PID → owning agent + own-PID guard live in the shared `_scanRmHolders`.
- **Single-flight ordering note (not a coverage regression):** `fileScanInterval` is registered before `hotReadInterval`, so on a 30s coincidence the **full** scan runs first, takes the flag, and the hot tick yields — full ⊇ hot, so nothing broad is dropped. `try/finally` guarantees the flag can never stick true.

## Tests

- **Cross-cycle dedup regression** (`file-watcher.test.js`, +5): hot→full and **full→hot (reverse)** of the same holder → **ONE** event; repeated hot scans of a sustained hold → one; hot event is `holding` + PID-attributed (C-01); no-source → `[]`. **RED by construction** — `scanHotFileHolders` is absent on master AND the assertions discriminate the correct shared-`knownHandles` impl from the wrong separate-dedup impl (the reverse-order case emits 2 under a private dedup map).
- **restart-manager.test.js** (+1): `buildSensitiveGroups(['.ssh'], false)` honors the subset + `includeEnv=false`; exports `getHotSensitiveHolders`.

## Verify

- `npm test` → **857 pass / 4 skip (52 files)** (re-run on committed bytes post lint-staged)
- `npm run build:renderer` clean · `npx eslint src/` 0 errors (23 pre-existing warnings) · `npx tsc --noEmit -p tsconfig.main.json` 0 · changed files prettier-clean (format:check 100+-file noise = known CRLF false-positive)

## Known bounds / follow-ups

- **Cost unmeasured (by design):** 10s × `Add-Type -TypeDefinition` recompiles the C# via csc each spawn. Per decision, NOT precompiling to a DLL this round (no new attack-surface). Cadence cost should be watched live post-merge; if too heavy, revisit precompile (DLL → `app.getPath('userData')`, not tmpdir).
- **Live-smoke gap:** all tests mock `getHotSensitiveHolders`; the real `getHotSensitiveHolders → buildSensitiveGroups(HOT_DIRS, true)` path is not live-verified this round. PR-B (#152-era) already live-proved the RM mechanism on Win11; this PR only narrows the dir set + cadence.
- **Agent-list freshness:** the hot timer maps holder PIDs against `getLatestAgents()` (refreshed every 10s by the process scan) — a just-launched agent not yet in the list is dropped. Consistent with current behavior; noted, not fixed.
- **File sizes:** `file-watcher.js` (591) and `scan-loop.js` (432) were already >300 before this change (accepted central-module exceptions the audit tolerates); additions kept minimal, no refactor (scope).
