### PR TITLE
feat(token): key cost records by instanceId so a recycled pid starts clean

### DIFF
--- a/src/main/token-cost-collector.js
+++ b/src/main/token-cost-collector.js
@@ -65,11 +65,16 @@ async function collectTokenCosts(agents) {
   // C-01: build the procs batch ONLY from agents whose OS birth-time is a real
   // epoch-ms number. The typeof check rejects both null (darwin/linux: not
   // surfaced) and undefined (not yet enriched) in a single predicate.
+  // identityByPid keeps the full agent object so the tracker can key the
+  // accounting by process INSTANCE (agent.instanceId, stamped upstream by
+  // enrichWithParentChains) instead of the recyclable bare pid.
   const procs = [];
+  const identityByPid = new Map();
   let droppedClaude = false;
   for (const a of list) {
     if (a && typeof a.startTime === 'number') {
       procs.push({ pid: a.pid, startTime: a.startTime });
+      identityByPid.set(a.pid, a);
     } else if (a && a.agent === CLAUDE_CODE_AGENT) {
       droppedClaude = true;
     }
@@ -102,8 +107,12 @@ async function collectTokenCosts(agents) {
     return [];
   }
 
-  // C-01: attribute each delta under the pid the SOURCE stamped on it.
-  for (const d of deltas) tokenTracker.trackTokens(d.pid, d);
+  // C-01: attribute each delta under the pid the SOURCE stamped on it, resolved
+  // to that pid's process INSTANCE from this tick's batch (subagent deltas are
+  // stamped with the MAIN pid, so the lookup always has a live entry). A miss
+  // falls back to the bare pid, which the tracker degrades honestly to its
+  // `"<pid>:u"` space rather than dropping the measured tokens.
+  for (const d of deltas) tokenTracker.trackTokens(identityByPid.get(d.pid) || d.pid, d);
   return deltas;
 }
 

--- a/src/main/token-tracker.js
+++ b/src/main/token-tracker.js
@@ -22,14 +22,25 @@
  *   figure: even where `MODEL_PRICING` rates are verified, an unknown model id
  *   still falls back to `DEFAULT_PRICING` and flips `estimated` true.
  *
- *   Attribution is per-PID (C-01): every count is stamped from the `pid`
- *   argument and stored under that pid only — concurrency or interleaved events
- *   can never cross-wire one agent's usage onto another.
+ *   Attribution is per-INSTANCE (C-01): every count is keyed by the process
+ *   INSTANCE (`instanceId` = pid bound to its OS birth time, see
+ *   process-identity.js), with the pid stored alongside for display — so
+ *   concurrency or interleaved events can never cross-wire one agent's usage
+ *   onto another, and a recycled pid can never inherit a dead instance's
+ *   accumulated tokens, cost, or sticky `estimated` flag.
+ *
+ *   Records for exited instances are RETAINED deliberately: the footer sums
+ *   `getAllCosts()` into a session-total spend, and that figure must be
+ *   monotonic — an agent exiting must not roll back money already spent. That
+ *   is why this module has no prune analogous to the file-watcher's
+ *   `pruneKnownHandles` (dedup must not leak; accounting must not forget).
  * @author AEGIS Contributors
  * @license MIT
  * @version 0.1.0
  */
 'use strict';
+
+const { buildInstanceId } = require('./process-identity');
 
 /**
  * Published per-model pricing, in USD per 1,000,000 tokens, split into input
@@ -80,8 +91,19 @@ const DEFAULT_PRICING = Object.freeze({ input: 3.0, output: 15.0 });
 const TOKENS_PER_PRICED_UNIT = 1_000_000;
 
 /**
+ * @typedef {Object} ProcRef
+ * @property {number} pid - OS process id; must be a finite number > 0.
+ * @property {number|null} [startTime] - OS process-creation time (epoch ms), used
+ *   to derive the instance key when no `instanceId` is stamped.
+ * @property {string} [instanceId] - instance key stamped upstream
+ *   (procUtil.enrichWithParentChains); preferred over local derivation.
+ */
+
+/**
  * @typedef {Object} CostRecord
- * @property {number} pid - the process this usage is attributed to (C-01 key).
+ * @property {string} instanceId - the process INSTANCE this usage is keyed by
+ *   (C-01 key; see process-identity.js for the three value spaces).
+ * @property {number} pid - the owning process id, stored alongside for display.
  * @property {number} inputTokens - accumulated prompt/input tokens.
  * @property {number} outputTokens - accumulated completion/output tokens.
  * @property {number} totalTokens - `inputTokens + outputTokens`.
@@ -101,7 +123,7 @@ const TOKENS_PER_PRICED_UNIT = 1_000_000;
  *   estimate the caller computed, not measured usage.
  */
 
-/** @type {Map<number, CostRecord>} Accumulated cost records keyed by pid. */
+/** @type {Map<string, CostRecord>} Accumulated cost records keyed by instanceId. */
 const records = new Map();
 
 /**
@@ -144,13 +166,46 @@ function computeCost(model, inputTokens, outputTokens) {
 }
 
 /**
- * Honest zero-state record for a pid with no tracked usage. `estimated:false`
- * because an exact zero is a fact, not a guess.
+ * Extract the owning pid from a proc ref (bare number or {@link ProcRef}).
+ * @param {number|ProcRef} proc
+ * @returns {*} the pid candidate, validated by the caller.
+ */
+function pidOf(proc) {
+  if (typeof proc === 'number') return proc;
+  return proc && typeof proc === 'object' ? proc.pid : null;
+}
+
+/**
+ * Accounting key for `records`: the process INSTANCE, never the bare pid — a
+ * recycled pid must never inherit a dead instance's accumulated record. Shared
+ * by every write AND read path, so a key mismatch between them is impossible by
+ * construction (same invariant as file-watcher's `handleKey`).
+ *
+ * Prefers the `instanceId` stamped upstream by procUtil.enrichWithParentChains;
+ * otherwise derives one from `{pid, startTime}`. A bare-number caller (or a ref
+ * with no usable startTime) degrades to the `"<pid>:u"` space — exactly the
+ * pre-instanceId behaviour, never an invented identity.
+ * @param {number|ProcRef} proc
+ * @returns {string}
+ */
+function recordKey(proc) {
+  if (typeof proc === 'number') return buildInstanceId({ pid: proc });
+  if (!proc || typeof proc !== 'object') return buildInstanceId({});
+  return typeof proc.instanceId === 'string' && proc.instanceId
+    ? proc.instanceId
+    : buildInstanceId({ pid: proc.pid, startTime: proc.startTime });
+}
+
+/**
+ * Honest zero-state record for an instance with no tracked usage.
+ * `estimated:false` because an exact zero is a fact, not a guess.
  * @param {number} pid
+ * @param {string} instanceId
  * @returns {CostRecord}
  */
-function zeroRecord(pid) {
+function zeroRecord(pid, instanceId) {
   return {
+    instanceId,
     pid,
     inputTokens: 0,
     outputTokens: 0,
@@ -162,23 +217,28 @@ function zeroRecord(pid) {
 }
 
 /**
- * Attribute one usage event to a pid and accumulate its tokens + cost (C-01).
+ * Attribute one usage event to a process instance and accumulate its tokens +
+ * cost (C-01).
  *
- * @param {number} pid - owning process id; must be a finite number > 0.
+ * @param {number|ProcRef} proc - owning process: a full ref keys by instance; a
+ *   bare pid degrades to the `"<pid>:u"` space. The pid itself must be a finite
+ *   number > 0 either way.
  * @param {TokenEvent} event - usage to record.
- * @returns {CostRecord|null} the updated record, or `null` when `pid` is invalid
- *   or `event` carries no usable token counts (nothing is fabricated).
+ * @returns {CostRecord|null} the updated record, or `null` when the pid is
+ *   invalid or `event` carries no usable token counts (nothing is fabricated).
  * @since v0.10.0-alpha
  */
-function trackTokens(pid, event) {
+function trackTokens(proc, event) {
+  const pid = pidOf(proc);
   if (!isPositiveNumber(pid)) return null;
   if (!event || typeof event !== 'object') return null;
 
+  const key = recordKey(proc);
   const hasInput = isNonNegativeNumber(event.inputTokens);
   const hasOutput = isNonNegativeNumber(event.outputTokens);
   // No usable counts → record nothing. You cannot estimate from nothing, and
   // fabricating a number here is exactly the dishonesty this module forbids.
-  if (!hasInput && !hasOutput) return records.get(pid) || null;
+  if (!hasInput && !hasOutput) return records.get(key) || null;
 
   const inTok = hasInput ? event.inputTokens : 0;
   const outTok = hasOutput ? event.outputTokens : 0;
@@ -188,7 +248,7 @@ function trackTokens(pid, event) {
   // estimated is sticky-true: caller-flagged estimate OR an unknown-model price.
   const eventEstimated = event.estimated === true || !knownModel;
 
-  const record = records.get(pid) || zeroRecord(pid);
+  const record = records.get(key) || zeroRecord(pid, key);
   record.inputTokens += inTok;
   record.outputTokens += outTok;
   record.totalTokens = record.inputTokens + record.outputTokens;
@@ -196,37 +256,32 @@ function trackTokens(pid, event) {
   record.estimated = record.estimated || eventEstimated;
   if (model && !record.models.includes(model)) record.models.push(model);
 
-  records.set(pid, record);
+  records.set(key, record);
   return record;
 }
 
 /**
- * Read the accumulated cost record for a pid.
- * @param {number} pid
+ * Read the accumulated cost record for one process instance. Resolved through
+ * the same {@link recordKey} as every write, so read and write can never
+ * disagree on identity.
+ * @param {number|ProcRef} proc - same shapes as {@link trackTokens}.
  * @returns {CostRecord} the tracked record, or an honest zero-state record when
- *   the pid has no usage (never `null`).
+ *   the instance has no usage (never `null`).
  * @since v0.10.0-alpha
  */
-function getCostByPid(pid) {
-  return records.get(pid) || zeroRecord(pid);
+function getCost(proc) {
+  const key = recordKey(proc);
+  const pid = pidOf(proc);
+  return records.get(key) || zeroRecord(isPositiveNumber(pid) ? pid : 0, key);
 }
 
 /**
- * @returns {CostRecord[]} every tracked per-pid record (excludes untracked pids).
+ * @returns {CostRecord[]} every tracked per-instance record (excludes untracked
+ *   instances; records of exited instances are retained — see the file header).
  * @since v0.10.0-alpha
  */
 function getAllCosts() {
   return Array.from(records.values());
-}
-
-/**
- * Drop the record for one pid (e.g. when an agent process exits).
- * @param {number} pid
- * @returns {boolean} true if a record existed and was removed.
- * @since v0.10.0-alpha
- */
-function reset(pid) {
-  return records.delete(pid);
 }
 
 /** @internal Clear all module state (for tests). @returns {void} */
@@ -239,8 +294,7 @@ module.exports = {
   DEFAULT_PRICING,
   computeCost,
   trackTokens,
-  getCostByPid,
+  getCost,
   getAllCosts,
-  reset,
   _resetForTest,
 };

--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -78,8 +78,17 @@
 
   let agentEvents = $derived($eventsByPid.get(agent.pid) || []);
 
-  /** Token + cost record for this agent's PID, from the `token-costs` push. */
-  let tokenRec = $derived($tokenCosts.find((r) => r.pid === agent.pid));
+  /**
+   * Token + cost record for this agent, from the `token-costs` push. Matched by
+   * process INSTANCE when both sides carry an instanceId — a recycled pid must
+   * not show a dead instance's frozen record. Pid matching is the fallback for
+   * records the tracker keyed from a bare pid (no instanceId on either side).
+   */
+  let tokenRec = $derived(
+    $tokenCosts.find((r) =>
+      agent.instanceId && r.instanceId ? r.instanceId === agent.instanceId : r.pid === agent.pid,
+    ),
+  );
 
   let lastFile = $derived.by(() => {
     const ev = agentEvents.find((e) => e.file);

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -36,11 +36,14 @@ interface WatchlistAddResult {
 }
 
 /**
- * Per-PID token + cost record pushed on the `token-costs` channel. Mirrors the
- * main process `CostRecord` (token-tracker.js). `estimated` reports whether the
- * TOKEN COUNTS are measured vs guessed — not whether the dollar figure is audited.
+ * Per process-instance token + cost record pushed on the `token-costs` channel.
+ * Mirrors the main process `CostRecord` (token-tracker.js). `estimated` reports
+ * whether the TOKEN COUNTS are measured vs guessed — not whether the dollar
+ * figure is audited. Keyed by `instanceId` so a recycled pid never inherits a
+ * dead instance's record; `pid` rides alongside for display and legacy matching.
  */
 interface TokenCostRecord {
+  readonly instanceId: string;
   readonly pid: number;
   readonly inputTokens: number;
   readonly outputTokens: number;
@@ -86,7 +89,7 @@ export const resourceUsage: Writable<Record<string, unknown>> = writable({});
 export const falsePositives: Writable<FalsePositiveEntry[]> = writable([]);
 export const scanActive: Writable<boolean> = writable(false);
 
-/** Per-PID token + cost records, refreshed each scan via the `token-costs` push. */
+/** Per process-instance token + cost records, refreshed each scan via the `token-costs` push. */
 export const tokenCosts: Writable<TokenCostRecord[]> = writable([]);
 
 /**

--- a/tests/main/token-cost-collector.test.js
+++ b/tests/main/token-cost-collector.test.js
@@ -81,4 +81,29 @@ describe('token-cost-collector — folds measured deltas into the tracker', () =
 
     expect(readUsage).toHaveBeenCalledTimes(1);
   });
+
+  it('(d) keys tracker records by the agent instanceId, pid stored alongside', async () => {
+    tokenFeed._setAdaptersForTest([{ id: 'fake', readUsage: vi.fn(async () => [delta(1, 100)]) }]);
+
+    await collectTokenCosts([{ ...agent(1, 1000), instanceId: '1:1000' }]);
+
+    const costs = tokenTracker.getAllCosts();
+    expect(costs).toHaveLength(1);
+    expect(costs[0].instanceId).toBe('1:1000');
+    expect(costs[0].pid).toBe(1);
+  });
+
+  it('(e) a recycled pid on a later tick gets its own record, not the dead instance sum', async () => {
+    const readUsage = vi.fn(async () => [delta(1, 100)]);
+    tokenFeed._setAdaptersForTest([{ id: 'fake', readUsage }]);
+
+    // Tick 1: pid 1 born at 1000. Tick 2: same pid recycled, born at 2000.
+    await collectTokenCosts([agent(1, 1000)]);
+    await collectTokenCosts([agent(1, 2000)]);
+
+    const costs = tokenTracker.getAllCosts();
+    expect(costs.map((c) => c.instanceId).sort()).toEqual(['1:1000', '1:2000']);
+    // Each instance carries only its own tick's tokens — no inheritance.
+    for (const c of costs) expect(c.inputTokens).toBe(100);
+  });
 });

--- a/tests/main/token-tracker.test.js
+++ b/tests/main/token-tracker.test.js
@@ -6,9 +6,8 @@ const {
   DEFAULT_PRICING,
   computeCost,
   trackTokens,
-  getCostByPid,
+  getCost,
   getAllCosts,
-  reset,
   _resetForTest,
 } = tracker;
 
@@ -43,9 +42,10 @@ describe('token-tracker', () => {
   });
 
   describe('zero-state', () => {
-    it('returns an honest all-zero record for an untracked pid', () => {
-      const rec = getCostByPid(9999);
+    it('returns an honest all-zero record for an untracked pid (degraded `:u` space)', () => {
+      const rec = getCost(9999);
       expect(rec).toEqual({
+        instanceId: '9999:u',
         pid: 9999,
         inputTokens: 0,
         outputTokens: 0,
@@ -54,6 +54,14 @@ describe('token-tracker', () => {
         estimated: false,
         models: [],
       });
+    });
+
+    it('returns an honest all-zero record for an untracked instance', () => {
+      const rec = getCost({ pid: 9999, startTime: 111 });
+      expect(rec.instanceId).toBe('9999:111');
+      expect(rec.pid).toBe(9999);
+      expect(rec.totalTokens).toBe(0);
+      expect(rec.estimated).toBe(false);
     });
 
     it('reports no tracked records before any event', () => {
@@ -91,13 +99,13 @@ describe('token-tracker', () => {
     });
   });
 
-  describe('per-PID attribution (C-01)', () => {
+  describe('per-instance attribution (C-01)', () => {
     it('keeps two pids independent — no cross-wiring', () => {
       trackTokens(100, { model: KNOWN_MODEL, inputTokens: 1000, outputTokens: 100 });
       trackTokens(200, { model: OTHER_MODEL, inputTokens: 5000, outputTokens: 500 });
 
-      const a = getCostByPid(100);
-      const b = getCostByPid(200);
+      const a = getCost(100);
+      const b = getCost(200);
 
       expect(a.pid).toBe(100);
       expect(a.inputTokens).toBe(1000);
@@ -106,6 +114,57 @@ describe('token-tracker', () => {
       expect(b.pid).toBe(200);
       expect(b.inputTokens).toBe(5000);
       expect(b.models).toEqual([OTHER_MODEL]);
+    });
+
+    // The reason this module keys by instance at all: Windows recycles PIDs, so
+    // a new process must never inherit a dead instance's accumulated record.
+    it('keeps a recycled pid clean: 100:111 dead, 100:222 starts from zero', () => {
+      trackTokens(
+        { pid: 100, startTime: 111 },
+        { model: KNOWN_MODEL, inputTokens: 1000, outputTokens: 100, estimated: true },
+      );
+      const fresh = trackTokens(
+        { pid: 100, startTime: 222 },
+        { model: KNOWN_MODEL, inputTokens: 7, outputTokens: 3 },
+      );
+
+      // The new instance inherits neither counts nor the sticky estimated flag.
+      expect(fresh.instanceId).toBe('100:222');
+      expect(fresh.totalTokens).toBe(10);
+      expect(fresh.estimated).toBe(false);
+
+      // The dead instance's record is retained (session-total honesty), untouched.
+      const dead = getCost({ pid: 100, startTime: 111 });
+      expect(dead.instanceId).toBe('100:111');
+      expect(dead.totalTokens).toBe(1100);
+      expect(dead.estimated).toBe(true);
+
+      expect(getAllCosts()).toHaveLength(2);
+    });
+
+    it('prefers a stamped instanceId over local derivation (same key as file-watcher handleKey)', () => {
+      trackTokens(
+        { pid: 100, startTime: 111, instanceId: '100:999' },
+        { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 },
+      );
+
+      expect(getCost({ pid: 100, instanceId: '100:999' }).totalTokens).toBe(11);
+      // The derived key was never written — the stamped one won.
+      expect(getCost({ pid: 100, startTime: 111 }).totalTokens).toBe(0);
+    });
+
+    it('accumulates a bare-number caller into the degraded `<pid>:u` record', () => {
+      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
+      const rec = trackTokens(
+        { pid: 100 },
+        { model: KNOWN_MODEL, inputTokens: 5, outputTokens: 2 },
+      );
+
+      // Bare pid and a ref without startTime resolve to the SAME `:u` key —
+      // exactly the pre-instanceId behaviour, not a third identity.
+      expect(rec.instanceId).toBe('100:u');
+      expect(rec.totalTokens).toBe(18);
+      expect(getAllCosts()).toHaveLength(1);
     });
   });
 
@@ -125,7 +184,7 @@ describe('token-tracker', () => {
 
     it('makes estimated sticky-true once any contributing event is estimated', () => {
       trackTokens(100, { model: KNOWN_MODEL, inputTokens: 1000, outputTokens: 200 });
-      expect(getCostByPid(100).estimated).toBe(false);
+      expect(getCost(100).estimated).toBe(false);
 
       trackTokens(100, {
         model: KNOWN_MODEL,
@@ -133,14 +192,14 @@ describe('token-tracker', () => {
         outputTokens: 10,
         estimated: true,
       });
-      expect(getCostByPid(100).estimated).toBe(true);
+      expect(getCost(100).estimated).toBe(true);
     });
 
     it('collects distinct models in first-seen order', () => {
       trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
       trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
       trackTokens(100, { model: OTHER_MODEL, inputTokens: 10, outputTokens: 1 });
-      expect(getCostByPid(100).models).toEqual([KNOWN_MODEL, OTHER_MODEL]);
+      expect(getCost(100).models).toEqual([KNOWN_MODEL, OTHER_MODEL]);
     });
   });
 
@@ -149,6 +208,13 @@ describe('token-tracker', () => {
       expect(trackTokens(0, { model: KNOWN_MODEL, inputTokens: 1 })).toBeNull();
       expect(trackTokens(-5, { model: KNOWN_MODEL, inputTokens: 1 })).toBeNull();
       expect(trackTokens(NaN, { model: KNOWN_MODEL, inputTokens: 1 })).toBeNull();
+      // Object refs are held to the same pid contract — an instanceId alone
+      // cannot smuggle in a record for a process that has no valid pid.
+      expect(
+        trackTokens({ pid: 0, startTime: 1 }, { model: KNOWN_MODEL, inputTokens: 1 }),
+      ).toBeNull();
+      expect(trackTokens({ instanceId: '7:1' }, { model: KNOWN_MODEL, inputTokens: 1 })).toBeNull();
+      expect(trackTokens(null, { model: KNOWN_MODEL, inputTokens: 1 })).toBeNull();
     });
 
     it('records nothing when an event carries no usable token counts', () => {
@@ -158,27 +224,19 @@ describe('token-tracker', () => {
   });
 
   describe('getAllCosts', () => {
-    it('returns one record per tracked pid', () => {
-      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
-      trackTokens(200, { model: KNOWN_MODEL, inputTokens: 20, outputTokens: 2 });
+    it('returns one record per tracked instance, each carrying its instanceId', () => {
+      trackTokens(
+        { pid: 100, startTime: 1 },
+        { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 },
+      );
+      trackTokens(
+        { pid: 200, startTime: 2 },
+        { model: KNOWN_MODEL, inputTokens: 20, outputTokens: 2 },
+      );
       const all = getAllCosts();
       expect(all).toHaveLength(2);
       expect(all.map((r) => r.pid).sort((x, y) => x - y)).toEqual([100, 200]);
-    });
-  });
-
-  describe('reset(pid)', () => {
-    it('drops only the targeted pid and reverts it to zero-state', () => {
-      trackTokens(100, { model: KNOWN_MODEL, inputTokens: 10, outputTokens: 1 });
-      trackTokens(200, { model: KNOWN_MODEL, inputTokens: 20, outputTokens: 2 });
-
-      expect(reset(100)).toBe(true);
-      expect(reset(100)).toBe(false); // already gone
-
-      expect(getCostByPid(100).totalTokens).toBe(0);
-      expect(getCostByPid(100).inputTokens).toBe(0);
-      expect(getCostByPid(200).inputTokens).toBe(20); // survives
-      expect(getAllCosts()).toHaveLength(1);
+      expect(all.map((r) => r.instanceId).sort()).toEqual(['100:1', '200:2']);
     });
   });
 


### PR DESCRIPTION
## What

Follow-up to #180/#181: the token-tracker was the last instanceId consumer still keyed by bare pid. On Windows a recycled pid inherited the dead instance's accumulated tokens, cost **and the sticky `estimated` flag** — a brand-new process could show `~$` forever.

- `token-tracker.js`: `records` is now `Map<instanceId, CostRecord>`; `pid` stays on the record for display. A single `recordKey()` serves every write AND read path (same invariant as file-watcher's `handleKey` from #181 — key mismatch impossible by construction). Prefers the upstream-stamped `instanceId`, otherwise derives from `{pid, startTime}`; a bare-number caller degrades honestly to the `"<pid>:u"` space (exactly the pre-instanceId behaviour).
- `token-cost-collector.js`: resolves each delta's pid to the tick's agent object (which carries `instanceId` from `enrichWithParentChains`) before folding into the tracker. Subagent deltas are stamped MAIN pid (C-01), so the lookup always hits; a miss falls back to bare pid instead of dropping measured tokens.
- `getCostByPid(pid)` → `getCost(proc)`: with per-instance keys a pid-only read is ambiguous; the new read resolves through the same `recordKey()`.
- `reset(pid)` **removed** — zero callers in production, and its pid-keyed delete is now also wrong-typed. Dead-instance records are retained deliberately: the footer sums `getAllCosts()` into a session-total spend, which must stay monotonic (an agent exiting must not roll back money already spent). That asymmetry vs `pruneKnownHandles` is documented in the module header.
- Renderer: `AgentCard` matches its record by `instanceId` (pid fallback for `:u`-space records) so a recycled pid never displays a dead instance's frozen record; `TokenCostRecord` in `ipc.ts` gains `instanceId`.

## Tests

- Regression: `100:111` dead / `100:222` recycled — fresh record, no inherited counts, no inherited sticky `estimated`; dead record retained (session-total honesty).
- Stamped `instanceId` wins over local derivation; bare pid and startTime-less ref collapse into the same `:u` record.
- Collector: keys by agent `instanceId` (d), recycled pid across ticks gets its own record (e).
- 1006 passed / 4 skipped, build:renderer ✓, lint ✓, svelte-check 0 errors. (Root `tsc --noEmit` TS1470 in `ipc.ts` pre-exists on master — untouched.)
