### PR TITLE
fix(watcher): key knownHandles by instanceId so a recycled pid starts clean

### DIFF
--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -27,6 +27,7 @@ const {
 } = require('../shared/constants');
 const { getAllRules, reloadRules } = require('./rule-loader');
 const { EVIDENCE, makeAttribution } = require('./attribution');
+const { buildInstanceId } = require('./process-identity');
 const _platform = require('./platform');
 const { IGNORE_FILE_PATTERNS } = _platform;
 
@@ -337,6 +338,21 @@ async function filterExistingDirs(dirs) {
 }
 
 /**
+ * Dedup key for _state.knownHandles: the agent's process INSTANCE, never its
+ * bare pid. Windows recycles PIDs, so a pid-keyed store lets a new process
+ * inherit a dead one's seen-set and silently lose its first sensitive access.
+ * Uses the instanceId stamped upstream by procUtil.enrichWithParentChains and
+ * derives one for un-enriched agents (same fallback as session-tracker).
+ * @param {{pid?: number, process?: string, agent?: string, startTime?: number|null, instanceId?: string}} agent
+ * @returns {string}
+ */
+function handleKey(agent) {
+  return typeof agent.instanceId === 'string' && agent.instanceId
+    ? agent.instanceId
+    : buildInstanceId(agent);
+}
+
+/**
  * @param {Object} agent
  * @returns {Promise<Array>}
  * @since v0.1.0
@@ -352,13 +368,14 @@ async function scanFileHandles(agent) {
   if (!Array.isArray(files) || files.length === 0) return [];
 
   const kh = _state.knownHandles;
-  if (!kh.has(pid)) kh.set(pid, new Set());
-  const known = kh.get(pid);
+  const key = handleKey(agent);
+  if (!kh.has(key)) kh.set(key, new Set());
+  const known = kh.get(key);
   const newAccess = [];
   for (const f of files) {
     if (shouldIgnore(f) || known.has(f)) continue;
     known.add(f);
-    // Cap per-PID set at 500 — evict oldest entries
+    // Cap per-instance set at 500 — evict oldest entries
     if (known.size > 500) {
       const iter = known.values();
       for (let i = 0; i < known.size - 500; i++) {
@@ -415,8 +432,8 @@ function rmEnabled() {
  * PID is mapped to its OWNING agent (C-01 — resolved from the PID, never
  * cross-wired); AEGIS's own PID and non-agent holders are dropped. Emits an
  * `action:'holding'` event — a point-in-time handle HOLD at the scan tick, NOT a
- * read/access. Dedups per-PID by group via knownHandles so a sustained hold fires
- * once, not once-per-scan.
+ * read/access. Dedups per-instance by group via knownHandles so a sustained hold
+ * fires once, not once-per-scan.
  *
  * Used by BOTH the full (30s) and the hot (~10s) cycles via `fetchHolders`; both
  * share `_state.knownHandles`, so a hold caught by one cycle is deduped against
@@ -465,8 +482,9 @@ async function _scanRmHolders(agents, fetchHolders) {
     const agent = pidToAgent.get(h.pid);
     if (!agent) continue; // holder is not a tracked (in-scope) agent — drop
     const group = h.group;
-    if (!kh.has(h.pid)) kh.set(h.pid, new Set());
-    const known = kh.get(h.pid);
+    const key = handleKey(agent);
+    if (!kh.has(key)) kh.set(key, new Set());
+    const known = kh.get(key);
     const dedupKey = 'holding|' + group;
     if (known.has(dedupKey)) continue;
     known.add(dedupKey);
@@ -578,13 +596,17 @@ async function scanAllFileHandles(agents) {
 }
 
 /**
+ * Drop knownHandles entries whose process INSTANCE is gone. Keyed by instanceId,
+ * so a recycled pid counts as gone: the dead instance's entry is removed even
+ * while a NEW process occupies the same pid — that new instance starts with a
+ * clean seen-set and its first sensitive access fires.
  * @param {Array} activeAgents
  * @returns {void} @since v0.1.0
  */
 function pruneKnownHandles(activeAgents) {
-  const activePids = new Set(activeAgents.map((a) => a.pid));
-  for (const pid of _state.knownHandles.keys()) {
-    if (!activePids.has(pid)) _state.knownHandles.delete(pid);
+  const activeKeys = new Set(activeAgents.map(handleKey));
+  for (const key of _state.knownHandles.keys()) {
+    if (!activeKeys.has(key)) _state.knownHandles.delete(key);
   }
 }
 

--- a/tests/main/file-watcher.test.js
+++ b/tests/main/file-watcher.test.js
@@ -358,20 +358,37 @@ describe('file-watcher event handling', () => {
   });
 
   describe('pruneKnownHandles()', () => {
-    it('removes handles for inactive PIDs', () => {
-      state.knownHandles.set(100, new Set(['/a']));
-      state.knownHandles.set(200, new Set(['/b']));
-      state.knownHandles.set(300, new Set(['/c']));
+    it('removes handles for inactive instances', () => {
+      // Keys are instanceIds; an agent without a startTime degrades to '<pid>:u'
+      // (process-identity space 3) — the pre-instanceId behaviour.
+      state.knownHandles.set('100:u', new Set(['/a']));
+      state.knownHandles.set('200:u', new Set(['/b']));
+      state.knownHandles.set('300:u', new Set(['/c']));
       fileWatcher.pruneKnownHandles([{ pid: 100 }, { pid: 300 }]);
-      expect(state.knownHandles.has(100)).toBe(true);
-      expect(state.knownHandles.has(200)).toBe(false);
-      expect(state.knownHandles.has(300)).toBe(true);
+      expect(state.knownHandles.has('100:u')).toBe(true);
+      expect(state.knownHandles.has('200:u')).toBe(false);
+      expect(state.knownHandles.has('300:u')).toBe(true);
     });
 
     it('removes all when no active agents', () => {
-      state.knownHandles.set(100, new Set(['/a']));
+      state.knownHandles.set('100:u', new Set(['/a']));
       fileWatcher.pruneKnownHandles([]);
       expect(state.knownHandles.size).toBe(0);
+    });
+
+    // PID reuse: Windows recycles PIDs, so a bare pid is not an identity. The
+    // dedup store must key on instanceId (pid+startTime, process-identity.js):
+    // the LIVE instance's entry survives the prune, the DEAD instance of the
+    // SAME pid is dropped — otherwise the recycled pid inherits "already seen"
+    // and its first .ssh access never fires.
+    it('keeps the live instance entry and drops the dead instance of the same pid', () => {
+      state.knownHandles.set('100:111', new Set(['holding|/home/user/.ssh']));
+      state.knownHandles.set('100:222', new Set(['/a']));
+      fileWatcher.pruneKnownHandles([
+        { pid: 100, agent: 'Claude Code', startTime: 222, instanceId: '100:222' },
+      ]);
+      expect(state.knownHandles.has('100:222')).toBe(true);
+      expect(state.knownHandles.has('100:111')).toBe(false);
     });
   });
 });
@@ -416,6 +433,22 @@ describe('file-watcher scanFileHandles', () => {
 
       await fileWatcher.scanAllFileHandles(agents);
       expect(state.activityLog.length).toBe(firstLen);
+    });
+
+    // PID reuse: a NEW process on a recycled pid must NOT inherit the dead
+    // process's seen-set — its first sensitive access is a real event. gen1
+    // carries a stamped instanceId (the enriched-agent case), gen2 only a
+    // startTime (the derivation fallback) — both must key apart.
+    it('a reused pid does not inherit the dead instance seen-set', async () => {
+      mockGetFileHandles.mockResolvedValue(['/home/user/.ssh/id_rsa']);
+      const gen1 = [
+        { pid: 100, agent: 'Claude Code', category: 'ai', startTime: 111, instanceId: '100:111' },
+      ];
+      const gen2 = [{ pid: 100, agent: 'Claude Code', category: 'ai', startTime: 222 }];
+      const first = await fileWatcher.scanAllFileHandles(gen1);
+      const second = await fileWatcher.scanAllFileHandles(gen2);
+      expect(first).toHaveLength(1);
+      expect(second).toHaveLength(1); // new instance → first access fires again
     });
 
     it('returns empty on getFileHandles error', async () => {
@@ -612,6 +645,21 @@ describe('file-watcher Restart Manager (RM) holder path', () => {
     const second = await fileWatcher.scanAllFileHandles(agents); // still holding
     expect(first).toHaveLength(1);
     expect(second).toHaveLength(0); // sustained hold → one event, not one-per-scan
+  });
+
+  // PID reuse under the RM path: a recycled pid holding the same group is a NEW
+  // instance — its hold must fire again, not be swallowed by the dead process's
+  // holding-dedup key.
+  it('a reused pid does not inherit the dead instance holding-dedup', async () => {
+    mockGetSensitiveHolders.mockResolvedValue([
+      { pid: 105, group: '/home/user/.ssh', reason: 'SSH keys/config' },
+    ]);
+    const gen1 = [{ pid: 105, agent: 'Agent5', category: 'ai', startTime: 111 }];
+    const gen2 = [{ pid: 105, agent: 'Agent5', category: 'ai', startTime: 222 }];
+    const first = await fileWatcher.scanAllFileHandles(gen1);
+    const second = await fileWatcher.scanAllFileHandles(gen2);
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1); // new instance on the recycled pid → real event
   });
 });
 


