### PR TITLE
docs: resync every count with the code, drop the pre-Svelte plan

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -2,7 +2,7 @@
 alwaysApply: true
 ---
 # Code Quality Rules
-- Max 300 lines per file. If approaching limit — extract component/util
+- 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 632, ipc-handlers.js 498), tests go up to 691. Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - No `any` type. Use proper types from src/shared/types/
 - GPG signing on all commits
 - Verify after EVERY change: npm test && npm run build && npx tsc --noEmit

--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -22,14 +22,14 @@ Read package.json for exact versions. NEVER hardcode.
 Electron 33, Svelte 5, Vite 7, TypeScript (incremental, allowJs:true, checkJs:true), chokidar.
 
 ## Architecture
-- Main process (Node.js): src/main/ — 23 CJS modules (scanners, watchers, IPC, scoring, logging)
-- Renderer (Svelte 5): src/renderer/ — 43 components + 9 stores + 15 utils via IPC bridge
-- Bridge: src/main/preload.js — contextBridge, 43 invoke + 6 push channels
+- Main process (Node.js): src/main/ — 43 CJS modules (34 top-level + 7 platform/ + 2 token-adapters/)
+- Renderer (Svelte 5): src/renderer/ — 46 components + 11 stores + 16 utils via IPC bridge
+- Bridge: src/main/preload.js — contextBridge, 39 invoke + 9 push = 48 channels
 - Data: src/shared/agent-database.json (110 agent signatures)
