### PR TITLE
fix(tsconfig): split shared base out of root so the renderer is actually type-checked

### DIFF
--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -12,7 +12,7 @@ You are a Senior Code Auditor. Run a full health check:
 
 1. npm test — count pass/fail/skip
 2. npm run build — time and errors
-3. npx tsc --noEmit — type errors
+3. npx tsc -b — type errors in BOTH projects via the root solution file. NOT `npx tsc --noEmit`: that resolves the same root file as a standalone project, checks zero sources, and always exits 0
 4. npx eslint src/ — lint errors
 5. Files >300 lines (find + wc -l)
 6. grep TODO/FIXME/HACK/XXX in src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npm run typecheck
       - run: npm run typecheck:svelte
 
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 out/
 coverage/
+# `npx tsc -b` writes one per referenced project, next to the config
+*.tsbuildinfo
 .env
 *.log
 *.json.bak

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ npm run dist              # Electron-builder NSIS installer
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
 7. Git: powershell.exe -NoProfile -Command "cd 'X:\Future\ESCAPE\AEGIS'; git ..."
-8. TypeScript: new files in .ts, `npx eslint` + `npx tsc --noEmit` before commit, zero `any`
+8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths
 - src/main/ — 44 CommonJS modules (35 top-level + platform/ 7 + token-adapters/ 2)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ When maintainers merge the Release PR → version bump + CHANGELOG + GitHub Rele
 - **Main process** (`.js`): uses JSDoc annotations + `checkJs: true` for type safety without converting to `.ts`
 - **Renderer** (`.ts`/`.svelte`): native TypeScript with ES modules
 - Shared type definitions live in `src/shared/types/` (types across 8 files)
-- Run `npx tsc --noEmit` (typecheck) before opening a PR — zero type errors required
+- Run `npm run typecheck` before opening a PR — zero type errors required. It checks both projects (`tsconfig.main.json` + `tsconfig.renderer.json`); a bare `npx tsc --noEmit` resolves the root solution file and checks nothing
 - **Zero `any`** — use proper types, generics, or `unknown` instead. ESLint warns on `any`
 - Explicit return types on exported functions (`@typescript-eslint/explicit-function-return-type`)
 - Unused variables are errors, not warnings, in `.ts` files

