### PR TITLE
refactor: remove dead code (C-19, C-20)

### DIFF
--- a/src/renderer/lib/components/ActivityFeed.svelte
+++ b/src/renderer/lib/components/ActivityFeed.svelte
@@ -74,7 +74,6 @@
     const m = String(d.getMinutes()).padStart(2, '0');
     const s = String(d.getSeconds()).padStart(2, '0');
     const diff = now - ts;
-    if (diff < 60000) return `${h}:${m}:${s}`;
     if (diff < 3600000) return `${h}:${m}:${s}`;
     if (diff < 86400000) return `${h}:${m}`;
     return `${d.getMonth() + 1}/${d.getDate()} ${h}:${m}`;

--- a/src/renderer/lib/components/AgentStatsPanel.svelte
+++ b/src/renderer/lib/components/AgentStatsPanel.svelte
@@ -23,7 +23,10 @@
   /** @type {import('../utils/agent-stats-utils.ts').SortDirection} */
   let sortDir = $state('desc');
 
-  let now = $derived($tick ? Date.now() : Date.now());
+  let now = $derived.by(() => {
+    $tick; // subscribe — re-derive each tick
+    return Date.now();
+  });
   let localAgents = $state([]);
 
   $effect(() => {


### PR DESCRIPTION
## Summary

Behavior-preserving dead-code purge. Two confirmed redundancies removed; one task item turned out to be live code and was intentionally left in place.

## Changes

- **C-19 — `AgentStatsPanel.svelte`**: `let now = $derived($tick ? Date.now() : Date.now())` used a ternary whose two arms are identical — pure theater to read `$tick`. Replaced with `$derived.by(() => { $tick; return Date.now(); })`, which touches `$tick` for reactivity (same idiom as `FooterMiniCharts.svelte:42`) and returns `Date.now()` unconditionally. Tick reactivity preserved; dead branch gone.
- **C-20 — `ActivityFeed.svelte` (`formatRelativeTime`)**: dropped the redundant `if (diff < 60000) return ...` guard, which returned the **same** `${h}:${m}:${s}` string as the subsuming `if (diff < 3600000)` guard. Output is byte-identical across every range.

## Not changed (task premise was wrong)

- **`win32.js` `extractCwdFromCommandLine`** was reported as dead (0 callers). Grep shows a **live caller** at `getProcessCwds` (L404), so it is not dead code. The L347 "inlined regex" is a *PowerShell* `-match` string in the single-PID path — a parallel implementation, not a duplicate. Left untouched to avoid breaking the batch CWD lookup.

## Verification

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | exit 0 |
| `npx eslint` (both files) | exit 0 |
| `svelte-check` | 0 errors / 0 warnings (213 files) |
| `npm test` | 933 passed, 4 skipped, 0 failed (59 files) |
| `npm run build:renderer` | built in 2.12s |

No regression — pass count did not drop.
