### PR TITLE
feat(process-utils): surface OS process start-time (epoch-ms) for PID-reuse guard

### DIFF
--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -62,14 +62,18 @@ function listProcesses() {
 
 /**
  * Build a map of all processes with their parent PIDs via PowerShell Get-CimInstance.
- * @returns {Promise<Map<number, {name: string, ppid: number}>>}
+ * `startTime` is the OS process creation time (epoch-ms). Get-CimInstance returns
+ * CreationDate as a System.DateTime (Kind=Local), NOT a DMTF string (that is the
+ * legacy Get-WmiObject shape) — so the [DateTimeOffset] cast is a direct, correct
+ * UTC-epoch conversion. Null when the OS withholds CreationDate (rare/access).
+ * @returns {Promise<Map<number, {name: string, ppid: number, startTime: number|null}>>}
  */
 function getParentProcessMap() {
   return new Promise((resolve) => {
     const psScript = [
       '$ErrorActionPreference="SilentlyContinue"',
       '$r=@{}',
-      'Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,Name|ForEach-Object{$r[[string]$_.ProcessId]=@{n=$_.Name;p=[int]$_.ParentProcessId}}',
+      'Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,Name,CreationDate|ForEach-Object{$r[[string]$_.ProcessId]=@{n=$_.Name;p=[int]$_.ParentProcessId;t=$(if($_.CreationDate){([DateTimeOffset]$_.CreationDate).ToUnixTimeMilliseconds()}else{$null})}}',
       '$r|ConvertTo-Json -Compress',
     ].join('\n');
     execFile(
@@ -84,7 +88,11 @@ function getParentProcessMap() {
             for (const [pidStr, info] of Object.entries(parsed)) {
               const pid = parseInt(pidStr, 10);
               if (!isNaN(pid)) {
-                map.set(pid, { name: info.n, ppid: info.p });
+                map.set(pid, {
+                  name: info.n,
+                  ppid: info.p,
+                  startTime: typeof info.t === 'number' ? info.t : null,
+                });
               }
             }
           } catch (_) {}

--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -90,7 +90,16 @@ async function getParentChains(pids) {
       }
       cur = pp;
     }
-    parentChainCache.set(pid, { chain, timestamp: now });
+    // Capture the OS process birth time (epoch-ms) for the agent's OWN pid from
+    // the same map fetch — zero extra spawn. Only win32 supplies it; darwin/linux
+    // map entries omit startTime, so the typeof guard yields null (honest).
+    // KNOWN BOUND: the 60s cache TTL means a pid REUSED within 60s serves the
+    // prior process's startTime. Mostly fail-safe (stale time won't match a new
+    // session's startedAt → the token-feed guard rejects it) and strictly better
+    // than no startTime (on which the Windows guard never passes).
+    const ownInfo = procMap.get(pid);
+    const startTime = ownInfo && typeof ownInfo.startTime === 'number' ? ownInfo.startTime : null;
+    parentChainCache.set(pid, { chain, startTime, timestamp: now });
     result.set(pid, chain);
   }
 
@@ -98,7 +107,11 @@ async function getParentChains(pids) {
 }
 
 /**
- * Attach parent-chain arrays to each agent object.
+ * Attach parent-chain arrays AND the OS process start-time to each agent object.
+ * `startTime` (epoch-ms, OS birth time) is distinct from `firstSeen`
+ * (AEGIS-observed) and is read from the same cache `getParentChains` populates —
+ * after the call every requested pid has an entry, so the read is safe. Used by
+ * the token-feed PID-reuse guard; null on non-Windows or absent pid.
  * @param {Array} agents
  * @returns {Promise<void>}
  * @since v0.1.0
@@ -109,6 +122,8 @@ async function enrichWithParentChains(agents) {
   const chains = await getParentChains(pids);
   for (const a of agents) {
     a.parentChain = chains.get(a.pid) || [];
+    const entry = parentChainCache.get(a.pid);
+    a.startTime = entry && typeof entry.startTime === 'number' ? entry.startTime : null;
   }
 }
 

--- a/tests/main/platform/win32.test.js
+++ b/tests/main/platform/win32.test.js
@@ -106,7 +106,7 @@ describe('platform/win32', () => {
   });
 
   describe('getParentProcessMap', () => {
-    it('parses PowerShell JSON output into Map', async () => {
+    it('parses PowerShell JSON output into Map (no CreationDate → startTime null)', async () => {
       const psOutput = JSON.stringify({
         100: { n: 'node.exe', p: 50 },
         200: { n: 'claude.exe', p: 100 },
@@ -117,8 +117,23 @@ describe('platform/win32', () => {
 
       const map = await win32.getParentProcessMap();
       expect(map).toBeInstanceOf(Map);
-      expect(map.get(100)).toEqual({ name: 'node.exe', ppid: 50 });
-      expect(map.get(200)).toEqual({ name: 'claude.exe', ppid: 100 });
+      expect(map.get(100)).toEqual({ name: 'node.exe', ppid: 50, startTime: null });
+      expect(map.get(200)).toEqual({ name: 'claude.exe', ppid: 100, startTime: null });
+    });
+
+    it('maps the CreationDate epoch (t) field onto startTime when present', async () => {
+      const psOutput = JSON.stringify({
+        100: { n: 'claude.exe', p: 50, t: 1717000000000 },
+        200: { n: 'node.exe', p: 100 },
+      });
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => {
+        cb(null, psOutput);
+      });
+
+      const map = await win32.getParentProcessMap();
+      expect(map.get(100).startTime).toBe(1717000000000);
+      // A row without the t field stays honest-null, never fabricates a time.
+      expect(map.get(200).startTime).toBeNull();
     });
 
     it('returns empty Map on error', async () => {

--- a/tests/main/process-utils.test.js
+++ b/tests/main/process-utils.test.js
@@ -106,6 +106,42 @@ describe('process-utils', () => {
     });
   });
 
+  describe('enrichWithParentChains() — OS startTime', () => {
+    it('surfaces OS startTime (epoch-ms) from the win32 map onto the agent', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code', ppid: 0, startTime: 1716999990000 }],
+        ]),
+      );
+
+      const agents = [{ pid: 100, agent: 'Claude' }];
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].startTime).toBe(1717000000000);
+    });
+
+    it('sets startTime null when the map entry has no startTime (darwin/linux shape)', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude', ppid: 200 }],
+          [200, { name: 'bash', ppid: 0 }],
+        ]),
+      );
+
+      const agents = [{ pid: 100, agent: 'Claude' }];
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].startTime).toBeNull();
+    });
+
+    it('sets startTime null for a synthetic PID absent from the map', async () => {
+      mockGetParentProcessMap.mockResolvedValue(new Map([[100, { name: 'a', ppid: 0 }]]));
+
+      const agents = [{ pid: 0, agent: 'Ollama' }];
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].startTime).toBeNull();
+    });
+  });
+
   describe('annotateHostApps()', () => {
     it('sets parentEditor/displayLabel for known editors', () => {
       const agents = [{ agent: 'Claude', parentChain: ['code'] }];


### PR DESCRIPTION
## What

Materialize the **real OS process start-time** (`startTime`, epoch-ms) on each agent object — beside the existing AEGIS-observed `firstSeen` (separate meaning, not renamed). This is the integration-time dependency the token-feed PID-reuse guard (`token-adapters/claude-code.js:143` `_passesGuard`) was waiting on: it compares `|startedAt − proc.startTime| ≤ 60s`, but until now nothing supplied a true OS birth time.

## How (zero new spawn)

`getParentProcessMap()` already runs `Get-CimInstance Win32_Process` every cycle — we just stop discarding `CreationDate`:

- **`platform/win32.js`** — PS-script adds `CreationDate` to `-Property` and emits `t = ([DateTimeOffset]$_.CreationDate).ToUnixTimeMilliseconds()` (honest `$null` when absent); JSON intake maps it to `startTime: typeof info.t === 'number' ? info.t : null`.
- **`process-utils.js`** — the **real** wiring point (`enrichWithParentChains`, not `process-scanner`, which is `tasklist`-only and never touches the CIM map). Own-PID birth time is captured into the existing `parentChainCache` and surfaced onto the agent. Feeds `scan-loop` and `cli` for free. C-01: each agent reads only its own pid's row.

## Format correctness

`Get-CimInstance` returns `CreationDate` as a `System.DateTime` (Kind=Local), **not** a DMTF string (that's legacy `Get-WmiObject`), so the `[DateTimeOffset]` cast is a direct, correct UTC-epoch conversion. Int64 survives `ConvertTo-Json` as a JS-safe-integer number.

**Live-conversion gate** (mocks can't catch a timezone bug): real script vs own `$PID` → `diff_sec=1` (a ~±10800 offset would signal a Kind/TZ bug); `ConvertTo-Json` → `JSON.parse` round-trip confirmed all 400 pids numeric, `Number.isSafeInteger=true`.

## darwin/linux

No code change — posix map omits `startTime` → `typeof` guard yields `null` → downstream guard fails closed (never fabricates a time). `posix-shared` untouched.

## Known bound (documented in JSDoc)

The 60s `parentChainCache` TTL means a pid reused within 60s serves the prior process's start-time. Mostly fail-safe (stale time won't match a new session's `startedAt` → guard rejects) and strictly better than today (no startTime → the Windows guard never passes).

## Tests / verify

- TDD RED→GREEN, **+4 tests** (process-utils +3: number / missing-field→null / absent-pid→null; win32 +1: JSON intake number + no-`t`→null).
- `tsc -p tsconfig.main.json` 0 · `eslint src/` 0 errors · `npm test` **876 pass / 4 skip** (+4, no regression) · `build:renderer` clean · changed files prettier LF-clean.

## Scope

Touches only `win32.js`, `process-utils.js` + their tests. **Not** touched: process-scanner, risk-scoring, renderer, preload, ipc-handlers, token-feed.*, posix-shared. Integration (feeding the token-feed reader from this `startTime`) is a separate follow-up task — **not** in this PR.
