### PR TITLE
feat(token-feed): sum Claude Code subagent transcript usage

### DIFF
--- a/src/main/token-adapters/claude-code-subagents.js
+++ b/src/main/token-adapters/claude-code-subagents.js
@@ -1,0 +1,161 @@
+/**
+ * @file claude-code-subagents.js
+ * @module main/token-adapters/claude-code-subagents
+ * @description Subagent-transcript reader for the Claude Code token-feed adapter.
+ *   Claude Code logs delegated (Task) turns to a nested folder
+ *   `projects/<enc-cwd>/<sessionId>/subagents/agent-*.jsonl`, SIBLING to the main
+ *   `<sessionId>.jsonl`. Each line is shaped exactly like the main transcript
+ *   (`type:"assistant"` → `message.{id,model,usage}`), so the SAME `_extractUsage`
+ *   parser from {@link module:main/token-adapters/claude-code} is reused verbatim —
+ *   this module never re-implements parsing. Historically only the main transcript
+ *   was summed, so heavily-delegated sessions undercounted; this module closes that
+ *   gap WITHOUT touching the main tail/guard/dedup machinery.
+ *
+ *   VERIFIED ON LIVE DISK (2026-06-05 — TRUST CODE OVER DOCS):
+ *     - path: `projects/<enc>/<sessionId>/subagents/agent-<id>.jsonl` (subagents/
+ *       nested under a folder named exactly <sessionId>, beside <sessionId>.jsonl);
+ *     - a sidecar `agent-<id>.meta.json` carries {agentType, toolUseId} only — NO
+ *       usage, NO pid — and is excluded by the strict `agent-*.jsonl` glob;
+ *     - subagent lines repeat one `message.id` across N content-block lines (same
+ *       N×-count hazard as the main file) → intra-file dedup by id is REQUIRED;
+ *     - a subagent's `message.model` differs from the main session (e.g. sonnet
+ *       under an opus session) → model is taken PER LINE, never hardcoded;
+ *     - `message.id`s are globally unique, so cross-file double-count never occurs,
+ *       but the caller's shared `seenIds` is still used (it also closes intra-file).
+ *
+ *   STATE OWNERSHIP: this module is pure of module-level state. The caller
+ *   (claude-code.js) owns the `SessionState` and passes it in; tail position lives
+ *   in `state.subOffsets` (one byte-offset PER agent file) and dedup in the shared
+ *   `state.seenIds`. ATTRIBUTION: deltas are returned PIDLESS — a subagent is not a
+ *   separate OS process, so the caller stamps the MAIN session pid (C-01). All
+ *   failure modes (no folder, unreadable, malformed line) degrade to honest empty.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ */
+'use strict';
+
+const path = require('path');
+
+/**
+ * @typedef {import('./claude-code').UsageDelta} UsageDelta
+ * @typedef {{ offset: number, seenIds: Set<string>, subOffsets: Map<string, number> }} SessionState
+ */
+
+/** Only `agent-<anything>.jsonl` — excludes the `agent-*.meta.json` sidecars. */
+const AGENT_FILE_RE = /^agent-.*\.jsonl$/;
+
+/**
+ * List the session's subagent transcript files (absolute paths, sorted for
+ * deterministic order). Returns `[]` when the folder is absent or unreadable.
+ * @param {string} sessionDir - `projects/<enc>/<sessionId>` (the folder beside the
+ *   main `<sessionId>.jsonl`).
+ * @param {{ existsSync: Function, readdirSync: Function }} fs - injected fs surface.
+ * @returns {string[]}
+ */
+function _listAgentFiles(sessionDir, fs) {
+  const dir = path.join(sessionDir, 'subagents');
+  if (!fs.existsSync(dir)) return [];
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch (_err) {
+    return [];
+  }
+  if (!Array.isArray(names)) return [];
+  return names
+    .filter((n) => typeof n === 'string' && AGENT_FILE_RE.test(n))
+    .sort()
+    .map((n) => path.join(dir, n));
+}
+
+/**
+ * Tail ONE agent file from its remembered byte offset, emitting measured deltas
+ * for newly-seen `message.id`s. Mirrors the main transcript tail: advance only by
+ * complete-line bytes, dedup with the shared `seenIds`. All failures → `[]`.
+ * @param {string} file - absolute path to an `agent-*.jsonl`.
+ * @param {SessionState} state - caller-owned tail + dedup state.
+ * @param {(parsed:*) => ({id:string,model:string,inputTokens:number,outputTokens:number}|null)} extractUsage
+ * @param {{ statSync: Function, readRange: Function }} fs - injected fs surface.
+ * @param {{ warn: Function }} log - injected logger (allowlist `{ error }` only).
+ * @returns {Array<{ model: string, inputTokens: number, outputTokens: number, estimated: false }>}
+ */
+function _tailAgentFile(file, state, extractUsage, fs, log) {
+  let size;
+  try {
+    size = fs.statSync(file).size;
+  } catch (_err) {
+    return []; // file vanished between listdir and stat
+  }
+
+  const prev = state.subOffsets.get(file) || 0;
+  let offset = prev;
+  if (size < offset) offset = 0; // truncated/rotated → restart tail
+  if (size <= offset) {
+    state.subOffsets.set(file, offset);
+    return []; // nothing new
+  }
+
+  const buf = fs.readRange(file, offset, size - offset);
+  const lastNl = buf.lastIndexOf(0x0a);
+  if (lastNl === -1) return []; // no complete line yet; re-read next call
+
+  const complete = buf.subarray(0, lastNl + 1);
+  state.subOffsets.set(file, offset + complete.length); // advance by BYTES
+
+  const deltas = [];
+  for (const line of complete.toString('utf-8').split('\n')) {
+    if (!line) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch (err) {
+      log.warn('token-feed:claude-code', 'skipped unparseable subagent line', {
+        error: err.message,
+      });
+      continue;
+    }
+    const u = extractUsage(parsed);
+    if (!u || state.seenIds.has(u.id)) continue; // dedup by message.id (intra + cross + main)
+    state.seenIds.add(u.id);
+    deltas.push({
+      model: u.model,
+      inputTokens: u.inputTokens,
+      outputTokens: u.outputTokens,
+      estimated: false,
+    });
+  }
+  return deltas;
+}
+
+/**
+ * Read new measured token deltas across ALL of a session's subagent transcripts.
+ * Pidless by contract — the caller stamps the main session pid (C-01). Reuses the
+ * caller's `extractUsage` and shared `seenIds`; keeps a byte offset per agent file
+ * in `state.subOffsets`. A missing/empty/unreadable `subagents/` yields `[]`.
+ * @param {string} sessionDir - `projects/<enc>/<sessionId>`.
+ * @param {SessionState} state - caller-owned tail + dedup state.
+ * @param {Function} extractUsage - the main adapter's `_extractUsage` (not duplicated).
+ * @param {{ existsSync: Function, readdirSync: Function, statSync: Function, readRange: Function }} fs
+ * @param {{ warn: Function }} log - injected logger.
+ * @returns {Array<{ model: string, inputTokens: number, outputTokens: number, estimated: false }>}
+ * @since v0.10.0-alpha
+ */
+function readSubagentUsage(sessionDir, state, extractUsage, fs, log) {
+  const files = _listAgentFiles(sessionDir, fs);
+  if (files.length === 0) return [];
+  const out = [];
+  for (const file of files) {
+    let deltas;
+    try {
+      deltas = _tailAgentFile(file, state, extractUsage, fs, log);
+    } catch (err) {
+      log.warn('token-feed:claude-code', 'subagent read failed for a file', { error: err.message });
+      continue;
+    }
+    for (const d of deltas) out.push(d);
+  }
+  return out;
+}
+
+module.exports = { readSubagentUsage, _listAgentFiles, AGENT_FILE_RE };