### PR DESCRIPTION
## Problem

`knownHandles` (the seen-set that dedups file-handle events) was keyed by bare `pid`. Windows recycles PIDs, so a NEW process spawned onto a dead agent's pid inherited the dead instance's "already seen" entries — and its FIRST access to a crown-jewel dir (`~/.ssh`, `~/.aws`, …) was silently swallowed by the stale dedup key. `pruneKnownHandles` couldn't help: the pid was still "active", so the stale entry survived.

This is the one place where pid reuse hides a real security event rather than just skewing a number.

## Fix

Key `knownHandles` by `instanceId` (pid + OS birth time, PR #180's `process-identity.js`) in all three touch points inside `file-watcher.js`:

- `scanFileHandles` (legacy pool path) — per-instance seen-set
- `_scanRmHolders` (win32 Restart Manager path) — per-instance `holding|<group>` dedup
- `pruneKnownHandles` — prunes by active instanceIds, so a dead instance's entry is dropped even while a new process occupies the same pid

New `handleKey()` helper uses the upstream-stamped `agent.instanceId` (from `enrichWithParentChains`, which already runs before every prune/scan) and falls back to `buildInstanceId(agent)` for un-enriched agents — the same fallback convention as `session-tracker.js`. Agents without a readable birth time degrade to `"<pid>:u"`, which is exactly the pre-instanceId behaviour — no regression on darwin/linux where `startTime` isn't wired yet.

## Tests

3 new tests (RED before the fix, each failing on the swallowed event):

- reused pid does not inherit the dead instance seen-set (pool path; covers both the stamped-instanceId and derived-key branches)
- reused pid does not inherit the dead instance holding-dedup (RM path)
- prune keeps the LIVE instance entry and drops the dead instance of the same pid

2 existing prune tests updated to the instanceId key scheme (same intent, new keys).

## Gates

- `npm test` — 1001 passed / 4 skipped (63 files)
- `npm run build:renderer` — clean
- `npm run typecheck` — clean (both configs)
- `npm run lint` — 0 errors (23 pre-existing warnings, none in touched files)
