### PR TITLE
feat(token-feed): extensible per-PID token-feed reader + Claude Code adapter

### DIFF
--- a/src/main/token-adapters/claude-code.js
+++ b/src/main/token-adapters/claude-code.js
@@ -1,0 +1,311 @@
+/**
+ * @file claude-code.js
+ * @module main/token-adapters/claude-code
+ * @description Token-feed adapter for the Claude Code agent family. Claude Code
+ *   persists its own decrypted per-turn `usage` block to local disk; this adapter
+ *   reads ONLY those numeric counts and returns them as honest, measured
+ *   (`estimated:false`) per-PID token deltas. It is the first concrete adapter
+ *   behind the extensible {@link module:main/token-feed} core.
+ *
+ *   VERIFIED C-01 CHAIN (live disk, 2026-06-04 — TRUST CODE OVER DOCS):
+ *     proc {pid, startTime}
+ *       → ~/.claude/sessions/<pid>.json   { sessionId, cwd, startedAt }
+ *       → startedAt-guard rejects PID reuse (|startedAt − startTime| ≤ tolerance)
+ *       → ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
+ *       → tail only NEW bytes since last offset; parse only `type==="assistant"`
+ *       → dedup by `message.id` (one message spans many content-block lines, each
+ *         repeating the same usage — counting per-line would N×-count)
+ *       → { pid, model, inputTokens, outputTokens, estimated:false }
+ *
+ *   PRIVACY INVARIANT (gating): allowlist-extract ONLY the numeric usage fields +
+ *   model + message id. Message content (prompts/responses) is never read into a
+ *   returned object and never written to any log — on a parse error we log only
+ *   `{ error }`, never the offending line. Scope is limited to the monitored PIDs
+ *   passed in; we never sweep unrelated project history.
+ *
+ *   `procStart` in the registry is an opaque .NET-ticks-like string (version
+ *   fragile) — the guard deliberately uses `startedAt` (clean epoch-ms) instead.
+ *
+ *   SCOPE / KNOWN LIMITATION: reads the main session transcript only. Subagent
+ *   turns are logged to separate `projects/<enc>/<sessionId>/subagents/agent-*.jsonl`
+ *   files; their usage is NOT yet summed, so heavily-delegated sessions undercount.
+ *   This is honest-but-partial (never over-counts) and a deliberate later extension.
+ *
+ *   The line shape (`type:"assistant"` with `message.{id,model,usage}`) and the
+ *   3-bucket input sum were validated against a live `2.1.x` transcript, not docs.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const logger = require('../logger');
+
+/**
+ * @typedef {Object} Proc
+ * @property {number} pid - live process id (C-01 attribution key).
+ * @property {number} startTime - live OS process-creation time (epoch ms),
+ *   supplied by the scan layer; compared against the registry to reject PID reuse.
+ */
+
+/**
+ * @typedef {Object} UsageDelta
+ * @property {number} pid - owning process (C-01).
+ * @property {string} model - model id from the usage block (may be absent from
+ *   the price table → cost becomes approximate downstream; tokens stay measured).
+ * @property {number} inputTokens - input_tokens + cache_creation + cache_read.
+ * @property {number} outputTokens - output_tokens.
+ * @property {boolean} estimated - always `false`: these are measured, not guessed.
+ */
+
+/** @type {string} stable adapter id used by the core registry. */
+const id = 'claude-code';
+
+/**
+ * Max |registry.startedAt − live startTime| (ms) still considered the SAME
+ * process. Generous enough to absorb startup jitter (startedAt is written a beat
+ * after process birth), tight enough that a reused PID — whose real creation time
+ * differs by minutes/hours — is rejected. Bias is toward rejection (honest empty)
+ * over mis-attribution.
+ * @type {number}
+ */
+const GUARD_TOLERANCE_MS = 60_000;
+
+/**
+ * @typedef {Object} SessionState
+ * @property {number} offset - bytes of the transcript already consumed.
+ * @property {Set<string>} seenIds - message.ids already counted (persists across
+ *   calls so a message whose blocks straddle a tail boundary is counted once).
+ */
+
+/** @type {Map<string, SessionState>} per-sessionId tail state. */
+const sessions = new Map();
+
+/** Injectable home dir (tests point this at a fixture root). @type {() => string} */
+let _homedir = () => os.homedir();
+
+/**
+ * Injectable fs surface. `readRange(path, start, length)` returns a Buffer of the
+ * byte slice — production reads only the new bytes, never the whole file.
+ * @type {{ readFileSync: Function, existsSync: Function, statSync: Function, readRange: Function }}
+ */
+let _fs = {
+  readFileSync: (p, enc) => fs.readFileSync(p, enc),
+  existsSync: (p) => fs.existsSync(p),
+  statSync: (p) => fs.statSync(p),
+  readRange: (p, start, length) => {
+    const fd = fs.openSync(p, 'r');
+    try {
+      const buf = Buffer.allocUnsafe(length);
+      const bytesRead = fs.readSync(fd, buf, 0, length, start);
+      return buf.subarray(0, bytesRead);
+    } finally {
+      fs.closeSync(fd);
+    }
+  },
+};
+
+/** Injectable logger (DI, not vi.mock — dodges the ESM/CJS identity trap). */
+let _log = logger;
+
+/**
+ * Encode an absolute cwd into Claude Code's `projects/` directory name. The
+ * encoding is lossy by design (`:` `\` `/` `.` all collapse to `-`); we only
+ * forward-encode a known cwd and existence-check the result — never reverse it.
+ * @param {string} cwd
+ * @returns {string}
+ */
+function _encodeCwd(cwd) {
+  return String(cwd).replace(/[/\\:.]/g, '-');
+}
+
+/**
+ * True when `v` is a usable pid (finite integer > 0).
+ * @param {*} v
+ * @returns {boolean}
+ */
+function isPositivePid(v) {
+  return typeof v === 'number' && Number.isInteger(v) && v > 0;
+}
+
+/**
+ * Decide whether a session registry belongs to the live process (PID-reuse
+ * guard). Both timestamps must be finite numbers and agree within tolerance.
+ * @param {{ startedAt?: number }} registry
+ * @param {{ startTime?: number }} proc
+ * @returns {boolean}
+ */
+function _passesGuard(registry, proc) {
+  if (!registry || typeof registry.startedAt !== 'number') return false;
+  if (!proc || typeof proc.startTime !== 'number') return false;
+  return Math.abs(registry.startedAt - proc.startTime) <= GUARD_TOLERANCE_MS;
+}
+
+/**
+ * Allowlist-extract the measured usage from one parsed transcript line. Returns
+ * `null` for any line that is not an assistant message carrying a usage block, so
+ * prompt/content-bearing lines are dropped before any content field is touched.
+ * @param {*} parsed - a parsed JSONL line object.
+ * @returns {{ id: string, model: string, inputTokens: number, outputTokens: number }|null}
+ */
+function _extractUsage(parsed) {
+  if (!parsed || parsed.type !== 'assistant') return null;
+  const msg = parsed.message;
+  if (!msg || !msg.usage || typeof msg.id !== 'string') return null;
+  const u = msg.usage;
+  const num = (x) => (typeof x === 'number' && Number.isFinite(x) ? x : 0);
+  const inputTokens =
+    num(u.input_tokens) + num(u.cache_creation_input_tokens) + num(u.cache_read_input_tokens);
+  return {
+    id: msg.id,
+    model: typeof msg.model === 'string' ? msg.model : '',
+    inputTokens,
+    outputTokens: num(u.output_tokens),
+  };
+}
+
+/** Get-or-create the tail state for a sessionId. @param {string} sessionId @returns {SessionState} */
+function _stateFor(sessionId) {
+  let st = sessions.get(sessionId);
+  if (!st) {
+    st = { offset: 0, seenIds: new Set() };
+    sessions.set(sessionId, st);
+  }
+  return st;
+}
+
+/**
+ * Read the registry for one pid. Returns the parsed object or `null` (absent /
+ * unreadable / malformed) — never logs the file body.
+ * @param {number} pid
+ * @returns {*}
+ */
+function _readRegistry(pid) {
+  const p = path.join(_homedir(), '.claude', 'sessions', `${pid}.json`);
+  try {
+    return JSON.parse(_fs.readFileSync(p, 'utf-8'));
+  } catch (_err) {
+    return null;
+  }
+}
+
+/**
+ * Resolve and tail one proc's transcript, returning new measured deltas. All
+ * failure modes degrade to `[]` (honest empty) without throwing.
+ * @param {Proc} proc
+ * @returns {UsageDelta[]}
+ */
+function _readOneProc(proc) {
+  const pid = proc && proc.pid;
+  if (!isPositivePid(pid)) return [];
+
+  const registry = _readRegistry(pid);
+  if (!_passesGuard(registry, proc)) return [];
+  const { sessionId, cwd } = registry;
+  if (typeof sessionId !== 'string' || typeof cwd !== 'string') return [];
+
+  const tPath = path.join(_homedir(), '.claude', 'projects', _encodeCwd(cwd), `${sessionId}.jsonl`);
+  if (!_fs.existsSync(tPath)) return [];
+
+  const size = _fs.statSync(tPath).size;
+  const st = _stateFor(sessionId);
+  if (size < st.offset) st.offset = 0; // file truncated/rotated → restart tail
+  if (size <= st.offset) return []; // nothing new
+
+  const buf = _fs.readRange(tPath, st.offset, size - st.offset);
+  const lastNl = buf.lastIndexOf(0x0a);
+  if (lastNl === -1) return []; // no complete line yet; re-read next call
+
+  const complete = buf.subarray(0, lastNl + 1);
+  st.offset += complete.length; // advance by BYTES (size is byte-counted)
+
+  const deltas = [];
+  for (const line of complete.toString('utf-8').split('\n')) {
+    if (!line) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch (err) {
+      _log.warn('token-feed:claude-code', 'skipped unparseable transcript line', {
+        error: err.message,
+      });
+      continue;
+    }
+    const u = _extractUsage(parsed);
+    if (!u || st.seenIds.has(u.id)) continue; // dedup by message.id
+    st.seenIds.add(u.id);
+    deltas.push({
+      pid,
+      model: u.model,
+      inputTokens: u.inputTokens,
+      outputTokens: u.outputTokens,
+      estimated: false,
+    });
+  }
+  return deltas;
+}
+
+/**
+ * Read new measured token deltas for the given live processes. Non-idempotent by
+ * design: a second call with no newly-appended transcript bytes returns `[]`
+ * (the deltas were already emitted), which matches the accumulating contract of
+ * the downstream token-tracker.
+ * @param {Proc[]} procs - live processes enriched with OS `startTime`.
+ * @returns {Promise<UsageDelta[]>}
+ * @since v0.10.0-alpha
+ */
+async function readUsage(procs) {
+  if (!Array.isArray(procs) || procs.length === 0) return [];
+  const out = [];
+  for (const proc of procs) {
+    let deltas;
+    try {
+      deltas = _readOneProc(proc);
+    } catch (err) {
+      _log.warn('token-feed:claude-code', 'adapter read failed for a pid', {
+        error: err.message,
+      });
+      continue;
+    }
+    for (const d of deltas) out.push(d);
+  }
+  return out;
+}
+
+/** @internal Override the home dir (tests). @param {() => string} fn */
+function _setHomedirForTest(fn) {
+  _homedir = fn;
+}
+
+/** @internal Override the fs surface (tests). @param {Partial<typeof _fs>} obj */
+function _setFsForTest(obj) {
+  _fs = { ..._fs, ...obj };
+}
+
+/** @internal Override the logger (tests). @param {*} obj */
+function _setLoggerForTest(obj) {
+  _log = obj;
+}
+
+/** @internal Reset all module state + DI seams (tests). @returns {void} */
+function _resetForTest() {
+  sessions.clear();
+  _homedir = () => os.homedir();
+  _log = logger;
+}
+
+module.exports = {
+  id,
+  GUARD_TOLERANCE_MS,
+  readUsage,
+  _encodeCwd,
+  _extractUsage,
+  _passesGuard,
+  _setHomedirForTest,
+  _setFsForTest,
+  _setLoggerForTest,
+  _resetForTest,
+};

