### PR TITLE
fix: add current model pricing (opus-4-8, sonnet-4-6) to token-tracker

### DIFF
--- a/src/main/token-tracker.js
+++ b/src/main/token-tracker.js
@@ -18,9 +18,9 @@
  *     as tokens, so a char proxy would imply a data source we do not have).
  *
  *   The `estimated` flag reports whether the TOKEN COUNTS are measured vs
- *   guessed — the thing AEGIS actually observes. It does NOT claim the dollar
- *   figure is audited: the price table below is explicitly unverified
- *   (see `MODEL_PRICING` / `// TODO: verify pricing`).
+ *   guessed — the thing AEGIS actually observes. It does NOT certify the dollar
+ *   figure: even where `MODEL_PRICING` rates are verified, an unknown model id
+ *   still falls back to `DEFAULT_PRICING` and flips `estimated` true.
  *
  *   Attribution is per-PID (C-01): every count is stamped from the `pid`
  *   argument and stored under that pid only — concurrency or interleaved events
@@ -35,16 +35,26 @@
  * Published per-model pricing, in USD per 1,000,000 tokens, split into input
  * (prompt) and output (completion) rates.
  *
- * TODO: verify pricing — these are approximate published rates captured at
- * authoring time and are NOT auto-refreshed. Confirm against the provider's
- * current price sheet before presenting any dollar figure as authoritative.
+ * Claude rates verified 2026-06-05 (see the inline note on the Claude block).
+ * GPT/Gemini rates are still approximate authoring-time guesses (their inline
+ * `TODO: verify pricing`) and none of these auto-refresh — confirm against the
+ * provider's current price sheet before presenting any dollar figure as
+ * authoritative.
  * @type {Readonly<Record<string, { input: number, output: number }>>}
  */
 const MODEL_PRICING = Object.freeze({
-  // Anthropic — Claude (USD / 1M tokens). TODO: verify pricing.
+  // Anthropic — Claude (USD / 1M tokens). Verified 2026-06-05 against the
+  // bundled Anthropic `claude-api` skill (models.md + SKILL.md, cached
+  // 2026-05-26): Opus 4.6/4.7/4.8 = $5/$25, Sonnet 4.6 = $3/$15, Haiku 4.5 =
+  // $1/$5. These bare ids match what Claude Code writes to `message.model`
+  // (confirmed against live transcripts). Re-confirm on the next model launch.
+  'claude-opus-4-8': { input: 5.0, output: 25.0 },
+  'claude-opus-4-7': { input: 5.0, output: 25.0 },
+  'claude-opus-4-6': { input: 5.0, output: 25.0 },
+  'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
   'claude-haiku-4-5-20251001': { input: 1.0, output: 5.0 },
   'claude-sonnet-4-5': { input: 3.0, output: 15.0 },
-  'claude-opus-4-1': { input: 15.0, output: 75.0 },
+  'claude-opus-4-1': { input: 15.0, output: 75.0 }, // legacy Opus rate (pre price cut)
   // OpenAI — GPT (USD / 1M tokens). TODO: verify pricing.
   'gpt-4o': { input: 2.5, output: 10.0 },
   'gpt-4o-mini': { input: 0.15, output: 0.6 },

--- a/tests/main/token-tracker.test.js
+++ b/tests/main/token-tracker.test.js
@@ -181,4 +181,52 @@ describe('token-tracker', () => {
       expect(getAllCosts()).toHaveLength(1);
     });
   });
