### PR TITLE
feat: wire token-feed reader into live scan loop + footer token readout

### DIFF
--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -11,6 +11,7 @@ const ideExtensionDetector = require('./ide-extension-detector');
 const wslDetector = require('./wsl-detector');
 const resourceMonitor = require('./resource-monitor');
 const tokenTracker = require('./token-tracker');
+const { collectTokenCosts } = require('./token-cost-collector');
 const blocklist = require('./blocklist');
 
 let scanInterval = null;
@@ -246,8 +247,12 @@ async function doProcessScan() {
       anomalyScores: scores,
     });
 
-    // Token costs ride a separate channel. With no usage feed wired this is an
-    // empty array (honest zero) — the tracker never fabricates counts.
+    // Token costs ride a separate channel. Pull any new measured per-PID token
+    // deltas from the feed and fold them into the tracker, then emit the full
+    // accumulated set. Runs inside this C-02-guarded scan (released only in the
+    // finally below) and never throws. A tick with no self-logging agent yields
+    // an honest empty array — the tracker never fabricates counts.
+    await collectTokenCosts(agents);
     sendToRenderer('token-costs', tokenTracker.getAllCosts());
 
     // Per-PID CPU/RAM/GPU is fetched fire-and-forget AFTER the batch so its

--- a/src/main/token-cost-collector.js
+++ b/src/main/token-cost-collector.js
@@ -1,0 +1,110 @@
+/**
+ * @file token-cost-collector.js
+ * @module main/token-cost-collector
+ * @description Per-tick bridge between the live scan loop and the token-feed /
+ *   token-tracker pair. Given the scan's current agent list it:
+ *     1. keeps only agents carrying a real OS birth-time (`startTime` is a
+ *        number) — the feed's PID-reuse guard needs an epoch-ms to trust a pid;
+ *     2. makes exactly ONE {@link module:main/token-feed} read for that batch;
+ *     3. folds every returned measured delta into {@link module:main/token-tracker}
+ *        under the delta's OWN pid (C-01 — never an index, never the loop var).
+ *
+ *   HONESTY (empirical-gap #1). If a live Claude Code agent is present on the
+ *   tick but had to be dropped because its birth-time was unreadable, its tokens
+ *   go unattributed and the readout silently undercounts. We refuse to be silent
+ *   about that: one `logger.warn` is emitted (once per process). It is gated to
+ *   win32 — on darwin/linux `startTime` is `null` for EVERY agent (an expected
+ *   platform limit, not an anomaly), so warning there would be pure noise. The
+ *   warn is emitted BEFORE the empty-procs early return, because the dropped
+ *   agent IS exactly the case that leaves `procs` empty.
+ *
+ *   RELIABILITY (C-02). The feed read is wrapped in try/catch so a corrupt or
+ *   locked transcript can never throw out of here, drop the scan tick, or block
+ *   the caller's reentrancy-guard release. On error we warn once and return the
+ *   nothing we have — the tick continues.
+ *
+ *   This module holds NO token knowledge of its own: it fabricates no counts,
+ *   reads no disk, and adds no agent-specific logic. All of that lives in the
+ *   feed's adapters and the tracker's accounting.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ */
+'use strict';
+
+const logger = require('./logger');
+const tokenFeed = require('./token-feed');
+const tokenTracker = require('./token-tracker');
+
+/**
+ * Display name (agent-database `displayName`) of the only agent family with a
+ * token-feed adapter today. Matched exactly — a substring like 'claude' would
+ * false-warn on other Claude-branded entries in the agent DB.
+ * @type {string}
+ */
+const CLAUDE_CODE_AGENT = 'Claude Code';
+
+/** One-time guards so the two honesty warnings below fire once, never per-tick. */
+let _warnedBirthtime = false;
+let _warnedReadError = false;
+
+/**
+ * Read any new measured per-PID token deltas for the live agents and accumulate
+ * them in the token-tracker. Pure orchestration — see the file header for the
+ * honesty and reliability contracts.
+ *
+ * @param {Array<{ agent?: string, pid?: number, startTime?: number }>} agents -
+ *   the scan tick's current agent list.
+ * @returns {Promise<Array>} the measured deltas applied this tick (possibly
+ *   empty — never throws).
+ * @since v0.11.0-alpha
+ */
+async function collectTokenCosts(agents) {
+  const list = Array.isArray(agents) ? agents : [];
+
+  // C-01: build the procs batch ONLY from agents whose OS birth-time is a real
+  // epoch-ms number. The typeof check rejects both null (darwin/linux: not
+  // surfaced) and undefined (not yet enriched) in a single predicate.
+  const procs = [];
+  let droppedClaude = false;
+  for (const a of list) {
+    if (a && typeof a.startTime === 'number') {
+      procs.push({ pid: a.pid, startTime: a.startTime });
+    } else if (a && a.agent === CLAUDE_CODE_AGENT) {
+      droppedClaude = true;
+    }
+  }
+
+  // Honesty: surface a live-but-unattributable Claude Code agent once (win32
+  // only). Emitted before the early return — the dropped agent is the empty case.
+  if (droppedClaude && !_warnedBirthtime && process.platform === 'win32') {
+    _warnedBirthtime = true;
+    logger.warn(
+      'token',
+      'Live Claude Code agent skipped: OS birth-time unread, its token usage is unattributed',
+    );
+  }
+
+  if (procs.length === 0) return [];
+
+  let deltas;
+  try {
+    deltas = await tokenFeed.readUsageByPid(procs);
+  } catch (err) {
+    // A corrupt/locked transcript must never drop the tick or block the caller's
+    // C-02 finally. Warn once, then carry on with nothing this cycle.
+    if (!_warnedReadError) {
+      _warnedReadError = true;
+      logger.warn('token', 'token-feed read failed; skipping token costs this tick', {
+        error: err.message,
+      });
+    }
+    return [];
+  }
+
+  // C-01: attribute each delta under the pid the SOURCE stamped on it.
+  for (const d of deltas) tokenTracker.trackTokens(d.pid, d);
+  return deltas;
+}
+
+module.exports = { collectTokenCosts };