--- a/src/main/token-feed.js
+++ b/src/main/token-feed.js
@@ -1,0 +1,75 @@
+/**
+ * @file token-feed.js
+ * @module main/token-feed
+ * @description Extensible per-PID token-feed CORE. A thin registry that fans a
+ *   list of live processes out to each registered token adapter and concatenates
+ *   the measured (`estimated:false`) token deltas they return. The core holds NO
+ *   agent-specific knowledge — every detail of where usage lives on disk, how to
+ *   tail it, and how to attribute it per-PID belongs to an adapter. Adding a new
+ *   self-logging agent is one `require` appended to {@link adapters}.
+ *
+ *   Each adapter implements the contract:
+ *     { id: string,
+ *       readUsage(procs: Proc[]) => Promise<UsageDelta[]>,
+ *       _resetForTest(): void }
+ *
+ *   An adapter that throws or finds no source contributes nothing — a single bad
+ *   adapter can never crash the feed or starve the others. The companion
+ *   accounting sink is `token-tracker.js`, whose `estimated:false` contract these
+ *   measured deltas satisfy; wiring this feed into the scan loop is a separate
+ *   task and is intentionally NOT done here.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ */
+'use strict';
+
+const logger = require('./logger');
+const claudeCode = require('./token-adapters/claude-code');
+
+/**
+ * @typedef {import('./token-adapters/claude-code').Proc} Proc
+ * @typedef {import('./token-adapters/claude-code').UsageDelta} UsageDelta
+ */
+
+/** Default adapter registry. Append a module here to support a new agent. */
+const DEFAULT_ADAPTERS = [claudeCode];
+
+/** @type {Array<{ id: string, readUsage: Function, _resetForTest?: Function }>} */
+let adapters = DEFAULT_ADAPTERS.slice();
+
+/**
+ * Read new measured token deltas for the given live processes across every
+ * registered adapter, in registration order.
+ * @param {Proc[]} procs - live processes enriched with OS `startTime` (see adapter).
+ * @returns {Promise<UsageDelta[]>} flat array of measured deltas (possibly empty).
+ * @since v0.10.0-alpha
+ */
+async function readUsageByPid(procs) {
+  const out = [];
+  for (const adapter of adapters) {
+    let deltas;
+    try {
+      deltas = await adapter.readUsage(procs);
+    } catch (err) {
+      // One adapter failing never crashes the feed or starves the others.
+      logger.debug('token-feed', 'adapter failed', { adapter: adapter.id, error: err.message });
+      continue;
+    }
+    if (Array.isArray(deltas)) for (const d of deltas) out.push(d);
+  }
+  return out;
+}
+
+/** @internal Swap the adapter registry (tests). @param {Array} arr */
+function _setAdaptersForTest(arr) {
+  adapters = arr;
+}
+
+/** @internal Restore the default registry and reset each adapter (tests). @returns {void} */
+function _resetForTest() {
+  adapters = DEFAULT_ADAPTERS.slice();
+  for (const a of DEFAULT_ADAPTERS) if (typeof a._resetForTest === 'function') a._resetForTest();
+}
+
+module.exports = { readUsageByPid, _setAdaptersForTest, _resetForTest };

