### PR TITLE
feat: confirm dialog + own-PID self-guard for process stop (C-10 A)

### DIFF
--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -481,6 +481,11 @@ ${findingsHtml}${recsHtml}
   ipcMain.handle('kill-process', (_e, pid) => {
     pid = Number(pid);
     if (!Number.isInteger(pid) || pid <= 0) return { success: false, error: 'Invalid PID' };
+    if (pid === process.pid) {
+      // C-01 own-PID self-guard — never terminate AEGIS itself.
+      logger.warn(`kill-process: refused — PID ${pid} is AEGIS itself`);
+      return { success: false, error: 'Refusing to act on AEGIS itself' };
+    }
     const agents = deps.getLatestAgents ? deps.getLatestAgents() : [];
     if (!agents.some((a) => a.pid === pid)) {
       logger.warn(`kill-process: PID ${pid} not monitored by Aegis`);
@@ -491,6 +496,11 @@ ${findingsHtml}${recsHtml}
   ipcMain.handle('suspend-process', (_e, pid) => {
     pid = Number(pid);
     if (!Number.isInteger(pid) || pid <= 0) return { success: false, error: 'Invalid PID' };
+    if (pid === process.pid) {
+      // C-01 own-PID self-guard — suspending AEGIS's own PID would freeze it.
+      logger.warn(`suspend-process: refused — PID ${pid} is AEGIS itself`);
+      return { success: false, error: 'Refusing to act on AEGIS itself' };
+    }
     const agents = deps.getLatestAgents ? deps.getLatestAgents() : [];
     if (!agents.some((a) => a.pid === pid)) {
       logger.warn(`suspend-process: PID ${pid} not monitored by Aegis`);
@@ -501,6 +511,11 @@ ${findingsHtml}${recsHtml}
   ipcMain.handle('resume-process', (_e, pid) => {
     pid = Number(pid);
     if (!Number.isInteger(pid) || pid <= 0) return { success: false, error: 'Invalid PID' };
+    if (pid === process.pid) {
+      // C-01 own-PID self-guard — keep process-control symmetric across all three.
+      logger.warn(`resume-process: refused — PID ${pid} is AEGIS itself`);
+      return { success: false, error: 'Refusing to act on AEGIS itself' };
+    }
     const agents = deps.getLatestAgents ? deps.getLatestAgents() : [];
     if (!agents.some((a) => a.pid === pid)) {
       logger.warn(`resume-process: PID ${pid} not monitored by Aegis`);

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -12,8 +12,11 @@
   import { theme, uiScale, toggleTheme, setTheme } from './lib/stores/theme.js';
   import Toast from './lib/components/Toast.svelte';
   import CommandPalette from './lib/components/CommandPalette.svelte';
+  import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
   import { commandPalette } from './lib/stores/command-palette.svelte.ts';
   import { addToast } from './lib/stores/toast.js';
+  import { pendingStop, requestStop, clearStop } from './lib/stores/process-action.js';
+  import { t } from './lib/i18n/index.js';
   import { agents, anomalies, isDemoMode, selectedAgentPid } from './lib/stores/ipc.js';
   import { get } from 'svelte/store';
   import DemoBanner from './lib/components/DemoBanner.svelte';
@@ -140,12 +143,14 @@
   });
 
   /**
-   * Run a kill/suspend intervention on the currently selected (expanded) agent
-   * via the existing IPC bridge. Reads the selection non-reactively so the
-   * dispatch effect is not re-triggered when the selection changes.
-   * @param {'killProcess'|'suspendProcess'} method
-   * @param {string} doneLabel  Success toast label, e.g. "Killed agent"
-   * @param {string} failLabel  Failure toast label, e.g. "Failed to kill agent"
+   * Run a reversible process action (suspend) on the currently selected
+   * (expanded) agent via the existing IPC bridge. Reads the selection
+   * non-reactively so the dispatch effect is not re-triggered when the
+   * selection changes. Destructive stop (kill) goes through `requestStopSelected`
+   * → confirmation dialog instead.
+   * @param {'suspendProcess'} method
+   * @param {string} doneLabel  Success toast label, e.g. "Suspended agent"
+   * @param {string} failLabel  Failure toast label, e.g. "Failed to suspend agent"
    */
   async function runSelectedAgentAction(method, doneLabel, failLabel) {
     const pid = get(selectedAgentPid);
@@ -159,6 +164,38 @@
       addToast(`${doneLabel} (PID ${pid})`, 'success');
     } else {
       addToast(`${failLabel}: ${result?.error ?? 'unknown error'}`, 'error');
+    }
+  }
+
+  /**
+   * Open the stop-process confirmation for the currently selected agent
+   * (command-palette `agent:kill` entry point). Resolves the display name from
+   * the risk-enriched agents so the dialog reads honestly.
+   */
+  function requestStopSelected() {
+    const pid = get(selectedAgentPid);
+    if (pid == null) {
+      addToast('No agent selected — open an agent card first', 'warning');
+      return;
+    }
+    const match = get(enrichedAgents).find((a) => a.pid === pid);
+    requestStop(pid, match?.name || match?.agent || String(pid));
+  }
+
+  /**
+   * Execute the pending stop-process request after the user confirms. Reads the
+   * pending entry non-reactively, clears the dialog, then terminates the process
+   * via the existing IPC bridge and toasts the outcome.
+   */
+  async function confirmStop() {
+    const target = get(pendingStop);
+    clearStop();
+    if (!target || !window.aegis) return;
+    const result = await window.aegis.killProcess(target.pid);
+    if (result?.success) {
+      addToast(`Stopped process ${target.name} (PID ${target.pid})`, 'success');
+    } else {
+      addToast(`Failed to stop process: ${result?.error ?? 'unknown error'}`, 'error');
     }
   }
 
@@ -209,9 +246,11 @@
       case 'theme:light-hc':
         setTheme('light-hc');
         break;
-      // Agent actions — operate on the currently selected (expanded) agent
+      // Agent actions — operate on the currently selected (expanded) agent.
+      // Destructive stop is gated behind a confirmation dialog; suspend (reversible)
+      // runs directly.
       case 'agent:kill':
-        runSelectedAgentAction('killProcess', 'Killed agent', 'Failed to kill agent');
+        requestStopSelected();
         break;
       case 'agent:suspend':
         runSelectedAgentAction('suspendProcess', 'Suspended agent', 'Failed to suspend agent');
@@ -297,6 +336,17 @@
 <Footer />
 <Toast />
 <CommandPalette />
+
+{#if $pendingStop}
+  <ConfirmDialog
+    title={$t('process_action.stop_title')}
+    message={$t('process_action.stop_body', { name: $pendingStop.name, pid: $pendingStop.pid })}
+    confirmLabel={$t('process_action.stop_confirm')}
+    cancelLabel={$t('process_action.cancel')}
+    onconfirm={confirmStop}
+    oncancel={clearStop}
+  />
+{/if}
 
 <!-- Fleet-wide risk index — fixed dock, fed the risk-enriched agents (riskScore
      lives on enrichedAgents, never on the raw `agents` store). Append-only. -->

--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -13,6 +13,7 @@
   import TrustBadge from './TrustBadge.svelte';
   import { getRiskInfo } from '../utils/trust-badge-utils';
   import { addToast } from '../stores/toast.js';
+  import { requestStop } from '../stores/process-action.js';
   import { t } from '../i18n/index.js';
 
   /** @type {{ agent: Object, expandedPid: number|null }} */
@@ -118,9 +119,17 @@
     }
   }
 
-  /** Run a process action against a specific PID (defaults to the representative). */
+  /**
+   * Run a process action against a specific PID (defaults to the representative).
+   * Destructive `killProcess` routes through a confirmation gate; the reversible
+   * `suspendProcess`/`resumeProcess` run directly.
+   */
   async function pidAction(e, method, pid = agent.pid) {
     e.stopPropagation();
+    if (method === 'killProcess') {
+      requestStop(pid, agent.name || agent.agent || String(pid));
+      return;
+    }
     if (window.aegis) await window.aegis[method](pid);
   }
 

--- a/src/renderer/lib/components/ConfirmDialog.svelte
+++ b/src/renderer/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,121 @@
+<script>
+  /**
+   * @file ConfirmDialog.svelte
+   * @description Generic destructive-action confirmation dialog. Mirrors the
+   *   delete-confirm pattern in AgentFormModal: a scrim overlay + glass modal
+   *   with title, message, a Cancel button and a danger confirm button. Esc or
+   *   an overlay click cancels. All text is passed in by the caller so the
+   *   component stays i18n-agnostic and reusable.
+   * @since v0.10.0-alpha
+   */
+
+  /**
+   * @type {{
+   *   title: string,
+   *   message: string,
+   *   confirmLabel: string,
+   *   cancelLabel: string,
+   *   onconfirm: () => void,
+   *   oncancel: () => void,
+   * }}
+   */
+  let { title, message, confirmLabel, cancelLabel, onconfirm, oncancel } = $props();
+
+  /** @type {HTMLDivElement | undefined} */
+  let modalRef = $state(undefined);
+
+  // Autofocus the dialog on open so the overlay subtree is in the keyboard
+  // event path immediately and Esc reaches our handler (see AgentFormModal).
+  $effect(() => {
+    modalRef?.focus();
+  });
+</script>
+
+<div
+  class="overlay"
+  role="button"
+  tabindex="-1"
+  onclick={oncancel}
+  onkeydown={(e) => {
+    if (e.key === 'Escape') oncancel();
+  }}
+>
+  <div
+    bind:this={modalRef}
+    class="modal"
+    role="alertdialog"
+    aria-modal="true"
+    tabindex="-1"
+    onclick={(e) => e.stopPropagation()}
+    onkeydown={(e) => {
+      if (e.key === 'Escape') oncancel();
+      e.stopPropagation();
+    }}
+  >
+    <h3 class="modal-title">{title}</h3>
+    <p class="modal-text">{message}</p>
+    <div class="modal-actions">
+      <button class="crud-btn" onclick={oncancel}>{cancelLabel}</button>
+      <button class="crud-btn danger" onclick={onconfirm}>{confirmLabel}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: var(--md-sys-color-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .modal {
+    background: var(--md-sys-color-surface-container-high);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow), var(--glass-highlight);
+    border-radius: var(--md-sys-shape-corner-large);
+    padding: var(--aegis-space-10);
+    min-width: calc(360px * var(--aegis-ui-scale));
+    max-width: 460px;
+  }
+  .modal-title {
+    font: var(--md-sys-typescale-headline-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--aegis-space-8);
+  }
+  .modal-text {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--aegis-space-9);
+  }
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--aegis-space-4);
+  }
+  .crud-btn {
+    font: var(--md-sys-typescale-label-medium);
+    font-weight: 600;
+    padding: calc(7px * var(--aegis-ui-scale)) var(--aegis-space-7);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-small);
+    color: var(--md-sys-color-on-surface-variant);
+    cursor: pointer;
+    transition: all 0.3s var(--ease-glass);
+  }
+  .crud-btn:hover {
+    background: var(--md-sys-color-outline-variant);
+    color: var(--md-sys-color-on-surface);
+    border-color: var(--aegis-border-hover);
+  }
+  .crud-btn.danger {
+    background: var(--md-sys-color-error);
+    color: var(--md-sys-color-on-error);
+    border-color: var(--md-sys-color-error);
+  }
+</style>

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -16,6 +16,12 @@
     "perm_warn": "PERM",
     "tokens": "TOK"
   },
