### PR TITLE
feat: tamper-evident hash-chained audit log

### DIFF
--- a/src/main/audit-hashchain.js
+++ b/src/main/audit-hashchain.js
@@ -1,0 +1,136 @@
+/**
+ * @file audit-hashchain.js
+ * @module main/audit-hashchain
+ * @description Tamper-evident (hash-chained) audit-log helpers. Each daily audit
+ *   file is an INDEPENDENT SHA-256 hash chain: every record's hash binds the
+ *   canonical form of the event to the previous record's hash, starting from a
+ *   fixed GENESIS constant. Verification recomputes the chain in place — there is
+ *   no stored prevHash field; linkage is proven by re-derivation.
+ *
+ *   Scope: the chain lives WITHIN a single daily file. A new day starts a fresh
+ *   chain (seq 0, prevHash = GENESIS), so retention deletion of old day-files
+ *   never invalidates a surviving file.
+ * @requires crypto
+ * @requires fs
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+
+/** Fixed seed for the first record of every daily file. */
+const GENESIS = 'AEGIS-AUDIT-GENESIS-v1';
+
+/**
+ * Deterministic, insertion-order-independent serialization of a JSON value.
+ * Object keys are sorted recursively so the output depends only on content,
+ * never on key insertion order.
+ * @param {*} value - Any JSON-serializable value.
+ * @returns {string} Canonical string form.
+ * @since v0.1.0
+ */
+function canonical(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonical).join(',') + ']';
+  const keys = Object.keys(value).sort();
+  return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonical(value[k])).join(',') + '}';
+}
+
+/**
+ * Compute a record's chain hash: sha256(prevHash + canonical(event)).
+ *
+ * The event is normalized through a JSON round-trip BEFORE hashing so the hashed
+ * form is byte-identical to what JSON.stringify writes to disk: JSON drops
+ * undefined-valued object keys and maps undefined array elements to null. Without
+ * this, a clean record carrying an undefined-valued detail would hash differently
+ * at write vs verify time and produce a FALSE tamper verdict.
+ * @param {string} prevHash - Previous record's hash, or GENESIS for the first record.
+ * @param {Object} event - The audit event WITHOUT its seq/hash fields.
+ * @returns {string} Hex-encoded SHA-256 hash.
+ * @since v0.1.0
+ */
+function computeHash(prevHash, event) {
+  const normalized = JSON.parse(JSON.stringify(event));
+  return crypto
+    .createHash('sha256')
+    .update(prevHash + canonical(normalized))
+    .digest('hex');
+}
+
+/**
+ * Verify the hash chain of a single daily audit file.
+ *
+ * Detects in-place edits, insertions, and deletions of interior lines; does NOT
+ * detect truncation of trailing lines (valid prefix remains a valid chain).
+ * @param {string} filePath - Path to an aegis-audit-YYYY-MM-DD.json file.
+ * @returns {{valid: boolean, brokenAtSeq: number|null, reason: string}}
+ *   On failure, brokenAtSeq is the 0-based line position where the chain breaks.
+ * @since v0.1.0
+ */
+function verifyChain(filePath) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    return { valid: false, brokenAtSeq: null, reason: `read-failed: ${err.message}` };
+  }
+  const lines = content.split('\n').filter((l) => l.trim().length > 0);
+  let prevHash = GENESIS;
+  for (let i = 0; i < lines.length; i++) {
+    let entry;
+    try {
+      entry = JSON.parse(lines[i]);
+    } catch (_) {
+      return { valid: false, brokenAtSeq: i, reason: `malformed JSON at line ${i}` };
+    }
+    if (entry.seq !== i) {
+      return {
+        valid: false,
+        brokenAtSeq: i,
+        reason: `seq discontinuity at line ${i}: got ${entry.seq}`,
+      };
+    }
+    const event = { ...entry };
+    delete event.seq;
+    delete event.hash;
+    if (computeHash(prevHash, event) !== entry.hash) {
+      return { valid: false, brokenAtSeq: i, reason: `hash mismatch at seq ${i}` };
+    }
+    prevHash = entry.hash;
+  }
+  return { valid: true, brokenAtSeq: null, reason: 'ok' };
+}
+
+/**
+ * Read the tail of a daily file to resume its chain after a process restart or a
+ * day rollover. Returns the seed for the NEXT record to append.
+ * @param {string} filePath - Path to today's audit file (may not exist yet).
+ * @returns {{prevHash: string, seq: number}} GENESIS/0 if the file is absent,
+ *   empty, or its last line predates hash-chaining.
+ * @since v0.1.0
+ */
+function seedFromTail(filePath) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch (_) {
+    return { prevHash: GENESIS, seq: 0 };
+  }
+  const lines = content.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return { prevHash: GENESIS, seq: 0 };
+  try {
+    const last = JSON.parse(lines[lines.length - 1]);
+    if (typeof last.hash === 'string' && typeof last.seq === 'number') {
+      return { prevHash: last.hash, seq: last.seq + 1 };
+    }
+  } catch (_) {
+    /* fall through to GENESIS */
+  }
+  return { prevHash: GENESIS, seq: 0 };
+}
+
+module.exports = { GENESIS, canonical, computeHash, verifyChain, seedFromTail };

