### PR TITLE
fix: honest preset labels + resume own-PID guard test

### DIFF
--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -164,9 +164,9 @@
     "protection": {
       "title": "Protection Level",
       "paranoid": "Paranoid",
-      "paranoid_desc": "Block all agent file access",
+      "paranoid_desc": "Alert only — enforcement planned",
       "strict": "Strict",
-      "strict_desc": "Monitor sensitive, block credentials",
+      "strict_desc": "Monitor sensitive — alert only",
       "balanced": "Balanced",
       "balanced_desc": "Monitor all, allow safe operations",
       "developer": "Developer",
@@ -182,7 +182,7 @@
       "states": {
         "allow": "allow",
         "monitor": "monitor",
-        "block": "block"
+        "block": "alert"
       },
       "categories": {
         "file_access": "File Access",

--- a/tests/main/ipc-handlers.test.js
+++ b/tests/main/ipc-handlers.test.js
@@ -520,6 +520,25 @@ describe('ipc-handlers', () => {
       expect(mockPlatform.suspendProcess).not.toHaveBeenCalled();
     });
 
+    it('resume-process refuses AEGIS own PID even when it is monitored', async () => {
+      // Mirror of the kill/suspend own-PID tests: inject AEGIS's own PID as a
+      // monitored agent so the monitored-agent check passes — only the own-PID
+      // self-guard must block resume-process.
+      ipcHandlers.init({
+        getWindow: () => null,
+        getStats: () => ({}),
+        getResourceUsage: () => ({}),
+        getLatestAgents: () => [{ agent: 'Self', pid: process.pid, category: 'ai' }],
+        setOtherPanelExpanded: vi.fn(),
+      });
+      ipcHandlers.register();
+      mockPlatform.resumeProcess.mockClear();
+      const handler = getHandler('resume-process');
+      const result = await handler(null, process.pid);
+      expect(result).toEqual({ success: false, error: 'Refusing to act on AEGIS itself' });
+      expect(mockPlatform.resumeProcess).not.toHaveBeenCalled();
+    });
+
     it('save-custom-agents delegates to config', () => {
       const handler = getHandler('save-custom-agents');
       const agents = [{ name: 'custom', process: 'custom.exe' }];


### PR DESCRIPTION
C-10 Workstream B. Part 1: honest display labels (en.json display-text only — paranoid_desc/strict_desc/states.block → alert-only wording; enum 'block' key + config values byte-identical, back-compat held, no kill-wiring/enforcement). Part 2: resume-process own-PID regression test (empirical-RED proven: guard removed → FAIL with correct error + resumeProcess called → restored). Verify green: typecheck 0, lint 0, test 914 (+1 via stash), build 1.41s. Invariants: no banned code-honesty words in new strings.