### PR TITLE
docs: correct subagent N-line dedup claim to defensive (live smoke: 1 line/id on subagents)

### DIFF
--- a/src/main/token-adapters/claude-code-subagents.js
+++ b/src/main/token-adapters/claude-code-subagents.js
@@ -16,8 +16,13 @@
  *       nested under a folder named exactly <sessionId>, beside <sessionId>.jsonl);
  *     - a sidecar `agent-<id>.meta.json` carries {agentType, toolUseId} only — NO
  *       usage, NO pid — and is excluded by the strict `agent-*.jsonl` glob;
- *     - subagent lines repeat one `message.id` across N content-block lines (same
- *       N×-count hazard as the main file) → intra-file dedup by id is REQUIRED;
+ *     - on these live subagent files each `message.id` appeared on exactly ONE
+ *       line (1 line/id); the N×-per-id repeat was NOT reproduced on subagents.
+ *       That N×-count hazard is CONFIRMED only on the MAIN transcript (live: 86
+ *       usage lines → 25 ids, one id spanning up to 7 lines). Subagent lines share
+ *       the SAME line shape, so the SAME intra-file dedup by id is applied
+ *       DEFENSIVELY — identical to the main path, not because it fired on today's
+ *       files;
  *     - a subagent's `message.model` differs from the main session (e.g. sonnet
  *       under an opus session) → model is taken PER LINE, never hardcoded;
  *     - `message.id`s are globally unique, so cross-file double-count never occurs,


### PR DESCRIPTION
## What

Doc-only fix to the JSDoc header of `src/main/token-adapters/claude-code-subagents.js` (the subagent-transcript reader). **Comment text only — code is byte-for-byte unchanged** (glob, offsets, `seenIds`, `extractUsage` untouched).

## Why

The Track B live-smoke (2026-06-05, real `claude` pid 35416) contradicted one bullet under the `VERIFIED ON LIVE DISK` header. The doc claimed, as a verified fact, that **subagent** lines repeat one `message.id` across N content-block lines (so intra-file dedup was "REQUIRED"). On disk, subagent files showed **1 line per `message.id`** — the N×-repeat was *not* reproduced on subagents. The N×-collapse is real, but only on the **main** transcript (live: 86 usage lines → 25 ids, one id spanning up to 7 lines).

## Change

Rewrites the one inaccurate bullet to separate **verified** from **defensive**:
- Verified live observation: subagents gave 1 line/id; N×-repeat NOT reproduced on subagents.
- N×-count hazard CONFIRMED only on the main transcript (with the live numbers).
- The shared intra-file dedup by `message.id` is applied **DEFENSIVELY** (identical to the main path), not because it fired on today's subagent files.

The genuinely-verified bullets (path layout, `.meta.json` sidecar exclusion, per-line model, globally-unique ids) are left intact.

## Verification

- `git diff` — only ` *` comment lines changed (+7 / -2)
- `npx eslint src/` — 0 errors (23 pre-existing `no-console` warnings, none in this file)
- `npm test` — 899 passed, 4 skipped (56 files); `claude-code-subagents.test.js` (11 tests) green → behavior unchanged
- File at 166 lines (≤300)
