### PR TITLE
fix(attribution): three-state attribution — never blame a substitute agent (C-01)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ _gitignore
 AEGIS-CONTEXT-*.md
 AEGIS-PERSONA-VAULT.md
 
+# Claude Code hook telemetry (UserPromptSubmit) — not produced by AEGIS
+events.jsonl
+
 # Sensitive production/cert files
 .env.production
 *.cert

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -347,7 +346,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -757,6 +755,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -778,6 +777,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -794,6 +794,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -808,6 +809,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1300,6 +1302,7 @@
       "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^3.0.3",
         "debug": "^4.3.1",
@@ -1315,6 +1318,7 @@
       "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.1.1"
       },
@@ -1328,6 +1332,7 @@
       "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1362,6 +1367,7 @@
       "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
@@ -1372,6 +1378,7 @@
       "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.1.1",
         "levn": "^0.4.1"
@@ -1404,6 +1411,7 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1414,6 +1422,7 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -1428,6 +1437,7 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -1442,6 +1452,7 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -2605,7 +2616,6 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -2802,7 +2812,8 @@
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2840,7 +2851,8 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
@@ -2952,7 +2964,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3326,7 +3337,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3359,7 +3369,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4362,7 +4371,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4535,7 +4545,8 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -4701,7 +4712,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -5010,6 +5020,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5030,6 +5041,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5366,6 +5378,7 @@
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
         "@types/estree": "^1.0.8",
@@ -5398,6 +5411,7 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -5411,6 +5425,7 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -5424,6 +5439,7 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5441,6 +5457,7 @@
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
@@ -5459,6 +5476,7 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -5472,6 +5490,7 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -5605,7 +5624,8 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -5623,6 +5643,7 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -5688,6 +5709,7 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -5705,6 +5727,7 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -5718,7 +5741,8 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
       "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -6573,7 +6597,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -6627,7 +6650,8 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -6690,6 +6714,7 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -6853,6 +6878,7 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -7335,6 +7361,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7543,6 +7570,7 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -7677,6 +7705,7 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -7726,6 +7755,7 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7904,7 +7934,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8029,6 +8058,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -8046,6 +8076,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8056,6 +8087,7 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -8066,7 +8098,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8378,6 +8409,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -8971,7 +9003,6 @@
       "integrity": "sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -9050,6 +9081,21 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/svelte-check/node_modules/readdirp": {
@@ -9185,6 +9231,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -9320,7 +9367,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9453,6 +9499,7 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -9480,7 +9527,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9587,7 +9633,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9681,7 +9726,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9715,7 +9759,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -9898,6 +9941,7 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "ajv": "^6.14.0",
         "chokidar": "^3.6.0",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -306,6 +306,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -346,6 +347,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -755,7 +757,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -777,7 +778,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -794,7 +794,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -809,7 +808,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1302,7 +1300,6 @@
       "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^3.0.3",
         "debug": "^4.3.1",
@@ -1318,7 +1315,6 @@
       "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.1.1"
       },
@@ -1332,7 +1328,6 @@
       "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1367,7 +1362,6 @@
       "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
@@ -1378,7 +1372,6 @@
       "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.1.1",
         "levn": "^0.4.1"
@@ -1411,7 +1404,6 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1422,7 +1414,6 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -1437,7 +1428,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -1452,7 +1442,6 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -2616,6 +2605,7 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -2812,8 +2802,7 @@
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2851,8 +2840,7 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
@@ -2964,6 +2952,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3337,6 +3326,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3369,6 +3359,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4371,8 +4362,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4545,8 +4535,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -4712,6 +4701,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -5020,7 +5010,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5041,7 +5030,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5378,7 +5366,6 @@
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
         "@types/estree": "^1.0.8",