--- a/tests/main/token-adapters/claude-code.test.js
+++ b/tests/main/token-adapters/claude-code.test.js
@@ -1,0 +1,373 @@
+/**
+ * @file claude-code.test.js
+ * @description Regression + privacy suite for the Claude Code token-feed adapter.
+ *   All fixtures are injected via DI (fake homedir + in-memory fs + spy logger) —
+ *   no live disk, so CI is deterministic. The three RED-first regression anchors
+ *   are: (2) message.id dedup (one message spread over N lines counts ×1, not ×N),
+ *   (4) startedAt-guard rejects PID reuse, (6) privacy — output carries no content.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import path from 'node:path';
+import adapter from '../../../src/main/token-adapters/claude-code.js';
+
+const {
+  id,
+  readUsage,
+  GUARD_TOLERANCE_MS,
+  _encodeCwd,
+  _extractUsage,
+  _passesGuard,
+  _setHomedirForTest,
+  _setFsForTest,
+  _setLoggerForTest,
+  _resetForTest,
+} = adapter;
+
+const HOME = path.join('/fake', 'home');
+const STARTED = 1_700_000_000_000; // arbitrary epoch-ms used by every fixture
+
+/** Build an in-memory fs over a { path: utf8-content } map (byte-accurate). */
+function makeFs(files) {
+  const store = new Map(Object.entries(files));
+  const enoent = (p) => {
+    const e = new Error(`ENOENT: no such file ${p}`);
+    e.code = 'ENOENT';
+    return e;
+  };
+  return {
+    store,
+    readFileSync(p) {
+      if (!store.has(p)) throw enoent(p);
+      return store.get(p);
+    },
+    existsSync(p) {
+      return store.has(p);
+    },
+    statSync(p) {
+      if (!store.has(p)) throw enoent(p);
+      return { size: Buffer.byteLength(store.get(p), 'utf-8') };
+    },
+    readRange(p, start, length) {
+      const buf = Buffer.from(store.get(p), 'utf-8');
+      return buf.subarray(start, start + length);
+    },
+  };
+}
+
+const sessionsPath = (pid) => path.join(HOME, '.claude', 'sessions', `${pid}.json`);
+const transcriptPath = (cwd, sessionId) =>
+  path.join(HOME, '.claude', 'projects', _encodeCwd(cwd), `${sessionId}.jsonl`);
+
+const registry = ({ pid, sessionId, cwd, startedAt = STARTED }) =>
+  JSON.stringify({
+    pid,
+    sessionId,
+    cwd,
+    startedAt,
+    procStart: '639162008149103680',
+    status: 'idle',
+  });
+
+function assistantLine({
+  id: msgId,
+  model = 'claude-opus-4-8',
+  input = 0,
+  cacheCreate = 0,
+  cacheRead = 0,
+  output = 0,
+  content,
+}) {
+  const message = {
+    id: msgId,
+    type: 'message',
+    role: 'assistant',
+    model,
+    usage: {
+      input_tokens: input,
+      cache_creation_input_tokens: cacheCreate,
+      cache_read_input_tokens: cacheRead,
+      output_tokens: output,
+    },
+  };
+  if (content !== undefined) message.content = content;
+  return JSON.stringify({ type: 'assistant', message });
+}
+
+const userLine = (content) => JSON.stringify({ type: 'user', message: { role: 'user', content } });
+const jsonl = (...lines) => lines.join('\n') + '\n';
+
+const logWarn = vi.fn();
+
+beforeEach(() => {
+  _resetForTest();
+  logWarn.mockClear();
+  _setHomedirForTest(() => HOME);
+  _setLoggerForTest({ warn: logWarn, debug: vi.fn(), info: vi.fn(), error: vi.fn() });
+});
+
+describe('claude-code adapter — identity', () => {
+  it('declares a stable adapter id', () => {
+    expect(id).toBe('claude-code');
+  });
+});
+
+describe('pure parsers', () => {
+  it('_encodeCwd collapses : \\ / . to - (verified live encoding)', () => {
+    expect(_encodeCwd('X:\\Future\\ESCAPE\\AEGIS')).toBe('X--Future-ESCAPE-AEGIS');
+    expect(_encodeCwd('C:\\Users\\murtu')).toBe('C--Users-murtu');
+    expect(_encodeCwd('/home/u/.config/app')).toBe('-home-u--config-app');
+  });
+
+  it('_extractUsage sums the three input buckets and keeps output separate', () => {
+    const parsed = JSON.parse(
+      assistantLine({ id: 'm1', input: 10, cacheCreate: 5, cacheRead: 2, output: 7 }),
+    );
+    expect(_extractUsage(parsed)).toEqual({
+      id: 'm1',
+      model: 'claude-opus-4-8',
+      inputTokens: 17,
+      outputTokens: 7,
+    });
+  });
+
+  it('_extractUsage returns null for non-assistant or usage-less lines', () => {
+    expect(_extractUsage(JSON.parse(userLine('hi')))).toBeNull();
+    expect(
+      _extractUsage(JSON.parse(JSON.stringify({ type: 'assistant', message: { id: 'x' } }))),
+    ).toBeNull();
+  });
+
+  it('_passesGuard accepts within tolerance, rejects beyond it and on missing fields', () => {
+    expect(_passesGuard({ startedAt: STARTED }, { startTime: STARTED })).toBe(true);
+    expect(_passesGuard({ startedAt: STARTED }, { startTime: STARTED + GUARD_TOLERANCE_MS })).toBe(
+      true,
+    );
+    expect(
+      _passesGuard({ startedAt: STARTED }, { startTime: STARTED + GUARD_TOLERANCE_MS + 1 }),
+    ).toBe(false);
+    expect(_passesGuard({ startedAt: STARTED }, {})).toBe(false);
+    expect(_passesGuard({}, { startTime: STARTED })).toBe(false);
+  });
+});
+
+describe('readUsage — happy path (real tokens, estimated:false)', () => {
+  it('returns one delta per distinct message.id with summed input buckets', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-aaa';
+    _setFsForTest(
+      makeFs({
+        [sessionsPath(1234)]: registry({ pid: 1234, sessionId: sid, cwd }),
+        [transcriptPath(cwd, sid)]: jsonl(
+          assistantLine({ id: 'm1', input: 10, cacheCreate: 5, cacheRead: 2, output: 7 }),
+          assistantLine({ id: 'm2', input: 100, output: 20 }),
+        ),
+      }),
+    );
+
+    const out = await readUsage([{ pid: 1234, startTime: STARTED }]);
+
+    expect(out).toEqual([
+      { pid: 1234, model: 'claude-opus-4-8', inputTokens: 17, outputTokens: 7, estimated: false },
+      { pid: 1234, model: 'claude-opus-4-8', inputTokens: 100, outputTokens: 20, estimated: false },
+    ]);
+  });
+});
+
+describe('readUsage — message.id dedup (THE regression anchor)', () => {
+  it('counts one message split across 5 lines exactly once, never ×5', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-dup';
+    const dup = (extra) =>
+      assistantLine({
+        id: 'msgDUP',
+        input: 8419,
+        cacheCreate: 11335,
+        cacheRead: 20060,
+        output: 753,
+        ...extra,
+      });
+    _setFsForTest(
+      makeFs({
+        [sessionsPath(42)]: registry({ pid: 42, sessionId: sid, cwd }),
+        // mirrors live lines 18,19,20, (21 = non-assistant), 22,23 — all msgDUP
+        [transcriptPath(cwd, sid)]: jsonl(
+          dup(),
+          dup(),
+          dup(),
+          userLine('UNRELATED USER PROMPT'),
+          dup(),
+          dup(),
+        ),
+      }),
+    );
+
+    const out = await readUsage([{ pid: 42, startTime: STARTED }]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].inputTokens).toBe(8419 + 11335 + 20060); // 39814, NOT ×5
+    expect(out[0].outputTokens).toBe(753);
+  });
+});
+
+describe('readUsage — offset tailing & cross-call dedup', () => {
+  it('emits nothing on a re-read with no new bytes, only new ids on append', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-tail';
+    const fs = makeFs({
+      [sessionsPath(7)]: registry({ pid: 7, sessionId: sid, cwd }),
+      [transcriptPath(cwd, sid)]: jsonl(assistantLine({ id: 'a', input: 1, output: 1 })),
+    });
+    _setFsForTest(fs);
+    const proc = [{ pid: 7, startTime: STARTED }];
+
+    const first = await readUsage(proc);
+    expect(first).toHaveLength(1);
+
+    const second = await readUsage(proc);
+    expect(second).toEqual([]); // nothing new
+
+    // append a brand-new message id
+    fs.store.set(
+      transcriptPath(cwd, sid),
+      jsonl(
+        assistantLine({ id: 'a', input: 1, output: 1 }),
+        assistantLine({ id: 'b', input: 2, output: 2 }),
+      ),
+    );
+    const third = await readUsage(proc);
+    expect(third).toHaveLength(1);
+    expect(third[0].inputTokens).toBe(2);
+  });
+
+  it('does not re-count a message whose blocks straddle a read boundary', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-straddle';
+    const blk = () => assistantLine({ id: 'split', input: 5, output: 5 });
+    const fs = makeFs({
+      [sessionsPath(9)]: registry({ pid: 9, sessionId: sid, cwd }),
+      [transcriptPath(cwd, sid)]: jsonl(blk(), blk()),
+    });
+    _setFsForTest(fs);
+    const proc = [{ pid: 9, startTime: STARTED }];
+
+    const first = await readUsage(proc);
+    expect(first).toHaveLength(1); // 2 blocks, one id → once
+
+    // more blocks of the SAME message arrive after the boundary
+    fs.store.set(transcriptPath(cwd, sid), jsonl(blk(), blk(), blk(), blk()));
+    const second = await readUsage(proc);
+    expect(second).toEqual([]); // same id already counted last call
+  });
+});
+
+describe('readUsage — PID-reuse guard (regression anchor)', () => {
+  it('returns [] when the live startTime diverges from registry.startedAt', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-reuse';
+    _setFsForTest(
+      makeFs({
+        [sessionsPath(555)]: registry({ pid: 555, sessionId: sid, cwd, startedAt: STARTED }),
+        [transcriptPath(cwd, sid)]: jsonl(assistantLine({ id: 'm', input: 9, output: 9 })),
+      }),
+    );
+
+    const reused = await readUsage([{ pid: 555, startTime: STARTED + 36_000_000 }]); // +10h
+    expect(reused).toEqual([]);
+
+    const same = await readUsage([{ pid: 555, startTime: STARTED }]);
+    expect(same).toHaveLength(1);
+  });
+});
+
+describe('readUsage — missing sources are honest empties (never throw)', () => {
+  it('returns [] for missing registry, missing transcript, and bad pids', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-x';
+    _setFsForTest(
+      makeFs({
+        // registry present but transcript absent
+        [sessionsPath(111)]: registry({ pid: 111, sessionId: sid, cwd }),
+      }),
+    );
+
+    expect(await readUsage([{ pid: 999, startTime: STARTED }])).toEqual([]); // no registry
+    expect(await readUsage([{ pid: 111, startTime: STARTED }])).toEqual([]); // no transcript
+    expect(await readUsage([{ pid: -1, startTime: STARTED }])).toEqual([]); // bad pid
+    expect(await readUsage([])).toEqual([]);
+    expect(await readUsage(null)).toEqual([]);
+  });
+});
+
+describe('readUsage — privacy invariant (regression anchor)', () => {
+  it('returns only numeric/token keys and never surfaces message content', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-priv';
+    const SECRET = 'SECRET_PROMPT_DO_NOT_LEAK';
+    _setFsForTest(
+      makeFs({
+        [sessionsPath(8)]: registry({ pid: 8, sessionId: sid, cwd }),
+        [transcriptPath(cwd, sid)]: jsonl(
+          userLine(SECRET),
+          assistantLine({
+            id: 'm',
+            input: 3,
+            output: 4,
+            content: [{ type: 'text', text: SECRET }],
+          }),
+        ),
+      }),
+    );
+
+    const out = await readUsage([{ pid: 8, startTime: STARTED }]);
+
+    expect(out).toHaveLength(1);
+    expect(Object.keys(out[0]).sort()).toEqual(
+      ['estimated', 'inputTokens', 'model', 'outputTokens', 'pid'].sort(),
+    );
+    expect(JSON.stringify(out)).not.toContain(SECRET);
+  });
+
+  it('logs only { error } on a malformed line — never the raw line content', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-bad';
+    const SECRET = 'GARBAGE_WITH_SECRET';
+    _setFsForTest(
+      makeFs({
+        [sessionsPath(8)]: registry({ pid: 8, sessionId: sid, cwd }),
+        [transcriptPath(cwd, sid)]:
+          `not json ${SECRET}\n` + jsonl(assistantLine({ id: 'm', input: 1, output: 1 })),
+      }),
+    );
+
+    const out = await readUsage([{ pid: 8, startTime: STARTED }]);
+
+    expect(out).toHaveLength(1); // the good line still counts
+    expect(logWarn).toHaveBeenCalled();
+    for (const call of logWarn.mock.calls) {
+      const meta = call[2] || {};
+      expect(Object.keys(meta)).toEqual(['error']);
+      expect(JSON.stringify(call)).not.toContain(SECRET);
+    }
+  });
+});
+
+describe('readUsage — C-01 cross-PID isolation', () => {
+  it('attributes each session to its own pid, never cross-wired', async () => {
+    _setFsForTest(
+      makeFs({
+        [sessionsPath(100)]: registry({ pid: 100, sessionId: 's100', cwd: 'X:\\a' }),
+        [sessionsPath(200)]: registry({ pid: 200, sessionId: 's200', cwd: 'X:\\b' }),
+        [transcriptPath('X:\\a', 's100')]: jsonl(assistantLine({ id: 'a', input: 11, output: 1 })),
+        [transcriptPath('X:\\b', 's200')]: jsonl(assistantLine({ id: 'b', input: 22, output: 2 })),
+      }),
+    );
+
+    const out = await readUsage([
+      { pid: 100, startTime: STARTED },
+      { pid: 200, startTime: STARTED },
+    ]);
+
+    const byPid = Object.fromEntries(out.map((d) => [d.pid, d.inputTokens]));
+    expect(byPid).toEqual({ 100: 11, 200: 22 });
+  });
+});

