### PR TITLE
fix: seed anomaly-toast tracker on first render to prevent toast storm (C-12)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -22,7 +22,7 @@
     SLIDE_OFFSET_PX,
     TRANSITION_DURATION_MS,
   } from './lib/utils/tab-transitions.js';
-  import { SvelteSet } from 'svelte/reactivity';
+  import { createAnomalyToastTracker } from './lib/utils/anomaly-toast-tracker.js';
 
   const TAB_IDS = ['shield', 'activity', 'rules', 'reports', 'stats'];
 
@@ -128,20 +128,15 @@
   });
 
   // ── Toast: anomaly detected ──
-  let prevAnomalyKeys = new SvelteSet();
+  // The tracker seeds itself on the first emission so anomalies already present
+  // at startup do not produce a toast storm (C-12); later emissions toast only
+  // genuinely-new anomalies.
+  const anomalyTracker = createAnomalyToastTracker();
   $effect(() => {
     const scores = $anomalies;
-    if (!scores || typeof scores !== 'object') return;
-    const currentKeys = new SvelteSet();
-    for (const [agent, score] of Object.entries(scores)) {
-      if (typeof score === 'number' && score >= 50) {
-        currentKeys.add(agent);
-        if (!prevAnomalyKeys.has(agent)) {
-          addToast(`Anomaly: ${agent} score ${score}`, 'warning');
-        }
-      }
+    for (const agent of anomalyTracker.ingest(scores)) {
+      addToast(`Anomaly: ${agent} score ${scores[agent]}`, 'warning');
     }
-    prevAnomalyKeys = currentKeys;
   });
 
   /**

--- a/src/renderer/lib/utils/anomaly-toast-tracker.ts
+++ b/src/renderer/lib/utils/anomaly-toast-tracker.ts
@@ -1,0 +1,82 @@
+/**
+ * anomaly-toast-tracker.ts — Seed-then-diff tracker for anomaly toasts
+ *
+ * Pure, no DOM dependency. Used by App.svelte to decide which anomaly scores
+ * are *newly* over-threshold and therefore warrant a toast.
+ *
+ * The first NON-EMPTY scores object SEEDS the known set and returns no keys, so
+ * anomalies already present when scores first arrive never trigger a toast storm
+ * (fixes C-12). Every later call diffs against the previous set and returns only
+ * the keys that have just crossed the threshold.
+ *
+ * Empty / null / non-object emissions are ignored entirely: they neither consume
+ * the seed nor wipe the known set. This matters because the `anomalies` store is
+ * `writable({})` — it emits `{}` at mount, before any scan batch lands. If `{}`
+ * consumed the seed, the first populated batch would arrive already-"initialized"
+ * and storm; if `{}` wiped the set, a transient empty emission would re-toast
+ * everything on the next batch.
+ *
+ * @module anomaly-toast-tracker
+ * @since v0.10.0-alpha
+ */
+
+// ═══ TYPES ═══
+
+/** Map of agent name → anomaly score, as emitted by the `anomalies` store. */
+export type AnomalyScores = Record<string, unknown> | null | undefined;
+
+/** Stateful tracker returned by {@link createAnomalyToastTracker}. */
+export interface AnomalyToastTracker {
+  /**
+   * Fold a new batch of anomaly scores into the tracker.
+   *
+   * @param scores - Latest anomaly scores (tolerates null/undefined/non-object
+   *   and empty `{}`, all treated as no-ops).
+   * @returns Agent names that are over threshold AND were not over threshold on
+   *   the previous non-empty call. Always `[]` for the first non-empty object
+   *   (seed) and for empty/invalid emissions.
+   */
+  ingest(scores: AnomalyScores): string[];
+}
+
+// ═══ PUBLIC API ═══
+
+/**
+ * Create a seed-then-diff anomaly-toast tracker.
+ *
+ * @param threshold - Minimum score (inclusive) for an agent to count as an
+ *   anomaly. Defaults to `50`, matching the gate in App.svelte.
+ * @returns A tracker whose `ingest` returns only freshly-anomalous agent names.
+ */
+export function createAnomalyToastTracker(threshold = 50): AnomalyToastTracker {
+  let prevKeys = new Set<string>();
+  let initialized = false;
+
+  return {
+    ingest(scores: AnomalyScores): string[] {
+      // Ignore empty/null/invalid emissions: do not seed, do not wipe state.
+      if (!scores || typeof scores !== 'object') return [];
+      const entries = Object.entries(scores);
+      if (entries.length === 0) return [];
+
+      const currentKeys = new Set<string>();
+      const fresh: string[] = [];
+
+      for (const [agent, score] of entries) {
+        if (typeof score === 'number' && score >= threshold) {
+          currentKeys.add(agent);
+          // On the seed (first non-empty) call, `initialized` is false → nothing
+          // is reported, so anomalies present when scores first arrive do not
+          // produce a toast storm.
+          if (initialized && !prevKeys.has(agent)) {
+            fresh.push(agent);
+          }
+        }
+      }
+
+      prevKeys = currentKeys;
+      initialized = true;
+      return fresh;
+    },
+  };
+}

--- a/tests/renderer/anomaly-toast-tracker.test.js
+++ b/tests/renderer/anomaly-toast-tracker.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { createAnomalyToastTracker } from '../../src/renderer/lib/utils/anomaly-toast-tracker';
+
+describe('createAnomalyToastTracker', () => {
+  describe('seed-then-diff (C-12 regression)', () => {
+    it('seeds on the first non-empty object and reports nothing (no toast storm)', () => {
+      const tracker = createAnomalyToastTracker();
+      // Under the C-12 bug, both starting anomalies would be reported as "new"
+      // and toasted. The seed call MUST return [].
+      expect(tracker.ingest({ agentA: 80, agentB: 90 })).toEqual([]);
+    });
+
+    it('does NOT consume the seed on the mount-time empty {} — the real C-12 path', () => {
+      // The `anomalies` store is writable({}) and emits {} at mount, BEFORE the
+      // first scan batch. If {} consumed the seed, the first populated batch
+      // would arrive already-initialized and toast every starting anomaly.
+      const tracker = createAnomalyToastTracker();
+      expect(tracker.ingest({})).toEqual([]); // mount default — must not seed
+      expect(tracker.ingest({ agentA: 80, agentB: 90 })).toEqual([]); // first real batch = seed
+      // Only genuinely-new anomalies after the seed are reported.
+      expect(tracker.ingest({ agentA: 80, agentB: 90, agentC: 70 })).toEqual(['agentC']);
+    });
+
+    it('reports only the genuinely-new key on a later batch, not the repeat', () => {
+      const tracker = createAnomalyToastTracker();
+      tracker.ingest({ agentA: 80, agentB: 90 }); // seed
+      // agentA is a repeat (already seeded), agentC is new.
+      expect(tracker.ingest({ agentA: 80, agentC: 70 })).toEqual(['agentC']);
+    });
+
+    it('does not re-report a key that was already over threshold', () => {
+      const tracker = createAnomalyToastTracker();
+      tracker.ingest({ agentA: 80 }); // seed
+      expect(tracker.ingest({ agentA: 80 })).toEqual([]);
+    });
+  });
+
+  describe('threshold gate', () => {
+    it('excludes scores below the default threshold (50)', () => {
+      const tracker = createAnomalyToastTracker();
+      tracker.ingest({ seed: 99 }); // non-empty seed
+      const fresh = tracker.ingest({ agentD: 40 });
+      expect(fresh).not.toContain('agentD');
+      expect(fresh).toEqual([]);
+    });
+
+    it('includes a score exactly at the threshold (inclusive)', () => {
+      const tracker = createAnomalyToastTracker();
+      tracker.ingest({ seed: 99 }); // non-empty seed
+      expect(tracker.ingest({ agentE: 50 })).toEqual(['agentE']);
+    });
+
+    it('honors a custom threshold', () => {
+      const tracker = createAnomalyToastTracker(70);
+      tracker.ingest({ seed: 99 }); // non-empty seed
+      const fresh = tracker.ingest({ agentF: 60, agentG: 75 });
+      expect(fresh).toEqual(['agentG']);
+    });
+  });
+
+  describe('empty / malformed emissions preserve state', () => {
+    it('returns [] for undefined without throwing or wiping state', () => {
+      const tracker = createAnomalyToastTracker();
+      tracker.ingest({ agentA: 80 }); // seed
+      expect(tracker.ingest(undefined)).toEqual([]);
+      // agentA is still known — not re-reported on the next batch.
+      expect(tracker.ingest({ agentA: 80 })).toEqual([]);
+    });
+
+    it('returns [] for null without throwing', () => {
+      const tracker = createAnomalyToastTracker();
+      expect(tracker.ingest(null)).toEqual([]);
+    });
+
+    it('returns [] for an empty object', () => {
+      const tracker = createAnomalyToastTracker();
+      expect(tracker.ingest({})).toEqual([]);
+    });
+
+    it('a transient empty/null between two populated batches does not re-report', () => {
+      const tracker = createAnomalyToastTracker();
+      tracker.ingest({ agentA: 80 }); // seed
+      tracker.ingest({}); // transient empty — must not wipe prevKeys
+      tracker.ingest(null); // transient null — must not wipe prevKeys
+      expect(tracker.ingest({ agentA: 80, agentB: 90 })).toEqual(['agentB']);
+    });
+
+    it('ignores non-numeric score values', () => {
+      const tracker = createAnomalyToastTracker();
+      tracker.ingest({ seed: 99 }); // non-empty seed
+      expect(tracker.ingest({ agentH: '90', agentI: null, agentJ: 80 })).toEqual(['agentJ']);
+    });
+  });
+});


### PR DESCRIPTION
## Root cause

The anomaly-toast tracker started with an **empty `prevAnomalyKeys`** and had **no seed guard**. On the first scan that returned anomalies, every key was "new" relative to the empty baseline, so the renderer fired a toast for *all* of them at once — a toast storm on first populated render.

## The hidden bug (why a naïve seed fails)

The anomalies store is `writable({})`, and like every renderer IPC store it **emits `{}` at mount**, before the first real scan arrives. A seed guard that latches on the *first effect run* or *first ingest* would consume its one-shot seed on that empty `{}` — leaving the first **populated** batch to storm anyway, while helper unit tests stayed green (they never exercised the mount-empty emission).

Fix: seed on the first **non-empty** scores object. Empty / null payloads are treated as no-ops — they neither seed nor wipe existing state.

## What changed

- **Helper** — seed-then-diff logic that latches on the first non-empty scores object; empty/null = no-op.
- **App.svelte** — wires the helper into the anomaly-toast path.
- **Tests** — 12 tests covering: mount-empty `{}` no-op, first non-empty seed (no storm), subsequent real diffs firing only on genuinely new keys, and null-payload safety.

## Verify

- `typecheck` — 0 errors
- `svelte-check` — 0 errors
- `eslint` — 0 errors
- tests — 911 pass
- `build:renderer` — ✓
