### PR TITLE
perf: instrument win32 spawn timing (measure-only)

### DIFF
--- a/src/main/platform/restart-manager.js
+++ b/src/main/platform/restart-manager.js
@@ -29,6 +29,7 @@ const { execFile } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const logger = require('../logger');
 const { getAllRules } = require('../rule-loader');
 const { AGENT_CONFIG_PATHS, SENSITIVE_AGENT_DIRS } = require('../../shared/constants');
 const { RM_CSHARP } = require('./rm-csharp');
@@ -159,6 +160,20 @@ function buildSensitiveGroups(
 }
 
 /**
+ * Measure-only spawn-timing probe: log the Restart Manager scan's external
+ * powershell.exe spawn round-trip duration to the operational log under
+ * mod='perf' (one NDJSON line per spawn). The logger stamps `timestamp` (ts) and
+ * `module` ('perf'); meta carries the spawn label and elapsed ms. Pure
+ * instrumentation — never alters read-detect behavior.
+ * @param {string} spawn - Spawn label (handle).
+ * @param {number} t0 - performance.now() captured immediately before the spawn.
+ * @returns {void}
+ */
+function logSpawnTax(spawn, t0) {
+  logger.debug('perf', 'spawn', { spawn, ms: Math.round(performance.now() - t0) });
+}
+
+/**
  * Run the Restart Manager scan: ONE powershell.exe spawn, one RM session per
  * group (sequentially opened/closed), returning every process holding a handle
  * to a registered sensitive resource. Holders are returned RAW (including
@@ -178,6 +193,7 @@ function getSensitiveHolders(dirNames, includeEnv) {
   const groups = buildSensitiveGroups(dirNames, includeEnv);
   if (groups.length === 0) return Promise.resolve([]);
   return new Promise((resolve) => {
+    const t0 = performance.now();
     execFile(
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', PS_BODY],
@@ -187,6 +203,7 @@ function getSensitiveHolders(dirNames, includeEnv) {
         env: { ...process.env, AEGIS_RM_GROUPS: JSON.stringify(groups) },
       },
       (err, stdout) => {
+        logSpawnTax('handle', t0);
         if (err) {
           resolve([]);
           return;

--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -38,12 +38,27 @@ const IGNORE_FILE_PATTERNS = [
 ];
 
 /**
+ * Measure-only spawn-timing probe: log one external spawn's round-trip duration
+ * to the operational log under mod='perf' (one NDJSON line per spawn). The logger
+ * stamps `timestamp` (ts) and `module` ('perf'); meta carries the spawn label and
+ * elapsed ms. Pure instrumentation — never alters collection behavior.
+ * @param {string} spawn - Spawn label (tasklist|cim-parent|cim-cwd).
+ * @param {number} t0 - performance.now() captured immediately before the spawn.
+ * @returns {void}
+ */
+function logSpawnTax(spawn, t0) {
+  logger.debug('perf', 'spawn', { spawn, ms: Math.round(performance.now() - t0) });
+}
+
+/**
  * List running processes via tasklist CSV output.
  * @returns {Promise<Array<{name: string, pid: number}>>}
  */
 function listProcesses() {
   return new Promise((resolve, reject) => {
+    const t0 = performance.now();
     execFile('tasklist', ['/FO', 'CSV', '/NH'], (err, stdout) => {
+      logSpawnTax('tasklist', t0);
       if (err) {
         reject(err);
         return;
@@ -76,11 +91,13 @@ function getParentProcessMap() {
       'Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,Name,CreationDate|ForEach-Object{$r[[string]$_.ProcessId]=@{n=$_.Name;p=[int]$_.ParentProcessId;t=$(if($_.CreationDate){([DateTimeOffset]$_.CreationDate).ToUnixTimeMilliseconds()}else{$null})}}',
       '$r|ConvertTo-Json -Compress',
     ].join('\n');
+    const t0 = performance.now();
     execFile(
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', psScript],
       { timeout: 8000 },
       (err, stdout) => {
+        logSpawnTax('cim-parent', t0);
         const map = new Map();
         if (!err && stdout.trim()) {
           try {
@@ -386,11 +403,13 @@ function getProcessCwds(pids) {
   return new Promise((resolve) => {
     const pidFilter = validPids.map((p) => `ProcessId=${p}`).join(' OR ');
     const psScript = `$ErrorActionPreference="SilentlyContinue";Get-CimInstance Win32_Process -Filter '${pidFilter}' -Property ProcessId,CommandLine | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress`;
+    const t0 = performance.now();
     execFile(
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', psScript],
       { timeout: 8000 },
       (err, stdout) => {
+        logSpawnTax('cim-cwd', t0);
         const map = new Map();
         if (err || !stdout.trim()) {
           resolve(map);


### PR DESCRIPTION
## What

Adds **measure-only** timing instrumentation around each external spawn in the win32 collection path. No behavior change — pure measurement to size the per-cycle "spawn tax" ahead of a future spawn-merge PR.

## Spawns instrumented (4, per the recon count)

| spawn label | function | file |
|-------------|----------|------|
| `tasklist`   | `listProcesses`       | `src/main/platform/win32.js` |
| `cim-parent` | `getParentProcessMap` | `src/main/platform/win32.js` |
| `cim-cwd`    | `getProcessCwds`      | `src/main/platform/win32.js` |
| `handle`     | `getSensitiveHolders` (RmGetList read-detect) | `src/main/platform/restart-manager.js` |

Each spawn is wrapped with `const t0 = performance.now()` immediately before `execFile`, and a `logSpawnTax(label, t0)` call as the **first** statement inside the callback (before any `if (err)` early-return), so error/timeout spawns are measured too.

## Log shape

One NDJSON line per spawn, into the existing `aegis-<DATE>.log` via the current `logger` (no new log file), matching the sibling `scan-loop.js` timing idiom:

```json
{"timestamp":"<iso>","level":"debug","module":"perf","message":"spawn","meta":{"spawn":"tasklist","ms":123}}
```

`module:'perf'` = the requested `mod`, `timestamp` = `ts`, and `meta.{spawn,ms}` carry the label + round-trip ms. `logger.debug` is recorded in dev and packaged (logger inits with `minLevel` defaulting to `debug`).

## Diff scope

`+36 / -0` — every PowerShell command string, parser branch, timeout, and env option is byte-for-byte untouched. Only additions: the `logSpawnTax` helper (one per file), one `require('../logger')` in restart-manager, and the per-spawn `t0` + log wrappers.

`getHotSensitiveHolders` routes through `getSensitiveHolders`, so the single `handle` instrumentation covers both the ~10s hot cycle and the 30s full scan (both emit `spawn:'handle'` on their own cadence — expected).

## Out of scope (note for follow-up)

`getRawTcpConnections` (network) is also a per-cycle win32 spawn but was not in the recon's ~4 count — deliberately left out of this PR. Add it in a follow-up if network belongs in the spawn-tax picture. Legacy `getFileHandles` (handle.exe) is dead on win32 (short-circuits to `[]` without spawning when the binary is absent) and is intentionally not instrumented.

## Verify gate

- `npx tsc --noEmit` → 0
- `npx eslint <changed files>` → 0
- `npm test` → 933 passed, 4 skipped (no regression)
- `npm run build:renderer` → ✓