+  "process_action": {
+    "stop_title": "Stop process?",
+    "stop_body": "Stop process {name} (PID {pid})? This terminates the process.",
+    "stop_confirm": "Stop process",
+    "cancel": "Cancel"
+  },
   "tabs": {
     "shield": "Shield",
     "activity": "Activity",

--- a/src/renderer/lib/stores/process-action.ts
+++ b/src/renderer/lib/stores/process-action.ts
@@ -1,0 +1,35 @@
+import { writable } from 'svelte/store';
+import type { Writable } from 'svelte/store';
+
+/** A pending request to stop (terminate) a monitored process, awaiting confirmation. */
+export interface PendingStop {
+  readonly pid: number;
+  readonly name: string;
+}
+
+/**
+ * The stop-process confirmation currently awaiting the user, or `null` when no
+ * dialog is open. Stopping a process is destructive (`taskkill /F` on Windows),
+ * so every UI entry point routes through this single gate. This store holds
+ * intent only — the owning component performs the IPC call on confirm.
+ * @since v0.10.0-alpha
+ */
+export const pendingStop: Writable<PendingStop | null> = writable(null);
+
+/**
+ * Open the stop-process confirmation for a specific PID.
+ * @param pid - OS process ID to stop
+ * @param name - Display name shown in the confirmation dialog
+ * @since v0.10.0-alpha
+ */
+export function requestStop(pid: number, name: string): void {
+  pendingStop.set({ pid, name });
+}
+
+/**
+ * Dismiss the pending stop-process confirmation without acting.
+ * @since v0.10.0-alpha
+ */
+export function clearStop(): void {
+  pendingStop.set(null);
+}

--- a/tests/main/ipc-handlers.test.js
+++ b/tests/main/ipc-handlers.test.js
@@ -486,6 +486,40 @@ describe('ipc-handlers', () => {
       expect(mockPlatform.resumeProcess).not.toHaveBeenCalled();
     });
 
+    it('kill-process refuses AEGIS own PID even when it is monitored', async () => {
+      // Inject AEGIS's own PID as a monitored agent so the monitored-agent
+      // check would otherwise pass — only the own-PID self-guard must block it.
+      ipcHandlers.init({
+        getWindow: () => null,
+        getStats: () => ({}),
+        getResourceUsage: () => ({}),
+        getLatestAgents: () => [{ agent: 'Self', pid: process.pid, category: 'ai' }],
+        setOtherPanelExpanded: vi.fn(),
+      });
+      ipcHandlers.register();
+      mockPlatform.killProcess.mockClear();
+      const handler = getHandler('kill-process');
+      const result = await handler(null, process.pid);
+      expect(result).toEqual({ success: false, error: 'Refusing to act on AEGIS itself' });
+      expect(mockPlatform.killProcess).not.toHaveBeenCalled();
+    });
+
+    it('suspend-process refuses AEGIS own PID even when it is monitored', async () => {
+      ipcHandlers.init({
+        getWindow: () => null,
+        getStats: () => ({}),
+        getResourceUsage: () => ({}),
+        getLatestAgents: () => [{ agent: 'Self', pid: process.pid, category: 'ai' }],
+        setOtherPanelExpanded: vi.fn(),
+      });
+      ipcHandlers.register();
+      mockPlatform.suspendProcess.mockClear();
+      const handler = getHandler('suspend-process');
+      const result = await handler(null, process.pid);
+      expect(result).toEqual({ success: false, error: 'Refusing to act on AEGIS itself' });
+      expect(mockPlatform.suspendProcess).not.toHaveBeenCalled();
+    });
+
     it('save-custom-agents delegates to config', () => {
       const handler = getHandler('save-custom-agents');
       const agents = [{ name: 'custom', process: 'custom.exe' }];


### PR DESCRIPTION
## C-10 (Workstream A) — make the existing process-stop safe

Kill/suspend/resume is already implemented, wired, and shipped. This PR closes the two **safety** gaps in it (honesty relabel of the `block`/Paranoid presets is a separate follow-up PR, Workstream B).

### What changed

**Main — own-PID self-guard (the hard floor; the renderer can be bypassed via the command palette)**
- `src/main/ipc-handlers.js`: each of `kill-process` / `suspend-process` / `resume-process` now refuses when `pid === process.pid` (reuses the existing primitive at `file-watcher.js:427`) — returns `{ success: false, error: 'Refusing to act on AEGIS itself' }` + a `logger.warn`, before the monitored-agent check. Inline 3-line guard per handler; no registration refactor, channels unchanged (IPC append-only). Suspend/resume *platform* logic untouched.

**Renderer — confirmation dialog before a destructive stop (both entry points)**
- New `ConfirmDialog.svelte` — generic destructive-action dialog mirroring `AgentFormModal`'s delete-confirm pattern (scrim overlay + glass modal + `.danger` button, Esc/overlay-click cancels, `var()` tokens only).
- New `process-action.ts` store — holds the pending stop request (pid + name) only; the IPC call stays in the component layer.
- `AgentCard.pidAction`: `killProcess` now routes through `requestStop(...)` → confirm; `suspendProcess`/`resumeProcess` (reversible) stay direct.
- `App.svelte`: command-palette `agent:kill` routes through the same confirm gate (`requestStopSelected`); `confirmStop` performs the actual `killProcess` + toast; renders one `<ConfirmDialog>` bound to `$pendingStop`.
- `en.json`: new honest `process_action` keys — body reads *"Stop process {name} (PID {pid})? This terminates the process."* No `block`/`contain`/`quarantine` wording.

### Honesty
"Stop" / "kill" is accurate — `taskkill /F` genuinely terminates. The dialog never claims containment or file-access blocking (capabilities AEGIS does not have).

### Tests
- `tests/main/ipc-handlers.test.js`: +2 regression tests. Each injects AEGIS's own PID as a *monitored* agent (so the monitored-agent check would otherwise pass) and asserts the action is refused and the platform fn is never called. Proven **RED without the guard** (`{success:true}`) → **GREEN with it**.

### Verification
- `npm test` — 913 pass / 4 skip (57 files)
- `npx eslint src/` — 0 errors (pre-existing no-console warnings only)
- `npx tsc --noEmit` (main + renderer) — clean
- `svelte-check` — 213 files, 0 errors, 0 warnings
- `npm run build:renderer` — clean

Workstream B (relabel overclaiming `block`/Paranoid preset strings to honest "alert only") follows as a separate PR.