--- a/tests/shared/tsconfig-projects.test.js
+++ b/tests/shared/tsconfig-projects.test.js
@@ -1,0 +1,112 @@
+/**
+ * @file tsconfig-projects.test.js
+ * @description Guards the TypeScript project layout.
+ *
+ *   The failure being pinned here is SILENT. `exclude` filters whatever `include`
+ *   picks up, and an extending config inherits the base `exclude` while overriding
+ *   only `include`. So a base `exclude` of `src/renderer/**` cancels
+ *   tsconfig.renderer.json's own `include` entirely: `tsc -p tsconfig.renderer.json`
+ *   exits 0 having type-checked NONE of the renderer, and every script and CI job
+ *   built on it reports success. Nothing in the output says the file set was empty.
+ *
+ *   Second pinned failure: a `module` / `moduleResolution` default in the shared
+ *   base. The renderer is ESM and uses `import.meta`; the main process is CommonJS.
+ *   A CJS default leaking from the base into renderer files raises TS1470
+ *   ("'import.meta' is not allowed in files which will build into CommonJS output")
+ *   on correct code, so each project must declare its own module system.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const BASE = 'tsconfig.base.json';
+const PROJECTS = ['tsconfig.main.json', 'tsconfig.renderer.json'];
+
+/**
+ * @param {string} name - Repo-relative config file name.
+ * @returns {Object} Parsed config.
+ */
+function readConfig(name) {
+  return JSON.parse(readFileSync(path.join(ROOT, name), 'utf-8'));
+}
+
+/**
+ * Leading non-glob path of a pattern: `src/renderer/**\/*` → `src/renderer`.
+ * Comparing these roots is what makes an exclude-swallows-include check possible
+ * without a full glob engine.
+ * @param {string} pattern
+ * @returns {string}
+ */
+function globRoot(pattern) {
+  return pattern
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter((seg) => seg.length > 0 && !seg.includes('*'))
+    .join('/');
+}
+
+describe('tsconfig project layout', () => {
+  it('root tsconfig.json is a solution file that owns no sources', () => {
+    const root = readConfig('tsconfig.json');
+    // `files: []` (legal only alongside `references`) keeps a bare `npx tsc` from
+    // sweeping the whole repo under one module system — the original TS1470 cause.
+    expect(root.files).toEqual([]);
+    expect(root.include).toBeUndefined();
+    expect(root.compilerOptions).toBeUndefined();
+  });
+
+  it('root references every project, so `tsc -b` covers the whole repo', () => {
+    const root = readConfig('tsconfig.json');
+    const referenced = (root.references || []).map((r) => r.path.replace('./', ''));
+    expect(new Set(referenced)).toEqual(new Set(PROJECTS));
+  });
+
+  it.each(PROJECTS)('%s extends the base, not the solution root', (project) => {
+    // Extending the solution root would inherit `files: []` and `references`,
+    // which re-breaks the file set and makes the project reference itself.
+    expect(readConfig(project).extends).toBe(`./${BASE}`);
+  });
+
+  it('the shared base pins no module system', () => {
+    const base = readConfig(BASE);
+    expect(base.compilerOptions.module).toBeUndefined();
+    expect(base.compilerOptions.moduleResolution).toBeUndefined();
+  });
+
+  it.each(PROJECTS)('%s declares its own module system', (project) => {
+    const { compilerOptions } = readConfig(project);
+    expect(compilerOptions.module).toBeTruthy();
+    expect(compilerOptions.moduleResolution).toBeTruthy();
+  });
+
+  it.each(PROJECTS)('no inherited exclude swallows %s own include', (project) => {
+    const excludeRoots = (readConfig(BASE).exclude || []).map(globRoot);
+    const includeRoots = (readConfig(project).include || []).map(globRoot);
+
+    expect(includeRoots.length).toBeGreaterThan(0);
+
+    for (const inc of includeRoots) {
+      for (const exc of excludeRoots) {
+        const swallowed = inc === exc || inc.startsWith(`${exc}/`);
+        expect(
+          swallowed,
+          `${project} includes "${inc}" but ${BASE} excludes "${exc}" — ` +
+            'the project would type-check zero files and still exit 0',
+        ).toBe(false);
+      }
+    }
+  });
+
+  it.each(PROJECTS)('%s keeps noEmit on via the base', (project) => {
+    // These are check-only projects; an accidental emit would write .js next to
+    // sources and be picked up by the Vite build.
+    const effective = {
+      ...readConfig(BASE).compilerOptions,
+      ...readConfig(project).compilerOptions,
+    };
+    expect(effective.noEmit).toBe(true);
+  });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "allowJs": true,
-    "checkJs": false,
-    "strict": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "forceConsistentCasingInFileNames": true
-  },
-  "exclude": ["node_modules", "dist", "tests/renderer/components", "src/renderer/**"]
+  "files": [],
+  "references": [{ "path": "./tsconfig.main.json" }, { "path": "./tsconfig.renderer.json" }]
 }

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "CommonJS",
     "moduleResolution": "Node10",

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
## What

The root `tsconfig.json` served two incompatible roles at once: the shared base that
`tsconfig.main.json` and `tsconfig.renderer.json` extend, **and** a runnable project.
Both roles were broken by the other.

Shared `compilerOptions` move to a new `tsconfig.base.json`. The root becomes a
solution file (`files: []` + `references`).

## The two failures

**1. The renderer project type-checked zero files — silently.**

The base `exclude` (`src/renderer/**`, `tests/renderer/components`) was inherited by
`tsconfig.renderer.json`, which overrode only `include`. Since `exclude` filters
whatever `include` matches, the renderer project's own `include` was cancelled
outright:

```
$ npx tsc --noEmit -p tsconfig.renderer.json --listFiles | grep -c "src/renderer"
0
```

`npm run typecheck:renderer` exited 0 the whole time. Nothing in tsc's output says
"the file set was empty" — the script reported success while checking `src/shared`
and nothing else.

**2. A bare `npx tsc --noEmit` failed on correct code.**

With no `include` of its own, the root project swept the whole repo under
`module: Node16`, reaching `src/renderer/lib/stores/ipc.ts` through `tests/` (an
`exclude` does not stop TS from following an import) and raising TS1470 on legitimate
`import.meta`. Recorded as debt in `memory-bank/progress.md`: *"root tsconfig is debt
(fix or remove)"*.

`module`/`moduleResolution` are dropped from the base for this reason — the main
process is CommonJS and the renderer is ESM, so a shared default is always wrong for
one of them. Each project declares its own.

## Turning the check on cost nothing

Measured before committing to the fix, because enabling tsc on 30 previously
unchecked files is an unbounded change hiding behind a config edit:

| | before | after |
|---|---|---|
| `src/renderer` files in the renderer project | 0 | 30 |
| component tests in scope | 0 | 5 |
| `svelte-check` files | 213 | 370 |
| type errors | 0 | **0** |
| `src/main` files in the main project | 44 | 44 |

Zero errors either way, so nothing is being suppressed or deferred.

## Proof the check is real, not just green

A config that passes and a config that checks are different things, so the fix was
verified with an injected error (`const __probe: number = "not a number"` in
`src/renderer/lib/stores/theme.ts`, reverted):

- `tsc -p tsconfig.renderer.json` → **caught** it (TS2322)
- `npm run typecheck` → **exit 2**
- `npx tsc -b` → **caught** it
- bare `npx tsc --noEmit` → silent, exit 0

That last line is the honest limitation of a solution file: it owns no sources, so it
can never fail. Every doc and tool that named `npx tsc --noEmit` as the gate now names
one that checks something — `npm run typecheck` in CLAUDE.md / CONTRIBUTING.md, and
`npx tsc -b` for the `auditor` agent, whose `Bash(npx tsc *)` scope can't run
`npm run`.

`npm run typecheck` also joins the existing CI `svelte-check` job — a script nothing
runs is how this rotted in the first place. It's a step inside a job that is already a
required check, so branch protection is unaffected.

## Regression guard

`tests/shared/tsconfig-projects.test.js` (11 tests) exists because this class of bug
is invisible in tsc output. It fails if any inherited `exclude` swallows a project's
own `include`, if the base pins a module system again, or if a project extends the
solution root (which would inherit `files: []` and reference itself).

Verified to actually catch the original bug — re-adding `src/renderer/**` to the base
`exclude` fails it with:

> `tsconfig.renderer.json includes "src/renderer" but tsconfig.base.json excludes "src/renderer" — the project would type-check zero files and still exit 0`

## Verification

- `npm test` — **1017 passed / 4 skipped (64 files)**, up from 1006/4 (63) by the 11 new tests
- `npm run typecheck` — 0 errors, both projects
- `npx tsc -b` — 0 errors
- `npm run typecheck:svelte` — 370 files, 0 errors
- `npm run lint` — 0 errors (23 pre-existing warnings)
- `npm run build:renderer` — clean, 1.37s
- Re-run after commit, since `lint-staged` rewrites staged files after the gate

`*.tsbuildinfo` added to `.gitignore`: `tsc -b` writes one per referenced project next
to the config, and this PR is what starts recommending `tsc -b`.

`npm run format:check` flags 129 working-copy files including ones untouched here;
`git show HEAD:<file> | prettier --check --stdin-filepath` confirms they are clean in
the repo. That is the known Windows CRLF false-positive, not a required CI check.