--- a/src/main/audit-logger.js
+++ b/src/main/audit-logger.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const hashchain = require('./audit-hashchain');
 
 let _logDir = '';
 let _buffer = [];
@@ -22,6 +23,14 @@ let _onFlushError = null;
 const FLUSH_INTERVAL = 5000;
 const FLUSH_THRESHOLD = 50;
 const RETENTION_DAYS = 30;
+
+/** Injectable clock — overridable via init({ now }) so day rotation is testable. */
+let _now = () => new Date();
+
+/** Hash-chain state for the current daily file (per-file chain; resets each day). */
+let _prevHash = hashchain.GENESIS;
+let _seq = 0;
+let _chainDate = /** @type {string|null} */ (null);
 
 /** In-memory counters — avoids re-reading all log files on every getStats() call */
 let _totalEntries = 0;
@@ -33,11 +42,14 @@ let _lastEntry = /** @type {string|null} */ (null);
  * and cleans up old log files.
  * @param {Object} opts
  * @param {string} opts.userDataPath - Electron app.getPath('userData')
+ * @param {function} [opts.onFlushError] - Called with the Error when a flush write fails
+ * @param {function} [opts.now] - Test seam: returns the current Date (defaults to real clock)
  * @returns {void}
  * @since v0.2.0
  */
 function init(opts) {
   _onFlushError = opts.onFlushError || null;
+  if (opts.now) _now = opts.now;
   _logDir = path.join(opts.userDataPath, 'audit-logs');
   try {
     if (!fs.existsSync(_logDir)) fs.mkdirSync(_logDir, { recursive: true });
@@ -86,14 +98,22 @@ function _seedCounters() {
 }
 
 /**
+ * Today's date as YYYY-MM-DD (local time, via the injectable clock). Used both
+ * for the file name and to detect day rotation in flush().
+ * @returns {string}
+ */
+function _todayDateStr() {
+  const d = _now();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/**
  * Get the log file path for today.
  * @returns {string} Path to today's audit log file.
  * @since v0.2.0
  */
 function getTodayLogPath() {
-  const d = new Date();
-  const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-  return path.join(_logDir, `aegis-audit-${dateStr}.json`);
+  return path.join(_logDir, `aegis-audit-${_todayDateStr()}.json`);
 }
 
 /**
@@ -129,6 +149,12 @@ function log(type, details) {
 
 /**
  * Flush the buffer to disk, appending entries to today's log file.
+ *
+ * Each entry is hash-chained: it gains a per-file `seq` and a `hash` binding it to
+ * the previous record (see audit-hashchain.js). The chain state (_prevHash/_seq/
+ * _chainDate) advances ONLY after a successful write, so a failed flush re-queues
+ * the pristine entries without consuming seq numbers — the next flush renumbers
+ * from the same point, keeping the chain gap-free (C-03 recovery).
  * @returns {void}
  * @since v0.2.0
  */
@@ -136,15 +162,42 @@ function flush() {
   if (_buffer.length === 0 || !_logDir) return;
   const entries = _buffer.splice(0);
   const fp = getTodayLogPath();
+  const todayDate = _todayDateStr();
+
+  // Seed the chain: continue the in-memory state for the same day, otherwise
+  // (process start or day rollover) resume from the tail of today's file.
+  let prevHash;
+  let seq;
+  if (_chainDate === todayDate) {
+    prevHash = _prevHash;
+    seq = _seq;
+  } else {
+    const seed = hashchain.seedFromTail(fp);
+    prevHash = seed.prevHash;
+    seq = seed.seq;
+  }
+
+  const out = [];
+  for (const e of entries) {
+    const hash = hashchain.computeHash(prevHash, e);
+    out.push(JSON.stringify({ ...e, seq, hash }));
+    prevHash = hash;
+    seq += 1;
+  }
+
   try {
-    const lines = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
-    fs.appendFileSync(fp, lines, 'utf-8');
+    fs.appendFileSync(fp, out.join('\n') + '\n', 'utf-8');
+    _prevHash = prevHash;
+    _seq = seq;
+    _chainDate = todayDate;
   } catch (err) {
     if (_onFlushError) _onFlushError(err);
     // TODO(C-03-followup): unbounded buffer growth — if the disk is permanently
     // broken (full / no perms), re-queuing on every failed flush grows _buffer
     // without bound (OOM). Add a cap (drop-oldest beyond a limit) in a follow-up;
     // out of scope for this PR.
+    // Re-queue PRISTINE entries (no seq/hash baked in) and leave chain state
+    // unadvanced so the retry produces an unbroken chain.
     _buffer = entries.concat(_buffer);
   }
 }
@@ -348,5 +401,6 @@ module.exports = {
   getStats,
   exportAll,
   getEntriesBefore,
+  verifyChain: hashchain.verifyChain,
   getLogDir: () => _logDir,
 };

--- a/tests/main/audit-hashchain.test.js
+++ b/tests/main/audit-hashchain.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('audit-hashchain', () => {
+  /** @type {string} */ let GENESIS;
+  /** @type {(value: unknown) => string} */ let canonical;
+  /** @type {(prevHash: string, event: object) => string} */ let computeHash;
+  /** @type {(filePath: string) => {valid: boolean, brokenAtSeq: number|null, reason: string}} */
+  let verifyChain;
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-hashchain-test-'));
+    const mod = await import('../../src/main/audit-hashchain.js');
+    ({ GENESIS, canonical, computeHash, verifyChain } = mod.default);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Build a valid on-disk chain using the real module functions, mirroring the
+  // logger's persisted record shape ({ ...event, seq, hash }).
+  function writeChain(filePath, events) {
+    let prev = GENESIS;
+    const lines = events.map((e, seq) => {
+      const hash = computeHash(prev, e);
+      prev = hash;
+      return JSON.stringify({ ...e, seq, hash });
+    });
+    fs.writeFileSync(filePath, lines.join('\n') + '\n', 'utf-8');
+  }
+
+  function readLines(filePath) {
+    return fs
+      .readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+  }
+
+  it('canonical() is insertion-order independent (recursively)', () => {
+    expect(canonical({ a: 1, b: 2 })).toBe(canonical({ b: 2, a: 1 }));
+    expect(canonical({ x: { p: 1, q: 2 } })).toBe(canonical({ x: { q: 2, p: 1 } }));
+  });
+
+  // #5.1 — the undefined-fix. An in-memory event carrying an undefined-valued
+  // detail must hash IDENTICALLY to the form JSON.stringify writes to disk
+  // (JSON drops undefined-valued keys), otherwise verify would falsely report
+  // a tamper on a perfectly clean record.
+  it('computeHash() treats undefined-valued keys the same as the JSON disk form', () => {
+    const inMemory = { type: 't', details: { foo: undefined, bar: 1 } };
+    const onDisk = { type: 't', details: { bar: 1 } };
+    expect(computeHash(GENESIS, inMemory)).toBe(computeHash(GENESIS, onDisk));
+  });
+
+  it('verifyChain() returns valid for an untampered 3-event chain', () => {
+    const fp = path.join(tmpDir, 'chain.json');
+    writeChain(fp, [{ type: 'a' }, { type: 'b' }, { type: 'c' }]);
+    expect(verifyChain(fp)).toEqual({ valid: true, brokenAtSeq: null, reason: 'ok' });
+  });
+
+  // #3 — TAMPER (the headline RED): edit an interior record's payload but keep
+  // its stored seq + hash. The recomputed hash must no longer match.
+  it('verifyChain() detects an in-place edit of an interior record', () => {
+    const fp = path.join(tmpDir, 'chain.json');
+    writeChain(fp, [
+      { type: 'a', details: { v: 1 } },
+      { type: 'b', details: { v: 2 } },
+      { type: 'c', details: { v: 3 } },
+    ]);
+
+    const lines = readLines(fp);
+    const forged = JSON.parse(lines[1]); // seq 1
+    forged.details = { v: 999 };
+    lines[1] = JSON.stringify(forged);
+    fs.writeFileSync(fp, lines.join('\n') + '\n', 'utf-8');
+
+    const result = verifyChain(fp);
+    expect(result.valid).toBe(false);
+    expect(result.brokenAtSeq).toBe(1);
+  });
+
+  it('verifyChain() detects deletion of an interior line', () => {
+    const fp = path.join(tmpDir, 'chain.json');
+    writeChain(fp, [{ type: 'a' }, { type: 'b' }, { type: 'c' }]);
+    const lines = readLines(fp);
+    lines.splice(1, 1); // remove seq 1
+    fs.writeFileSync(fp, lines.join('\n') + '\n', 'utf-8');
+
+    const result = verifyChain(fp);
+    expect(result.valid).toBe(false);
+    expect(typeof result.brokenAtSeq).toBe('number');
+  });
+
+  it('verifyChain() detects insertion of a line', () => {
+    const fp = path.join(tmpDir, 'chain.json');
+    writeChain(fp, [{ type: 'a' }, { type: 'b' }, { type: 'c' }]);
+    const lines = readLines(fp);
+    lines.splice(1, 0, lines[0]); // duplicate line 0 into position 1
+    fs.writeFileSync(fp, lines.join('\n') + '\n', 'utf-8');
+
+    expect(verifyChain(fp).valid).toBe(false);
+  });
+
+  // #8 — TRUNCATION is a documented KNOWN LIMITATION, not a bug: a valid prefix
+  // of a chain is itself a valid chain, so per-file chaining cannot detect that
+  // trailing records were dropped.
+  it('verifyChain() does NOT detect truncation of trailing lines (known limitation)', () => {
+    const fp = path.join(tmpDir, 'chain.json');
+    writeChain(fp, [{ type: 'a' }, { type: 'b' }, { type: 'c' }]);
+    const lines = readLines(fp);
+    lines.pop(); // drop the last line (seq 2)
+    fs.writeFileSync(fp, lines.join('\n') + '\n', 'utf-8');
+
+    expect(verifyChain(fp).valid).toBe(true);
+  });
+});

--- a/tests/main/audit-logger.test.js
+++ b/tests/main/audit-logger.test.js
@@ -176,4 +176,131 @@ describe('audit-logger', () => {
     const content = fs.readFileSync(path.join(auditDir, files[0]), 'utf-8');
     expect(content).toContain('requeue-me');
   });
+
+  // --- tamper-evident hash chain (per-file) ---------------------------------
+
+  function todayFile() {
+    const auditDir = path.join(tmpDir, 'audit-logs');
+    const name = fs.readdirSync(auditDir).find((f) => f.endsWith('.json'));
+    return path.join(auditDir, name);
+  }
+
+  it('hash-chain: log x3 -> flush -> verifyChain valid with seq 0/1/2', () => {
+    auditLogger.init({ userDataPath: tmpDir });
+    auditLogger.log('t', { agent: 'A' });
+    auditLogger.log('t', { agent: 'B' });
+    auditLogger.log('t', { agent: 'C' });
+    auditLogger.flush();
+
+    const fp = todayFile();
+    const seqs = fs
+      .readFileSync(fp, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l).seq);
+    expect(seqs).toEqual([0, 1, 2]);
+    expect(auditLogger.verifyChain(fp)).toEqual({ valid: true, brokenAtSeq: null, reason: 'ok' });
+  });
+
+  it('hash-chain: details carrying undefined-valued keys still verify clean', () => {
+    auditLogger.init({ userDataPath: tmpDir });
+    // details.extra becomes the persisted `details` field; the undefined key is
+    // dropped by JSON.stringify on disk but must not break the chain.
+    auditLogger.log('t', { agent: 'A', extra: { foo: undefined, bar: 1 } });
+    auditLogger.flush();
+
+    expect(auditLogger.verifyChain(todayFile()).valid).toBe(true);
+  });
+
+  it('hash-chain: rotation — each day-file verifies, day 2 restarts at seq 0', () => {
+    let fakeNow = new Date(2026, 5, 5, 12, 0, 0); // 2026-06-05 (local, TZ-safe)
+    auditLogger.init({ userDataPath: tmpDir, now: () => fakeNow });
+    const auditDir = path.join(tmpDir, 'audit-logs');
+
+    auditLogger.log('day1', { agent: 'A' });
+    auditLogger.log('day1', { agent: 'B' });
+    auditLogger.flush();
+
+    fakeNow = new Date(2026, 5, 6, 12, 0, 0); // roll over to 2026-06-06
+    auditLogger.log('day2', { agent: 'C' });
+    auditLogger.flush();
+
+    const day1 = path.join(auditDir, 'aegis-audit-2026-06-05.json');
+    const day2 = path.join(auditDir, 'aegis-audit-2026-06-06.json');
+    expect(fs.existsSync(day1)).toBe(true);
+    expect(fs.existsSync(day2)).toBe(true);
+
+    expect(auditLogger.verifyChain(day1).valid).toBe(true);
+    expect(auditLogger.verifyChain(day2).valid).toBe(true);
+
+    const day2first = JSON.parse(fs.readFileSync(day2, 'utf-8').trim().split('\n')[0]);
+    expect(day2first.seq).toBe(0); // fresh chain, GENESIS-seeded
+  });
+
+  it('hash-chain: C-03 re-queue after a failed flush keeps the chain valid (no seq gap)', () => {
+    auditLogger.init({ userDataPath: tmpDir, onFlushError: vi.fn() });
+    const auditDir = path.join(tmpDir, 'audit-logs');
+
+    auditLogger.log('c03', { agent: 'first' });
+    auditLogger.log('c03', { agent: 'second' });
+
+    // First flush fails (dir gone) — entries must re-queue WITHOUT consuming seq.
+    fs.rmSync(auditDir, { recursive: true, force: true });
+    auditLogger.flush();
+
+    // Recover and flush again.
+    fs.mkdirSync(auditDir, { recursive: true });
+    auditLogger.flush();
+
+    const fp = todayFile();
+    const seqs = fs
+      .readFileSync(fp, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l).seq);
+    expect(seqs).toEqual([0, 1]); // contiguous, no gap from the failed flush
+    expect(auditLogger.verifyChain(fp).valid).toBe(true);
+  });
+
+  it('hash-chain: resumes the chain from the file tail after a same-day restart', async () => {
+    const now = () => new Date(2026, 5, 5, 12, 0, 0);
+    auditLogger.init({ userDataPath: tmpDir, now });
+    auditLogger.log('t', { agent: 'A' });
+    auditLogger.log('t', { agent: 'B' });
+    auditLogger.flush();
+    auditLogger.shutdown();
+
+    // Simulate a process restart: fresh module instance, same dir + same day.
+    vi.resetModules();
+    auditLogger = (await import('../../src/main/audit-logger.js')).default;
+    auditLogger.init({ userDataPath: tmpDir, now });
+    auditLogger.log('t', { agent: 'C' });
+    auditLogger.flush();
+
+    const fp = todayFile();
+    const seqs = fs
+      .readFileSync(fp, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l).seq);
+    expect(seqs).toEqual([0, 1, 2]); // continued from the tail, NOT restarted at 0
+    expect(auditLogger.verifyChain(fp).valid).toBe(true);
+  });
+
+  it('hash-chain: continues the in-memory chain across multiple same-day flushes', () => {
+    auditLogger.init({ userDataPath: tmpDir });
+    auditLogger.log('t', { agent: 'A' });
+    auditLogger.flush(); // seeds _chainDate
+    auditLogger.log('t', { agent: 'B' });
+    auditLogger.flush(); // hits the _chainDate === todayDate continuation branch
+
+    const fp = todayFile();
+    const seqs = fs
+      .readFileSync(fp, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l).seq);
+    expect(seqs).toEqual([0, 1]);
+    expect(auditLogger.verifyChain(fp).valid).toBe(true);
+  });
 });


### PR DESCRIPTION
Phase 3 trust. Per-file SHA-256 hash-chain on JSONL audit log: each record gains seq (0-based per daily file) + hash = sha256(prevHash + canonical(event)); prevHash recomputed from GENESIS, not stored. New module audit-hashchain.js (canonical/computeHash/verifyChain/seedFromTail). verifyChain detects in-place edits, interior insertions/deletions; does NOT detect trailing truncation (valid prefix = valid chain) -- documented in JSDoc + test #8. Per-file chain resets daily (retention-safe). C-03 recovery preserved (state advances only inside try -> reseed idempotent, no seq gaps). undefined-canonical trap fixed via JSON normalization. 13 new tests, TDD RED-proven. typecheck 0, lint 0, test 927. No IPC/UI wiring (out of scope). Honesty: tamper-evident (hash-chained), not tamper-proof.