+
+  // Regression (2026-06-05): the live token-feed records bare model ids verbatim
+  // (`claude-opus-4-8`, `claude-sonnet-4-6` — confirmed against real transcripts).
+  // Before this pricing fix those ids were absent from MODEL_PRICING, so they hit
+  // DEFAULT_PRICING and flipped `estimated:true` — the footer showed `~$`. Dollar
+  // amounts are hard-coded (NOT read from MODEL_PRICING) so the assertion locks
+  // the actual money: it fails red if a rate drifts or an entry is dropped.
+  describe('current model pricing (regression)', () => {
+    it('prices claude-opus-4-8 at $5 in / $25 out — measured, not estimated', () => {
+      const { costUsd, knownModel } = computeCost('claude-opus-4-8', 1_000_000, 1_000_000);
+      expect(costUsd).toBeCloseTo(30.0, 10); // 5 input + 25 output
+      expect(knownModel).toBe(true);
+
+      const rec = trackTokens(4242, {
+        model: 'claude-opus-4-8',
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      });
+      expect(rec.costUsd).toBeCloseTo(30.0, 10);
+      expect(rec.estimated).toBe(false);
+    });
+
+    it('prices claude-sonnet-4-6 at $3 in / $15 out — measured, not estimated', () => {
+      const { costUsd, knownModel } = computeCost('claude-sonnet-4-6', 1_000_000, 1_000_000);
+      expect(costUsd).toBeCloseTo(18.0, 10); // 3 input + 15 output
+      expect(knownModel).toBe(true);
+
+      const rec = trackTokens(4343, {
+        model: 'claude-sonnet-4-6',
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      });
+      expect(rec.estimated).toBe(false);
+    });
+
+    it('keeps DEFAULT + sticky-estimated for a genuinely unknown model', () => {
+      const { costUsd, knownModel } = computeCost('foo-1', 1_000_000, 0);
+      expect(knownModel).toBe(false);
+      expect(costUsd).toBeCloseTo(DEFAULT_PRICING.input, 10); // 1M input only → $3
+
+      const rec = trackTokens(4444, {
+        model: 'foo-1',
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+      });
+      expect(rec.estimated).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## What

Add current Anthropic model pricing to `token-tracker.js` so the live token
readout stops falling back to `DEFAULT_PRICING` (and stops flipping the cost to
`estimated`/`~$`) for the models actually in use.

| Model id (verbatim from `message.model`) | Input $/1M | Output $/1M |
|---|---|---|
| `claude-opus-4-8` | 5.00 | 25.00 |
| `claude-opus-4-7` | 5.00 | 25.00 |
| `claude-opus-4-6` | 5.00 | 25.00 |
| `claude-sonnet-4-6` | 3.00 | 15.00 |

`claude-haiku-4-5-20251001` was already present and still correct ($1/$5) — unchanged.

## Why this was wrong

Acceptance 2B found the footer showing `~$` (estimated) because `claude-opus-4-8`
was absent from `MODEL_PRICING`. `computeCost` does an **exact** `model in
MODEL_PRICING` match, so any unlisted id hit the $3/$15 fallback and flipped
`estimated:true` — measured tokens, but a wrong, dishonest dollar figure.

## Scope justification (empirical)

The model ids were pinned against **real local transcripts** (`message.model`,
recorded verbatim by the adapter at `token-adapters/claude-code.js:164`):

```
9436  claude-opus-4-8
6552  claude-opus-4-7      ← 2nd-most-common; would still show ~$ if omitted
 996  claude-sonnet-4-6
 159  claude-haiku-4-5-20251001  (already priced)
  14  claude-opus-4-6
  11  <synthetic>          ← left unpriced (not a real model → honest DEFAULT+estimated)
   2  sonnet               ← left unpriced (negligible alias)
```

Adding 4.7/4.6 is not scope-creep — they are present in the live workload and
share the confirmed $5/$25 rate. `<synthetic>` and `sonnet` are intentionally
left to fall back, since pricing a non-model would be fabrication.

## Pricing source

Verified 2026-06-05 against the bundled Anthropic `claude-api` skill
(`models.md` + `SKILL.md`, cached 2026-05-26), cross-confirmed across both files.
GPT/Gemini rows keep their `TODO: verify pricing` — untouched.

## Honesty

- Sticky-`estimated` contract preserved: a genuinely unknown model still hits
  `DEFAULT_PRICING` and flips `estimated:true` (covered by the regression test).
- Stale `// TODO: verify pricing` on the Claude block and the "explicitly
  unverified" header line updated to reflect the verified rows.

## Tests

New `describe('current model pricing (regression)')` block (DI-style, no
`vi.mock`) with hard-coded dollar amounts (not read from `MODEL_PRICING`, so it
locks the money and goes red on drift):

- `claude-opus-4-8` 1M+1M → **$30.00**, `knownModel:true`, `estimated:false`
- `claude-sonnet-4-6` 1M+1M → **$18.00**, `knownModel:true`, `estimated:false`
- unknown `foo-1` → DEFAULT `$3.00`, `estimated:true` (contract intact)

Proven **red before the fix** (`expected 18 to be close to 30`), green after.

## Gates

- `npm test` — 888 passed, 4 skipped
- `npx eslint src/` — 0 errors
- `npx tsc --noEmit` — clean

## Boundaries

Only `src/main/token-tracker.js` + its test. No change to
collector/feed/scan-loop/risk-scoring. Source file stays under 300 lines.