--- a/src/renderer/lib/components/Footer.svelte
+++ b/src/renderer/lib/components/Footer.svelte
@@ -1,10 +1,14 @@
 <script>
-  import { resourceUsage, stats } from '../stores/ipc.js';
+  import { resourceUsage, stats, tokenCosts } from '../stores/ipc.js';
   import { t } from '../i18n/index.js';
   import FooterMiniCharts from './FooterMiniCharts.svelte';
   import { tick, startTick } from '../stores/tick.ts';
 
   let permDenied = $derived($stats.permissionDeniedScans || 0);
+
+  let totalTokens = $derived($tokenCosts.reduce((sum, r) => sum + (r.totalTokens || 0), 0));
+  let totalCost = $derived($tokenCosts.reduce((sum, r) => sum + (r.costUsd || 0), 0));
+  let anyEstimated = $derived($tokenCosts.some((r) => r.estimated));
 
   let heapMB = $state('--');
   let scanInterval = $state('--');
@@ -63,6 +67,15 @@
       <span class="footer-label">{$t('footer.up')}</span>
       <span class="footer-value">{formatUptime(uptimeMs)}</span>
     </div>
+
+    {#if totalTokens > 0}
+      <div class="footer-item">
+        <span class="footer-label">{$t('footer.tokens')}</span>
+        <span class="footer-value"
+          >{totalTokens.toLocaleString()} {anyEstimated ? '~$' : '$'}{totalCost.toFixed(4)}</span
+        >
+      </div>
+    {/if}
 
     {#if permDenied > 5}
       <div

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -13,7 +13,8 @@
     "heap": "HEAP",
     "scan": "SCAN",
     "up": "UP",
-    "perm_warn": "PERM"
+    "perm_warn": "PERM",
+    "tokens": "TOK"
   },
   "tabs": {
     "shield": "Shield",

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -35,6 +35,21 @@ interface WatchlistAddResult {
   readonly error?: string;
 }
 
+/**
+ * Per-PID token + cost record pushed on the `token-costs` channel. Mirrors the
+ * main process `CostRecord` (token-tracker.js). `estimated` reports whether the
+ * TOKEN COUNTS are measured vs guessed — not whether the dollar figure is audited.
+ */
+interface TokenCostRecord {
+  readonly pid: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly costUsd: number;
+  readonly estimated: boolean;
+  readonly models: string[];
+}
+
 /** Minimal type for the window.aegis IPC bridge exposed by preload.js */
 interface AegisIpcBridge {
   onScanBatch(cb: (data: ScanBatchData) => void): void;
@@ -42,6 +57,7 @@ interface AegisIpcBridge {
   onStatsUpdate(cb: (data: Record<string, unknown>) => void): void;
   onNetworkUpdate(cb: (data: NetworkConnection[]) => void): void;
   onScanStatus(cb: (data: ScanStatusData) => void): void;
+  onTokenCosts(cb: (data: TokenCostRecord[]) => void): void;
   getStats(): Promise<Record<string, unknown>>;
   getResourceUsage(): Promise<Record<string, unknown>>;
   getFalsePositives(): Promise<FalsePositiveEntry[]>;
@@ -69,6 +85,9 @@ export const anomalies: Writable<Record<string, number>> = writable({});
 export const resourceUsage: Writable<Record<string, unknown>> = writable({});
 export const falsePositives: Writable<FalsePositiveEntry[]> = writable([]);
 export const scanActive: Writable<boolean> = writable(false);
+
+/** Per-PID token + cost records, refreshed each scan via the `token-costs` push. */
+export const tokenCosts: Writable<TokenCostRecord[]> = writable([]);
 
 /**
  * True once the first scan batch has arrived from the main process. Monotonic
@@ -117,6 +136,7 @@ if (!isDemoMode) {
     network.set(arr.length > 500 ? arr.slice(-500) : arr);
   });
   window.aegis!.onScanStatus((data) => scanActive.set(data?.scanning ?? false));
+  window.aegis!.onTokenCosts((data) => tokenCosts.set(Array.isArray(data) ? data : []));
 
   // Fetch initial data
   window.aegis!.getStats().then((data) => stats.set(data));

--- a/tests/main/token-cost-collector.test.js
+++ b/tests/main/token-cost-collector.test.js
@@ -1,0 +1,84 @@
+/**
+ * @file token-cost-collector.test.js
+ * @description Unit suite for the per-tick token-cost COLLECTOR — the seam that
+ *   sits between the live scan loop and the token-feed/token-tracker pair. It
+ *   filters the scanned agents down to those carrying a real OS birth-time,
+ *   makes ONE feed read for them, and folds every returned measured delta into
+ *   the tracker under its own source pid (C-01).
+ *
+ *   DI-style: the feed's adapter registry is swapped via `_setAdaptersForTest`
+ *   (NOT `vi.mock`, which would hit the ESM/CJS module-identity trap), and both
+ *   the tracker and the feed are reset before each case so accounting state
+ *   never leaks across tests.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'module';
+
+// createRequire pulls the main-process CJS modules through Node's native require
+// cache — the SAME cache the collector's own `require('./token-feed')` hits. A
+// bare ESM `import` would key a separate module record (the ESM/CJS identity
+// trap), so `_setAdaptersForTest` set here would be invisible to the collector.
+// Mirrors the blocklist / scan-loop test convention.
+const require = createRequire(import.meta.url);
+const tokenFeed = require('../../src/main/token-feed.js');
+const tokenTracker = require('../../src/main/token-tracker.js');
+const { collectTokenCosts } = require('../../src/main/token-cost-collector.js');
+
+/** A scanned-agent stub. `name` defaults to a non-token agent so the procs-filter
+ *  cases stay isolated from the Claude-Code honesty-warn path. */
+const agent = (pid, startTime, name = 'OtherAgent') => ({ agent: name, pid, startTime });
+
+/** A measured per-PID usage delta as the claude-code adapter would emit one. */
+const delta = (pid, inputTokens) => ({
+  pid,
+  model: 'claude-opus-4-8',
+  inputTokens,
+  outputTokens: 5,
+  estimated: false,
+});
+
+beforeEach(() => {
+  tokenTracker._resetForTest();
+  tokenFeed._resetForTest();
+});
+
+describe('token-cost-collector — folds measured deltas into the tracker', () => {
+  it('(a) records one non-zero cost entry per delta pid (C-01: keyed by source pid)', async () => {
+    tokenFeed._setAdaptersForTest([
+      { id: 'fake', readUsage: vi.fn(async () => [delta(1, 100), delta(2, 200)]) },
+    ]);
+
+    await collectTokenCosts([agent(1, 1000), agent(2, 2000)]);
+
+    const costs = tokenTracker.getAllCosts();
+    expect(costs).toHaveLength(2);
+    const byPid = Object.fromEntries(costs.map((c) => [c.pid, c]));
+    expect(byPid[1]).toBeDefined();
+    expect(byPid[2]).toBeDefined();
+    expect(byPid[1].totalTokens).toBeGreaterThan(0);
+    expect(byPid[2].totalTokens).toBeGreaterThan(0);
+  });
+
+  it('(b) forwards procs ONLY for agents whose startTime is a number', async () => {
+    const readUsage = vi.fn(async () => []);
+    tokenFeed._setAdaptersForTest([{ id: 'fake', readUsage }]);
+
+    await collectTokenCosts([agent(1, 1000), agent(2, 2000), agent(3, undefined), agent(4, null)]);
+
+    expect(readUsage).toHaveBeenCalledTimes(1);
+    const procs = readUsage.mock.calls[0][0];
+    expect(procs).toEqual([
+      { pid: 1, startTime: 1000 },
+      { pid: 2, startTime: 2000 },
+    ]);
+  });
+
+  it('(c) reads the feed exactly once per tick', async () => {
+    const readUsage = vi.fn(async () => [delta(1, 10)]);
+    tokenFeed._setAdaptersForTest([{ id: 'fake', readUsage }]);
+
+    await collectTokenCosts([agent(1, 1000)]);
+
+    expect(readUsage).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## STAGE 2B — wire the token-feed reader into the live scan loop + footer token readout

Connects the two parallel branches that were left unwired:
- `feat/token-feed-reader` (PR #162) built the **reader** (`token-feed.js` + `claude-code` adapter).
- `feat/process-start-time` supplied **`agent.startTime`** (the OS birth-time the PID-reuse guard needs).

This PR is the integration seam between them: each scan tick now pulls measured per-PID token deltas from the feed, folds them into `token-tracker`, and a minimal footer item shows the running total + cost.

### Backend
- **NEW `src/main/token-cost-collector.js`** — `collectTokenCosts(agents)`:
  - filters to `typeof a.startTime === 'number'` (rejects darwin/linux `null` + unenriched `undefined` in one predicate) → `{pid, startTime}` → **one** `await tokenFeed.readUsageByPid(procs)` → `trackTokens(d.pid, d)` per delta.
  - **C-01:** every delta is attributed under the pid the *source* stamped on it — never an index.
  - **Honesty (empirical-gap #1):** a live `'Claude Code'` agent dropped for a non-numeric `startTime` emits **one** `logger.warn` (`mod='token'`). Gated to win32 (darwin/linux `null` is an expected platform limit, not an anomaly) and emitted **before** the empty-procs early return — the dropped agent *is* the empty case. Exact `a.agent === 'Claude Code'` match (DB displayName), not a `'claude'` substring.
  - **Reliability (C-02):** `readUsageByPid` wrapped in try/catch so a corrupt/locked `.jsonl` never throws out, drops the tick, or blocks the caller's reentrancy-guard `finally`.
- **`scan-loop.js`** — `await collectTokenCosts(agents)` inserted inside the existing C-02 `processScanRunning` guard, just before the existing `sendToRenderer('token-costs', tokenTracker.getAllCosts())` (which stays in scan-loop).

### Renderer (minimal consumer — no redesign)
- **`ipc.ts`** — `TokenCostRecord` interface (mirrors `CostRecord`), `onTokenCosts` added to `AegisIpcBridge` (the PR #160 svelte-check gotcha), `tokenCosts` writable + subscription inside `if(!isDemoMode)`.
- **`Footer.svelte`** — `$derived` totals + `anyEstimated`; one `{#if totalTokens > 0}` item reusing `.footer-item/.footer-label/.footer-value` (no new CSS). Value: `toLocaleString()` count + (`~$` when any estimate else `$`) + `toFixed(4)`.
- **`en.json`** — `footer.tokens: "TOK"` (single locale, per plan). `preload.js` already exposed `onTokenCosts` (PR #162) → no preload change.

### Tests (TDD)
- **NEW `tests/main/token-cost-collector.test.js`** (DI-style, `createRequire` to share one CJS instance — avoids the ESM-import/CJS-require module-identity trap): (a) 2 deltas → 2 non-zero cost records under their pids; (b) only numeric-`startTime` agents are forwarded as procs; (c) feed read exactly once per tick.

### Interpretation note (confirm-gate is yours)
The honesty `logger.warn` fires **once per process lifetime** (module flag), not once per tick — a mis-read `startTime` recurs every ~10s, so per-tick would be the spam the plan forbids. If you intended per-tick, say so and I'll switch it.

### Verify gate (all green)
- `npm test` — **885 pass / 4 skip (55 files)** (+3)
- `npm run build:renderer` — clean (2.50s)
- `npm run typecheck:svelte` — 0 errors / 0 warnings
- `npx tsc --noEmit` — 0
- `npm run lint` (`eslint src/`, CI gate) — 0 errors (23 pre-existing `no-console` warnings)
- Svelte MCP autofixer on `Footer.svelte` — `issues: []`

> Repo-wide `eslint .` reports pre-existing errors in test files **outside this diff** and outside the CI lint scope (`src/`); not touched.

**Scope:** only the 6 intended files. Untracked `aegis_landing.html` left alone.
