### PR TITLE
feat: per-agent token + cost readout in agent card

### DIFF
--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -5,7 +5,7 @@
    *   trust badge, spotlight hover, and expandable details. [F2.3]
    * @since v0.5.0
    */
-  import { focusedAgentPid } from '../stores/ipc.js';
+  import { focusedAgentPid, tokenCosts } from '../stores/ipc.js';
   import { eventsByPid } from '../stores/events-index.ts';
   import AgentCardDetails from './AgentCardDetails.svelte';
   import AgentActions from './AgentActions.svelte';
@@ -76,6 +76,9 @@
   });
 
   let agentEvents = $derived($eventsByPid.get(agent.pid) || []);
+
+  /** Token + cost record for this agent's PID, from the `token-costs` push. */
+  let tokenRec = $derived($tokenCosts.find((r) => r.pid === agent.pid));
 
   let lastFile = $derived.by(() => {
     const ev = agentEvents.find((e) => e.file);
@@ -175,6 +178,16 @@
       <span class="stat-chip">
         <span class="stat-label">{$t('agents.stat_net')}</span>
         <span class="stat-value">{agent.networkCount}</span>
+      </span>
+    {/if}
+    {#if tokenRec && tokenRec.totalTokens > 0}
+      <span class="stat-chip">
+        <span class="stat-label">{$t('agents.tokens')}</span>
+        <span class="stat-value"
+          >{tokenRec.totalTokens.toLocaleString()}{tokenRec.estimated
+            ? ' ~$'
+            : ' $'}{tokenRec.costUsd.toFixed(4)}</span
+        >
       </span>
     {/if}
   </div>

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -120,7 +120,8 @@
     "copy_pid": "Click to copy PID",
     "stat_proc": "Proc",
     "stat_files": "Files",
-    "stat_net": "Net"
+    "stat_net": "Net",
+    "tokens": "TOK"
   },
   "timeline": {
     "title": "Event Timeline",


### PR DESCRIPTION
## What

Adds a per-agent **token + cost** readout to the existing agent card, as a new
metric chip alongside PID / Proc / Files / Net. Renderer-only — no new design,
no new IPC, no backend changes.

## How

- `AgentCard.svelte`: import the existing `tokenCosts` store, derive the record
  for this card's PID (`$derived($tokenCosts.find(r => r.pid === agent.pid))`),
  and render one new `.stat-chip` (reusing the existing metric-row classes) only
  when `tokenRec && tokenRec.totalTokens > 0`.
- Value: `totalTokens.toLocaleString()` + (` ~$` when token counts are estimated,
  else ` $`) + `costUsd.toFixed(4)`.
- `en.json`: new `agents.tokens` label `"TOK"` (single locale, mirrors the
  existing `footer.tokens` precedent).

## Scope / boundaries

Only `AgentCard.svelte` + `en.json` touched. No changes to
token-tracker / feed / collector / scan-loop / ipc.ts / Footer / risk-scoring.
No new CSS, no hardcoded colors. Pre-existing `$effect`/`bind:this` code left
untouched (Svelte autofixer reported **0 issues** on the change).

## Verify (all green)

- `npm run build:renderer` — built in 1.46s
- `typecheck:svelte` (svelte-check) — 0 errors / 0 warnings
- `npm run typecheck` (tsc --noEmit) — clean
- `npx eslint src/` — 0 errors (pre-existing `no-console` warnings only)
- `npm test` — 888 passed / 4 skipped