@@ -5411,7 +5398,6 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -5425,7 +5411,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -5439,7 +5424,6 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5457,7 +5441,6 @@
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
@@ -5476,7 +5459,6 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -5490,7 +5472,6 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -5624,8 +5605,7 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -5643,7 +5623,6 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -5709,7 +5688,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -5727,7 +5705,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -5741,8 +5718,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
       "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -6570,9 +6546,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6587,6 +6573,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -6640,8 +6627,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -6704,7 +6690,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -6868,7 +6853,6 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -7351,7 +7335,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7560,7 +7543,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -7695,7 +7677,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -7745,7 +7726,6 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7924,6 +7904,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8048,7 +8029,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -8066,7 +8046,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8077,7 +8056,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -8088,6 +8066,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8399,7 +8378,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -8993,6 +8971,7 @@
       "integrity": "sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -9071,21 +9050,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/svelte-check/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/svelte-check/node_modules/readdirp": {
@@ -9221,7 +9185,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -9357,6 +9320,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9489,7 +9453,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -9517,6 +9480,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9623,6 +9587,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9716,6 +9681,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9749,6 +9715,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -9931,7 +9898,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "dependencies": {
     "ajv": "^6.14.0",
     "chokidar": "^3.6.0",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.3.0"
   },
   "overrides": {
     "picomatch@<=2.3.1": "^2.3.2"

--- a/src/main/ai-analysis.js
+++ b/src/main/ai-analysis.js
@@ -234,6 +234,9 @@ function analyzeSessionActivity() {
     // Per-agent summary
     const agentSummaries = {};
     for (const ev of allEvents) {
+      // An unattributed event has no owner (agent ''), and an empty-keyed bucket
+      // would ship a nameless "agent" into the prompt sent to the model.
+      if (ev.attribution?.status === 'unattributed' || !ev.agent) continue;
       if (!agentSummaries[ev.agent])
         agentSummaries[ev.agent] = { files: 0, sensitive: 0, configAccess: 0, reasons: new Set() };
       agentSummaries[ev.agent].files++;

--- a/src/main/ai-analysis.js
+++ b/src/main/ai-analysis.js
@@ -13,6 +13,7 @@
 'use strict';
 
 const https = require('https');
+const { UNKNOWN_SOURCE_LABEL } = require('./attribution');
 
 /** Max allowed lengths for untrusted fields */
 const FIELD_LIMITS = { agentName: 256, path: 1024, reason: 512 };
@@ -271,7 +272,7 @@ function analyzeSessionActivity() {
         .slice(-30)
         .map(
           (e) =>
-            `  - [${sanitizeField(e.agent, FIELD_LIMITS.agentName)}] ${e.action}: ${sanitizeField(e.file, FIELD_LIMITS.path)} (${sanitizeField(e.reason, FIELD_LIMITS.reason)})`,
+            `  - [${sanitizeField(e.agent || UNKNOWN_SOURCE_LABEL, FIELD_LIMITS.agentName)}] ${e.action}: ${sanitizeField(e.file, FIELD_LIMITS.path)} (${sanitizeField(e.reason, FIELD_LIMITS.reason)})`,
         )
         .join('\n') || '  (none)';
     const configDetails =
@@ -279,7 +280,7 @@ function analyzeSessionActivity() {
         .slice(-20)
         .map(
           (e) =>
-            `  - [${sanitizeField(e.agent, FIELD_LIMITS.agentName)}] ${e.action}: ${sanitizeField(e.file, FIELD_LIMITS.path)} (${sanitizeField(e.reason, FIELD_LIMITS.reason)})`,
+            `  - [${sanitizeField(e.agent || UNKNOWN_SOURCE_LABEL, FIELD_LIMITS.agentName)}] ${e.action}: ${sanitizeField(e.file, FIELD_LIMITS.path)} (${sanitizeField(e.reason, FIELD_LIMITS.reason)})`,
         )
         .join('\n') || '  (none)';
     const netDetails =

--- a/src/main/attribution.js
+++ b/src/main/attribution.js
@@ -1,0 +1,108 @@
+/**
+ * @file attribution.js
+ * @module main/attribution
+ * @description Attribution status + evidence for file events — answers ONE
+ *   question: how do we know which agent a file event belongs to.
+ *
+ *   Three statuses, a CLOSED list of six evidence codes, and deliberately NO
+ *   numeric confidence anywhere. A score invites "0.7 is probably fine" reasoning
+ *   where the honest answer is a hard three-way distinction: resolved from a PID
+ *   (`confirmed`), guessed from a path (`inferred`), or unknown (`unattributed`).
+ *   An unattributed event keeps no agent at all — substituting one would poison
+ *   that agent's baselines, risk score and audit trail (C-01).
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.11.0
+ */
+'use strict';
+
+/**
+ * Closed list of evidence codes. Nothing outside this list may appear in an
+ * event's `attribution.evidence` — {@link deriveStatus} throws on an unknown
+ * code so a typo can never silently degrade an event into `unattributed`.
+ *
+ * PID-backed (→ `confirmed`):
+ * - `rm-holder-pid` — Restart Manager reported this PID as holding the resource.
+ * - `handle-scan-pid` — the per-PID handle scan was run FOR this agent's pid.
+ *
+ * Heuristic (→ `inferred`):
+ * - `self-config-path` — the path matches this agent's OWN config dir.
+ * - `cwd-containment` — the path lies inside this agent's working directory.
+ *
+ * Negative (→ `unattributed`):
+ * - `no-owner-match` — no self-config and no cwd containment matched any AI agent.
+ * - `no-ai-agents-online` — no AI-category agent was online to own the event.
+ * @type {Readonly<Object<string, string>>}
+ * @since v0.11.0
+ */
+const EVIDENCE = Object.freeze({
+  RM_HOLDER_PID: 'rm-holder-pid',
+  HANDLE_SCAN_PID: 'handle-scan-pid',
+  SELF_CONFIG_PATH: 'self-config-path',
+  CWD_CONTAINMENT: 'cwd-containment',
+  NO_OWNER_MATCH: 'no-owner-match',
+  NO_AI_AGENTS_ONLINE: 'no-ai-agents-online',
+});
+
+/**
+ * Every legal evidence code, in declaration order. Mirrors the
+ * `AttributionEvidence` union in src/shared/types/events.ts.
+ * @type {ReadonlyArray<string>}
+ * @since v0.11.0
+ */
+const EVIDENCE_CODES = Object.freeze(Object.values(EVIDENCE));
+
+/** @type {Set<string>} Lookup set for the closed-list check. */
+const KNOWN_CODES = new Set(EVIDENCE_CODES);
+
+/** @type {Set<string>} PID-backed codes — any one of them means `confirmed`. */
+const PID_EVIDENCE = new Set([EVIDENCE.RM_HOLDER_PID, EVIDENCE.HANDLE_SCAN_PID]);
+
+/** @type {Set<string>} Heuristic codes — any one of them means `inferred`. */
+const HEURISTIC_EVIDENCE = new Set([EVIDENCE.SELF_CONFIG_PATH, EVIDENCE.CWD_CONTAINMENT]);
+
+/**
+ * Derive the attribution status from a list of evidence codes.
+ *
+ * PID beats heuristic: an event whose agent came from a holder PID stays
+ * `confirmed` even when `self-config-path` is also present — that second code
+ * only documents WHY the self-access exemption applied, it does not weaken the
+ * PID proof.
+ * @param {string[]} evidence - One or more codes from {@link EVIDENCE_CODES}.
+ * @returns {string} `'confirmed'` | `'inferred'` | `'unattributed'`.
+ * @throws {Error} When evidence is not a non-empty array, or carries a code
+ *   outside the closed list.
+ * @since v0.11.0
+ */
+function deriveStatus(evidence) {
+  if (!Array.isArray(evidence) || evidence.length === 0) {
+    throw new Error('attribution: evidence must be a non-empty array');
+  }
+  for (const code of evidence) {
+    if (!KNOWN_CODES.has(code)) {
+      throw new Error(`attribution: unknown evidence code "${code}"`);
+    }
+  }
+  if (evidence.some((c) => PID_EVIDENCE.has(c))) return 'confirmed';
+  if (evidence.some((c) => HEURISTIC_EVIDENCE.has(c))) return 'inferred';
+  return 'unattributed';
+}
+
+/**
+ * Build the `attribution` object stamped onto a file event. The evidence array is
+ * copied so a caller's mutable working array can never leak into the event.
+ * @param {string[]} evidence - One or more codes from {@link EVIDENCE_CODES}.
+ * @returns {{status: string, evidence: string[]}}
+ * @throws {Error} Propagated from {@link deriveStatus} on invalid evidence.
+ * @since v0.11.0
+ */
+function makeAttribution(evidence) {
+  return { status: deriveStatus(evidence), evidence: [...evidence] };
+}
+
+module.exports = {
+  EVIDENCE,
+  EVIDENCE_CODES,
+  deriveStatus,
+  makeAttribution,
+};

--- a/src/main/attribution.js
+++ b/src/main/attribution.js
@@ -55,6 +55,23 @@ const EVIDENCE_CODES = Object.freeze(Object.values(EVIDENCE));
 /** @type {Set<string>} Lookup set for the closed-list check. */
 const KNOWN_CODES = new Set(EVIDENCE_CODES);
 
+/**
+ * Human-facing label for an event with no known owner (`agent: ''`). Used
+ * wherever a main-process surface shows the name to a PERSON — tray body, CSV,
+ * HTML report, LLM prompt — so a blank never reads as a formatting bug.
+ *
+ * NOT for machine-readable output: a JSON export must keep the raw empty `agent`
+ * plus the attribution status, otherwise a downstream tool would group real
+ * activity under a fabricated agent name.
+ *
+ * The renderer keeps its own copy in lib/utils/grouped-feed-utils.ts — main is
+ * CJS and the renderer never imports from src/main, so the string cannot be
+ * shared across the process boundary. Keep the two in sync.
+ * @type {string}
+ * @since v0.11.0
+ */
+const UNKNOWN_SOURCE_LABEL = 'Unknown source';
+
 /** @type {Set<string>} PID-backed codes — any one of them means `confirmed`. */
 const PID_EVIDENCE = new Set([EVIDENCE.RM_HOLDER_PID, EVIDENCE.HANDLE_SCAN_PID]);
 
@@ -103,6 +120,7 @@ function makeAttribution(evidence) {
 module.exports = {
   EVIDENCE,
   EVIDENCE_CODES,
+  UNKNOWN_SOURCE_LABEL,
   deriveStatus,
   makeAttribution,
 };

--- a/src/main/exports.js
+++ b/src/main/exports.js
@@ -16,8 +16,21 @@
 const fs = require('fs');
 const path = require('path');
 const { dialog, shell, app } = require('electron');
+const { UNKNOWN_SOURCE_LABEL } = require('./attribution');
 
 let _state = null;
+
+/**
+ * Agent name for a HUMAN-facing export cell (CSV, HTML report). An unattributed
+ * event carries `agent: ''`; a blank cell in a report the user forwards to
+ * someone else reads as a bug rather than as "we did not know".
+ * @param {Object} ev - Activity-log event.
+ * @returns {string}
+ * @since v0.11.0
+ */
+function displayAgent(ev) {
+  return ev.agent || UNKNOWN_SOURCE_LABEL;
+}
 
 /**
  * Initialise with shared state references.
@@ -100,6 +113,9 @@ async function exportLog() {
       peakAgents: stats.peakAgents,
       uniqueAgents: stats.uniqueAgents,
     },
+    // MACHINE-readable: `agent` stays raw ('' when unattributed) and the status
+    // is exported alongside it. Substituting a display label here would make a
+    // downstream tool group real activity under an agent that does not exist.
     events: _state.activityLog.map((e) => ({
       timestamp: new Date(e.timestamp).toISOString(),
       agent: e.agent,
@@ -108,6 +124,7 @@ async function exportLog() {
       sensitive: e.sensitive,
       reason: e.reason,
       action: e.action || 'accessed',
+      attribution: e.attribution ? e.attribution.status : null,
     })),
   };
   fs.writeFileSync(result.filePath, JSON.stringify(payload, null, 2));
@@ -133,7 +150,7 @@ async function exportCsv() {
       const ts = new Date(e.timestamp).toISOString();
       const action = e.action || 'accessed';
       const sensitive = e.sensitive ? 'yes' : 'no';
-      return [ts, e.agent, action, e.file, sensitive].map(csvEscape).join(',');
+      return [ts, displayAgent(e), action, e.file, sensitive].map(csvEscape).join(',');
     })
     .join('\n');
   const netConns = _state.getLatestNetConnections();
@@ -164,8 +181,10 @@ async function generateReport() {
   const sensitiveEvents = _state.activityLog.filter((e) => e.sensitive);
   const netConns = _state.getLatestNetConnections();
   const agentFileCounts = {};
-  for (const e of _state.activityLog)
-    agentFileCounts[e.agent] = (agentFileCounts[e.agent] || 0) + 1;
+  for (const e of _state.activityLog) {
+    const name = displayAgent(e);
+    agentFileCounts[name] = (agentFileCounts[name] || 0) + 1;
+  }
   const maxCount = Math.max(1, ...Object.values(agentFileCounts));
   const barChartRows = Object.entries(agentFileCounts)
     .map(([agent, count]) => {
@@ -176,7 +195,7 @@ async function generateReport() {
   const sensitiveRows = sensitiveEvents
     .map((e) => {
       const ts = new Date(e.timestamp).toISOString().replace('T', ' ').slice(0, 19);
-      return `<tr><td style="padding:3px 8px;color:#546e7a">${escHtml(ts)}</td><td style="padding:3px 8px;color:#00e5ff">${escHtml(e.agent)}</td><td style="padding:3px 8px;color:#ff1744">${escHtml(e.file)}</td><td style="padding:3px 8px;color:#ffc107">${escHtml(e.reason)}</td></tr>`;
+      return `<tr><td style="padding:3px 8px;color:#546e7a">${escHtml(ts)}</td><td style="padding:3px 8px;color:#00e5ff">${escHtml(displayAgent(e))}</td><td style="padding:3px 8px;color:#ff1744">${escHtml(e.file)}</td><td style="padding:3px 8px;color:#ffc107">${escHtml(e.reason)}</td></tr>`;
     })
     .join('');
   const netRows = netConns

--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -26,6 +26,7 @@ const {
   AGENT_SELF_CONFIG,
 } = require('../shared/constants');
 const { getAllRules, reloadRules } = require('./rule-loader');
+const { EVIDENCE, makeAttribution } = require('./attribution');
 const _platform = require('./platform');
 const { IGNORE_FILE_PATTERNS } = _platform;
 
@@ -141,23 +142,31 @@ function isSelfAccess(agentName, filePath) {
  * Find the AI agent that owns a file path so the event is attributed to it
  * (and the self-access exemption is checked against the right agent). An
  * agent's OWN config dir wins first — a cwd may contain another agent's config
- * dir, so self-config must outrank cwd containment. Returns null if none match,
- * letting the caller fall back to its prior default.
+ * dir, so self-config must outrank cwd containment.
+ *
+ * Returns the owner TOGETHER WITH the evidence code that resolved it, so the
+ * caller never has to re-derive "why" (and never re-runs isSelfAccess against a
+ * different agent). Returns null when nothing matches — the caller must then emit
+ * an UNATTRIBUTED event rather than blame a substitute (C-01).
  * @param {string} filePath - Resolved file path from the watcher event.
  * @param {Array<{agent:string,cwd?:string}>} aiAgents - Candidate AI agents.
- * @returns {Object|null} The owning agent, or null when no agent matches.
+ * @returns {{agent: Object, evidence: string[]}|null} Owner plus why, or null.
  * @since v0.10.0
  */
 function findOwningAgent(filePath, aiAgents) {
   for (const a of aiAgents) {
-    if (isSelfAccess(a.agent, filePath)) return a;
+    if (isSelfAccess(a.agent, filePath)) {
+      return { agent: a, evidence: [EVIDENCE.SELF_CONFIG_PATH] };
+    }
   }
   const target = process.platform === 'win32' ? filePath.toLowerCase() : filePath;
   for (const a of aiAgents) {
     if (!a.cwd) continue;
     let base = path.resolve(a.cwd);
     if (process.platform === 'win32') base = base.toLowerCase();
-    if (target === base || target.startsWith(base + path.sep)) return a;
+    if (target === base || target.startsWith(base + path.sep)) {
+      return { agent: a, evidence: [EVIDENCE.CWD_CONTAINMENT] };
+    }
   }
   return null;
 }
@@ -208,20 +217,36 @@ function handleWatcherEvent(action, filePath) {
   const reason = classifySensitive(filePath);
   const aiAgents = _state.getLatestAiAgents();
   const owner = aiAgents.length > 0 ? findOwningAgent(filePath, aiAgents) : null;
-  const agent = owner || (aiAgents.length > 0 ? aiAgents[0] : agents[0]);
-  const selfAccess = reason !== null && isSelfAccess(agent.agent, filePath);
+  // C-01: chokidar hands us a PATH, never a PID — so this path can be `inferred`
+  // at best, and MUST be `unattributed` when no owner matches. Substituting the
+  // first AI agent (or the first agent of any kind) poisoned that agent's
+  // baselines, risk score, tray alert and audit trail. `pid: null`, not 0 — pid 0
+  // is taken by synthetic WSL / local-runtime agents, so 0 would collide with a
+  // real agent card.
+  const evidence = owner
+    ? owner.evidence
+    : [aiAgents.length > 0 ? EVIDENCE.NO_OWNER_MATCH : EVIDENCE.NO_AI_AGENTS_ONLINE];
+  const attribution = makeAttribution(evidence);
+  const agent = owner ? owner.agent : null;
+  // D2: the self-access exemption belongs to the agent that OWNS the path, and is
+  // implied by the evidence — findOwningAgent's first loop already ran
+  // isSelfAccess over every AI agent, so reaching the cwd branch (or no branch at
+  // all) proves no agent self-matched. Re-running it against a substituted agent
+  // is what let a foreign agent's exemption silently clear `sensitive`.
+  const selfAccess = reason !== null && evidence.includes(EVIDENCE.SELF_CONFIG_PATH);
   const event = {
-    agent: agent.agent,
-    pid: agent.pid,
-    parentEditor: agent.parentEditor || null,
-    cwd: agent.cwd || null,
+    agent: agent ? agent.agent : '',
+    pid: agent ? agent.pid : null,
+    parentEditor: (agent && agent.parentEditor) || null,
+    cwd: (agent && agent.cwd) || null,
     file: filePath,
     sensitive: reason !== null && !selfAccess,
     selfAccess,
     reason: reason || '',
     action,
     timestamp: now,
-    category: agent.category || 'other',
+    category: agent ? agent.category || 'other' : 'other',
+    attribution,
   };
   _state.activityLog.push(event);
   if (_state.onActivityPush) _state.onActivityPush(event);
@@ -229,7 +254,12 @@ function handleWatcherEvent(action, filePath) {
     const evicted = _state.activityLog.shift();
     if (_state.onActivityEvict) _state.onActivityEvict(evicted);
   }
-  _state.recordFileAccess(event.agent, filePath, event.sensitive, event.reason);
+  // An unattributed event enters NO agent's behaviour baseline: recording it under
+  // an empty name would create a phantom agent in sessionData, which
+  // checkDeviations() then iterates and warns about.
+  if (attribution.status !== 'unattributed') {
+    _state.recordFileAccess(event.agent, filePath, event.sensitive, event.reason);
+  }
   if (_state.onFileEvent) _state.onFileEvent(event);
 }
 
@@ -337,6 +367,9 @@ async function scanFileHandles(agent) {
     }
     const reason = classifySensitive(f);
     const selfAccess = reason !== null && isSelfAccess(agent.agent, f);
+    // Confirmed: this scan was run FOR agent.pid, so the owner IS the pid.
+    const evidence = [EVIDENCE.HANDLE_SCAN_PID];
+    if (selfAccess) evidence.push(EVIDENCE.SELF_CONFIG_PATH);
     const event = {
       agent: agent.agent,
       pid,
@@ -349,6 +382,7 @@ async function scanFileHandles(agent) {
       action: 'accessed',
       timestamp: Date.now(),
       category: agent.category || 'other',
+      attribution: makeAttribution(evidence),
     };
     newAccess.push(event);
     _state.activityLog.push(event);
@@ -449,6 +483,9 @@ async function _scanRmHolders(agents, fetchHolders) {
     const reason = h.reason || classifySensitive(groupSep) || classifySensitive(group) || '';
     const selfAccess =
       reason !== '' && (isSelfAccess(agent.agent, groupSep) || isSelfAccess(agent.agent, group));
+    // Confirmed: the agent was resolved from the holder PID (never cross-wired).
+    const evidence = [EVIDENCE.RM_HOLDER_PID];
+    if (selfAccess) evidence.push(EVIDENCE.SELF_CONFIG_PATH);
     const event = {
       agent: agent.agent,
       pid: h.pid,
@@ -461,6 +498,7 @@ async function _scanRmHolders(agents, fetchHolders) {
       action: 'holding',
       timestamp: Date.now(),
       category: agent.category || 'other',
+      attribution: makeAttribution(evidence),
     };
     newAccess.push(event);
     _state.activityLog.push(event);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -328,7 +328,15 @@ function initDeferredSubsystems(userData) {
       const deduped = scanLoop.dedupFileEvent(ev);
       if (!deduped) return;
       fileAccessBatcher.push(deduped);
-      if (deduped.sensitive && deduped.category === 'ai') tray.notifySensitive([deduped]);
+      // An unattributed hit carries category 'other' (no agent to take it from),
+      // so the ai-only gate would silence exactly the crown-jewel case: a secret
+      // touched with no known owner. A vague alert beats no alert.
+      if (
+        deduped.sensitive &&
+        (deduped.category === 'ai' || deduped.attribution?.status === 'unattributed')
+      ) {
+        tray.notifySensitive([deduped]);
+      }
       statsUpdateBatcher.push(getStats());
       tray.updateTrayIcon();
       scanLoop.logAuditForFile(deduped);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -61,6 +61,34 @@ const fileWatchers = [];
 // ═══ RUNNING COUNTERS for getStats() — O(1) instead of O(n) ═══
 let totalSensitive = 0;
 let aiSensitive = 0;
+// ── Attribution counters (blindness metric) ──
+// How many events in the CURRENT activity log we could attach to an agent by PID
+// (confirmed), only by path heuristic (inferred), or not at all (unattributed).
+// attrUnattributedSensitive is the honest blindness number: sensitive accesses we
+// observed but could not blame on anyone.
+let attrConfirmed = 0;
+let attrInferred = 0;
+let attrUnattributed = 0;
+let attrUnattributedSensitive = 0;
+
+/**
+ * Move the attribution counters by `delta` for one event. Called with +1 on push
+ * and -1 on eviction so the counters always describe the current activity log.
+ * Events without an `attribution` field (pre-v0.11.0 entries) move nothing.
+ * @param {Object} ev - Activity log event.
+ * @param {number} delta - +1 when added, -1 when evicted.
+ */
+function bumpAttribution(ev, delta) {
+  const status = ev && ev.attribution && ev.attribution.status;
+  if (status === 'confirmed') {
+    attrConfirmed += delta;
+  } else if (status === 'inferred') {
+    attrInferred += delta;
+  } else if (status === 'unattributed') {
+    attrUnattributed += delta;
+    if (ev.sensitive) attrUnattributedSensitive += delta;
+  }
+}
 
 /** @param {Object} ev - Activity log event being added */
 function onActivityPush(ev) {
@@ -68,6 +96,7 @@ function onActivityPush(ev) {
     totalSensitive++;
     if (ev.category === 'ai') aiSensitive++;
   }
+  bumpAttribution(ev, 1);
 }
 
 /** @param {Object} ev - Activity log event being evicted */
@@ -76,6 +105,7 @@ function onActivityEvict(ev) {
     totalSensitive--;
     if (ev.category === 'ai') aiSensitive--;
   }
+  bumpAttribution(ev, -1);
 }
 
 /** Loads modules not needed until first scan cycle. Called after ready-to-show. */
@@ -117,6 +147,7 @@ function getStats() {
       otherAgentCount: 0,
       uniqueAgents: [],
       permissionDeniedScans: 0,
+      attribution: { confirmed: 0, inferred: 0, unattributed: 0, unattributedSensitive: 0 },
     };
   }
   const log = scanner.activityLog;
@@ -132,6 +163,12 @@ function getStats() {
     otherAgentCount: new Set(latestOtherAgents.map((a) => a.agent)).size,
     uniqueAgents: Array.from(scanner.uniqueAgentNames),
     permissionDeniedScans: scanner.permissionDeniedScans,
+    attribution: {
+      confirmed: attrConfirmed,
+      inferred: attrInferred,
+      unattributed: attrUnattributed,
+      unattributedSensitive: attrUnattributedSensitive,
+    },
   };
 }
 

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -80,6 +80,11 @@ function logAuditForFile(ev) {
     action: ev.action,
     path: ev.file,
     severity: ev.sensitive ? 'sensitive' : 'normal',
+    // Attribution rides inside the EXISTING `extra` slot (audit-logger stores it
+    // as `details`), so the record's field set — and therefore the hash chain —
+    // is unchanged. Without it an empty `agent` is indistinguishable from a
+    // pre-v0.11.0 entry when reading the JSONL back.
+    extra: ev.attribution ? { attribution: ev.attribution.status } : undefined,
   });
 }
 

--- a/src/main/tray-icon.js
+++ b/src/main/tray-icon.js
@@ -129,9 +129,12 @@ function notifySensitive(events) {
   _state.lastNotificationTime = now;
   const f = se[0],
     more = se.length > 1 ? ` (+${se.length - 1} more)` : '';
+  // An unattributed event carries an empty agent name; without a label the body
+  // would open with a bare space and read as a formatting bug.
+  const source = f.agent || 'Unknown source';
   new Notification({
     title: 'AEGIS \u2014 Sensitive File Access',
-    body: `${f.agent} ${f.action || 'accessed'}: ${path.basename(f.file)}${more}\n${f.reason}`,
+    body: `${source} ${f.action || 'accessed'}: ${path.basename(f.file)}${more}\n${f.reason}`,
     urgency: 'critical',
   }).show();
 }

--- a/src/main/tray-icon.js
+++ b/src/main/tray-icon.js
@@ -14,6 +14,7 @@
 const { Tray, Menu, Notification, nativeImage } = require('electron');
 const zlib = require('zlib');
 const path = require('path');
+const { UNKNOWN_SOURCE_LABEL } = require('./attribution');
 
 const TRAY_COLORS = { green: [0, 230, 118], yellow: [255, 193, 7], red: [255, 23, 68] };
 let _state = null;
@@ -131,7 +132,7 @@ function notifySensitive(events) {
     more = se.length > 1 ? ` (+${se.length - 1} more)` : '';
   // An unattributed event carries an empty agent name; without a label the body
   // would open with a bare space and read as a formatting bug.
-  const source = f.agent || 'Unknown source';
+  const source = f.agent || UNKNOWN_SOURCE_LABEL;
   new Notification({
     title: 'AEGIS \u2014 Sensitive File Access',
     body: `${source} ${f.action || 'accessed'}: ${path.basename(f.file)}${more}\n${f.reason}`,

--- a/src/renderer/lib/components/ActivityFeed.svelte
+++ b/src/renderer/lib/components/ActivityFeed.svelte
@@ -4,6 +4,7 @@
   import { t } from '../i18n/index.js';
   import { getSeverity } from '../utils/timeline-utils';
   import { shortenPath } from '../utils/path-utils';
+  import { UNKNOWN_SOURCE } from '../utils/grouped-feed-utils';
 
   let { active = true, agentFilter = 'all', severityFilter = 'all', typeFilter = 'all' } = $props();
 
@@ -218,7 +219,7 @@
           ></span>
           <span class="feed-time">{formatRelativeTime(ev.timestamp)}</span>
           <span class="feed-agent" title={ev.userAgent ? `Process: ${ev.userAgent}` : ''}
-            >{ev.agent}</span
+            >{ev.agent || UNKNOWN_SOURCE}</span
           >
           <span class="feed-action">{ev.action || ev._type}</span>
           <button class="feed-path" title={ev.file} onclick={(e) => handlePathClick(ev, e)}

--- a/src/renderer/lib/stores/events-index.ts
+++ b/src/renderer/lib/stores/events-index.ts
@@ -17,6 +17,11 @@ import type { FileEvent } from '../../../shared/types';
 export const eventsByPid = derived(events, ($events: FileEvent[]) => {
   const map = new Map<number, FileEvent[]>();
   for (const evt of $events) {
+    // Skip by STATUS, before bucketing. The pid==null guard below is not enough
+    // on its own: synthetic agents (WSL, local LLM runtimes) are registered with
+    // pid 0, so any unattributed event that ever carried 0 would surface inside
+    // their agent card.
+    if (evt.attribution?.status === 'unattributed') continue;
     const pid = evt.pid;
     if (pid == null) continue;
     let list = map.get(pid);

--- a/src/renderer/lib/stores/risk.ts
+++ b/src/renderer/lib/stores/risk.ts
@@ -91,6 +91,10 @@ export const enrichedAgents: Readable<EnrichedAgent[]> = derived(
     const eventsByPid = new Map<number, FileEvent[]>();
     const eventsByName = new Map<string, FileEvent[]>();
     for (const ev of allEvents) {
+      // An unattributed event belongs to no agent, so it must not raise anyone's
+      // sensitiveFiles / riskScore / trustGrade. Checked by STATUS, not by falsy
+      // agent/pid: the intent has to be readable and independently testable.
+      if (ev.attribution?.status === 'unattributed') continue;
       if (ev.selfAccess) continue;
       if (ev.pid) {
         let arr = eventsByPid.get(ev.pid);

--- a/src/renderer/lib/utils/grouped-feed-utils.ts
+++ b/src/renderer/lib/utils/grouped-feed-utils.ts
@@ -56,6 +56,13 @@ export interface FeedGroup {
 
 // ═══ DISPLAY HELPERS ═══
 
+/**
+ * Label for an event whose owning agent is unknown (`attribution.status ===
+ * 'unattributed'` → `agent: ''`). Single source of truth so the feed row and the
+ * grouped view never drift apart.
+ */
+export const UNKNOWN_SOURCE = 'Unknown source';
+
 /** Shorten a file path to last 2 segments if over 40 chars. */
 export function shortenPath(p: string | undefined): string {
   return _shortenPath(p, 40, 2);
@@ -130,7 +137,10 @@ export function groupByAgent(events: FeedEvent[], agents: EnrichedAgent[]): Feed
     .map(([name, evs]) => {
       const a = agents.find((x) => x.name === name);
       return {
-        name,
+        // Unattributed events all share the '' key, so they collapse into ONE
+        // named group instead of a nameless header. No enriched agent matches ''
+        // → riskScore 0 / trustGrade '?', which is the honest readout.
+        name: name || UNKNOWN_SOURCE,
         count: evs.length,
         lastActivity: evs[0]?.timestamp || 0,
         severity: maxSev(evs),

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -14,10 +14,45 @@
  */
 export type FileAction = 'created' | 'modified' | 'deleted' | 'accessed' | 'holding';
 
+/**
+ * How the owning agent was attached to a file event.
+ * - `confirmed`: resolved from a PID (Restart Manager holder / per-PID handle scan).
+ * - `inferred`: guessed from a path (own config dir or cwd containment); no PID proof.
+ * - `unattributed`: owner unknown — NO agent is substituted (C-01).
+ */
+export type AttributionStatus = 'confirmed' | 'inferred' | 'unattributed';
+
+/**
+ * Closed list of attribution evidence codes — mirrors `EVIDENCE_CODES` in
+ * src/main/attribution.js. PID-backed codes yield `confirmed`, heuristic codes
+ * yield `inferred`, negative codes yield `unattributed`.
+ */
+export type AttributionEvidence =
+  | 'rm-holder-pid'
+  | 'handle-scan-pid'
+  | 'self-config-path'
+  | 'cwd-containment'
+  | 'no-owner-match'
+  | 'no-ai-agents-online';
+
+/**
+ * Attribution record carried by a file event. Deliberately carries NO numeric
+ * confidence: the status is a hard three-way distinction, not a score to threshold.
+ */
+export interface Attribution {
+  readonly status: AttributionStatus;
+  readonly evidence: readonly AttributionEvidence[];
+}
+
 /** File access event from watcher or handle scan */
 export interface FileEvent {
+  /** Owning agent's display name, or `''` when the event is unattributed. */
   readonly agent: string;
-  readonly pid: number;
+  /**
+   * Owning agent's PID, or `null` when the event is unattributed. Never 0 for an
+   * unknown owner — pid 0 is used by synthetic WSL / local-runtime agents.
+   */
+  readonly pid: number | null;
   readonly parentEditor: string | null;
   readonly cwd: string | null;
   readonly file: string;
@@ -27,6 +62,8 @@ export interface FileEvent {
   readonly action: FileAction;
   readonly timestamp: number;
   readonly category: string;
+  /** Optional: absent on events emitted before v0.11.0 (older activity-log entries). */
+  readonly attribution?: Attribution;
 }
 
 /** Enriched network connection from scanNetworkConnections */

--- a/tests/main/ai-analysis.test.js
+++ b/tests/main/ai-analysis.test.js
@@ -411,6 +411,43 @@ describe('ai-analysis', () => {
       expect(result.error).toContain('API key');
     });
 
+    it('keeps unattributed events out of the per-agent summary but labels them in the event list', async () => {
+      setupState({
+        activityLog: [
+          {
+            agent: 'Claude',
+            sensitive: true,
+            reason: 'SSH key',
+            file: '/home/user/a/.env',
+            action: 'read',
+            attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
+          },
+          {
+            agent: '',
+            pid: null,
+            sensitive: true,
+            reason: 'SSH keys/config',
+            file: '/home/user/.ssh/id_rsa',
+            action: 'modified',
+            attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+          },
+        ],
+        agents: [{ agent: 'Claude', pid: 100 }],
+        netConns: [],
+      });
+      const req = mockHttpSuccess({ content: [{ text: '{"summary":"ok"}' }] });
+
+      await analysis.analyzeSessionActivity();
+
+      const body = req.write.mock.calls[0][0];
+      // Event list: labelled, never bare brackets.
+      expect(body).toContain('[Unknown source]');
+      expect(body).not.toContain('[] modified');
+      // Per-agent summary: no nameless bucket (would render as "  : 1 files").
+      expect(body).not.toMatch(/\\n\s*: \d+ files/);
+      expect(body).toContain('Claude:');
+    });
+
     it('returns structured session analysis on valid response', async () => {
       setupState({
         activityLog: [

--- a/tests/main/exports.test.js
+++ b/tests/main/exports.test.js
@@ -184,6 +184,45 @@ describe('exports', () => {
       expect(data.events[0].action).toBe('read');
     });
 
+    it('keeps the raw empty agent in JSON but exports the attribution status', async () => {
+      // JSON is machine-readable: inventing a display name here would make a
+      // downstream tool group real activity under an agent that does not exist.
+      const filePath = path.join(tmpDir, 'log.json');
+      initExporter({
+        activityLog: [
+          {
+            timestamp: 1700000000000,
+            agent: '',
+            pid: null,
+            file: '/home/user/.ssh/id_rsa',
+            sensitive: true,
+            reason: 'SSH keys/config',
+            action: 'modified',
+            attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+          },
+          {
+            timestamp: 1700000001000,
+            agent: 'Claude',
+            pid: 100,
+            file: '/a.js',
+            sensitive: false,
+            reason: '',
+            action: 'read',
+          },
+        ],
+      });
+
+      mockShowSaveDialog.mockResolvedValue({ canceled: false, filePath });
+      await exporter.exportLog();
+
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(data.events[0].agent).toBe('');
+      expect(data.events[0].agent).not.toBe('Unknown source');
+      expect(data.events[0].attribution).toBe('unattributed');
+      // Pre-v0.11.0 shape: no attribution field → explicit null, not undefined.
+      expect(data.events[1].attribution).toBeNull();
+    });
+
     it('defaults action to "accessed" when missing', async () => {
       const filePath = path.join(tmpDir, 'log.json');
       initExporter({
@@ -247,6 +286,33 @@ describe('exports', () => {
       expect(lines[1]).toContain('no');
       expect(lines[2]).toContain('write');
       expect(lines[2]).toContain('yes');
+    });
+
+    it('writes "Unknown source" instead of a blank cell for an unattributed event', async () => {
+      const filePath = path.join(tmpDir, 'log.csv');
+      initExporter({
+        activityLog: [
+          {
+            timestamp: 1700000000000,
+            agent: '',
+            pid: null,
+            file: '/home/user/.ssh/id_rsa',
+            sensitive: true,
+            reason: 'SSH keys/config',
+            action: 'modified',
+            attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+          },
+        ],
+        netConns: [],
+      });
+
+      mockShowSaveDialog.mockResolvedValue({ canceled: false, filePath });
+      await exporter.exportCsv();
+
+      const row = fs.readFileSync(filePath, 'utf-8').split('\n')[1];
+      expect(row).toContain('Unknown source');
+      // A blank Agent Name cell would leave two commas back to back.
+      expect(row).not.toContain(',,');
     });
 
     it('includes network connections in CSV', async () => {
@@ -356,6 +422,33 @@ describe('exports', () => {
       const result = await exporter.generateReport();
       const html = fs.readFileSync(result.path, 'utf-8');
       expect(html).toContain('No file activity recorded');
+    });
+
+    it('labels unattributed events in the HTML report, in both table and bar chart', async () => {
+      initExporter({
+        activityLog: [
+          {
+            timestamp: Date.now(),
+            agent: '',
+            pid: null,
+            file: '/home/user/.ssh/id_rsa',
+            sensitive: true,
+            reason: 'SSH keys/config',
+            action: 'modified',
+            attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+          },
+        ],
+        netConns: [],
+      });
+
+      const result = await exporter.generateReport();
+      const html = fs.readFileSync(result.path, 'utf-8');
+      // Sensitive-events table row.
+      expect(html).toContain('Unknown source');
+      // Per-agent bar chart must not render a blank label either.
+      const chartLabels = [...html.matchAll(/font-weight:600">([^<]*)<\/td>/g)].map((m) => m[1]);
+      expect(chartLabels).toContain('Unknown source');
+      expect(chartLabels).not.toContain('');
     });
 
     it('HTML-escapes agent names to prevent XSS', async () => {

--- a/tests/main/file-watcher-attribution.test.js
+++ b/tests/main/file-watcher-attribution.test.js
@@ -1,0 +1,309 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fileWatcher from '../../src/main/file-watcher.js';
+import { EVIDENCE_CODES, deriveStatus } from '../../src/main/attribution.js';
+
+/**
+ * Two AI agents online with DISJOINT working directories. This is the fixture the
+ * old C-01 tests lacked: with a single agent in the list, "attributed correctly"
+ * and "fell back to aiAgents[0]" are indistinguishable.
+ */
+function makeMultiAgentState(overrides = {}) {
+  const ai = [
+    { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user/a' },
+    { pid: 200, agent: 'opencode', category: 'ai', cwd: '/home/user/b' },
+  ];
+  return {
+    getCustomRules: () => [],
+    getLatestAgents: () => ai,
+    getLatestAiAgents: () => ai,
+    isMonitoringPaused: () => false,
+    isOtherPanelExpanded: () => false,
+    activityLog: [],
+    knownHandles: new Map(),
+    watchers: [],
+    recordFileAccess: vi.fn(),
+    onFileEvent: vi.fn(),
+    onActivityPush: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('file-watcher attribution — chokidar path (no PID available)', () => {
+  let state;
+
+  beforeEach(() => {
+    state = makeMultiAgentState();
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+  });
+
+  it('case 1: ~/.ssh/id_rsa with two live agents → unattributed, nobody blamed', () => {
+    fileWatcher.handleWatcherEvent('modified', '/home/user/.ssh/id_rsa');
+
+    expect(state.activityLog).toHaveLength(1);
+    const event = state.activityLog[0];
+    expect(event.attribution).toEqual({ status: 'unattributed', evidence: ['no-owner-match'] });
+    expect(event.agent).toBe('');
+    expect(event.pid).toBeNull();
+    expect(event.cwd).toBeNull();
+    expect(event.parentEditor).toBeNull();
+    // The sensitive fact survives — only the (unknown) owner is withheld.
+    expect(event.sensitive).toBe(true);
+    expect(event.reason).toBe('SSH keys/config');
+    expect(event.selfAccess).toBe(false);
+    // No agent's behaviour baseline may absorb an event with no known owner.
+    expect(state.recordFileAccess).not.toHaveBeenCalled();
+    // It stays visible downstream.
+    expect(state.onFileEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('case 2: a file inside the SECOND agent cwd → inferred via cwd-containment', () => {
+    fileWatcher.handleWatcherEvent('modified', '/home/user/b/src/index.js');
+
+    const event = state.activityLog[0];
+    expect(event.attribution).toEqual({ status: 'inferred', evidence: ['cwd-containment'] });
+    expect(event.agent).toBe('opencode');
+    expect(event.pid).toBe(200);
+    expect(event.selfAccess).toBe(false);
+    // Decision "inferred rides on equal terms": it DOES reach baselines.
+    expect(state.recordFileAccess).toHaveBeenCalledTimes(1);
+    expect(state.recordFileAccess.mock.calls[0][0]).toBe('opencode');
+  });
+
+  it('case 2b: a SENSITIVE file inside an agent cwd → inferred, and it feeds baselines', () => {
+    // The common real-world shape, and the only path where inferred evidence adds
+    // to baselines.sensitiveCount (decision: inferred rides on equal terms).
+    fileWatcher.handleWatcherEvent('modified', '/home/user/b/.env');
+
+    const event = state.activityLog[0];
+    expect(event.attribution).toEqual({ status: 'inferred', evidence: ['cwd-containment'] });
+    expect(event.agent).toBe('opencode');
+    expect(event.sensitive).toBe(true);
+    expect(event.selfAccess).toBe(false);
+    expect(state.recordFileAccess).toHaveBeenCalledWith(
+      'opencode',
+      expect.stringContaining('.env'),
+      true,
+      'Environment variables',
+    );
+  });
+
+  it('case 3: an agent own config dir → inferred via self-config-path, exempted', () => {
+    fileWatcher.handleWatcherEvent('modified', '/home/user/.opencode/auth.json');
+
+    const event = state.activityLog[0];
+    expect(event.attribution).toEqual({ status: 'inferred', evidence: ['self-config-path'] });
+    expect(event.agent).toBe('opencode');
+    expect(event.pid).toBe(200);
+    expect(event.selfAccess).toBe(true);
+    expect(event.sensitive).toBe(false);
+  });
+
+  it('case 4 (D2): a foreign agent self-config pattern cannot clear `sensitive`', () => {
+    // No AI agent online; the only detected process is a non-AI one whose NAME
+    // matches the AGENT_SELF_CONFIG keyword "docker". Old code substituted
+    // agents[0] and then ran isSelfAccess against it → selfAccess true →
+    // sensitive false → a real hit on ~/.docker/config.json disappeared.
+    state = makeMultiAgentState({
+      getLatestAgents: () => [{ pid: 50, agent: 'Docker Desktop', category: 'other' }],
+      getLatestAiAgents: () => [],
+    });
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+
+    fileWatcher.handleWatcherEvent('modified', '/home/user/.docker/config.json');
+
+    const event = state.activityLog[0];
+    expect(event.attribution).toEqual({
+      status: 'unattributed',
+      evidence: ['no-ai-agents-online'],
+    });
+    expect(event.agent).toBe('');
+    expect(event.pid).toBeNull();
+    expect(event.selfAccess).toBe(false);
+    expect(event.sensitive).toBe(true);
+    expect(event.reason).toBe('Docker credentials');
+    expect(state.recordFileAccess).not.toHaveBeenCalled();
+  });
+
+  it('case 5: no AI agent online at all → no-ai-agents-online, not agents[0]', () => {
+    state = makeMultiAgentState({
+      getLatestAgents: () => [{ pid: 77, agent: 'VS Code', category: 'other' }],
+      getLatestAiAgents: () => [],
+    });
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+
+    fileWatcher.handleWatcherEvent('created', '/home/user/.ssh/known_hosts');
+
+    const event = state.activityLog[0];
+    expect(event.attribution.status).toBe('unattributed');
+    expect(event.attribution.evidence).toEqual(['no-ai-agents-online']);
+    expect(event.agent).not.toBe('VS Code');
+    expect(event.agent).toBe('');
+    expect(event.category).toBe('other');
+  });
+
+  it('self-config outranks cwd containment when both could match', () => {
+    // The file lives inside agent B cwd AND is agent A own config dir.
+    state = makeMultiAgentState({
+      getLatestAgents: () => [
+        { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user/a' },
+        { pid: 200, agent: 'opencode', category: 'ai', cwd: '/home/user' },
+      ],
+      getLatestAiAgents: () => [
+        { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user/a' },
+        { pid: 200, agent: 'opencode', category: 'ai', cwd: '/home/user' },
+      ],
+    });
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+
+    fileWatcher.handleWatcherEvent('modified', '/home/user/.claude/settings.json');
+
+    const event = state.activityLog[0];
+    expect(event.attribution.evidence).toEqual(['self-config-path']);
+    expect(event.agent).toBe('Claude Code');
+  });
+
+  it('reports the unattributed status to the activity-push counter hook exactly once', () => {
+    fileWatcher.handleWatcherEvent('modified', '/home/user/.ssh/id_ed25519');
+
+    expect(state.onActivityPush).toHaveBeenCalledTimes(1);
+    const pushed = state.onActivityPush.mock.calls[0][0];
+    expect(pushed.attribution.status).toBe('unattributed');
+    expect(pushed.sensitive).toBe(true);
+  });
+});
+
+describe('file-watcher attribution — confirmed (PID-backed) paths', () => {
+  let state;
+
+  beforeEach(() => {
+    state = makeMultiAgentState();
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+  });
+
+  it('case 7: handle scan stamps confirmed / handle-scan-pid', async () => {
+    fileWatcher._setDepsForTest({
+      getFileHandles: vi.fn(async () => ['/home/user/.aws/credentials']),
+    });
+
+    const events = await fileWatcher.scanAllFileHandles([
+      { pid: 100, agent: 'Claude Code', category: 'ai' },
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].attribution).toEqual({
+      status: 'confirmed',
+      evidence: ['handle-scan-pid'],
+    });
+    expect(events[0].pid).toBe(100);
+  });
+
+  it('case 7b: handle scan on the agent OWN config adds self-config-path', async () => {
+    fileWatcher._setDepsForTest({
+      getFileHandles: vi.fn(async () => ['/home/user/.claude/settings.json']),
+    });
+
+    const events = await fileWatcher.scanAllFileHandles([
+      { pid: 100, agent: 'Claude Code', category: 'ai' },
+    ]);
+
+    expect(events[0].attribution).toEqual({
+      status: 'confirmed',
+      evidence: ['handle-scan-pid', 'self-config-path'],
+    });
+    expect(events[0].selfAccess).toBe(true);
+  });
+
+  it('case 6: RM holder stamps confirmed / rm-holder-pid from the holder PID', async () => {
+    fileWatcher._setDepsForTest({
+      getSensitiveHolders: vi.fn(async () => [
+        { pid: 200, group: '/home/user/.ssh', reason: 'SSH keys/config' },
+      ]),
+    });
+
+    const events = await fileWatcher.scanAllFileHandles([
+      { pid: 100, agent: 'Claude Code', category: 'ai' },
+      { pid: 200, agent: 'opencode', category: 'ai' },
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].agent).toBe('opencode');
+    expect(events[0].attribution).toEqual({ status: 'confirmed', evidence: ['rm-holder-pid'] });
+  });
+
+  it('case 6b: RM holder on its OWN config dir carries both codes', async () => {
+    fileWatcher._setDepsForTest({
+      getSensitiveHolders: vi.fn(async () => [
+        { pid: 200, group: '/home/user/.opencode', reason: 'AI agent config — opencode' },
+      ]),
+    });
+
+    const events = await fileWatcher.scanAllFileHandles([
+      { pid: 200, agent: 'opencode', category: 'ai' },
+    ]);
+
+    expect(events[0].attribution).toEqual({
+      status: 'confirmed',
+      evidence: ['rm-holder-pid', 'self-config-path'],
+    });
+    expect(events[0].selfAccess).toBe(true);
+  });
+});
+
+describe('attribution evidence is a closed list (case 8)', () => {
+  let state;
+
+  beforeEach(() => {
+    state = makeMultiAgentState();
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+  });
+
+  it('exposes exactly the six documented codes', () => {
+    expect([...EVIDENCE_CODES]).toEqual([
+      'rm-holder-pid',
+      'handle-scan-pid',
+      'self-config-path',
+      'cwd-containment',
+      'no-owner-match',
+      'no-ai-agents-online',
+    ]);
+  });
+
+  it('every code emitted by real watcher events belongs to the closed list', async () => {
+    fileWatcher.handleWatcherEvent('modified', '/home/user/.ssh/id_rsa');
+    fileWatcher.handleWatcherEvent('modified', '/home/user/b/src/main.js');
+    fileWatcher.handleWatcherEvent('modified', '/home/user/.opencode/auth.json');
+    fileWatcher._setDepsForTest({
+      getFileHandles: vi.fn(async () => ['/home/user/.aws/credentials']),
+    });
+    await fileWatcher.scanAllFileHandles([{ pid: 100, agent: 'Claude Code', category: 'ai' }]);
+
+    expect(state.activityLog.length).toBeGreaterThanOrEqual(4);
+    for (const event of state.activityLog) {
+      expect(event.attribution).toBeDefined();
+      expect(['confirmed', 'inferred', 'unattributed']).toContain(event.attribution.status);
+      expect(event.attribution.evidence.length).toBeGreaterThan(0);
+      for (const code of event.attribution.evidence) {
+        expect(EVIDENCE_CODES).toContain(code);
+      }
+      // The status is always derivable from the evidence — never stored independently.
+      expect(deriveStatus(event.attribution.evidence)).toBe(event.attribution.status);
+    }
+  });
+
+  it('rejects an unknown code instead of degrading it to unattributed', () => {
+    expect(() => deriveStatus(['made-up-code'])).toThrow(/unknown evidence code/);
+    expect(() => deriveStatus([])).toThrow(/non-empty array/);
+  });
+
+  it('carries no confidence field anywhere in the attribution object', () => {
+    fileWatcher.handleWatcherEvent('modified', '/home/user/b/src/index.js');
+    const { attribution } = state.activityLog[0];
+    expect(Object.keys(attribution).sort()).toEqual(['evidence', 'status']);
+  });
+});

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -203,6 +203,11 @@ describe('file-watcher event handling', () => {
 
   describe('handleWatcherEvent()', () => {
     it('creates event with correct structure', () => {
+      // The agent needs a cwd containing the file: without an owner the event is
+      // now UNATTRIBUTED (C-01) instead of being pinned on aiAgents[0].
+      const owner = { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user/project' };
+      state.getLatestAgents = () => [owner];
+      state.getLatestAiAgents = () => [owner];
       fileWatcher.handleWatcherEvent('modified', '/home/user/project/index.js');
       expect(state.activityLog).toHaveLength(1);
       const event = state.activityLog[0];
@@ -212,6 +217,7 @@ describe('file-watcher event handling', () => {
       expect(event.sensitive).toBe(false);
       expect(event.reason).toBe('');
       expect(event.timestamp).toBeGreaterThan(0);
+      expect(event.attribution).toEqual({ status: 'inferred', evidence: ['cwd-containment'] });
     });
 
     it('marks sensitive files', () => {
@@ -258,7 +264,12 @@ describe('file-watcher event handling', () => {
       expect(state.activityLog).toHaveLength(0);
     });
 
-    it('calls recordFileAccess', () => {
+    it('calls recordFileAccess for an attributed sensitive event', () => {
+      // ~/.ssh is nobody's cwd and nobody's self-config, so an owner has to be
+      // manufactured for this assertion to be about recordFileAccess at all.
+      const owner = { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user/.ssh' };
+      state.getLatestAgents = () => [owner];
+      state.getLatestAiAgents = () => [owner];
       fileWatcher.handleWatcherEvent('created', '/home/user/.ssh/key');
       expect(state.recordFileAccess).toHaveBeenCalledWith(
         'Claude Code',
@@ -266,6 +277,15 @@ describe('file-watcher event handling', () => {
         true,
         'SSH keys/config',
       );
+    });
+
+    it('does NOT call recordFileAccess for an unattributed event', () => {
+      // Default fixture: one AI agent, no cwd → ~/.ssh/key has no owner. Baselines
+      // must not absorb an event we cannot attribute (C-01).
+      fileWatcher.handleWatcherEvent('created', '/home/user/.ssh/key');
+      expect(state.activityLog[0].attribution.status).toBe('unattributed');
+      expect(state.activityLog[0].sensitive).toBe(true);
+      expect(state.recordFileAccess).not.toHaveBeenCalled();
     });
 
     it('calls onFileEvent callback', () => {
@@ -281,11 +301,29 @@ describe('file-watcher event handling', () => {
       expect(state.activityLog.length).toBeLessThanOrEqual(10000);
     });
 
-    it('uses AI agent over generic agent when available', () => {
+    it('prefers the owning AI agent over a generic agent', () => {
+      // The AI agent OWNS the path (cwd containment); the generic one is a decoy.
+      // Previously this test passed with a single cwd-less AI agent, so it could
+      // not tell correct attribution from a blind fallback to aiAgents[0].
       state.getLatestAgents = () => [{ pid: 50, agent: 'Generic', category: 'other' }];
-      state.getLatestAiAgents = () => [{ pid: 100, agent: 'Claude Code', category: 'ai' }];
+      state.getLatestAiAgents = () => [
+        { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user' },
+      ];
       fileWatcher.handleWatcherEvent('modified', '/home/user/file.js');
       expect(state.activityLog[0].agent).toBe('Claude Code');
+      expect(state.activityLog[0].attribution.status).toBe('inferred');
+    });
+
+    it('does not fall back to a generic agent when no AI agent owns the path', () => {
+      state.getLatestAgents = () => [{ pid: 50, agent: 'Generic', category: 'other' }];
+      state.getLatestAiAgents = () => [
+        { pid: 100, agent: 'Claude Code', category: 'ai', cwd: '/home/user/elsewhere' },
+      ];
+      fileWatcher.handleWatcherEvent('modified', '/home/user/file.js');
+      const event = state.activityLog[0];
+      expect(event.agent).toBe('');
+      expect(event.pid).toBeNull();
+      expect(event.attribution).toEqual({ status: 'unattributed', evidence: ['no-owner-match'] });
     });
 
     it('attributes a self-config event to the owning agent, not aiAgents[0] (C-01)', () => {

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -99,6 +99,7 @@ describe('scan-loop', () => {
         file: '/home/user/.bashrc',
         sensitive: true,
         reason: 'dotfile',
+        attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
       });
 
       expect(auditLog).toHaveBeenCalledOnce();
@@ -107,7 +108,45 @@ describe('scan-loop', () => {
         action: 'read',
         path: '/home/user/.bashrc',
         severity: 'sensitive',
+        extra: { attribution: 'confirmed' },
       });
+    });
+
+    it('records the unattributed status so an empty agent is not read as a legacy entry', () => {
+      const auditLog = vi.fn();
+      scanLoop.init({ audit: { log: auditLog } });
+
+      scanLoop.logAuditForFile({
+        agent: '',
+        action: 'modified',
+        file: '/home/user/.ssh/id_rsa',
+        sensitive: true,
+        reason: 'SSH keys/config',
+        attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+      });
+
+      expect(auditLog).toHaveBeenCalledWith('file-access', {
+        agent: '',
+        action: 'modified',
+        path: '/home/user/.ssh/id_rsa',
+        severity: 'sensitive',
+        extra: { attribution: 'unattributed' },
+      });
+    });
+
+    it('omits extra for an event with no attribution (pre-v0.11.0 shape)', () => {
+      const auditLog = vi.fn();
+      scanLoop.init({ audit: { log: auditLog } });
+
+      scanLoop.logAuditForFile({
+        agent: 'Cursor',
+        action: 'read',
+        file: '/home/user/.bashrc',
+        sensitive: false,
+        reason: '',
+      });
+
+      expect(auditLog.mock.calls[0][1].extra).toBeUndefined();
     });
 
     it('logs config-access for AI agent config events', () => {
@@ -120,6 +159,7 @@ describe('scan-loop', () => {
         file: '/home/.copilot/config.json',
         sensitive: false,
         reason: 'AI agent config modification',
+        attribution: { status: 'inferred', evidence: ['self-config-path'] },
       });
 
       expect(auditLog).toHaveBeenCalledWith('config-access', {
@@ -127,6 +167,7 @@ describe('scan-loop', () => {
         action: 'write',
         path: '/home/.copilot/config.json',
         severity: 'normal',
+        extra: { attribution: 'inferred' },
       });
     });
   });
@@ -393,17 +434,15 @@ describe('scan-loop', () => {
         network: {
           isNetworkScanRunning: vi.fn().mockReturnValue(false),
           setNetworkScanRunning: vi.fn(),
-          scanNetworkConnections: vi
-            .fn()
-            .mockResolvedValue([
-              {
-                agent: 'Cursor',
-                remoteIp: '1.2.3.4',
-                remotePort: 443,
-                state: 'ESTABLISHED',
-                flagged: false,
-              },
-            ]),
+          scanNetworkConnections: vi.fn().mockResolvedValue([
+            {
+              agent: 'Cursor',
+              remoteIp: '1.2.3.4',
+              remotePort: 443,
+              state: 'ESTABLISHED',
+              flagged: false,
+            },
+          ]),
         },
       });
       scanLoop.init(deps);

--- a/tests/main/tray-icon.test.js
+++ b/tests/main/tray-icon.test.js
@@ -221,6 +221,26 @@ describe('tray-icon', () => {
       expect(mockNotificationConstructor).toHaveBeenCalledTimes(1);
     });
 
+    it('labels an unattributed event "Unknown source" instead of a blank name', () => {
+      initTray();
+      tray.notifySensitive([
+        {
+          sensitive: true,
+          agent: '',
+          action: 'modified',
+          file: '/home/user/.ssh/id_rsa',
+          reason: 'SSH keys/config',
+          attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+        },
+      ]);
+      expect(mockNotificationConstructor).toHaveBeenCalledTimes(1);
+      const body = mockNotificationConstructor.mock.calls[0][0].body;
+      expect(body).toContain('Unknown source');
+      // Without the label the body would open with a bare space.
+      expect(body.startsWith(' ')).toBe(false);
+      expect(body).toContain('id_rsa');
+    });
+
     it('shows (+N more) for multiple sensitive events', () => {
       initTray();
       const events = [

--- a/tests/renderer/grouped-feed-utils.test.ts
+++ b/tests/renderer/grouped-feed-utils.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  groupByAgent,
+  UNKNOWN_SOURCE,
+  type FeedEvent,
+  type EnrichedAgent,
+} from '../../src/renderer/lib/utils/grouped-feed-utils';
+
+const NOW = Date.now();
+
+function ev(over: Partial<FeedEvent> = {}): FeedEvent {
+  return {
+    agent: 'Claude Code',
+    timestamp: NOW,
+    file: '/home/user/a/src/index.js',
+    action: 'modified',
+    sensitive: false,
+    reason: '',
+    _type: 'file',
+    ...over,
+  };
+}
+
+const AGENTS: EnrichedAgent[] = [{ name: 'Claude Code', riskScore: 42, trustGrade: 'C' }];
+
+describe('groupByAgent — unattributed events', () => {
+  it('collapses every unattributed event into ONE group named "Unknown source"', () => {
+    const groups = groupByAgent(
+      [
+        ev(),
+        ev({
+          agent: '',
+          file: '/home/user/.ssh/id_rsa',
+          sensitive: true,
+          reason: 'SSH keys/config',
+        }),
+        ev({ agent: '', file: '/home/user/.aws/credentials', sensitive: true, reason: 'AWS' }),
+      ],
+      AGENTS,
+    );
+
+    expect(groups).toHaveLength(2);
+    const unknown = groups.find((g) => g.name === UNKNOWN_SOURCE);
+    expect(unknown).toBeDefined();
+    expect(unknown!.count).toBe(2);
+    // No agent matches the empty key, so the readout stays honest.
+    expect(unknown!.riskScore).toBe(0);
+    expect(unknown!.trustGrade).toBe('?');
+  });
+
+  it('never emits a group with a blank name', () => {
+    const groups = groupByAgent([ev({ agent: '' }), ev()], AGENTS);
+    for (const g of groups) {
+      expect(g.name).not.toBe('');
+      expect(g.name.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('leaves attributed groups untouched', () => {
+    const groups = groupByAgent([ev(), ev({ file: '/home/user/a/b.js' })], AGENTS);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].name).toBe('Claude Code');
+    expect(groups[0].count).toBe(2);
+    expect(groups[0].riskScore).toBe(42);
+    expect(groups[0].trustGrade).toBe('C');
+  });
+});

--- a/tests/renderer/risk.test.ts
+++ b/tests/renderer/risk.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+// stores/ipc.ts reads `window.aegis` at module load (and would start demo-mode
+// timers in a browserless env), so its input stores are replaced with plain
+// writables. The factory is self-contained — it must not close over module-scope
+// bindings, because vi.mock is hoisted above the imports below.
+vi.mock('../../src/renderer/lib/stores/ipc.js', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    agents: writable([]),
+    events: writable([]),
+    anomalies: writable({}),
+    network: writable([]),
+    falsePositives: writable([]),
+  };
+});
+
+import { enrichedAgents } from '../../src/renderer/lib/stores/risk.js';
+import { eventsByPid } from '../../src/renderer/lib/stores/events-index.js';
+import * as ipc from '../../src/renderer/lib/stores/ipc.js';
+
+const inputs = ipc as unknown as {
+  agents: { set: (v: unknown[]) => void };
+  events: { set: (v: unknown[]) => void };
+  anomalies: { set: (v: Record<string, number>) => void };
+  network: { set: (v: unknown[]) => void };
+  falsePositives: { set: (v: unknown[]) => void };
+};
+
+const NOW = Date.now();
+
+/** A confirmed, non-sensitive file event owned by Claude Code (pid 100). */
+function fileEvent(over: Record<string, unknown> = {}) {
+  return {
+    agent: 'Claude Code',
+    pid: 100,
+    parentEditor: null,
+    cwd: '/home/user/a',
+    file: '/home/user/a/src/index.js',
+    sensitive: false,
+    selfAccess: false,
+    reason: '',
+    action: 'modified',
+    timestamp: NOW,
+    category: 'ai',
+    attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
+    ...over,
+  };
+}
+
+/** An unattributed event: no owner, agent '' and pid null (C-01). */
+function unattributed(over: Record<string, unknown> = {}) {
+  return fileEvent({
+    agent: '',
+    pid: null,
+    cwd: null,
+    category: 'other',
+    file: '/home/user/.ssh/id_rsa',
+    sensitive: true,
+    reason: 'SSH keys/config',
+    attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+    ...over,
+  });
+}
+
+const TWO_AGENTS = [
+  { agent: 'Claude Code', pid: 100, cwd: '/home/user/a', category: 'ai' },
+  { agent: 'opencode', pid: 200, cwd: '/home/user/b', category: 'ai' },
+];
+
+/** Per-agent risk figures — the numbers an unattributed event must never move. */
+function riskShape() {
+  return get(enrichedAgents).map((a) => ({
+    name: a.name,
+    sensitiveFiles: a.sensitiveFiles,
+    riskScore: a.riskScore,
+    trustGrade: a.trustGrade,
+    fileCount: a.fileCount,
+  }));
+}
+
+beforeEach(() => {
+  inputs.agents.set([]);
+  inputs.events.set([]);
+  inputs.anomalies.set({});
+  inputs.network.set([]);
+  inputs.falsePositives.set([]);
+});
+
+describe('risk store — enrichedAgents', () => {
+  it('case 11: a confirmed sensitive event raises risk for THAT agent only', () => {
+    inputs.agents.set(TWO_AGENTS);
+    inputs.events.set([
+      [
+        fileEvent({
+          file: '/home/user/a/.env',
+          sensitive: true,
+          reason: 'Environment variables',
+        }),
+      ],
+    ]);
+
+    const [claude, opencode] = get(enrichedAgents);
+    expect(claude.name).toBe('Claude Code');
+    expect(claude.sensitiveFiles).toBeGreaterThan(0);
+    expect(claude.riskScore).toBeGreaterThan(0);
+    expect(opencode.name).toBe('opencode');
+    expect(opencode.sensitiveFiles).toBe(0);
+    expect(opencode.riskScore).toBe(0);
+    expect(opencode.trustGrade).toBe('A+');
+  });
+
+  it('case 9: an unattributed sensitive event changes nothing for anybody', () => {
+    const attributed = [
+      fileEvent({ file: '/home/user/a/src/a.js' }),
+      fileEvent({
+        agent: 'opencode',
+        pid: 200,
+        cwd: '/home/user/b',
+        file: '/home/user/b/b.js',
+      }),
+    ];
+
+    inputs.agents.set(TWO_AGENTS);
+    inputs.events.set([attributed]);
+    const before = riskShape();
+
+    // Same stream plus an unattributed hit on a real secret.
+    inputs.events.set([[...attributed, unattributed()]]);
+    const after = riskShape();
+
+    expect(after).toEqual(before);
+    for (const a of after) {
+      expect(a.sensitiveFiles).toBe(0);
+      expect(a.riskScore).toBe(0);
+    }
+  });
+
+  it('case 10: an unattributed event never lands on a synthetic pid-0 agent', () => {
+    // WSL-inner agents and local LLM runtimes are registered with pid 0.
+    inputs.agents.set([
+      { agent: 'grok', pid: 0, category: 'ai' },
+      { agent: 'Ollama', pid: 0, category: 'local-llm-runtime' },
+    ]);
+    inputs.events.set([
+      [
+        unattributed({ file: '/home/user/.aws/credentials', reason: 'AWS credentials' }),
+        // Belt and braces: even if an unattributed event ever carried pid 0
+        // instead of null, the status check must still keep it out.
+        unattributed({ pid: 0, file: '/home/user/.ssh/id_ed25519' }),
+      ],
+    ]);
+
+    const enriched = get(enrichedAgents);
+    expect(enriched).toHaveLength(2);
+    for (const a of enriched) {
+      expect(a.sensitiveFiles).toBe(0);
+      expect(a.fileCount).toBe(0);
+      expect(a.riskScore).toBe(0);
+      expect(a.trustGrade).toBe('A+');
+    }
+  });
+
+  it('case 12: selfAccess events stay excluded (pre-existing invariant)', () => {
+    inputs.agents.set([TWO_AGENTS[0]]);
+    inputs.events.set([
+      [
+        fileEvent({
+          file: '/home/user/.claude/settings.json',
+          selfAccess: true,
+          reason: 'AI agent config — Claude Code',
+          attribution: { status: 'confirmed', evidence: ['handle-scan-pid', 'self-config-path'] },
+        }),
+      ],
+    ]);
+
+    const [claude] = get(enrichedAgents);
+    expect(claude.fileCount).toBe(0);
+    expect(claude.sensitiveFiles).toBe(0);
+    expect(claude.riskScore).toBe(0);
+  });
+
+  it('an inferred event counts on equal terms with a confirmed one', () => {
+    inputs.agents.set([TWO_AGENTS[1]]);
+    inputs.events.set([
+      [
+        fileEvent({
+          agent: 'opencode',
+          pid: 200,
+          cwd: '/home/user/b',
+          file: '/home/user/b/.env',
+          sensitive: true,
+          reason: 'Environment variables',
+          attribution: { status: 'inferred', evidence: ['cwd-containment'] },
+        }),
+      ],
+    ]);
+
+    const [opencode] = get(enrichedAgents);
+    expect(opencode.sensitiveFiles).toBeGreaterThan(0);
+    expect(opencode.riskScore).toBeGreaterThan(0);
+  });
+
+  it('events with no attribution field (pre-v0.11.0) are still counted', () => {
+    inputs.agents.set([TWO_AGENTS[0]]);
+    const legacy: Record<string, unknown> = fileEvent({
+      file: '/home/user/a/.env',
+      sensitive: true,
+      reason: 'Environment variables',
+    });
+    delete legacy.attribution;
+    inputs.events.set([[legacy]]);
+
+    const [claude] = get(enrichedAgents);
+    expect(claude.sensitiveFiles).toBeGreaterThan(0);
+  });
+});
+
+describe('events-index store — eventsByPid', () => {
+  it('drops unattributed events before bucketing by pid', () => {
+    inputs.events.set([fileEvent(), unattributed({ pid: 0 })]);
+
+    const map = get(eventsByPid);
+    expect(map.get(100)).toHaveLength(1);
+    expect(map.has(0)).toBe(false);
+  });
+});


### PR DESCRIPTION
`chokidar` reports a **path**, never a PID. When no agent owned that path, `file-watcher.js` fell back to `aiAgents[0]` (or `agents[0]`) and stamped a real agent's name and pid onto the event — so a secret touched by nobody-we-could-identify poisoned that agent's behaviour baseline, inflated its risk score and trust grade, fired a tray alert naming it, and wrote it into the hash-chained audit log as fact. This is P0 because everything downstream of attribution inherits the error, and `memory-bank/AEGIS-MASTER-PLAN.md` lists C-01 as a hard prerequisite for per-agent baselines and process→file→network correlation. A second, quieter half of the same bug: the self-access exemption was re-evaluated against the *substituted* agent, so on the `agents[0]` branch a foreign agent's exemption could flip `sensitive` to `false` and hide the access entirely.

## Commits

- `609f653` — `fix(attribution)`: three-state attribution in the watcher; the substitute-agent fallback is gone
- `a4d4ec0` — `fix(attribution)`: unattributed events surfaced to tray, feed, risk store, events-index, ai-analysis
- `f2f5570` — `fix(attribution)`: blank agent name no longer leaks into CSV / HTML report / LLM prompt
- `9446aba` — `chore`: ignore `events.jsonl` (Claude Code hook telemetry, not produced by AEGIS)

## What the events look like now

`attribution: { status, evidence }` on every file event. Three statuses and a **closed** list of six evidence codes (`deriveStatus()` throws on anything outside it, so a typo cannot silently degrade an event):

| status | how | evidence codes |
|---|---|---|
| `confirmed` | resolved from a PID | `rm-holder-pid`, `handle-scan-pid` |
| `inferred` | guessed from a path | `self-config-path`, `cwd-containment` |
| `unattributed` | owner unknown, **no agent substituted** | `no-owner-match`, `no-ai-agents-online` |

An unattributed event carries `agent: ''`, `pid: null`, and never reaches `baselines.recordFileAccess`.

## What is proven

- **Multi-agent case.** Two live AI agents with disjoint cwds, event on `~/.ssh/id_rsa` → `unattributed` / `['no-owner-match']`, `agent ''`, `pid null`, `sensitive true`, `selfAccess false`, and `recordFileAccess` not called once. The old fixtures held a *single* cwd-less agent, so "attributed correctly" and "fell back to `[0]`" were indistinguishable — that test (`file-watcher.test.js:284`) passed on the very code being fixed and is now split in two.
- **D2 regression pin, OLD vs NEW on the same fixture** (no AI agent online, one non-AI process named `Docker Desktop`, event on `~/.docker/config.json`):
  ```
  OLD → { agent: 'Docker Desktop', pid: 50, reason: 'Docker credentials',
          selfAccess: true, sensitive: false }   ← the hit disappeared
  NEW → unattributed / ['no-ai-agents-online'], selfAccess false, sensitive true
  ```
- **Guards disabled to find out which tests actually hold the fix.** With both store guards neutered, 6 of 7 `risk.test.ts` cases still passed — so the `risk.ts` guard is defence-in-depth (`pid: null` / `agent: ''` are already falsy at `risk.ts:95,103`), while the `events-index.ts` guard is load-bearing: without it an unattributed event lands in the `pid 0` bucket shared with synthetic WSL / local-LLM-runtime agents and shows up inside their card. Stated plainly rather than claimed as covered.
- **All four export/prompt assertions fail without their fix** — CSV emitted `,,`, JSON emitted `undefined`, HTML and the prompt lacked the label. The "no nameless bucket in the prompt summary" assertion was verified separately, because the shared test aborted on an earlier assertion before reaching it.
- **Audit schema intact.** The status rides in the pre-existing `extra` slot, so the record's field set is unchanged. On a live run a real entry appeared as `{"agent":"OpenAI Codex CLI","action":"holding","details":{"attribution":"confirmed"}}`, and `verifyChain` on that same file returned `{"valid":true,"brokenAtSeq":null,"reason":"ok"}`.
- App boots clean on win32 across three launches (32–34 agents detected, no ERROR/WARN/exception in the console).

## Deliberate decisions

- **`pid: null`, not `0`.** pid 0 is already taken by synthetic agents — WSL-inner agents (`wsl-detector.js`) and local LLM runtimes (`scan-loop.js` `attachModels`). Using 0 for "unknown" would collide with a real agent card, which is exactly the leak the `events-index.ts` guard now blocks.
- **JSON export keeps the raw empty name; CSV and the HTML report get a label.** A CSV opened in a spreadsheet and a report forwarded to another person are read by a *human*, where a blank cell reads as a bug. A JSON export is read by a *machine*, and substituting `Unknown source` there would make a downstream tool group real activity under an agent that does not exist. JSON therefore keeps `agent: ""` and gains an `attribution` field alongside it.
- **No numeric confidence, anywhere.** The distinction is a hard three-way one — PID-proven, path-guessed, unknown. A score would invite "0.7 is probably fine" thresholding, and nothing here has been benchmarked to calibrate such a number.
- **`scan-loop.js:326,359` (`notifySensitive` filters) deliberately not widened.** Both the handle scan and the Restart Manager path resolve the agent from a PID, so `unattributed` is structurally impossible there and the extra branch would be dead code.
- **`inferred` counts on equal terms** with `confirmed` in baselines and risk, and **`unattributed` is written to no baseline at all** — recording it under an empty name would create a phantom agent that `checkDeviations()` then iterates and warns about.

## Known limitations (not addressed here)

- `timeline-utils.ts:220` labels an unknown owner `Unknown` while the feed says `Unknown source` — two different strings for one state.
- The "mark false positive" button is shown on unattributed rows and stores `{ agentName: '' }`. Harmless (`risk.ts:135` matches by name, `''` matches nobody) but it accumulates junk.
- No way to filter the feed to unattributed events: `FeedFilters` builds its list from `enrichedAgents`, which excludes them by design.
- `Reports.svelte:78` sums `sensitiveFiles` across agents (unattributed excluded) while `getStats().totalSensitive` counts them — two different numbers on one screen. The most visible of the five.
- `exports.js` HTML report and CSV now label the owner, but the report's own per-agent bar chart groups by that label, so several distinct unknown sources share one bar. Correct as a readout, coarse as attribution.
- **No unit test for the `getStats()` attribution counters or the widened tray gate.** `main.js` requires Electron at module top level, so it cannot be loaded headless; both were verified by reading the code plus the live runs above. The nearest proxy that does exist asserts `onActivityPush` receives the event with the right status.

## Numbers

- Tests: **968 passed, 4 skipped, 972 total, 62 files** (`npx vitest run`)
- Gates: `tsc --noEmit` clean on both configs · `eslint src/` 0 errors (23 pre-existing `no-console` warnings) · `npm run build:renderer` clean · `prettier --check` clean on every touched file
- Diff vs `master`: **production 322/24**, **tests 845/14**, chore 3/0 — **total 1170/38**
- New: `src/main/attribution.js` (126), `tests/main/file-watcher-attribution.test.js` (309), `tests/renderer/risk.test.ts` (228), `tests/renderer/grouped-feed-utils.test.ts` (67)
