### PR TITLE
refactor: hoist sensitive-dir list to constants (single source of truth)

### DIFF
--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -19,7 +19,12 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const chokidar = require('chokidar');
-const { IGNORE_PATTERNS, AGENT_CONFIG_PATHS, AGENT_SELF_CONFIG } = require('../shared/constants');
+const {
+  IGNORE_PATTERNS,
+  AGENT_CONFIG_PATHS,
+  SENSITIVE_AGENT_DIRS,
+  AGENT_SELF_CONFIG,
+} = require('../shared/constants');
 const { getAllRules, reloadRules } = require('./rule-loader');
 const _platform = require('./platform');
 const { IGNORE_FILE_PATTERNS } = _platform;
@@ -231,9 +236,7 @@ function handleWatcherEvent(action, filePath) {
 /** @returns {Promise<void>} @since v0.1.0 */
 async function setupFileWatchers() {
   const homeDir = os.homedir();
-  const sensitiveDirCandidates = ['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.azure'].map((d) =>
-    path.join(homeDir, d),
-  );
+  const sensitiveDirCandidates = SENSITIVE_AGENT_DIRS.map((d) => path.join(homeDir, d));
   const sensitiveDirs = await filterExistingDirs(sensitiveDirCandidates);
   const projectDir = path.join(__dirname, '..', '..');
   if (sensitiveDirs.length > 0) {
@@ -248,7 +251,7 @@ async function setupFileWatchers() {
     _state.watchers.push(w);
   }
   // AI agent config directories (Hudson Rock threat vector — critical)
-  const sensitiveDirNames = new Set(['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.azure']);
+  const sensitiveDirNames = new Set(SENSITIVE_AGENT_DIRS);
   const agentConfigCandidates = AGENT_CONFIG_PATHS.filter((d) => !sensitiveDirNames.has(d)).map(
     (d) => path.join(homeDir, d),
   );

--- a/src/main/platform/restart-manager.js
+++ b/src/main/platform/restart-manager.js
@@ -30,17 +30,16 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { getAllRules } = require('../rule-loader');
-const { AGENT_CONFIG_PATHS } = require('../../shared/constants');
+const { AGENT_CONFIG_PATHS, SENSITIVE_AGENT_DIRS } = require('../../shared/constants');
 const { RM_CSHARP } = require('./rm-csharp');
 
 /**
- * Secret credential directories watched for held handles (mirror of the roots in
- * file-watcher.setupFileWatchers). Each existing dir becomes ONE registration
- * group → dir-level honest attribution ("holding a file under ~/.ssh"), never a
- * fabricated per-file claim RM cannot confirm.
- * @type {string[]}
+ * Secret credential directories watched for held handles. Each existing dir
+ * becomes ONE registration group → dir-level honest attribution ("holding a file
+ * under ~/.ssh"), never a fabricated per-file claim RM cannot confirm.
+ * @type {readonly string[]}
  */
-const SECRET_DIRS = ['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.azure'];
+const SECRET_DIRS = SENSITIVE_AGENT_DIRS;
 
 /**
  * The crown-jewel credential roots scanned by the FAST hot read-detect cycle

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -114,6 +114,16 @@ const AGENT_CONFIG_PATHS = [
 ];
 
 /**
+ * @type {readonly string[]} Secret credential directories (relative to home dir)
+ * watched for sensitive-file access. Single source of truth shared by
+ * file-watcher.setupFileWatchers (the credential roots + the Set that dedupes
+ * them out of the agent-config watch) and restart-manager (held-handle scan).
+ * Order and membership are load-bearing — keep byte-identical across consumers.
+ * @since 0.10.0
+ */
+const SENSITIVE_AGENT_DIRS = ['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.azure'];
+
+/**
  * @type {Readonly<Record<string, RegExp>>} Map of agent name keywords to their own config directory patterns.
  * Used for self-access exemption: an agent accessing its OWN config is expected, not a threat.
  * @since 0.3.0
@@ -409,6 +419,7 @@ module.exports = {
   EDITOR_HOSTS,
   IGNORE_PATTERNS,
   AGENT_CONFIG_PATHS,
+  SENSITIVE_AGENT_DIRS,
   AGENT_SELF_CONFIG,
   SENSITIVE_RULES,
   PERMISSION_CATEGORIES,


### PR DESCRIPTION
## What

Hoist the sensitive-dir credential list `['.ssh', '.aws', '.gnupg', '.kube', '.docker', '.azure']` into a single named export `SENSITIVE_AGENT_DIRS` in `src/shared/constants.js`, and replace the three byte-identical hardcodes that previously duplicated it:

- `file-watcher.js` — the credential-root candidates (`setupFileWatchers`)
- `file-watcher.js` — the `Set` that dedupes those roots out of the agent-config watch
- `restart-manager.js` — `SECRET_DIRS` (held-handle scan), whose JSDoc openly admitted being a "mirror of … file-watcher" — now an alias of the shared constant, comment removed

## Why

The list lived in three places. Two of them (`.aws`, `.docker`) also appear in `AGENT_CONFIG_PATHS`, and the `Set` at `file-watcher.js` subtracts them so the agent-config watcher doesn't double-register the same path. With three independent copies, that dedupe key could silently drift out of sync with the roots it filters against. One source of truth makes the drift structurally impossible.

## Behavior

Zero behavior change. The new export is byte-identical to all three previous literals (verified before merging). `restart-manager`'s `HOT_DIRS = ['.ssh', '.aws', '.gnupg']` — a deliberate strict subset — is intentionally left untouched.

## Verify gate

- `npx tsc --noEmit` — clean
- `npx eslint` (3 touched files) — 0
- `npm test` — 933 passed, 4 skipped (no change)
- `npm run build:renderer` — built