--- a/tests/main/token-feed.test.js
+++ b/tests/main/token-feed.test.js
@@ -1,0 +1,91 @@
+/**
+ * @file token-feed.test.js
+ * @description Unit suite for the extensible token-feed CORE — a thin registry
+ *   that fans a `procs` list out to each registered adapter and concatenates the
+ *   measured deltas. Adapters are faked via DI so the core is tested in isolation
+ *   from any disk I/O.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import feed from '../../src/main/token-feed.js';
+
+const { readUsageByPid, _setAdaptersForTest, _resetForTest } = feed;
+
+const delta = (pid, inputTokens) => ({
+  pid,
+  model: 'claude-opus-4-8',
+  inputTokens,
+  outputTokens: 1,
+  estimated: false,
+});
+
+const fakeAdapter = (id, impl) => ({
+  id,
+  readUsage: vi.fn(impl),
+  _resetForTest: vi.fn(),
+});
+
+beforeEach(() => {
+  _resetForTest();
+});
+
+describe('token-feed core — default registry', () => {
+  it('ships the claude-code adapter and returns [] for empty procs', async () => {
+    // default registry, no procs → no adapter does any disk I/O
+    expect(await readUsageByPid([])).toEqual([]);
+  });
+});
+
+describe('token-feed core — fan-out & concatenation', () => {
+  it('flattens the deltas returned by a single adapter', async () => {
+    _setAdaptersForTest([fakeAdapter('a', async () => [delta(1, 10), delta(2, 20)])]);
+    expect(await readUsageByPid([{ pid: 1, startTime: 0 }])).toEqual([delta(1, 10), delta(2, 20)]);
+  });
+
+  it('concatenates results from multiple adapters in registration order', async () => {
+    _setAdaptersForTest([
+      fakeAdapter('a', async () => [delta(1, 10)]),
+      fakeAdapter('b', async () => [delta(2, 20)]),
+    ]);
+    expect(await readUsageByPid([{ pid: 1, startTime: 0 }])).toEqual([delta(1, 10), delta(2, 20)]);
+  });
+
+  it('forwards the same procs to every adapter', async () => {
+    const a = fakeAdapter('a', async () => []);
+    const b = fakeAdapter('b', async () => []);
+    _setAdaptersForTest([a, b]);
+    const procs = [{ pid: 7, startTime: 123 }];
+    await readUsageByPid(procs);
+    expect(a.readUsage).toHaveBeenCalledWith(procs);
+    expect(b.readUsage).toHaveBeenCalledWith(procs);
+  });
+});
+
+describe('token-feed core — adapter failure isolation', () => {
+  it('isolates a throwing adapter so others still contribute', async () => {
+    _setAdaptersForTest([
+      fakeAdapter('boom', async () => {
+        throw new Error('adapter exploded');
+      }),
+      fakeAdapter('ok', async () => [delta(3, 30)]),
+    ]);
+    expect(await readUsageByPid([{ pid: 3, startTime: 0 }])).toEqual([delta(3, 30)]);
+  });
+
+  it('ignores a non-array adapter return without crashing', async () => {
+    _setAdaptersForTest([
+      fakeAdapter('weird', async () => null),
+      fakeAdapter('ok', async () => [delta(4, 40)]),
+    ]);
+    expect(await readUsageByPid([{ pid: 4, startTime: 0 }])).toEqual([delta(4, 40)]);
+  });
+});
+
+describe('token-feed core — reset', () => {
+  it('_resetForTest restores the default registry (fake no longer called)', async () => {
+    const fake = fakeAdapter('fake', async () => [delta(9, 99)]);
+    _setAdaptersForTest([fake]);
+    _resetForTest();
+    await readUsageByPid([]);
+    expect(fake.readUsage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

An **extensible per-PID token-feed reader** — the missing honest data source behind the
already-shipped `token-tracker.js`. Today the app emits `tokenTracker.getAllCosts()` as an
honest empty array (no usage is ever fed in). This adds the reader that produces real,
measured (`estimated:false`) per-PID token deltas for self-logging agents.

- **`src/main/token-feed.js`** (core, 67 lines) — a thin registry that fans a `procs` list
  out to each registered adapter and concatenates their deltas. No agent-specific knowledge;
  a new agent is one `require` appended to the array. A throwing/empty adapter never crashes
  the feed or starves the others.
- **`src/main/token-adapters/claude-code.js`** (adapter, 282 lines) — first adapter. Reads
  Claude Code's own on-disk transcripts.

## The verified C-01 read chain (live disk, not docs)

```
proc {pid, startTime}
  -> ~/.claude/sessions/<pid>.json   { sessionId, cwd, startedAt }
  -> startedAt-guard: |startedAt - startTime| <= 60s  else []   (PID-reuse rejection)
  -> ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
  -> tail only NEW bytes since last offset; parse only type==="assistant"
  -> dedup by message.id
  -> { pid, model, inputTokens, outputTokens, estimated:false }
```

Key facts validated against a live `2.1.x` transcript on this machine (the repo has shipped
silent-wrong-data twice when coding against asserted-but-unchecked mechanisms):

- **One message spans many content-block lines, each repeating identical `message.usage`** —
  observed `msg_…` on 5 lines. Per-line summing would 5×-count, so dedup is by `message.id`,
  persisted across read-calls (blocks can straddle a tail boundary).
- **`procStart` is an opaque .NET-ticks-like string** (version-fragile, ~4h offset) — the
  guard deliberately uses `startedAt` (clean epoch-ms), comparable to an OS creation time.
- **`inputTokens = input_tokens + cache_creation_input_tokens + cache_read_input_tokens`**;
  `outputTokens = output_tokens`. All four are measured. The live model `claude-opus-4-8` is
  absent from `MODEL_PRICING`, so cost downstream stays approximate — **"real tokens,
  approximate cost."**
- A live probe of the real `_extractUsage` against the real transcript returned
  `{model:'claude-opus-4-8', inputTokens:39814, outputTokens:753}` (39814 = 8419+11335+20060).

## Privacy invariant

Allowlist-extracts ONLY the numeric usage fields + model + message id. Message content
(prompts/responses) is never read into a returned object and never logged — on a parse error
we log only `{ error }`, never the offending line. Scope is limited to the monitored PIDs
passed in; no sweeping of unrelated project history.

## Scope / not in this PR

- **No `token-tracker.js` edits** — its `estimated:false` contract is exactly what this feed
  satisfies.
- **No scan-loop / IPC / preload wiring** — integration touches parallel-branch files and is
  a separate task. The `procStart` guard needs the live OS process-creation time as input
  (`readUsageByPid([{pid, startTime}])`); supplying it (process-scanner does not collect
  `CreationDate` today) is part of that integration.
- **Known limitation (documented in the header):** reads the main session transcript only;
  subagent-turn usage in `subagents/agent-*.jsonl` is not yet summed → heavily-delegated
  sessions undercount. Honest-but-partial (never over-counts).

## Tests / verify

- 21 new tests (14 adapter + 7 core), TDD RED→GREEN. Anchors: message.id dedup (5 lines →
  ×1), `startedAt` guard rejects reuse, privacy (output carries no content; malformed line
  logs `{error}` only), C-01 cross-PID isolation, offset tailing.
- `npm test` 872 pass / 4 skip (was 851/4, +21, no regression) · `tsc -p tsconfig.main.json`
  0 · `eslint src/` 0 errors · `build:renderer` clean · prettier clean · both files <=300.
