### PR TITLE
feat(process): identify processes by pid+startTime, not pid alone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ AEGIS-PERSONA-VAULT.md
 # Claude Code hook telemetry (UserPromptSubmit) — not produced by AEGIS
 events.jsonl
 
+# Standalone marketing landing page — external artifact, not part of the product
+aegis_landing.html
+
 # Sensitive production/cert files
 .env.production
 *.cert

--- a/src/main/process-identity.js
+++ b/src/main/process-identity.js
@@ -1,0 +1,161 @@
+/**
+ * @file process-identity.js
+ * @module main/process-identity
+ * @description The single authority for AEGIS's process INSTANCE key. Windows
+ *   recycles PIDs, so a bare PID is not an identity: a new process can inherit a
+ *   dead one's session, dedup sets and accumulated accounting. `instanceId` binds
+ *   the PID to the OS process-creation time — a pair the OS never reissues.
+ *
+ *   THREE VALUE SPACES, disjoint by construction (a value from one can never
+ *   equal a value from another — the pid segment and the `u` marker separate them):
+ *
+ *     1. `"<pid>:<epochMs>"` — source `'os'`. pid > 0 with a readable OS birth
+ *        time. The reuse-resistant case.
+ *     2. `"0:<name>"` — source `'synthetic'`. pid 0. Editor-extension agents
+ *        (Kilo Code, Cline), WSL-inner agents and local LLM runtimes have no OS
+ *        process at all and are registered with pid 0 (ide-extension-detector.js,
+ *        wsl-detector.js, scan-loop.js `attachModels`). Their NAME is the
+ *        identity, so two synthetics never collapse onto one key, and the key is
+ *        stable across ticks — a per-tick surrogate would churn their agent cards.
+ *     3. `"<pid>:u"` — source `'unknown'`. A real process whose birth time is
+ *        unreadable. Honest by construction: "this pid, instances
+ *        indistinguishable". Cannot collide with space 1 (`u` is not a number),
+ *        and the degradation is exactly the pre-instanceId behaviour, not a
+ *        regression.
+ *
+ *   `:u` is deliberately NOT a fabricated surrogate (no counter, no first-seen
+ *   stamp). Distinguishability we do not have is not invented here; a caller that
+ *   needs name-level discrimination composes it itself — session-tracker.js keys
+ *   on `instanceId|process`, so the process name still separates instances
+ *   wherever space 3 applies.
+ *
+ *   TIME RESOLUTION — the bound on space 1, per platform. Two instances sharing
+ *   BOTH a pid and a birth timestamp are indistinguishable; that is the only
+ *   failure mode, and it degrades to space 3's behaviour (two instances read as
+ *   one). No tie-breaker is added for it — that code would never run.
+ *     - win32: MILLISECONDS. `Win32_Process.CreationDate` →
+ *       `ToUnixTimeMilliseconds()` (platform/win32.js `getParentProcessMap`).
+ *       A collision needs the OS to free and reissue the same pid inside 1 ms.
+ *     - linux: 10 ms would be available from `/proc/<pid>/stat` field 22 at the
+ *       usual USER_HZ=100. The `/proc/stat` btime anchor carries up to ±1 s of
+ *       systematic error, but it is identical for every process on the machine,
+ *       so it affects only cross-machine comparability — never distinguishability.
+ *       NOT WIRED: platform/linux.js `getParentProcessMap` omits startTime today,
+ *       so linux resolves to space 3.
+ *     - darwin: 1 SECOND at best (`ps` lstart/etime). Reuse inside one second
+ *       would require the macOS pid counter to wrap (~99k spawns in that second).
+ *       NOT WIRED: platform/darwin.js omits startTime, so darwin resolves to
+ *       space 3.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ * @since v0.11.0
+ */
+'use strict';
+
+/**
+ * Closed set of `instanceId` provenances. Exported so callers and tests assert
+ * against the set instead of re-listing the literals: `'os'` = bound to an OS
+ * birth time (space 1), `'synthetic'` = named pid-0 entity (space 2),
+ * `'unknown'` = real pid, birth time unreadable (space 3).
+ * @type {readonly ['os', 'synthetic', 'unknown']}
+ * @since v0.11.0
+ */
+const INSTANCE_ID_SOURCES = Object.freeze(['os', 'synthetic', 'unknown']);
+
+/**
+ * @typedef {'os'|'synthetic'|'unknown'} InstanceIdSource
+ */
+
+/**
+ * @typedef {Object} ProcessIdentity
+ * @property {string} instanceId - the instance key; one of the three value spaces.
+ * @property {InstanceIdSource} instanceIdSource - where the key came from, so a
+ *   consumer can be honest about reuse-resistance without parsing the string.
+ */
+
+/**
+ * @typedef {Object} IdentityInput
+ * @property {number} [pid] - OS process id; 0 marks a synthetic (process-less) agent.
+ * @property {string} [process] - OS process name (preferred name source).
+ * @property {string} [agent] - display name; used only when `process` is absent.
+ * @property {number|null} [startTime] - OS process-creation time (epoch ms), or
+ *   null/absent when the platform did not supply one.
+ */
+
+/**
+ * Normalise a pid to a non-negative integer, or null when it is unusable.
+ * @param {*} v
+ * @returns {number|null}
+ */
+function _normalizePid(v) {
+  return Number.isInteger(v) && v >= 0 ? v : null;
+}
+
+/**
+ * Name segment for the synthetic space: lowercased, whitespace collapsed to `-`
+ * so the key stays a single readable token in JSON and audit JSONL. `process` is
+ * preferred over `agent` because the detectors already emit a normalised process
+ * name (e.g. 'lm-studio'); the display name is the fallback.
+ * @param {IdentityInput} agent
+ * @returns {string} normalised name, or '' when there is none.
+ */
+function _normalizeName(agent) {
+  const raw = agent && (agent.process || agent.agent);
+  if (typeof raw !== 'string') return '';
+  return raw.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
+/**
+ * True when a value is a usable OS birth time (finite epoch-ms above zero).
+ * @param {*} v
+ * @returns {boolean}
+ */
+function _isUsableStartTime(v) {
+  return typeof v === 'number' && Number.isFinite(v) && v > 0;
+}
+
+/**
+ * Resolve a detected agent to its instance key AND the key's provenance. Pure —
+ * no module state, no I/O, no clock. See the file header for the three value
+ * spaces and their platform bounds.
+ * @param {IdentityInput} agent - detected agent (or any {pid, process, startTime}).
+ * @returns {ProcessIdentity}
+ * @since v0.11.0
+ */
+function identify(agent) {
+  const pid = _normalizePid(agent && agent.pid);
+
+  // Space 1 — a real process with a readable OS birth time.
+  if (pid !== null && pid > 0 && _isUsableStartTime(agent.startTime)) {
+    return { instanceId: `${pid}:${agent.startTime}`, instanceIdSource: 'os' };
+  }
+
+  // Space 2 — pid 0 is not an OS process; the name IS the identity. An unnamed
+  // pid-0 entry falls through to space 3: without a name there is nothing to
+  // distinguish it by, and inventing one would be a fabricated identity.
+  if (pid === 0) {
+    const name = _normalizeName(agent);
+    if (name) return { instanceId: `0:${name}`, instanceIdSource: 'synthetic' };
+  }
+
+  // Space 3 — honest "cannot distinguish instances of this pid". An unusable pid
+  // normalises to 0 so the key stays well-formed rather than embedding 'NaN'.
+  return { instanceId: `${pid === null ? 0 : pid}:u`, instanceIdSource: 'unknown' };
+}
+
+/**
+ * The instance key alone, for callers that do not need the provenance.
+ * @param {IdentityInput} agent
+ * @returns {string}
+ * @since v0.11.0
+ */
+function buildInstanceId(agent) {
+  return identify(agent).instanceId;
+}
+
+module.exports = {
+  INSTANCE_ID_SOURCES,
+  identify,
+  buildInstanceId,
+};

--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -12,6 +12,7 @@
 
 const path = require('path');
 const _platform = require('./platform');
+const { identify } = require('./process-identity');
 const { EDITORS } = require('../shared/constants');
 
 let _getParentProcessMap = _platform.getParentProcessMap;
@@ -31,13 +32,45 @@ const parentChainCache = new Map();
 const PARENT_CHAIN_TTL = 60000;
 
 /**
+ * Cache key for the parent-chain / startTime cache: pid PLUS the process name.
+ *
+ * A bare pid is not enough. Windows recycles PIDs, so a live TTL entry keyed on
+ * pid alone serves the DEAD process's chain and — far worse — its `startTime`,
+ * the one field `instanceId` is built from. Folding the name in turns a recycled
+ * pid that belongs to a different executable into a cache MISS.
+ *
+ * KNOWN BOUND: a pid recycled by an executable with the SAME name still hits
+ * inside the TTL. `forceRefresh` (passed by scan-loop whenever the scanned pid
+ * SET changed) covers the common case; the residue is a same-name reuse on a tick
+ * where the set is unchanged.
+ * @param {number} pid
+ * @param {string} [name] - OS process name (or display name) observed for that pid.
+ * @returns {string}
+ * @since v0.11.0
+ */
+function _cacheKey(pid, name) {
+  return `${pid}|${typeof name === 'string' ? name.toLowerCase() : ''}`;
+}
+
+/**
  * Resolve parent process chains for a list of PIDs via platform adapter.
  * @param {number[]} pids
+ * @param {Object} [opts]
+ * @param {Map<number, string>} [opts.names] - pid → process name, used to key the
+ *   cache (see {@link _cacheKey}). Omitted names key as the empty string, which is
+ *   consistent for a caller that never supplies them.
+ * @param {boolean} [opts.forceRefresh=false] - when true, ignore cached entries for
+ *   the requested pids and re-read the OS process map. Costs one platform call —
+ *   the SAME `cim-parent` fetch the scan tick already pays for on win32.
  * @returns {Promise<Map<number, string[]>>} pid to parent-name chain
  * @since v0.1.0
  */
-async function getParentChains(pids) {
+async function getParentChains(pids, opts = {}) {
   if (pids.length === 0) return new Map();
+
+  const names = opts.names instanceof Map ? opts.names : null;
+  const forceRefresh = opts.forceRefresh === true;
+  const keyOf = (pid) => _cacheKey(pid, names ? names.get(pid) : undefined);
 
   const now = Date.now();
   // Prune stale entries when cache grows too large
@@ -47,14 +80,15 @@ async function getParentChains(pids) {
     }
   }
   const needLookup = pids.filter((pid) => {
-    const cached = parentChainCache.get(pid);
+    if (forceRefresh) return true;
+    const cached = parentChainCache.get(keyOf(pid));
     return !cached || now - cached.timestamp > PARENT_CHAIN_TTL;
   });
 
   if (needLookup.length === 0) {
     const result = new Map();
     for (const pid of pids) {
-      const cached = parentChainCache.get(pid);
+      const cached = parentChainCache.get(keyOf(pid));
       if (cached) result.set(pid, cached.chain);
     }
     return result;
@@ -63,11 +97,14 @@ async function getParentChains(pids) {
   const procMap = await _getParentProcessMap();
   const result = new Map();
 
-  // Populate cached entries first
-  for (const pid of pids) {
-    const cached = parentChainCache.get(pid);
-    if (cached && now - cached.timestamp <= PARENT_CHAIN_TTL) {
-      result.set(pid, cached.chain);
+  // Populate cached entries first — skipped entirely under forceRefresh, where
+  // every requested pid is re-walked from the fresh map below.
+  if (!forceRefresh) {
+    for (const pid of pids) {
+      const cached = parentChainCache.get(keyOf(pid));
+      if (cached && now - cached.timestamp <= PARENT_CHAIN_TTL) {
+        result.set(pid, cached.chain);
+      }
     }
   }
 
@@ -93,13 +130,12 @@ async function getParentChains(pids) {
     // Capture the OS process birth time (epoch-ms) for the agent's OWN pid from
     // the same map fetch — zero extra spawn. Only win32 supplies it; darwin/linux
     // map entries omit startTime, so the typeof guard yields null (honest).
-    // KNOWN BOUND: the 60s cache TTL means a pid REUSED within 60s serves the
-    // prior process's startTime. Mostly fail-safe (stale time won't match a new
-    // session's startedAt → the token-feed guard rejects it) and strictly better
-    // than no startTime (on which the Windows guard never passes).
+    // The cache entry is keyed by pid AND process name, so a pid recycled by a
+    // different executable no longer serves this startTime (see _cacheKey for the
+    // residual same-name bound).
     const ownInfo = procMap.get(pid);
     const startTime = ownInfo && typeof ownInfo.startTime === 'number' ? ownInfo.startTime : null;
-    parentChainCache.set(pid, { chain, startTime, timestamp: now });
+    parentChainCache.set(keyOf(pid), { chain, startTime, timestamp: now });
     result.set(pid, chain);
   }
 
@@ -107,23 +143,45 @@ async function getParentChains(pids) {
 }
 
 /**
- * Attach parent-chain arrays AND the OS process start-time to each agent object.
+ * Attach parent-chain arrays, the OS process start-time AND the process instance
+ * key to each agent object.
+ *
  * `startTime` (epoch-ms, OS birth time) is distinct from `firstSeen`
  * (AEGIS-observed) and is read from the same cache `getParentChains` populates —
- * after the call every requested pid has an entry, so the read is safe. Used by
- * the token-feed PID-reuse guard; null on non-Windows or absent pid.
+ * after the call every requested pid has an entry under the same key, so the read
+ * is safe. Used by the token-feed PID-reuse guard; null on non-Windows or absent pid.
+ *
+ * `instanceId` / `instanceIdSource` are derived from that startTime by
+ * process-identity.js. This is the ONLY place they are stamped, so it must run
+ * BEFORE anything that keys on a process instance — session-tracker's reconcile in
+ * particular (see scan-loop.js).
  * @param {Array} agents
+ * @param {Object} [opts]
+ * @param {boolean} [opts.forceRefresh=false] - re-read the OS process map instead of
+ *   trusting cached entries. Pass true when the scanned pid set changed: a pid new
+ *   to the set must never be identified from a dead process's cached birth time.
  * @returns {Promise<void>}
  * @since v0.1.0
  */
-async function enrichWithParentChains(agents) {
+async function enrichWithParentChains(agents, opts = {}) {
   if (agents.length === 0) return;
   const pids = agents.map((a) => a.pid);
-  const chains = await getParentChains(pids);
+  // pid → name for the cache key. Synthetic agents all share pid 0, so the last
+  // one wins here; harmless because pid 0 is absent from the OS process map (its
+  // startTime is null either way) and identify() below reads each agent's OWN name.
+  const names = new Map();
+  for (const a of agents) names.set(a.pid, String(a.process || a.agent || ''));
+  const chains = await getParentChains(pids, {
+    names,
+    forceRefresh: opts.forceRefresh === true,
+  });
   for (const a of agents) {
     a.parentChain = chains.get(a.pid) || [];
-    const entry = parentChainCache.get(a.pid);
+    const entry = parentChainCache.get(_cacheKey(a.pid, names.get(a.pid)));
     a.startTime = entry && typeof entry.startTime === 'number' ? entry.startTime : null;
+    const identity = identify(a);
+    a.instanceId = identity.instanceId;
+    a.instanceIdSource = identity.instanceIdSource;
   }
 }
 

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -195,6 +195,14 @@ async function doProcessScan() {
     const result = await scanner.scanProcesses();
     setAgents(result.agents);
     const agents = result.agents;
+    // Process IDENTITY first. This attaches the OS birth time and the derived
+    // `instanceId`, which the session key is built from — so it MUST precede
+    // reconcile, or every session would key on a degraded `"<pid>:u"` and a
+    // recycled pid running the same executable would silently continue the dead
+    // process's session. `forceRefresh` on a changed pid set keeps a pid that is
+    // new to the scan from being identified out of a stale cache entry. No new
+    // spawn: on win32 this is the same `cim-parent` fetch the tick already pays.
+    await procUtil.enrichWithParentChains(agents, { forceRefresh: result.changed === true });
     // Eager-enter / lazy-exit session reconciliation: an agent seen in even ONE
     // scan logs session-start immediately, and a flickering or permission-denied
     // scan never spawns a duplicate session. See session-tracker.js.
@@ -207,7 +215,10 @@ async function doProcessScan() {
         action: 'started',
         path: '',
         severity: 'normal',
-        extra: { pid: s.pid, startTime: s.firstSeen },
+        // instanceId rides the EXISTING `extra` slot (audit-logger stores it as
+        // `details`), so the record's top-level field set — and therefore the hash
+        // chain — is unchanged and older files stay verifiable.
+        extra: { pid: s.pid, instanceId: s.instanceId, startTime: s.firstSeen },
       });
     for (const s of exited)
       audit.log('agent-exit', {
@@ -215,10 +226,9 @@ async function doProcessScan() {
         action: 'exited',
         path: '',
         severity: 'normal',
-        extra: { pid: s.pid },
+        extra: { pid: s.pid, instanceId: s.instanceId },
       });
     watcher.pruneKnownHandles(agents);
-    await procUtil.enrichWithParentChains(agents);
     procUtil.annotateHostApps(agents);
     await procUtil.annotateWorkingDirs(agents);
     // Surface extension-only (Kilo/Cline) and WSL-inner (grok/opencode) agents

--- a/src/main/session-tracker.js
+++ b/src/main/session-tracker.js
@@ -13,16 +13,30 @@
  *     `tasklist`, or a permission-denied scan) does NOT end it and reappearance
  *     does NOT create a duplicate session.
  *
- *   Identity is `pid + process name`. The OS process start-time is not available
- *   from the snapshot scanner (`tasklist /FO CSV /NH` returns only name+pid), so
- *   PID-reuse is disambiguated by the process name (a recycled PID belonging to a
- *   different agent yields a different key → a new session); each session also
- *   carries an AEGIS-observed `firstSeen` timestamp as its start-time field.
+ *   Identity is `instanceId + process name`, where `instanceId` binds the pid to
+ *   the OS process-creation time (process-identity.js). The snapshot scanner
+ *   itself still returns only name+pid (`tasklist /FO CSV /NH`), so the birth time
+ *   is attached upstream by `procUtil.enrichWithParentChains`, which scan-loop runs
+ *   BEFORE reconcile. Consequences:
+ *
+ *   - Where the platform supplies a birth time (win32), a recycled PID yields a
+ *     different `instanceId` → the dead process gets its `exited` event and the new
+ *     one a fresh session with its own `firstSeen`, EVEN WHEN both run the same
+ *     executable. That same-name case used to collapse into one never-ending session.
+ *   - Where it does not (darwin/linux today, or an unreadable birth time),
+ *     `instanceId` degrades to `"<pid>:u"` and the process NAME in the composite key
+ *     still separates a recycled pid belonging to a different agent — the
+ *     pre-instanceId behaviour, unchanged.
+ *
+ *   Each session also carries an AEGIS-observed `firstSeen` timestamp as its
+ *   start-time field, distinct from the OS birth time inside `instanceId`.
  * @author AEGIS Contributors
  * @license MIT
- * @version 0.1.0
+ * @version 0.2.0
  */
 'use strict';
+
+const { buildInstanceId } = require('./process-identity');
 
 /**
  * Consecutive RELIABLE scans an active session may go unseen before it is
@@ -35,6 +49,7 @@ const DEFAULT_EXIT_GRACE = 2;
 /**
  * @typedef {Object} Session
  * @property {number} pid
+ * @property {string} instanceId - process instance key (see process-identity.js)
  * @property {string} agent - display name (e.g. "Claude Code")
  * @property {string} process - OS process name (e.g. "claude")
  * @property {number} firstSeen - AEGIS-observed start time (ms epoch)
@@ -42,26 +57,53 @@ const DEFAULT_EXIT_GRACE = 2;
  * @property {number} missed - consecutive reliable scans unseen
  */
 
-/** @type {Map<string, Session>} Active sessions keyed by `pid|process`. */
+/** @type {Map<string, Session>} Active sessions keyed by `instanceId|process`. */
 const activeSessions = new Map();
 
 /**
- * Stable identity key for a detected agent: pid + lowercased process name.
- * NOT keyed on firstSeen — keying on a timestamp would give every reappearance
- * a fresh identity and re-create the session on each flicker.
- * @param {{pid: number, agent?: string, process?: string}} agent
+ * Stable identity key for a detected agent: `instanceId` + lowercased process name.
+ *
+ * COMPOSITE on purpose. `instanceId` alone would lose the name-level
+ * discrimination wherever it degrades to `"<pid>:u"` (no OS birth time); the name
+ * alone cannot separate two runs of the same executable on a recycled pid. Each
+ * segment covers the other's blind spot.
+ *
+ * `instanceId` is normally stamped upstream by `procUtil.enrichWithParentChains`;
+ * it is derived here when absent so this module stays usable standalone (and its
+ * key format has exactly one definition).
+ *
+ * NOT keyed on firstSeen — keying on an AEGIS-observed timestamp would give every
+ * reappearance a fresh identity and re-create the session on each flicker.
+ * @param {{pid: number, agent?: string, process?: string, startTime?: number|null,
+ *          instanceId?: string}} agent
  * @returns {string}
  */
 function sessionKey(agent) {
   const proc = String(agent.process || agent.agent || '').toLowerCase();
-  return `${agent.pid}|${proc}`;
+  return `${_instanceIdOf(agent)}|${proc}`;
+}
+
+/**
+ * The agent's stamped `instanceId`, or a freshly derived one when the upstream
+ * enrichment did not run (standalone use, tests). One definition, two callers —
+ * `sessionKey` and the session record built in `reconcile` must never disagree.
+ * @param {{pid: number, agent?: string, process?: string, startTime?: number|null,
+ *          instanceId?: string}} agent
+ * @returns {string}
+ */
+function _instanceIdOf(agent) {
+  return typeof agent.instanceId === 'string' && agent.instanceId
+    ? agent.instanceId
+    : buildInstanceId(agent);
 }
 
 /**
  * Reconcile a process scan against the active-session set.
  *
- * @param {Array<{pid: number, agent: string, process?: string}>} agents
- *   Agents detected in THIS scan (deduped by pid upstream).
+ * @param {Array<{pid: number, agent: string, process?: string, startTime?: number|null,
+ *                instanceId?: string}>} agents
+ *   Agents detected in THIS scan (deduped by pid upstream), already carrying
+ *   `instanceId` from `procUtil.enrichWithParentChains`.
  * @param {Object} [opts]
  * @param {boolean} [opts.reliable=true] - false when the scan could not
  *   enumerate processes (e.g. permission-denied → empty list). An unreliable
@@ -70,8 +112,8 @@ function sessionKey(agent) {
  * @param {number} [opts.now] - injectable timestamp (ms) for tests.
  * @param {number} [opts.grace=DEFAULT_EXIT_GRACE] - consecutive reliable misses
  *   before a session is reported as exited.
- * @returns {{entered: Array<{pid: number, agent: string, process: string, firstSeen: number}>,
- *            exited: Array<{pid: number, agent: string, process: string, firstSeen: number, lastSeen: number}>}}
+ * @returns {{entered: Array<{pid: number, instanceId: string, agent: string, process: string, firstSeen: number}>,
+ *            exited: Array<{pid: number, instanceId: string, agent: string, process: string, firstSeen: number, lastSeen: number}>}}
  * @since v0.10.0-alpha
  */
 function reconcile(agents, opts = {}) {
@@ -97,6 +139,7 @@ function reconcile(agents, opts = {}) {
     } else {
       const session = {
         pid: a.pid,
+        instanceId: _instanceIdOf(a),
         agent: a.agent,
         process: a.process || '',
         firstSeen: now,
@@ -106,6 +149,7 @@ function reconcile(agents, opts = {}) {
       activeSessions.set(key, session);
       entered.push({
         pid: session.pid,
+        instanceId: session.instanceId,
         agent: session.agent,
         process: session.process,
         firstSeen: session.firstSeen,
@@ -120,6 +164,7 @@ function reconcile(agents, opts = {}) {
     if (s.missed >= grace) {
       exited.push({
         pid: s.pid,
+        instanceId: s.instanceId,
         agent: s.agent,
         process: s.process,
         firstSeen: s.firstSeen,

--- a/src/shared/types/process.ts
+++ b/src/shared/types/process.ts
@@ -14,7 +14,19 @@ export interface ProcessInfo {
 export interface ParentProcessInfo {
   readonly name: string;
   readonly ppid: number;
+  /**
+   * OS process-creation time (epoch ms). Supplied by win32 only; darwin/linux map
+   * entries omit it, so the field is null there.
+   */
+  readonly startTime?: number | null;
 }
+
+/**
+ * Provenance of a {@link DetectedAgent.instanceId} — see main/process-identity.js.
+ * `os` = bound to an OS birth time (reuse-resistant); `synthetic` = named pid-0
+ * entity with no OS process; `unknown` = real pid whose birth time is unreadable.
+ */
+export type InstanceIdSource = 'os' | 'synthetic' | 'unknown';
 
 /** Raw TCP connection from Get-NetTCPConnection */
 export interface RawTcpConnection {
@@ -40,6 +52,21 @@ export interface DetectedAgent {
   readonly parentEditor?: string | null;
   readonly cwd?: string | null;
   readonly projectName?: string | null;
+  /**
+   * OS process-creation time (epoch ms), attached by
+   * `process-utils.enrichWithParentChains`. Null when the platform withholds it
+   * (darwin/linux today) or for synthetic pid-0 agents. Distinct from the
+   * AEGIS-observed session `firstSeen`.
+   */
+  readonly startTime?: number | null;
+  /**
+   * Process instance key, `pid` bound to `startTime` — the reuse-resistant
+   * identity. Stamped by `process-utils.enrichWithParentChains`; absent on a raw
+   * scanner result. See main/process-identity.js for the three value spaces.
+   */
+  readonly instanceId?: string;
+  /** Where {@link DetectedAgent.instanceId} came from. */
+  readonly instanceIdSource?: InstanceIdSource;
 }
 
 /** Result of a process scan cycle */

--- a/tests/main/process-identity.test.js
+++ b/tests/main/process-identity.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import identity from '../../src/main/process-identity.js';
+
+const { identify, buildInstanceId, INSTANCE_ID_SOURCES } = identity;
+
+/** A win32-shaped agent: real pid + readable OS birth time. */
+const BIRTH = 1_717_000_000_000;
+
+describe('process-identity', () => {
+  describe('space 1 — os (pid + OS birth time)', () => {
+    it('binds pid to the birth time', () => {
+      const res = identify({ pid: 18324, process: 'claude', startTime: BIRTH });
+      expect(res.instanceId).toBe(`18324:${BIRTH}`);
+      expect(res.instanceIdSource).toBe('os');
+    });
+
+    it('the SAME pid with a different birth time is a different instance', () => {
+      // This is the whole point: PID reuse must not read as one process.
+      const first = buildInstanceId({ pid: 18324, process: 'claude', startTime: BIRTH });
+      const reused = buildInstanceId({
+        pid: 18324,
+        process: 'claude',
+        startTime: BIRTH + 36_000_000, // +10h — the recycled pid
+      });
+      expect(first).not.toBe(reused);
+    });
+
+    it('is stable across calls for the same pid + birth time', () => {
+      const a = buildInstanceId({ pid: 7, process: 'claude', startTime: BIRTH });
+      const b = buildInstanceId({ pid: 7, process: 'claude', startTime: BIRTH });
+      expect(a).toBe(b);
+    });
+
+    it('ignores the process name — identity is pid + birth time, not the exe', () => {
+      // A pid cannot host two executables at one birth time, so the name adds
+      // nothing here; session-tracker composes it separately where it matters.
+      expect(buildInstanceId({ pid: 7, process: 'claude', startTime: BIRTH })).toBe(
+        buildInstanceId({ pid: 7, process: 'cursor', startTime: BIRTH }),
+      );
+    });
+  });
+
+  describe('space 2 — synthetic (pid 0)', () => {
+    it('keys a pid-0 agent by its process name', () => {
+      const res = identify({ pid: 0, process: 'ollama', agent: 'Ollama' });
+      expect(res.instanceId).toBe('0:ollama');
+      expect(res.instanceIdSource).toBe('synthetic');
+    });
+
+    it('two synthetic agents with different names do NOT collapse onto one key', () => {
+      // wsl-detector / ide-extension-detector / attachModels all register pid 0.
+      const ollama = buildInstanceId({ pid: 0, process: 'ollama' });
+      const lmStudio = buildInstanceId({ pid: 0, process: 'lm-studio' });
+      const grok = buildInstanceId({ pid: 0, process: 'grok', agent: 'grok' });
+      const kilo = buildInstanceId({ pid: 0, agent: 'Kilo Code' });
+      const keys = new Set([ollama, lmStudio, grok, kilo]);
+      expect(keys.size).toBe(4);
+    });
+
+    it('falls back to the display name, normalised', () => {
+      expect(buildInstanceId({ pid: 0, agent: 'LM Studio' })).toBe('0:lm-studio');
+    });
+
+    it('prefers the process name over the display name', () => {
+      expect(buildInstanceId({ pid: 0, process: 'lm-studio', agent: 'LM Studio' })).toBe(
+        '0:lm-studio',
+      );
+    });
+
+    it('is stable across calls (an agent card must not churn per tick)', () => {
+      expect(buildInstanceId({ pid: 0, process: 'ollama' })).toBe(
+        buildInstanceId({ pid: 0, process: 'ollama' }),
+      );
+    });
+
+    it('ignores a birth time on pid 0 — it has no OS process', () => {
+      const res = identify({ pid: 0, process: 'ollama', startTime: BIRTH });
+      expect(res.instanceId).toBe('0:ollama');
+      expect(res.instanceIdSource).toBe('synthetic');
+    });
+  });
+
+  describe('space 3 — unknown (no readable birth time)', () => {
+    it('degrades to "<pid>:u" when startTime is null (darwin/linux today)', () => {
+      const res = identify({ pid: 18324, process: 'claude', startTime: null });
+      expect(res.instanceId).toBe('18324:u');
+      expect(res.instanceIdSource).toBe('unknown');
+    });
+
+    it('degrades when startTime is absent entirely (not yet enriched)', () => {
+      expect(buildInstanceId({ pid: 18324, process: 'claude' })).toBe('18324:u');
+    });
+
+    it('rejects a non-finite or non-positive birth time', () => {
+      for (const bad of [0, -1, NaN, Infinity, '1717000000000', {}]) {
+        expect(buildInstanceId({ pid: 5, process: 'claude', startTime: bad })).toBe('5:u');
+      }
+    });
+
+    it('an unnamed pid-0 entry has nothing to distinguish it by', () => {
+      const res = identify({ pid: 0 });
+      expect(res.instanceId).toBe('0:u');
+      expect(res.instanceIdSource).toBe('unknown');
+    });
+
+    it('normalises an unusable pid to 0 rather than embedding NaN', () => {
+      for (const bad of [undefined, null, NaN, -3, 1.5, '18324']) {
+        const res = identify({ pid: bad, process: 'claude', startTime: BIRTH });
+        expect(res.instanceId).toBe('0:u');
+        expect(res.instanceIdSource).toBe('unknown');
+      }
+    });
+
+    it('survives a missing agent object', () => {
+      expect(buildInstanceId(undefined)).toBe('0:u');
+      expect(buildInstanceId(null)).toBe('0:u');
+    });
+  });
+
+  describe('value spaces are disjoint', () => {
+    it('"<pid>:u" can never equal "<pid>:<epochMs>" for the same pid', () => {
+      const os = buildInstanceId({ pid: 42, process: 'claude', startTime: BIRTH });
+      const unknown = buildInstanceId({ pid: 42, process: 'claude' });
+      expect(os).not.toBe(unknown);
+    });
+
+    it('the "0:" namespace belongs to synthetics alone — a real pid never enters it', () => {
+      expect(buildInstanceId({ pid: 0, process: 'ollama' })).toBe('0:ollama');
+      for (const pid of [1, 42, 18324]) {
+        expect(buildInstanceId({ pid, process: 'ollama' }).startsWith('0:')).toBe(false);
+        expect(buildInstanceId({ pid, process: 'ollama', startTime: BIRTH }).startsWith('0:')).toBe(
+          false,
+        );
+      }
+    });
+  });
+
+  describe('instanceIdSource is a closed set', () => {
+    it('exposes exactly the three declared sources, frozen', () => {
+      expect(INSTANCE_ID_SOURCES).toEqual(['os', 'synthetic', 'unknown']);
+      expect(Object.isFrozen(INSTANCE_ID_SOURCES)).toBe(true);
+    });
+
+    it('never returns a source outside the set, for any input shape', () => {
+      const inputs = [
+        { pid: 1, process: 'claude', startTime: BIRTH },
+        { pid: 0, process: 'ollama' },
+        { pid: 0 },
+        { pid: 1, process: 'claude', startTime: null },
+        { pid: -1 },
+        { pid: NaN, startTime: NaN },
+        {},
+        undefined,
+      ];
+      for (const input of inputs) {
+        const res = identify(input);
+        expect(INSTANCE_ID_SOURCES).toContain(res.instanceIdSource);
+        expect(typeof res.instanceId).toBe('string');
+        expect(res.instanceId.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/tests/main/process-utils.test.js
+++ b/tests/main/process-utils.test.js
@@ -142,6 +142,105 @@ describe('process-utils', () => {
     });
   });
 
+  describe('enrichWithParentChains() — PID-reuse cache poisoning', () => {
+    it('the same PID with a DIFFERENT process name misses the cache and gets a fresh startTime', async () => {
+      // The cache TTL is 60s. Keyed on pid alone, a pid recycled by another
+      // executable inside that window served the DEAD process's startTime — the
+      // one field instanceId is built from.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code', ppid: 0, startTime: 1716999990000 }],
+        ]),
+      );
+      const dead = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(dead);
+      expect(dead[0].startTime).toBe(1717000000000);
+
+      // Same tick window, same pid — now held by a different executable.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([[100, { name: 'node.exe', ppid: 300, startTime: 1717000500000 }]]),
+      );
+      const reused = [{ pid: 100, agent: 'opencode', process: 'node.exe' }];
+      await processUtils.enrichWithParentChains(reused);
+
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(2); // cache MISS
+      expect(reused[0].startTime).toBe(1717000500000);
+      expect(reused[0].instanceId).not.toBe(dead[0].instanceId);
+    });
+
+    it('forceRefresh re-reads the map even for a cached pid + name', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code', ppid: 0 }],
+        ]),
+      );
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(agents);
+      await processUtils.enrichWithParentChains(agents);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1); // cached
+
+      await processUtils.enrichWithParentChains(agents, { forceRefresh: true });
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(2);
+    });
+
+    it('a same-name reuse inside the TTL is the documented residual bound', async () => {
+      // Honest test of the KNOWN BOUND in _cacheKey: pid + SAME exe name still
+      // hits the cache, so the stale startTime survives until forceRefresh or TTL.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000000000 }]]),
+      );
+      const first = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(first);
+
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000500000 }]]),
+      );
+      const second = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(second);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1); // cache HIT
+      expect(second[0].startTime).toBe(1717000000000); // stale, by design
+
+      // forceRefresh — what scan-loop passes on a changed pid set — clears it.
+      await processUtils.enrichWithParentChains(second, { forceRefresh: true });
+      expect(second[0].startTime).toBe(1717000500000);
+    });
+  });
+
+  describe('enrichWithParentChains() — instanceId stamping', () => {
+    it('stamps instanceId + source os when the OS birth time is readable', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000000000 }]]),
+      );
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].instanceId).toBe('100:1717000000000');
+      expect(agents[0].instanceIdSource).toBe('os');
+    });
+
+    it('stamps the honest unknown key when the platform withholds the birth time', async () => {
+      mockGetParentProcessMap.mockResolvedValue(new Map([[100, { name: 'claude', ppid: 0 }]]));
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude' }];
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].instanceId).toBe('100:u');
+      expect(agents[0].instanceIdSource).toBe('unknown');
+    });
+
+    it('stamps distinct synthetic keys for pid-0 agents', async () => {
+      mockGetParentProcessMap.mockResolvedValue(new Map());
+      const agents = [
+        { pid: 0, agent: 'Ollama', process: 'ollama' },
+        { pid: 0, agent: 'LM Studio', process: 'lm-studio' },
+      ];
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].instanceId).toBe('0:ollama');
+      expect(agents[1].instanceId).toBe('0:lm-studio');
+      expect(agents[0].instanceIdSource).toBe('synthetic');
+      expect(agents[1].startTime).toBeNull();
+    });
+  });
+
   describe('annotateHostApps()', () => {
     it('sets parentEditor/displayLabel for known editors', () => {
       const agents = [{ agent: 'Claude', parentChain: ['code'] }];

--- a/tests/main/session-tracker.test.js
+++ b/tests/main/session-tracker.test.js
@@ -126,6 +126,75 @@ describe('session-tracker', () => {
       expect(names).toEqual(['Copilot', 'Cursor']);
       expect(allEntered).toHaveLength(2);
     });
+
+    // The case the name-only key could NOT see: the OS hands pid 200 to a SECOND
+    // run of the same executable. Before instanceId this collapsed into one
+    // never-ending session — no exit for the dead process, no enter for the new
+    // one, and firstSeen frozen at the dead process's first sighting.
+    // Shape follows the existing reuse guard test in
+    // tests/main/token-adapters/claude-code.test.js:264-278 (divergent startTime).
+    describe('same process name, different OS birth time', () => {
+      const STARTED = 1_717_000_000_000;
+      const live = (startTime) => ({
+        pid: 200,
+        agent: 'Claude Code',
+        process: 'claude',
+        startTime,
+        instanceId: `200:${startTime}`,
+      });
+
+      it('ends the dead session and starts a new one', () => {
+        const first = tracker.reconcile([live(STARTED)], { now: 0, grace: 2 });
+        expect(first.entered).toHaveLength(1);
+
+        // The recycled pid appears (+10h birth time). The dead session is not in
+        // this scan, so it ages out over the grace window.
+        tracker.reconcile([live(STARTED + 36_000_000)], { now: 10000, grace: 2 });
+        const res = tracker.reconcile([live(STARTED + 36_000_000)], { now: 20000, grace: 2 });
+
+        expect(res.exited).toHaveLength(1);
+        expect(res.exited[0].pid).toBe(200);
+        expect(res.exited[0].instanceId).toBe(`200:${STARTED}`);
+        expect(tracker.activeCount()).toBe(1);
+      });
+
+      it('gives the new instance its own firstSeen, not the dead process one', () => {
+        const first = tracker.reconcile([live(STARTED)], { now: 5000, grace: 2 });
+        const second = tracker.reconcile([live(STARTED + 36_000_000)], { now: 15000, grace: 2 });
+
+        expect(first.entered[0].firstSeen).toBe(5000);
+        expect(second.entered).toHaveLength(1);
+        expect(second.entered[0].firstSeen).toBe(15000);
+        expect(second.entered[0].instanceId).toBe(`200:${STARTED + 36_000_000}`);
+      });
+
+      it('derives instanceId itself when the scan layer did not stamp one', () => {
+        // Same reuse, but the agent objects carry only startTime (no instanceId) —
+        // session-tracker must still separate the two instances.
+        const bare = (startTime) => ({
+          pid: 200,
+          agent: 'Claude Code',
+          process: 'claude',
+          startTime,
+        });
+        const first = tracker.reconcile([bare(STARTED)], { now: 0, grace: 2 });
+        const second = tracker.reconcile([bare(STARTED + 36_000_000)], { now: 10000, grace: 2 });
+        expect(first.entered).toHaveLength(1);
+        expect(second.entered).toHaveLength(1);
+        expect(second.entered[0].instanceId).not.toBe(first.entered[0].instanceId);
+      });
+
+      it('a same-birth-time re-sighting is still ONE session (no flicker split)', () => {
+        const { allEntered, allExited } = runScans(
+          [{ agents: [live(STARTED)] }, { agents: [] }, { agents: [live(STARTED)] }],
+          0,
+          2,
+        );
+        expect(allEntered).toHaveLength(1);
+        expect(allExited).toHaveLength(0);
+        expect(tracker.activeCount()).toBe(1);
+      });
+    });
   });
 
   describe('reconcile — multiple concurrent agents', () => {


### PR DESCRIPTION
## Summary

Pass 1 of the process-identity work: processes are identified by `pid + startTime` (instanceId), not by bare pid.

**Closed:**
- Session inheritance on PID reuse — a new process reusing a freed PID no longer inherits the previous process's session state.
- startTime cache poisoning keyed by bare pid — cached lookups are validated against the process instance.

**Deliberately out of scope:**
- Residual bound inside the 60s TTL window when the recycled PID belongs to a same-named process (accepted risk for now).
- `instanceIdSource` is emitted but has no consumer yet — consumed in pass 2.

Also: `aegis_landing.html` added to `.gitignore` as a separate commit (external landing, not part of the product).

## Verification

- vitest: 63 files, 998 passed / 4 skipped
- tsc main: 0 errors
- tsc renderer: 0 errors
- eslint src/: 0 errors (23 pre-existing no-console warnings)
- build:renderer: ✓ built in 1.34s