--- a/src/main/token-adapters/claude-code.js
+++ b/src/main/token-adapters/claude-code.js
@@ -1,38 +1,23 @@
 /**
  * @file claude-code.js
  * @module main/token-adapters/claude-code
- * @description Token-feed adapter for the Claude Code agent family. Claude Code
- *   persists its own decrypted per-turn `usage` block to local disk; this adapter
- *   reads ONLY those numeric counts and returns them as honest, measured
- *   (`estimated:false`) per-PID token deltas. It is the first concrete adapter
- *   behind the extensible {@link module:main/token-feed} core.
+ * @description Token-feed adapter for the Claude Code agent family. Reads ONLY the
+ *   numeric `usage` blocks Claude Code persists to disk → honest measured
+ *   (`estimated:false`) per-PID deltas; first adapter behind {@link module:main/token-feed}.
  *
- *   VERIFIED C-01 CHAIN (live disk, 2026-06-04 — TRUST CODE OVER DOCS):
- *     proc {pid, startTime}
- *       → ~/.claude/sessions/<pid>.json   { sessionId, cwd, startedAt }
- *       → startedAt-guard rejects PID reuse (|startedAt − startTime| ≤ tolerance)
- *       → ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
- *       → tail only NEW bytes since last offset; parse only `type==="assistant"`
- *       → dedup by `message.id` (one message spans many content-block lines, each
- *         repeating the same usage — counting per-line would N×-count)
- *       → { pid, model, inputTokens, outputTokens, estimated:false }
+ *   C-01 CHAIN (live disk — TRUST CODE OVER DOCS): proc {pid, startTime} →
+ *   `sessions/<pid>.json` {sessionId, cwd, startedAt} → startedAt-guard rejects PID
+ *   reuse → `projects/<enc-cwd>/<sessionId>.jsonl` → tail NEW bytes; parse
+ *   `type==="assistant"` → dedup by `message.id` (a message spans N usage-repeating
+ *   lines; per-line would N×-count) → delta. PRIVACY (gating): allowlist usage
+ *   numbers + model + id only — never content, in objects or logs (errors log
+ *   `{ error }`); scope is monitored PIDs, no history sweep.
  *
- *   PRIVACY INVARIANT (gating): allowlist-extract ONLY the numeric usage fields +
- *   model + message id. Message content (prompts/responses) is never read into a
- *   returned object and never written to any log — on a parse error we log only
- *   `{ error }`, never the offending line. Scope is limited to the monitored PIDs
- *   passed in; we never sweep unrelated project history.
- *
- *   `procStart` in the registry is an opaque .NET-ticks-like string (version
- *   fragile) — the guard deliberately uses `startedAt` (clean epoch-ms) instead.
- *
- *   SCOPE / KNOWN LIMITATION: reads the main session transcript only. Subagent
- *   turns are logged to separate `projects/<enc>/<sessionId>/subagents/agent-*.jsonl`
- *   files; their usage is NOT yet summed, so heavily-delegated sessions undercount.
- *   This is honest-but-partial (never over-counts) and a deliberate later extension.
- *
- *   The line shape (`type:"assistant"` with `message.{id,model,usage}`) and the
- *   3-bucket input sum were validated against a live `2.1.x` transcript, not docs.
+ *   SUBAGENTS: delegated (Task) turns log to nested
+ *   `projects/<enc>/<sessionId>/subagents/agent-*.jsonl` and ARE summed (see
+ *   {@link module:main/token-adapters/claude-code-subagents}) — SAME line shape (so
+ *   `_extractUsage` is reused), attributed to the MAIN session pid. Shared `seenIds`
+ *   + per-file `subOffsets` block double-count; read independently of main activity.
  * @author AEGIS Contributors
  * @license MIT
  * @version 0.1.0
@@ -43,42 +28,42 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const logger = require('../logger');
+const { readSubagentUsage } = require('./claude-code-subagents');
 
 /**
  * @typedef {Object} Proc
  * @property {number} pid - live process id (C-01 attribution key).
- * @property {number} startTime - live OS process-creation time (epoch ms),
- *   supplied by the scan layer; compared against the registry to reject PID reuse.
+ * @property {number} startTime - live OS process-creation time (epoch ms), from the
+ *   scan layer; compared against the registry to reject PID reuse.
  */
 
 /**
  * @typedef {Object} UsageDelta
  * @property {number} pid - owning process (C-01).
- * @property {string} model - model id from the usage block (may be absent from
- *   the price table → cost becomes approximate downstream; tokens stay measured).
+ * @property {string} model - model id from the usage block (may be absent from the
+ *   price table → cost approximate downstream; tokens stay measured).
  * @property {number} inputTokens - input_tokens + cache_creation + cache_read.
  * @property {number} outputTokens - output_tokens.
- * @property {boolean} estimated - always `false`: these are measured, not guessed.
+ * @property {boolean} estimated - always `false`: measured, not guessed.
  */
 
 /** @type {string} stable adapter id used by the core registry. */
 const id = 'claude-code';
 
 /**
- * Max |registry.startedAt − live startTime| (ms) still considered the SAME
- * process. Generous enough to absorb startup jitter (startedAt is written a beat
- * after process birth), tight enough that a reused PID — whose real creation time
- * differs by minutes/hours — is rejected. Bias is toward rejection (honest empty)
- * over mis-attribution.
- * @type {number}
+ * Max |registry.startedAt − live startTime| (ms) still treated as the SAME process.
+ * Absorbs startup jitter yet rejects a reused PID (creation time off by min/hours);
+ * bias toward rejection (honest empty) over mis-attribution. @type {number}
  */
 const GUARD_TOLERANCE_MS = 60_000;
 
 /**
  * @typedef {Object} SessionState
- * @property {number} offset - bytes of the transcript already consumed.
- * @property {Set<string>} seenIds - message.ids already counted (persists across
- *   calls so a message whose blocks straddle a tail boundary is counted once).
+ * @property {number} offset - bytes of the MAIN transcript already consumed.
+ * @property {Set<string>} seenIds - message.ids already counted (counts a
+ *   boundary-straddling message once); SHARED across main + all subagent files.
+ * @property {Map<string, number>} subOffsets - per-subagent-file byte offset
+ *   (`agent-*.jsonl` path → bytes consumed); independent of `offset`.
  */
 
 /** @type {Map<string, SessionState>} per-sessionId tail state. */