-- Config: src/shared/constants.js (68 rules across 8 categories)
-- Rules: src/main/rule-loader.js — loadRules() + categoryIndex Map for O(1) lookup by category
+- Rules: rules/*.yaml — 73 active rules across 8 categories, validated against rules/_schema.json
+- Rule loader: src/main/rule-loader.js — loadRules() + categoryIndex Map exposed via getRulesByCategory(); built and tested, but no production caller consumes it yet (C-16)
 - Types: src/shared/types/ — 8 .ts files
-- Tests: 707 pass, 4 skip across 44 files (Vitest, all ESM)
+- Tests: 968 pass, 4 skip (972 total) across 62 files (Vitest, all ESM)
 
 ## Key Components (Fancy UI — complete)
 - ShieldTab: bento grid with SummaryCards, RiskRing, ActivityFeed
@@ -45,7 +45,7 @@ Electron 33, Svelte 5, Vite 7, TypeScript (incremental, allowJs:true, checkJs:tr
 ## Key Files
 - src/renderer/lib/styles/tokens.css — 60+ design tokens (Fancy UI)
 - src/renderer/lib/styles/global.css — atmosphere, fonts, resets
-- src/shared/constants.js — ~70 SENSITIVE_RULES
+- src/shared/constants.js — ignore patterns, editor lists, AGENT_CONFIG_PATHS. SENSITIVE_RULES (68) is DEPRECATED and unused at runtime — classifySensitive() reads getAllRules() from rule-loader
 
 ## MCP
 - Context7: fresh docs for any library (append "use context7")
@@ -60,6 +60,9 @@ Electron 33, Svelte 5, Vite 7, TypeScript (incremental, allowJs:true, checkJs:tr
 - prompt-craft — prompt formula for Claude Code and Antigravity
 - pr-monitor — PR triage, contributor management, /loop monitoring
 - ci-monitor — CI watching, repo health, post-launch metrics
+- audit-check — pre-push / pre-release repo audit (format, build, lint, counts, git status)
+- commit-and-track — post-task gate: verify, stage only touched files, conventional commit, push to feature branch
+- ship — full deploy pipeline (manual invocation only)
 
 ## Commands
 - /audit — full health check via auditor agent

--- a/.claude/skills/electron-main/SKILL.md
+++ b/.claude/skills/electron-main/SKILL.md
@@ -5,9 +5,9 @@ description: Electron main process patterns for Aegis. CJS modules, platform abs
 # Electron Main Process
 
 ## Architecture
-- 23 CJS modules loaded directly by Node.js (NO build step)
+- 43 CJS modules loaded directly by Node.js (34 top-level + 7 platform/ + 2 token-adapters/, NO build step)
 - Platform dispatcher: src/main/platform/index.js → win32|darwin|linux
-- IPC: 43 invoke + 6 push channels, scan-batch consolidation
+- IPC: 39 invoke + 9 push = 48 channels, scan-batch consolidation
 - File watcher: chokidar 3.6, function-form ignored (NOT glob)
 
 ## Rules

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -6,7 +6,7 @@ description: Vitest testing patterns for Aegis. ESM imports, mocking, test struc
 
 ## Stack
 - Vitest 4 + esbuild transform
-- 44 test files, 707 tests, 4 skip
+- 62 test files, 968 pass, 4 skip (972 total)
 
 ## Structure
 - tests/ directory mirrors src/ structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ AEGIS is an independent AI oversight layer — a desktop app that monitors AI ag
 ```
 src/main/           Electron main process (CommonJS, require/module.exports)
 src/renderer/       Svelte 5 dashboard UI (ES modules, runes)
-src/shared/         Constants + agent-database.json (106 agent signatures)
+src/shared/         Constants + agent-database.json (110 agent signatures) + types/ (8 .ts)
+rules/              73 detection rules in 8 YAML files + _schema.json
 tests/              Vitest unit tests with v8 coverage
 ```
 
@@ -22,8 +23,9 @@ Key modules:
 - `src/main/llm-runtime-detector.js` — local LLM runtime detection (Ollama, LM Studio HTTP probes)
 - `src/main/cli.js` — CLI interface (`--scan-json`, `--version`, `--help`)
 - `src/main/platform/` — OS abstraction (win32.js, darwin.js, linux.js)
-- `src/shared/agent-database.json` — 106 known agent signatures
-- `src/shared/constants.js` — sensitive file rules (70+ patterns)
+- `src/shared/agent-database.json` — 110 known agent signatures
+- `src/main/rule-loader.js` — loads `rules/*.yaml` (73 rules, 8 categories) against `rules/_schema.json`, hot-reload
+- `src/shared/constants.js` — ignore patterns, editor lists, AGENT_CONFIG_PATHS. `SENSITIVE_RULES` (68) is deprecated and unread at runtime — editing it changes nothing
 
 ## Build & test
 
@@ -38,14 +40,14 @@ CI runs all three on every push and PR (`.github/workflows/ci.yml`).
 
 ## Code conventions
 
-- **Max 200 lines per file.** Split into focused modules when exceeding.
+- 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 632, ipc-handlers.js 498), tests go up to 691. Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - **Main process:** CommonJS (`require`/`module.exports`). Never use `import` in `src/main/`.
 - **Renderer:** ES modules (`import`/`export`). Never use `require()` in `src/renderer/`.
 - **Svelte 5 runes:** `$state`, `$derived`, `$effect`, `$props`. No legacy `let` reactivity.
 - **JSDoc** on all exported functions (`@param`, `@returns`, `@since`).
 - **DI pattern:** Modules expose `init(deps)` for wiring. Tests use `_setDepsForTest()` / `_resetForTest()`.
 - **Paths:** Always split with `/[/\\]/` — never hardcode `/` or `\\` alone.
-- **No TypeScript.** This project uses plain JS + JSDoc.
+- **TypeScript:** 31 `.ts` files exist (renderer stores/utils + `src/shared/types/`). New renderer files go in `.ts`, zero `any`, `npm run typecheck` before commit. `src/main/` stays plain JS + JSDoc until the tsc build step lands.
 - **Prettier:** semi, singleQuote, trailingComma: all, printWidth: 100, tabWidth: 2.
 - **CSS:** Scoped styles in `.svelte` files. Global tokens in `src/renderer/lib/styles/tokens.css`. Use `var()` references, not raw colors.
 
@@ -58,11 +60,11 @@ CI runs all three on every push and PR (`.github/workflows/ci.yml`).
 
 ## What NOT to do
 
-- Don't use TypeScript — project is plain JS + JSDoc
+- Don't convert `src/main/` to TypeScript — main stays plain JS + JSDoc until the tsc build step lands
 - Don't use `require()` in `src/renderer/` — ES modules only
 - Don't use `import` in `src/main/` — CommonJS only
 - Don't hardcode OS paths — use `src/main/platform/` abstraction
 - Don't skip tests — every new module needs a test file in `tests/`
 - Don't add features not explicitly requested
 - Don't modify files not mentioned in the task
-- Don't exceed 200 lines per file
+- Don't let a new file blow past 300 lines — extract instead

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 │  └───────────────┬──────────────┘     └──────────────┬───────────────┘  │
 │                  │          preload.js                │                  │
 │                  └─────── (IPC bridge) ───────────────┘                  │
-│                     contextBridge API (54 channels)                     │
+│              contextBridge API (48 channels: 39 invoke + 9 push)        │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -60,15 +60,15 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 ### What's Covered Now
 
 #### 1. Process Intelligence — `process-scanner.js`
-- **What it sees:** All running processes matched against 106 agent signatures
+- **What it sees:** All running processes matched against 110 agent signatures
 - **How:** `tasklist /FO CSV /NH` on Windows, pattern matching against known process names
 - **Depth:** Parent-child process tree resolution via PowerShell (60s TTL cache), IDE host app detection (e.g., "Copilot inside VS Code"), PID tracking for enter/exit events
 - **Coverage:** ~95% of known AI agents. Unknown agents detected via wildcard patterns.
 
-#### 2. File & Data Access — `file-watcher.js` + `constants.js`
+#### 2. File & Data Access — `file-watcher.js` + `rule-loader.js`
 - **What it sees:** File create/modify/delete in sensitive directories, per-process file handles
 - **How:** chokidar watchers on `.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`, `.azure`, `.env*`, 27 agent config directories, project directory. PowerShell handle scanning (`handle64.exe` or `Get-Process` fallback).
-- **Depth:** 70+ sensitive file patterns with severity classification. AI agent config directory protection (Hudson Rock threat vector). 2-second debounce per path.
+- **Depth:** 73 sensitive file rules (from `rules/*.yaml`) with severity classification. AI agent config directory protection (Hudson Rock threat vector). 2-second debounce per path.
 - **Limitation:** chokidar cannot attribute events to specific processes. Handle scanning provides per-process attribution but runs on a timer.
 
 #### 3. Network Intelligence — `network-monitor.js`
@@ -263,10 +263,17 @@ Process Scan (every Ns)
 Edit `agent-database.json` — add entry with `processPatterns`, `knownDomains`, `configPaths`, and trust/risk metadata. The process scanner, network monitor, and file watcher all consume this database automatically.
 
 ### Adding New Sensitive File Rules
-Edit `src/shared/constants.js` — add to `SENSITIVE_RULES` array:
-```javascript
-{ pattern: /my-pattern/i, reason: 'Display reason', category: 'my-cat', severity: 'critical' }
+Rules live in `rules/*.yaml` (one file per category), validated against `rules/_schema.json` and loaded by `rule-loader.js` with hot-reload. Add an entry to the ruleset matching the category:
+```yaml
+  - id: "SS007"
+    name: "SSH agent socket"
+    pattern: "ssh-agent"
+    reason: "SSH agent socket"
+    category: "ssh"
+    risk: critical
+    enabled: true
 ```
+`category` must be one of the 8 values allowed by `_schema.json` (ai-config, secrets, ssh, certificates, cloud, browser, devtools, crypto). `SENSITIVE_RULES` in `src/shared/constants.js` is deprecated and not read at runtime — editing it has no effect.
 
 ### Adding a New Monitoring Module
 1. Create `src/main/new-module.js` with `init(state)` pattern

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Landing: aegisprotect.vercel.app | Demo: aegis-demo-ten.vercel.app
 npm run build:renderer    # Vite build (MUST pass before commit)
 npm run lint              # ESLint
 npm run format            # Prettier
-npm test                  # Vitest (707 tests, 44 files)
+npm test                  # Vitest (968 passed / 4 skipped = 972, 62 files)
 npm run dist              # Electron-builder NSIS installer
 
 ## Background Tasks (/loop)
@@ -17,7 +17,7 @@ npm run dist              # Electron-builder NSIS installer
 ## Critical Rules
 1. Read memory-bank/ai-mistakes.md before ANY code change
 2. Do ONLY what the prompt says — no extra features, no unrequested changes
-3. Main = CJS (require). Renderer = ESM (import). Max 300 lines/file
+3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 632, ipc-handlers.js 498), tests go up to 691. Don't split an existing file just to hit the number; do extract when adding to one that's already over
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
@@ -25,12 +25,13 @@ npm run dist              # Electron-builder NSIS installer
 8. TypeScript: new files in .ts, `npx eslint` + `npx tsc --noEmit` before commit, zero `any`
 
 ## Key Paths
-- src/main/ — 23 CommonJS modules (scanners, watchers, IPC, scoring, zip-writer)
-- src/renderer/ — 43 Svelte 5 components + 9 stores + 15 utils + tokens.css/global.css
-- src/shared/ — agent-database.json (110 agents), constants.js (68 rules), types/ (8 TS files)
+- src/main/ — 43 CommonJS modules (34 top-level + platform/ 7 + token-adapters/ 2)
+- src/renderer/ — 46 Svelte 5 components + 11 stores + 16 utils + tokens.css/global.css
+- src/shared/ — agent-database.json (110 agents), types/ (8 TS files), constants.js (ignore patterns, config paths; SENSITIVE_RULES deprecated)
+- rules/ — 73 active detection rules in 8 YAML files, validated by rules/_schema.json
 - memory-bank/ — ai-mistakes.md (READ FIRST), progress.md, architecture.md
-- .claude/skills/ — 9 skills: context, design-system, electron-main, svelte-patterns, testing, ship, pr-monitor, ci-monitor, prompt-craft
-- IPC: preload.js — 43 invoke + 6 push channels via contextBridge
+- .claude/skills/ — 11 skills: aegis-context, design-system, electron-main, svelte-patterns, testing, ship, pr-monitor, ci-monitor, prompt-craft, audit-check, commit-and-track
+- IPC: preload.js — 39 invoke + 9 push = 48 channels via contextBridge
 
 ## MCP & Skills
 - Context7 MCP: проверяй доку ПЕРЕД решениями | Svelte MCP: autofixer на .svelte
@@ -50,7 +51,7 @@ only the project-level settings.json `deny` (rm -rf, git push --force, .env read
 | architecture-mapper | prompt-only (bare Bash) | Structural map: main/renderer/preload split, detection pipeline, IPC channels, dead code, JS→TS completeness | Before a refactor or release when you need an architecture map |
 | security-reviewer | prompt-only (bare Bash) | Electron hardening, IPC surface, secrets-leak trace, Anthropic key handling, dep CVEs (RED/YELLOW/GREEN) | Before any release, dep bump, or IPC/preload/logging/export change |
 | test-auditor | prompt-only (bare Bash) | Coverage matrix, untested monitoring/IPC/cross-platform paths, weak/tautological tests | When you need what is actually tested vs untested |
-| consistency-reviewer | prompt-only (bare Bash) | Docs-vs-reality: verify 107 agents / 68 rules / <2s boot / CSP / JS-vs-TS / IPC counts | Before README, grant/investor material, or public release |
+| consistency-reviewer | prompt-only (bare Bash) | Docs-vs-reality: verify 110 agents / 73 rules / <2s boot / CSP / JS-vs-TS / IPC counts | Before README, grant/investor material, or public release |
 | researcher | prompt-only (write-block structural via `agent: Explore`; Bash unscoped) | Explore codebase, answer questions with file:line refs | Quick read-only investigation of how something works (`/research`) |
 | shipper | **no** — releases via `Bash(git *)` (push/merge) | Release workflow: verify loop, show diff, push/merge/tag, waits for confirmation | Shipping a version (`/ship`) |
 | ui-designer | **no** — has `Edit` | Implements Fancy UI Svelte components from the master plan | Any visual/CSS/Svelte component work (`/fancy-ui`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Requires Node.js 18+ and Windows 10/11 for full monitoring functionality. The El
 1. **Fork** the repository
 2. **Branch** from `master`: `git checkout -b feature/your-feature`
 3. **Implement** your changes following the code standards below
-4. **Test**: run `npm test` (707 tests across 44 files) and `npm start` — verify no console errors, all tabs render, existing features work
+4. **Test**: run `npm test` (968 tests across 62 files) and `npm start` — verify no console errors, all tabs render, existing features work
 5. **Commit** with [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 6. **Push** your branch and open a **Pull Request** with a clear description of what changed and why
 
@@ -154,16 +154,27 @@ If the renderer needs data, register an IPC handler in `registerIpc()` and add t
 
 ## How to Add New Sensitive File Rules
 
-Edit `src/shared/constants.js` — add to the `SENSITIVE_RULES` array:
+Rules live in `rules/*.yaml` — one ruleset file per category, validated against `rules/_schema.json` and loaded by `src/main/rule-loader.js` with hot-reload. Add an entry to the ruleset for your category:
 
-```javascript
-{ pattern: /my-pattern/i, reason: 'Description shown in UI', category: 'my-category', severity: 'critical' }
+```yaml
+  - id: "SS007"
+    name: "SSH agent socket"
+    pattern: "ssh-agent"
+    reason: "Description shown in UI"
+    category: "ssh"
+    risk: critical
+    enabled: true
 ```
 
-- `pattern` — RegExp tested against the full file path
+- `id` — Unique rule id (2-letter category prefix + 3 digits)
+- `name` — Short rule name
+- `pattern` — Regex source string tested against the full file path
 - `reason` — Human-readable label displayed in the activity feed
-- `category` — Optional grouping (e.g., `agent-config`, `credential`)
-- `severity` — Optional: `critical`, `high`, `medium`, or `low`
+- `category` — Must be one of the 8 values in `_schema.json`: `ai-config`, `secrets`, `ssh`, `certificates`, `cloud`, `browser`, `devtools`, `crypto`
+- `risk` — `critical`, `high`, `medium`, or `low`
+- `enabled` — Set `false` to ship a rule disabled by default
+
+`SENSITIVE_RULES` in `src/shared/constants.js` is deprecated and not read at runtime — editing it has no effect on detection.
 
 ## Issue Labels
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/antropos17/Aegis/releases/latest"><img src="https://img.shields.io/github/v/release/antropos17/Aegis?include_prereleases&style=flat-square&label=Release" alt="Release"></a>
   <img src="https://img.shields.io/github/actions/workflow/status/antropos17/Aegis/ci.yml?style=flat-square&label=CI" alt="CI">
-  <img src="https://img.shields.io/badge/Tests-707%20passing-brightgreen?style=flat-square" alt="Tests">
+  <img src="https://img.shields.io/badge/Tests-968%20passing-brightgreen?style=flat-square" alt="Tests">
   <a href="#monitor-first"><img src="https://img.shields.io/badge/Mode-monitor--first-8a2be2?style=flat-square" alt="Monitor-first"></a>
   <img src="https://img.shields.io/badge/License-MIT-blue?style=flat-square" alt="MIT License">
   <img src="https://img.shields.io/badge/Platform-Win%20%7C%20macOS%20%7C%20Linux-lightgrey?style=flat-square" alt="Platform">
@@ -47,7 +47,7 @@
 | **0** | open-source EDR tools existed for AI agents before Aegis |
 | **110** | AI agent signatures in the detection database, from Claude Code to AutoGPT |
 | **73** | behavioral detection rules across 8 categories, with hot-reload and custom overrides |
-| **707** | tests passing, 0 failures — the monitoring engine is verified on every commit |
+| **968** | tests passing, 0 failures — the monitoring engine is verified on every commit |
 | **<2s** | cold boot to full dashboard — lightweight enough to run alongside the agents it monitors |
 
 AI agents now have deep access to your machine — files, commands, network. Every existing AI security tool is enterprise SaaS that monitors what humans send *to* AI. Nobody monitors what AI agents do *on local machines*. Aegis is the open-source answer.
@@ -205,7 +205,7 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
             └─────────────┘    └─────────────┘
 ```
 
-**Stack**: Electron 33, Svelte 5, Vite 7, Vitest (707 tests across 44 files). The monitoring engine is JavaScript (CommonJS); TypeScript is used in the renderer and shared types.
+**Stack**: Electron 33, Svelte 5, Vite 7, Vitest (968 tests across 62 files). The monitoring engine is JavaScript (CommonJS); TypeScript is used in the renderer and shared types.
 
 ## Agent Database
 
@@ -264,7 +264,7 @@ Aegis ships with 110 agent signatures across five categories: coding assistants 
 
 ### Can I use Aegis in production?
 
-Aegis is currently at v0.10.0-alpha and is recommended for development and testing environments. The core monitoring engine is stable with 707 tests passing, but production deployment features (auto-update, OS-level enforcement) are on the roadmap for v1.0.
+Aegis is currently at v0.10.0-alpha and is recommended for development and testing environments. The core monitoring engine is stable with 968 tests passing, but production deployment features (auto-update, OS-level enforcement) are on the roadmap for v1.0.
 
 ### Is Aegis free?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,7 @@ AEGIS follows Electron security best practices:
 
 - **Context isolation:** Enabled. The renderer process cannot access Node.js APIs.
 - **Node integration:** Disabled in the renderer.
-- **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (49 channels: 43 invoke + 6 push). No arbitrary IPC.
+- **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (48 channels: 39 invoke + 9 push). No arbitrary IPC.
 - **Content Security Policy:** Strict `default-src 'self'` policy, no external font loading.
 - **No remote content:** The app loads only local files. No external URLs in the renderer.
 - **Input sanitization:** All user-visible strings pass through `escapeHtml()` before DOM insertion. Template literals are used for HTML generation, not `innerHTML` with raw strings.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -33,7 +33,7 @@ Watches sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs) and 27 A
 Logs outbound TCP connections per agent PID with reverse DNS and known-vs-unknown API endpoint classification.
 
 ### Behavioral Analysis
-Applies 68 detection rules across 8 categories (AI config, secrets, SSH, cloud, browser, devtools, crypto, certificates) with rolling 10-session baselines and 4-axis anomaly scoring (Network/FS/Process/Baseline).
+Applies 73 detection rules across 8 categories (AI config, secrets, SSH, cloud, browser, devtools, crypto, certificates) with rolling 10-session baselines and 4-axis anomaly scoring (Network/FS/Process/Baseline).
 
 ### Trust Scoring
 Assigns real-time risk scores with trust grades (A+ through F) using time-decay algorithms and multi-dimensional threat assessment.
@@ -45,7 +45,7 @@ Bento grid layout with RiskRing gauge, sparklines, TrustBadge, agent stats, acti
 JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily rotation and 30-day retention.
 
 ### YAML Rulesets
-68 detection rules, JSON Schema validated, hot-reload without restart. Extend or override via rules/custom/ directory.
+73 detection rules, JSON Schema validated, hot-reload without restart. Extend or override via rules/custom/ directory.
 
 ## Documentation
 
@@ -57,7 +57,7 @@ JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily r
 ## Technical Details
 
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
-- **Tests**: 707 passing across 44 files (Vitest)
+- **Tests**: 968 passing, 4 skipped across 62 files (Vitest)
 - **License**: MIT
 - **Version**: 0.10.0-alpha
 - **Platform**: Windows, macOS, Linux

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@
 - Process monitoring with 110 known AI agent signatures and parent-child tree resolution
 - File system watching for sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs)
 - Network activity logging with per-agent PID tracking and reverse DNS
-- Behavioral analysis with 68 detection rules across 8 categories
+- Behavioral analysis with 73 detection rules across 8 categories
 - Trust scoring with grades A+ through F using time-decay algorithms
 - Local LLM detection (Ollama, LM Studio, vLLM, llama.cpp)
 - Export to JSON, CSV, HTML reports and ZIP archives
@@ -23,7 +23,7 @@
 ## Technical Details
 
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
-- **Tests**: 707 passing across 44 files (Vitest)
+- **Tests**: 968 passing, 4 skipped across 62 files (Vitest)
 - **License**: MIT
 - **Version**: 0.10.0-alpha
 - **Platform**: Windows, macOS, Linux


### PR DESCRIPTION
Docs had drifted a full generation. Every number in this PR was re-derived with a command against the tree, not copied from a neighbouring doc.

| Claim | Was | Is | Source command |
|---|---|---|---|
| Tests | 707 / 44 files | **968 pass, 4 skip (972) / 62 files** | `npm test` |
| `src/main` modules | 23 | **43** (34 top-level + 7 `platform/` + 2 `token-adapters/`) | `find src/main -name '*.js' \| wc -l` |
| Renderer inventory | 43 components / 9 stores / 15 utils | **46 / 11 / 16** | `find src/renderer/lib/{components,stores,utils}` |
| IPC channels | 54 (and 49 in SECURITY.md, and 43+6 elsewhere) | **48 = 39 invoke + 9 push** | `grep -c 'invoke(' preload.js`, cross-checked against `grep -c 'ipcMain.handle(' ipc-handlers.js` |
| Detection rules | 68 in `constants.js` | **73 in `rules/*.yaml`** | `grep -c '^  - id:' rules/*.yaml` |
| Agent signatures | 106 / 107 | **110** | `agent-database.json`.`agents.length` |
| Skills | 9 | **11** | `ls .claude/skills` |

## Three fixes that matter more than the counts

**`.claude/skills/aegis-context/SKILL.md` auto-loads into every session.** Its stale figures were seeding each new context with a wrong picture of the repo — this was the highest-leverage file in the set, not the most visible one.

**Four docs told contributors to add detection rules by editing `SENSITIVE_RULES` in `constants.js`.** That array has been deprecated and unread at runtime since the YAML migration — `classifySensitive()` reads `getAllRules()` from `rule-loader`. Following the old instruction produced no detection change at all. `ARCHITECTURE.md`, `CONTRIBUTING.md` and both affected skills now document the real path: a YAML entry in `rules/*.yaml`, validated against `rules/_schema.json`, hot-reloaded.

**`memory-bank/implementation-plan.md` is deleted, not corrected.** It described a vanilla-JS renderer with no build step and an unstarted Svelte migration. The migration shipped. It was the last source in the repo claiming this project has no build step, so correcting it would have preserved a document with no remaining purpose. (The file is git-ignored, so the deletion does not appear in this diff.)

Two further `memory-bank/` files were resynced in the same pass and are **not in this diff** for the same reason — `memory-bank/*` is git-ignored (`.gitignore:19`): `architecture.md` (module/IPC/component counts, plus the same `categoryIndex` correction) and `honesty-audit.md` (stale reference figures; the IPC-drift and agent-count drift items are now closed). They are local working notes and will not reach a clone or CI.

## The 300-line limit

`CLAUDE.md` and `.claude/rules/code-quality.md` now carry a **word-for-word identical** statement: 300 lines is a target for new files, not an invariant. 18 source files already exceed it (largest `file-watcher.js` at 632) and tests reach 691. The two files stated the same rule separately and were free to drift apart again; identical wording is the point.

## Verification

- `npm test` → 62 files, 968 passed, 4 skipped — run before and after the edits
- `npm run build:renderer` → clean
- `npm run lint` → 0 errors (23 pre-existing warnings, unchanged)
- `npm run format:check` fails on 129 files **identically on `master`** — pre-existing, and Prettier's globs do not cover `.md`, so nothing here contributes to it
- All changed files verified as valid UTF-8 (`iconv -f UTF-8 -t UTF-8`)

Docs only. No source, test, rule, or `package.json` change.

## Known remaining, deliberately out of scope

- `AGENTS.md:14` still says 106 agent signatures — a live public doc, not in this block's file list
- `llms.txt:26` and `llms-full.txt:60` say "707 passing across 44 files"; `llms.txt:17` and `llms-full.txt:36,48` say 68 detection rules. Both files are tracked and exist to be fed to LLMs verbatim, so they are the highest-impact remaining stale surface after `AGENTS.md`
- `.claude/agents/consistency-reviewer.md:35` instructs the reviewer agent to count `SENSITIVE_RULES` in `constants.js` — i.e. to audit docs against the deprecated array
- `.claude/agents/test-auditor.md:26`, `.prompts/02-coverage.md:10` (the latter also encoding-damaged)
- `README.md:129` keeps "68 rules" in the v0.7.0-alpha release-history row, which is correct history