@@ -88,14 +73,15 @@ const sessions = new Map();
 let _homedir = () => os.homedir();
 
 /**
- * Injectable fs surface. `readRange(path, start, length)` returns a Buffer of the
- * byte slice — production reads only the new bytes, never the whole file.
- * @type {{ readFileSync: Function, existsSync: Function, statSync: Function, readRange: Function }}
+ * Injectable fs surface. `readRange(path, start, length)` returns a Buffer slice —
+ * production reads only the new bytes, never the whole file.
+ * @type {{ readFileSync: Function, existsSync: Function, statSync: Function, readdirSync: Function, readRange: Function }}
  */
 let _fs = {
   readFileSync: (p, enc) => fs.readFileSync(p, enc),
   existsSync: (p) => fs.existsSync(p),
   statSync: (p) => fs.statSync(p),
+  readdirSync: (p) => fs.readdirSync(p),
   readRange: (p, start, length) => {
     const fd = fs.openSync(p, 'r');
     try {
@@ -112,31 +98,23 @@ let _fs = {
 let _log = logger;
 
 /**
- * Encode an absolute cwd into Claude Code's `projects/` directory name. The
- * encoding is lossy by design (`:` `\` `/` `.` all collapse to `-`); we only
- * forward-encode a known cwd and existence-check the result — never reverse it.
- * @param {string} cwd
- * @returns {string}
+ * Encode an absolute cwd into Claude Code's `projects/` directory name. Lossy by
+ * design (`:` `\` `/` `.` → `-`); we only forward-encode a known cwd and
+ * existence-check the result — never reverse it. @param {string} cwd @returns {string}
  */
 function _encodeCwd(cwd) {
   return String(cwd).replace(/[/\\:.]/g, '-');
 }
 
-/**
- * True when `v` is a usable pid (finite integer > 0).
- * @param {*} v
- * @returns {boolean}
- */
+/** True when `v` is a usable pid (finite integer > 0). @param {*} v @returns {boolean} */
 function isPositivePid(v) {
   return typeof v === 'number' && Number.isInteger(v) && v > 0;
 }
 
 /**
- * Decide whether a session registry belongs to the live process (PID-reuse
- * guard). Both timestamps must be finite numbers and agree within tolerance.
- * @param {{ startedAt?: number }} registry
- * @param {{ startTime?: number }} proc
- * @returns {boolean}
+ * Session registry belongs to the live process (PID-reuse guard): both timestamps
+ * finite and within tolerance. @param {{ startedAt?: number }} registry
+ * @param {{ startTime?: number }} proc @returns {boolean}
  */
 function _passesGuard(registry, proc) {
   if (!registry || typeof registry.startedAt !== 'number') return false;
@@ -145,10 +123,8 @@ function _passesGuard(registry, proc) {
 }
 
 /**
- * Allowlist-extract the measured usage from one parsed transcript line. Returns
- * `null` for any line that is not an assistant message carrying a usage block, so
- * prompt/content-bearing lines are dropped before any content field is touched.
- * @param {*} parsed - a parsed JSONL line object.
+ * Allowlist-extract measured usage from one parsed line; `null` for non-assistant
+ * or usage-less lines (content-bearing lines drop first). @param {*} parsed
  * @returns {{ id: string, model: string, inputTokens: number, outputTokens: number }|null}
  */
 function _extractUsage(parsed) {
@@ -171,17 +147,15 @@ function _extractUsage(parsed) {
 function _stateFor(sessionId) {
   let st = sessions.get(sessionId);
   if (!st) {
-    st = { offset: 0, seenIds: new Set() };
+    st = { offset: 0, seenIds: new Set(), subOffsets: new Map() };
     sessions.set(sessionId, st);
   }
   return st;
 }
 
 /**
- * Read the registry for one pid. Returns the parsed object or `null` (absent /
- * unreadable / malformed) — never logs the file body.
- * @param {number} pid
- * @returns {*}
+ * Read the registry for one pid → parsed object or `null` (absent / unreadable /
+ * malformed); never logs the file body. @param {number} pid @returns {*}
  */
 function _readRegistry(pid) {
   const p = path.join(_homedir(), '.claude', 'sessions', `${pid}.json`);
@@ -193,25 +167,16 @@ function _readRegistry(pid) {
 }
 
 /**
- * Resolve and tail one proc's transcript, returning new measured deltas. All
- * failure modes degrade to `[]` (honest empty) without throwing.
- * @param {Proc} proc
+ * Tail ONE proc's MAIN transcript → new measured deltas. Behaviour unchanged from
+ * the original inline tail (offset/dedup machinery intact); failures degrade to `[]`.
+ * Subagent files are handled separately so this never short-circuits them.
+ * @param {string} tPath - absolute path to `<sessionId>.jsonl`.
+ * @param {SessionState} st - session tail + dedup state. @param {number} pid - C-01 key.
  * @returns {UsageDelta[]}
  */
-function _readOneProc(proc) {
-  const pid = proc && proc.pid;
-  if (!isPositivePid(pid)) return [];
-
-  const registry = _readRegistry(pid);
-  if (!_passesGuard(registry, proc)) return [];
-  const { sessionId, cwd } = registry;
-  if (typeof sessionId !== 'string' || typeof cwd !== 'string') return [];
-
-  const tPath = path.join(_homedir(), '.claude', 'projects', _encodeCwd(cwd), `${sessionId}.jsonl`);
+function _tailMain(tPath, st, pid) {
   if (!_fs.existsSync(tPath)) return [];
-
   const size = _fs.statSync(tPath).size;
-  const st = _stateFor(sessionId);
   if (size < st.offset) st.offset = 0; // file truncated/rotated → restart tail
   if (size <= st.offset) return []; // nothing new
 
@@ -249,13 +214,37 @@ function _readOneProc(proc) {
 }
 
 /**
- * Read new measured token deltas for the given live processes. Non-idempotent by
- * design: a second call with no newly-appended transcript bytes returns `[]`
- * (the deltas were already emitted), which matches the accumulating contract of
- * the downstream token-tracker.
+ * Resolve one proc's session → new measured deltas from BOTH the main transcript and
+ * its subagent transcripts. Subagent usage is read independently of main-file
+ * activity (a subagent can append while the main agent is blocked on it) and shares
+ * the pid (C-01). All failures degrade to `[]`. @param {Proc} proc @returns {UsageDelta[]}
+ */
+function _readOneProc(proc) {
+  const pid = proc && proc.pid;
+  if (!isPositivePid(pid)) return [];
+
+  const registry = _readRegistry(pid);
+  if (!_passesGuard(registry, proc)) return [];
+  const { sessionId, cwd } = registry;
+  if (typeof sessionId !== 'string' || typeof cwd !== 'string') return [];
+
+  const projDir = path.join(_homedir(), '.claude', 'projects', _encodeCwd(cwd));
+  const st = _stateFor(sessionId);
+
+  const deltas = _tailMain(path.join(projDir, `${sessionId}.jsonl`), st, pid);
+  const sessionDir = path.join(projDir, sessionId);
+  for (const d of readSubagentUsage(sessionDir, st, _extractUsage, _fs, _log)) {
+    deltas.push({ pid, ...d }); // C-01: subagent tokens → MAIN session pid
+  }
+  return deltas;
+}
+
+/**
+ * Read new measured token deltas for the given live processes. Non-idempotent: a
+ * second call with no newly-appended bytes returns `[]` (already emitted), matching
+ * the accumulating contract of the downstream token-tracker.
  * @param {Proc[]} procs - live processes enriched with OS `startTime`.
- * @returns {Promise<UsageDelta[]>}
- * @since v0.10.0-alpha
+ * @returns {Promise<UsageDelta[]>} @since v0.10.0-alpha
  */
 async function readUsage(procs) {
   if (!Array.isArray(procs) || procs.length === 0) return [];

--- a/tests/main/token-adapters/claude-code-subagents.test.js
+++ b/tests/main/token-adapters/claude-code-subagents.test.js
@@ -1,0 +1,365 @@
+/**
+ * @file claude-code-subagents.test.js
+ * @description RED-first suite for the Claude Code SUBAGENT transcript reader.
+ *   Claude Code logs delegated (Task) turns to a nested folder
+ *   `projects/<enc>/<sessionId>/subagents/agent-*.jsonl` whose lines are shaped
+ *   exactly like the main transcript (`type:"assistant"` → `message.{id,model,usage}`).
+ *   The main adapter historically summed ONLY the main `<sessionId>.jsonl`, so any
+ *   heavily-delegated session undercounted. This suite pins the fix:
+ *     (a) distinct subagent ids across agent-1/agent-2 → summed,
+ *     (b) one message split over N lines within a file → counted ×1, never ×N,
+ *     (c) an id already in the shared `seenIds` (a main-file message) → not re-counted,
+ *     (d) per-delta model is the LINE's model (sub=sonnet ≠ main=opus) — never hardcoded,
+ *     (e) `.meta.json` sidecars are ignored — only `agent-*.jsonl` is read,
+ *     (f) per-file byte offset means a re-read with no new bytes emits nothing,
+ *     (g) a missing/empty `subagents/` degrades to [] (honest empty, never throws),
+ *   plus an end-to-end pin through the adapter: subagent tokens attribute to the
+ *   MAIN session pid (C-01) and BOTH models surface in the final deltas.
+ *
+ *   All fixtures are injected via DI (in-memory fs surface + caller-owned state) —
+ *   no live disk, deterministic CI. No vi.mock (ESM/CJS identity trap); the helper
+ *   carries no module state, so the test owns every byte of mutable state.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import path from 'node:path';
+import subagents from '../../../src/main/token-adapters/claude-code-subagents.js';
+import adapter from '../../../src/main/token-adapters/claude-code.js';
+
+const { readSubagentUsage } = subagents;
+const {
+  readUsage,
+  _encodeCwd,
+  _extractUsage,
+  _setHomedirForTest,
+  _setFsForTest,
+  _setLoggerForTest,
+  _resetForTest,
+} = adapter;
+
+const HOME = path.join('/fake', 'home');
+const STARTED = 1_700_000_000_000;
+
+/**
+ * In-memory fs over a { path: utf8-content } map, byte-accurate, WITH a
+ * directory-aware `readdirSync` (basenames whose dirname === the queried dir).
+ */
+function makeFs(files) {
+  const store = new Map(Object.entries(files));
+  const enoent = (p) => {
+    const e = new Error(`ENOENT: no such file ${p}`);
+    e.code = 'ENOENT';
+    return e;
+  };
+  return {
+    store,
+    readFileSync(p) {
+      if (!store.has(p)) throw enoent(p);
+      return store.get(p);
+    },
+    existsSync(p) {
+      if (store.has(p)) return true;
+      // a directory "exists" when any stored file lives under it
+      const prefix = p.endsWith(path.sep) ? p : p + path.sep;
+      for (const key of store.keys()) if (key.startsWith(prefix)) return true;
+      return false;
+    },
+    statSync(p) {
+      if (!store.has(p)) throw enoent(p);
+      return { size: Buffer.byteLength(store.get(p), 'utf-8') };
+    },
+    readRange(p, start, length) {
+      const buf = Buffer.from(store.get(p), 'utf-8');
+      return buf.subarray(start, start + length);
+    },
+    readdirSync(dir) {
+      const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
+      const names = [];
+      for (const key of store.keys()) {
+        if (!key.startsWith(prefix)) continue;
+        const rest = key.slice(prefix.length);
+        if (!rest.includes(path.sep)) names.push(rest); // direct child only
+      }
+      return names;
+    },
+  };
+}
+
+function assistantLine({
+  id: msgId,
+  model = 'claude-opus-4-8',
+  input = 0,
+  cacheCreate = 0,
+  cacheRead = 0,
+  output = 0,
+  content,
+}) {
+  const message = {
+    id: msgId,
+    type: 'message',
+    role: 'assistant',
+    model,
+    usage: {
+      input_tokens: input,
+      cache_creation_input_tokens: cacheCreate,
+      cache_read_input_tokens: cacheRead,
+      output_tokens: output,
+    },
+  };
+  if (content !== undefined) message.content = content;
+  return JSON.stringify({ type: 'assistant', message });
+}
+
+const userLine = (content) => JSON.stringify({ type: 'user', message: { role: 'user', content } });
+const jsonl = (...lines) => lines.join('\n') + '\n';
+
+const sessionsPath = (pid) => path.join(HOME, '.claude', 'sessions', `${pid}.json`);
+const projectDir = (cwd) => path.join(HOME, '.claude', 'projects', _encodeCwd(cwd));
+const transcriptPath = (cwd, sid) => path.join(projectDir(cwd), `${sid}.jsonl`);
+const sessionDirPath = (cwd, sid) => path.join(projectDir(cwd), sid);
+const subagentFile = (cwd, sid, name) => path.join(sessionDirPath(cwd, sid), 'subagents', name);
+
+const registry = ({ pid, sessionId, cwd, startedAt = STARTED }) =>
+  JSON.stringify({
+    pid,
+    sessionId,
+    cwd,
+    startedAt,
+    procStart: '639162008149103680',
+    status: 'idle',
+  });
+
+/** Fresh caller-owned tail state, mirroring claude-code.js SessionState. */
+const freshState = () => ({ offset: 0, seenIds: new Set(), subOffsets: new Map() });
+
+const logWarn = vi.fn();
+const log = { warn: logWarn, debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+
+beforeEach(() => {
+  _resetForTest();
+  logWarn.mockClear();
+  _setHomedirForTest(() => HOME);
+  _setLoggerForTest(log);
+});
+
+describe('readSubagentUsage — helper (DI, caller-owned state)', () => {
+  const CWD = 'X:\\proj';
+  const SID = 'sid-sub';
+  const dir = sessionDirPath(CWD, SID);
+
+  it('(a) sums distinct ids across agent-1 and agent-2, pidless deltas', () => {
+    const fs = makeFs({
+      [subagentFile(CWD, SID, 'agent-1.jsonl')]: jsonl(
+        assistantLine({ id: 's1', model: 'claude-sonnet-4-6', input: 10, output: 1 }),
+      ),
+      [subagentFile(CWD, SID, 'agent-2.jsonl')]: jsonl(
+        assistantLine({ id: 's2', model: 'claude-sonnet-4-6', input: 20, output: 2 }),
+      ),
+    });
+    const st = freshState();
+
+    const out = readSubagentUsage(dir, st, _extractUsage, fs, log);
+
+    const byInput = out.map((d) => d.inputTokens).sort((a, b) => a - b);
+    expect(byInput).toEqual([10, 20]);
+    // pidless: caller stamps pid, helper must not invent one
+    for (const d of out) {
+      expect(d.estimated).toBe(false);
+      expect('pid' in d).toBe(false);
+    }
+  });
+
+  it('(b) counts one message split over N lines within a file exactly once', () => {
+    const dup = () =>
+      assistantLine({
+        id: 'msgDUP',
+        model: 'claude-sonnet-4-6',
+        input: 100,
+        cacheCreate: 50,
+        output: 7,
+      });
+    const fs = makeFs({
+      [subagentFile(CWD, SID, 'agent-1.jsonl')]: jsonl(dup(), dup(), userLine('noise'), dup()),
+    });
+    const st = freshState();
+
+    const out = readSubagentUsage(dir, st, _extractUsage, fs, log);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].inputTokens).toBe(150); // 100 + 50, NOT ×3
+    expect(out[0].outputTokens).toBe(7);
+  });
+
+  it('(c) does not re-count an id already present in shared seenIds (cross-file/main dedup)', () => {
+    const fs = makeFs({
+      [subagentFile(CWD, SID, 'agent-1.jsonl')]: jsonl(
+        assistantLine({ id: 'shared', model: 'claude-sonnet-4-6', input: 99, output: 9 }),
+        assistantLine({ id: 'fresh', model: 'claude-sonnet-4-6', input: 5, output: 1 }),
+      ),
+    });
+    const st = freshState();
+    st.seenIds.add('shared'); // pretend the main transcript already counted it
+
+    const out = readSubagentUsage(dir, st, _extractUsage, fs, log);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].inputTokens).toBe(5); // only the fresh id
+  });
+
+  it('(d) per-delta model is the line model, never hardcoded', () => {
+    const fs = makeFs({
+      [subagentFile(CWD, SID, 'agent-1.jsonl')]: jsonl(
+        assistantLine({ id: 's1', model: 'claude-sonnet-4-6', input: 1, output: 1 }),
+        assistantLine({ id: 'h1', model: 'claude-haiku-4-5', input: 2, output: 1 }),
+      ),
+    });
+    const st = freshState();
+
+    const out = readSubagentUsage(dir, st, _extractUsage, fs, log);
+
+    const models = out.map((d) => d.model).sort();
+    expect(models).toEqual(['claude-haiku-4-5', 'claude-sonnet-4-6']);
+  });
+
+  it('(e) ignores .meta.json sidecars — reads only agent-*.jsonl', () => {
+    const fs = makeFs({
+      [subagentFile(CWD, SID, 'agent-1.jsonl')]: jsonl(
+        assistantLine({ id: 's1', model: 'claude-sonnet-4-6', input: 7, output: 1 }),
+      ),
+      // a sidecar that, if globbed as agent-*, would be a JSON object with no usage
+      [subagentFile(CWD, SID, 'agent-1.meta.json')]: JSON.stringify({
+        agentType: 'researcher',
+        toolUseId: 'toolu_x',
+      }),
+    });
+    const st = freshState();
+
+    const out = readSubagentUsage(dir, st, _extractUsage, fs, log);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].inputTokens).toBe(7);
+    expect(logWarn).not.toHaveBeenCalled(); // .meta.json never parsed → no warn
+  });
+
+  it('(f) per-file offset: a re-read with no new bytes emits nothing; an append emits only the new id', () => {
+    const file = subagentFile(CWD, SID, 'agent-1.jsonl');
+    const fs = makeFs({
+      [file]: jsonl(assistantLine({ id: 'a', model: 'claude-sonnet-4-6', input: 1, output: 1 })),
+    });
+    const st = freshState();
+
+    expect(readSubagentUsage(dir, st, _extractUsage, fs, log)).toHaveLength(1);
+    expect(readSubagentUsage(dir, st, _extractUsage, fs, log)).toEqual([]); // no new bytes
+
+    fs.store.set(
+      file,
+      jsonl(
+        assistantLine({ id: 'a', model: 'claude-sonnet-4-6', input: 1, output: 1 }),
+        assistantLine({ id: 'b', model: 'claude-sonnet-4-6', input: 4, output: 2 }),
+      ),
+    );
+    const third = readSubagentUsage(dir, st, _extractUsage, fs, log);
+    expect(third).toHaveLength(1);
+    expect(third[0].inputTokens).toBe(4);
+  });
+
+  it('(g) missing or empty subagents/ degrades to [] without throwing', () => {
+    const st = freshState();
+    // no subagents dir at all
+    expect(readSubagentUsage(dir, st, _extractUsage, makeFs({}), log)).toEqual([]);
+    // dir present but no agent files (only a sidecar)
+    const onlyMeta = makeFs({
+      [subagentFile(CWD, SID, 'agent-1.meta.json')]: '{}',
+    });
+    expect(readSubagentUsage(dir, st, _extractUsage, onlyMeta, log)).toEqual([]);
+  });
+});
+
+describe('adapter readUsage — end-to-end subagent summation (C-01 + multi-model)', () => {
+  it('attributes subagent tokens to the MAIN session pid and surfaces BOTH models', async () => {
+    const cwd = 'X:\\proj';
+    const sid = 'sid-e2e';
+    const pid = 4321;
+    _setFsForTest(
+      makeFs({
+        [sessionsPath(pid)]: registry({ pid, sessionId: sid, cwd }),
+        [transcriptPath(cwd, sid)]: jsonl(
+          assistantLine({ id: 'main1', model: 'claude-opus-4-8', input: 1000, output: 100 }),
+        ),
+        [subagentFile(cwd, sid, 'agent-1.jsonl')]: jsonl(
+          assistantLine({ id: 'sub1', model: 'claude-sonnet-4-6', input: 30, output: 3 }),
+          assistantLine({ id: 'sub1', model: 'claude-sonnet-4-6', input: 30, output: 3 }), // dup id
+          assistantLine({ id: 'sub2', model: 'claude-sonnet-4-6', input: 40, output: 4 }),
+        ),
+      }),
+    );
+
+    const out = await readUsage([{ pid, startTime: STARTED }]);
+
+    // every delta attributed to the one live pid (C-01)
+    for (const d of out) expect(d.pid).toBe(pid);
+
+    // main opus + two distinct subagent ids (dup collapsed) = 3 deltas
+    const inputs = out.map((d) => d.inputTokens).sort((a, b) => a - b);
+    expect(inputs).toEqual([30, 40, 1000]);
+
+    // both model families present per-delta
+    const models = new Set(out.map((d) => d.model));
+    expect(models.has('claude-opus-4-8')).toBe(true);
+    expect(models.has('claude-sonnet-4-6')).toBe(true);
+  });
+
+  it('counts subagent appends while the MAIN transcript is byte-idle (no lump-on-resume loss)', async () => {
+    const cwd = 'X:\\idle';
+    const sid = 'sid-idle';
+    const pid = 7000;
+    const agentFile = subagentFile(cwd, sid, 'agent-1.jsonl');
+    const fs = makeFs({
+      [sessionsPath(pid)]: registry({ pid, sessionId: sid, cwd }),
+      [transcriptPath(cwd, sid)]: jsonl(
+        assistantLine({ id: 'main1', model: 'claude-opus-4-8', input: 1000, output: 100 }),
+      ),
+      [agentFile]: jsonl(
+        assistantLine({ id: 'sub1', model: 'claude-sonnet-4-6', input: 30, output: 3 }),
+      ),
+    });
+    _setFsForTest(fs);
+    const proc = [{ pid, startTime: STARTED }];
+
+    const first = await readUsage(proc);
+    expect(first.map((d) => d.inputTokens).sort((a, b) => a - b)).toEqual([30, 1000]);
+
+    // MAIN stays byte-identical; only the subagent file grows.
+    fs.store.set(
+      agentFile,
+      jsonl(
+        assistantLine({ id: 'sub1', model: 'claude-sonnet-4-6', input: 30, output: 3 }),
+        assistantLine({ id: 'sub2', model: 'claude-sonnet-4-6', input: 40, output: 4 }),
+      ),
+    );
+
+    const second = await readUsage(proc);
+    expect(second).toHaveLength(1);
+    expect(second[0].inputTokens).toBe(40); // sub2 only — NOT lost behind an idle main file
+    expect(second[0].pid).toBe(pid);
+  });
+
+  it('a session with no subagents/ folder is unchanged (main-only deltas)', async () => {
+    const cwd = 'X:\\solo';
+    const sid = 'sid-solo';
+    const pid = 5555;
+    _setFsForTest(
+      makeFs({
+        [sessionsPath(pid)]: registry({ pid, sessionId: sid, cwd }),
+        [transcriptPath(cwd, sid)]: jsonl(
+          assistantLine({ id: 'm1', model: 'claude-opus-4-8', input: 12, output: 2 }),
+        ),
+      }),
+    );
+
+    const out = await readUsage([{ pid, startTime: STARTED }]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].inputTokens).toBe(12);
+    expect(out[0].pid).toBe(pid);
+  });
+});


### PR DESCRIPTION
## What

Track B — the Claude Code token-feed adapter now sums **subagent** transcript usage. Previously only the main `<sessionId>.jsonl` was tailed, so any heavily-delegated session (Task spawns) **undercounted** tokens. Claude Code logs each delegated turn to a nested `projects/<enc>/<sessionId>/subagents/agent-*.jsonl` whose lines are shaped exactly like the main transcript — those are now read, deduped, and attributed.

## Disk recon (code-over-docs, verified live on this machine)

- **Path:** `~/.claude/projects/<enc-cwd>/<sessionId>/subagents/agent-*.jsonl` — `subagents/` nested under a folder named exactly `<sessionId>`, sibling to `<sessionId>.jsonl`. A sidecar `agent-*.meta.json` (`{agentType, toolUseId}` — no usage, no pid) sits beside each and is **excluded** by the strict `agent-*.jsonl` glob.
- **Line shape identical** to main (`type:"assistant"` → `message.{id,model,usage}`), so the existing `_extractUsage` is **reused verbatim** — no parser duplication.
- **Model differs:** a real subagent line was `claude-sonnet-4-6` while the same session's main file was `claude-opus-4-8`. Model is taken **per-delta** from each line's `message.model`, never hardcoded → token-tracker prices opus/sonnet separately (#165).
- **Dedup needed both ways:** one `message.id` repeats across N content-block lines inside a subagent file too (16/18 ids in the busiest session repeated) → intra-file dedup required. Cross-file id intersection main∩sub was 0 (`message.id`s are globally unique), but the **shared `seenIds`** is used anyway (it also closes intra-file).

## How

- **New** `src/main/token-adapters/claude-code-subagents.js` — `readSubagentUsage(sessionDir, state, extractUsage, fs, log)`: strict `agent-*.jsonl` glob, **per-file** byte offset in `state.subOffsets`, dedup via the shared `state.seenIds`, model per-line, **pidless** deltas (caller stamps the pid). Missing/empty/unreadable `subagents/` → `[]` (honest empty, degrades like the rest of the adapter).
- `claude-code.js` — `SessionState` gains `subOffsets`; `_fs` gains `readdirSync`. The main tail is extracted into `_tailMain` (behaviour unchanged — offset/guard/dedup intact) so the subagent read runs **independently of main-file activity** and stamps the **MAIN session pid** (C-01: a subagent is not its own process).

### Why independent of main-file activity (not just "after the main tail")
A subagent writes its transcript while the main agent is **blocked waiting on it** — the main file is byte-idle for those ticks. With the literal "read after the main tail" placement, every early `return []` (no new main bytes) would skip the subagent read, so subagent tokens would only land in a lump when the main agent resumes — and would be **lost entirely** if the process exits first. For a live footer readout that's a real undercount, so the subagent read is decoupled. A dedicated test pins this exact property.

## Tests (RED-first, DI — no `vi.mock`)

New `tests/main/token-adapters/claude-code-subagents.test.js` (10 tests): distinct ids across `agent-1`/`agent-2` summed; one message split over N lines counted ×1; id already in shared `seenIds` not re-counted; per-delta model is the line model (sonnet+haiku both surface); `.meta.json` ignored; per-file offset (re-read with no new bytes → `[]`); missing `subagents/` → `[]`; **end-to-end**: subagent tokens attribute to the main pid and both opus+sonnet models appear; **subagent appends while main is byte-idle are counted** (the decoupling pin).

## Verify

- `npm test` → **898 pass / 4 skip (56 files)** — existing `claude-code.test.js` unchanged
- `npx eslint src/` → 0 · `npx tsc --noEmit` → 0 · `prettier --check` clean
- `npm run build:renderer` → ✓
- both `.js` ≤ 300 lines (300 / 161)

## Scope / honesty

- Only the adapter + new helper + new test. **Not touched:** token-feed core, collector, scan-loop, token-tracker, IPC, renderer, risk-scoring.
- `estimated: false` (measured); cost stays approximate only where a model id is absent from the price table (tokens always measured).
- Live-smoke (real subagent run feeding the footer) not yet observed — pinned by deterministic fixtures; flagged as a follow-up watch.
