### PR TITLE
docs: re-derive every factual claim from source (51 drifts, incl. an IPC table that documented 11 nonexistent channels)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -2,10 +2,10 @@
 alwaysApply: true
 ---
 # Code Quality Rules
-- 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 632, ipc-handlers.js 498), tests go up to 691. Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 654, ipc-handlers.js 498), tests go up to 734. Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - No `any` type. Use proper types from src/shared/types/
 - GPG signing on all commits
-- Verify after EVERY change: npm test && npm run build && npx tsc --noEmit
+- Verify after EVERY change: npm test && npm run build && npm run typecheck (NOT `npx tsc --noEmit` — the root tsconfig is a solution file and checks nothing)
 
 ## Git Workflow (GitHub Flow — strict)
 - master ВСЕГДА стабильный. Прямые коммиты в master ЗАПРЕЩЕНЫ.

--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -15,21 +15,21 @@ description: >-
 ## Project
 AEGIS — Independent AI Oversight Layer (Electron desktop)
 Repo: github.com/antropos17/Aegis | Version: 0.10.0-alpha
-Current Focus: Launch preparation (GIF, Dev.to, Reddit, HN)
+Current Focus: read `memory-bank/progress.md` — it is the live record. Do not restate it here; a copy goes stale silently.
 
 ## Stack
 Read package.json for exact versions. NEVER hardcode.
-Electron 33, Svelte 5, Vite 7, TypeScript (incremental, allowJs:true, checkJs:true), chokidar.
+Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs: false`** — `src/main/*.js` bodies are NOT type-checked, their JSDoc is documentation. Two projects (`tsconfig.main.json` CommonJS / `tsconfig.renderer.json` ESM) share `tsconfig.base.json`; root `tsconfig.json` is a solution file, so gate with `npm run typecheck`, never a bare `npx tsc --noEmit`.
 
 ## Architecture
-- Main process (Node.js): src/main/ — 43 CJS modules (34 top-level + 7 platform/ + 2 token-adapters/)
+- Main process (Node.js): src/main/ — 44 CJS modules (35 top-level + 7 platform/ + 2 token-adapters/)
 - Renderer (Svelte 5): src/renderer/ — 46 components + 11 stores + 16 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 39 invoke + 9 push = 48 channels
 - Data: src/shared/agent-database.json (110 agent signatures)
 - Rules: rules/*.yaml — 73 active rules across 8 categories, validated against rules/_schema.json
 - Rule loader: src/main/rule-loader.js — loadRules() + categoryIndex Map exposed via getRulesByCategory(); built and tested, but no production caller consumes it yet (C-16)
 - Types: src/shared/types/ — 8 .ts files
-- Tests: 968 pass, 4 skip (972 total) across 62 files (Vitest, all ESM)
+- Tests: 1017 pass, 4 skip (1021 total) across 64 files (Vitest, all ESM)
 
 ## Key Components (Fancy UI — complete)
 - ShieldTab: bento grid with SummaryCards, RiskRing, ActivityFeed

--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -25,7 +25,7 @@ Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs
 - Main process (Node.js): src/main/ — 44 CJS modules (35 top-level + 7 platform/ + 2 token-adapters/)
 - Renderer (Svelte 5): src/renderer/ — 46 components + 11 stores + 16 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 39 invoke + 9 push = 48 channels
-- Data: src/shared/agent-database.json (110 agent signatures)
+- Data: src/shared/agent-database.json (110 agents / 262 name signatures)
 - Rules: rules/*.yaml — 73 active rules across 8 categories, validated against rules/_schema.json
 - Rule loader: src/main/rule-loader.js — loadRules() + categoryIndex Map exposed via getRulesByCategory(); built and tested, but no production caller consumes it yet (C-16)
 - Types: src/shared/types/ — 8 .ts files
@@ -40,7 +40,7 @@ Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs
 - AgentCard: sparkline + badge + spotlight hover
 - FooterMiniCharts: CPU/memory sparklines in footer
 - TabBar: sliding indicator + tab transitions
-- VisTimeline, AgentGraph, EventFeed, AgentStatsPanel
+- Timeline (+ TimelineCanvas/Controls/Legend/Tooltip), ActivityFeed, GroupedFeed (+ GroupedFeedItem), FeedFilters, AgentPanel, AgentStatsPanel
 
 ## Key Files
 - src/renderer/lib/styles/tokens.css — 60+ design tokens (Fancy UI)

--- a/.claude/skills/electron-main/SKILL.md
+++ b/.claude/skills/electron-main/SKILL.md
@@ -5,7 +5,7 @@ description: Electron main process patterns for Aegis. CJS modules, platform abs
 # Electron Main Process
 
 ## Architecture
-- 43 CJS modules loaded directly by Node.js (34 top-level + 7 platform/ + 2 token-adapters/, NO build step)
+- 44 CJS modules loaded directly by Node.js (35 top-level + 7 platform/ + 2 token-adapters/, NO build step)
 - Platform dispatcher: src/main/platform/index.js → win32|darwin|linux
 - IPC: 39 invoke + 9 push = 48 channels, scan-batch consolidation
 - File watcher: chokidar 3.6, function-form ignored (NOT glob)

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -6,7 +6,7 @@ description: Vitest testing patterns for Aegis. ESM imports, mocking, test struc
 
 ## Stack
 - Vitest 4 + esbuild transform
-- 62 test files, 968 pass, 4 skip (972 total)
+- 64 test files, 1017 pass, 4 skip (1021 total)
 
 ## Structure
 - tests/ directory mirrors src/ structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ AEGIS is an independent AI oversight layer — a desktop app that monitors AI ag
 ```
 src/main/           Electron main process (CommonJS, require/module.exports)
 src/renderer/       Svelte 5 dashboard UI (ES modules, runes)
-src/shared/         Constants + agent-database.json (110 agent signatures) + types/ (8 .ts)
+src/shared/         Constants + agent-database.json (110 agents, 262 name signatures) + types/ (8 .ts)
 rules/              73 detection rules in 8 YAML files + _schema.json
 tests/              Vitest unit tests with v8 coverage
 ```
@@ -23,7 +23,7 @@ Key modules:
 - `src/main/llm-runtime-detector.js` — local LLM runtime detection (Ollama, LM Studio HTTP probes)
 - `src/main/cli.js` — CLI interface (`--scan-json`, `--version`, `--help`)
 - `src/main/platform/` — OS abstraction (win32.js, darwin.js, linux.js)
-- `src/shared/agent-database.json` — 110 known agent signatures
+- `src/shared/agent-database.json` — 110 known agents; their `names` arrays hold 262 process-name signatures in total
 - `src/main/rule-loader.js` — loads `rules/*.yaml` (73 rules, 8 categories) against `rules/_schema.json`, hot-reload
 - `src/shared/constants.js` — ignore patterns, editor lists, AGENT_CONFIG_PATHS. `SENSITIVE_RULES` (68) is deprecated and unread at runtime — editing it changes nothing
 
@@ -54,8 +54,9 @@ CI runs all three on every push and PR (`.github/workflows/ci.yml`).
 ## Git conventions
 
 - **Conventional commits:** `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `style:`, `test:`
-- **Feature branches:** `feat/feature-name` → PR → squash merge to `master`
-- **Direct commits to master:** OK for `docs:` and `chore:` only
+- **Feature branches, always:** `feat/*` | `fix/*` | `chore/*` | `docs/*` → push → PR. One PR = one logical task.
+- **Merge commits only.** Squash and rebase are disabled on the repository, so `gh pr merge <n> --merge --delete-branch` is the only available method and every merge lands as a two-parent commit. Squash the noisy commits on your own branch *before* opening the PR — the merge will not do it for you.
+- **Direct commits to master are impossible, not merely discouraged.** `master` requires a pull request plus green `audit` / `build` / `lint` / `svelte-check` / `test`, with admin enforcement on, so a local commit on master cannot be pushed at all. `.claude/hooks/branch-guard.js` refuses edits on master before you reach that point.
 - **No Co-Authored-By lines.** No "Generated with" attribution in commits or PRs.
 
 ## What NOT to do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ CI runs all three on every push and PR (`.github/workflows/ci.yml`).
 
 ## Code conventions
 
-- 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 632, ipc-handlers.js 498), tests go up to 691. Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 654, ipc-handlers.js 498), tests go up to 734. Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - **Main process:** CommonJS (`require`/`module.exports`). Never use `import` in `src/main/`.
 - **Renderer:** ES modules (`import`/`export`). Never use `require()` in `src/renderer/`.
 - **Svelte 5 runes:** `$state`, `$derived`, `$effect`, `$props`. No legacy `let` reactivity.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,7 +67,7 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 
 #### 2. File & Data Access — `file-watcher.js` + `rule-loader.js`
 - **What it sees:** File create/modify/delete in sensitive directories, per-process file handles
-- **How:** chokidar watchers on `.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`, `.azure`, `.env*`, 27 agent config directories, project directory. PowerShell handle scanning (`handle64.exe` or `Get-Process` fallback).
+- **How:** chokidar watchers on `.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`, `.azure`, `.env*`, the 35 directories in `AGENT_CONFIG_PATHS` (minus those already covered as sensitive dirs), and the project directory. Open-handle detection is per-platform: Windows uses the Restart Manager (`rstrtmgr.dll`), macOS/Linux use `lsof` / `/proc`.
 - **Depth:** 73 sensitive file rules (from `rules/*.yaml`) with severity classification. AI agent config directory protection (Hudson Rock threat vector). 2-second debounce per path.
 - **Limitation:** chokidar cannot attribute events to specific processes. Handle scanning provides per-process attribution but runs on a timer.
 
@@ -77,21 +77,22 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 - **Depth:** Domain classification against 50+ known-safe vendor patterns (from agent database). Unknown domains flagged. Connection state tracking.
 - **Limitation:** Cannot inspect encrypted traffic. Sees endpoints but not payload.
 
-#### 4. Risk Engine — `risk-scoring.js` + `baselines.js`
-- **What it computes:** Per-agent risk scores (0-100+), trust grades (A+ through F), anomaly scores (0-100)
-- **Risk formula:** `Base = min(40, log2(1 + sensitiveFiles) * 8)` + `Network = min(30, unknownDomains * 12)` + `Anomaly = min(30, anomalyScore * 0.3)` → `Total = min(100, Base + Network + Anomaly)`
-- **Anomaly scoring:** 5 weighted factors — file volume (30pts), sensitive spike (25pts), new sensitive categories (20pts), new network endpoints (15pts), unusual timing (10pts)
+#### 4. Risk Engine — `src/renderer/lib/utils/risk-scoring.js` + `src/main/anomaly-detector.js` + `src/main/baselines.js`
+- **What it computes:** Per-agent risk scores (0-100), trust grades (A+ through F), anomaly scores (0-100)
+- **Where it runs:** risk scoring lives in the RENDERER (`lib/utils/risk-scoring.js`); there is no `src/main/risk-scoring.js`. Anomaly scoring and baselines are main-process modules.
+- **Risk formula:** a sum of six independently capped contributions, each saturating so no single signal can dominate — `min(40, sensitive * 5 * (1 / (1 + sensitive * 0.1)))` + `min(20, sshAwsFiles * 5)` + `min(20, unknownDomains * 8)` + `min(10, networkCount * 0.5)` + `min(5, configFiles * 0.5)` + `min(5, fileCount * 0.02)`, the total clamped to 100. The sensitive term is deliberately sub-linear: the `1 / (1 + sensitive * 0.1)` damping is what stops `sensitive * 10` from pinning the score at 100 on the first burst (ai-mistakes.md #10).
+- **Anomaly scoring:** 4 weighted dimensions, `composite = Σ(dimension.score × weight)` with `{network: 0.3, filesystem: 0.25, process: 0.25, baseline: 0.2}`. Individual signals such as file volume and sensitive-access spikes are sub-factors inside a dimension, not top-level weighted factors.
 - **Baselines:** Rolling averages over 10 sessions, persisted to `baselines.json`
 
 #### 5. AI Analysis — `ai-analysis.js`
 - **What it provides:** Structured threat assessment with executive summary, findings, risk rating, recommendations
-- **How:** Anthropic Messages API (`claude-sonnet-4-5-20250929`) with session data context
+- **How:** Anthropic Messages API (`claude-haiku-4-5-20251001`, both call sites in `ai-analysis.js`) with session data context
 - **Modes:** Per-agent analysis and full-session analysis
 - **Privacy:** Only triggered when user explicitly clicks the button. No background API calls.
 
 #### 6. Audit Trail — `audit-logger.js`
-- **What it logs:** 7 event types — file-access, network-connection, anomaly-alert, permission-deny, agent-enter, agent-exit, config-access
-- **Format:** Append-only JSONL. Each entry: `{timestamp, type, agent, action, path, severity, riskScore, details}`
+- **What it logs:** 6 event types are actually emitted — file-access, config-access, network-connection, anomaly-alert, agent-enter, agent-exit. A 7th, `permission-deny`, is listed in the logger's JSDoc and accepted by the renderer timeline, but no call site emits it.
+- **Format:** Append-only JSONL. Each entry: `{timestamp, type, agent, action, path, severity, riskScore, details, seq, hash}` — `seq` and `hash` are added at flush time by `audit-hashchain.js`, which makes each daily file an independent SHA-256 chain. The chain proves no record was EDITED; it cannot prove none was lost, since a record that never reached disk leaves no gap.
 - **Rotation:** New file per day (`aegis-audit-YYYY-MM-DD.json`), auto-delete after 30 days
 - **Performance:** Buffered writes — flush every 5 seconds or at 50 events
 
@@ -111,7 +112,7 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 | **Syscall Monitoring** | No kernel-level visibility into system calls | Windows Minifilter, macOS Endpoint Security, Linux eBPF |
 | **Memory Inspection** | Cannot inspect agent process memory | ReadProcessMemory API, `/proc/[pid]/mem` |
 | **Cross-device Correlation** | Single-machine visibility only | Local network discovery + shared audit format |
-| **Mac/Linux Support** | Process scanning is Windows-only | `ps aux`, `fanotify`, `ss`/`lsof` implementations |
+| **Mac/Linux parity** | Narrower than it looks: `platform/darwin.js` and `platform/linux.js` both implement `listProcesses()` (via `ps`) and `suspendProcess()`/`resumeProcess()` (via `posix-shared.js`), so process scanning and stop/resume are cross-platform. What is Windows-only is open-handle detection via the Restart Manager (`rstrtmgr.dll`); POSIX falls back to `lsof` / `/proc` | `fanotify` (Linux) and Endpoint Security (macOS) for richer file-access attribution |
 
 ## Module Dependency Diagram
 
@@ -188,79 +189,80 @@ Process Scan (every Ns)
 
 ### Invoke (Renderer → Main → Response)
 
+All 39 registered in `src/main/ipc-handlers.js` and exposed through `src/main/preload.js`. A
+channel absent from `preload.js` is unreachable from the renderer under `contextIsolation`,
+so this table is the complete surface — nothing else can be invoked.
+
 | Channel | Module | Purpose |
 |---|---|---|
-| `scan-processes` | process-scanner | Trigger manual process scan |
-| `get-stats` | main | File counts, agent counts, uptime |
+| `get-stats` | main | File counts, agent counts, uptime, attribution counters |
 | `get-resource-usage` | main | CPU, memory, heap metrics |
 | `get-settings` | config-manager | Read settings |
-| `save-settings` | config-manager | Persist settings + restart watchers |
-| `get-all-permissions` | config-manager | Full permission map + seen agents |
-| `get-agent-permissions` | config-manager | Per-agent permission state |
-| `save-agent-permissions` | config-manager | Persist permission map |
+| `save-settings` | config-manager + settings-validation | Validate, persist, restart watchers |
+| `get-all-permissions` | config-manager | Agent + instance permission maps and seen agents |
+| `save-agent-permissions` | config-manager | Persist per-agent permission map |
+| `save-instance-permissions` | config-manager | Persist per-instance permission map |
 | `reset-permissions-to-defaults` | config-manager | Reset all permissions |
-| `get-agent-baseline` | baselines | Per-agent session history + averages |
 | `analyze-agent` | ai-analysis | Per-agent AI threat analysis |
 | `analyze-session` | ai-analysis | Full session AI threat analysis |
 | `open-threat-report` | main | Write HTML to temp + open in browser |
-| `get-audit-stats` | audit-logger | Audit log statistics |
-| `open-audit-log-dir` | audit-logger | Open audit directory in explorer |
-| `export-full-audit` | audit-logger | Export all logs to single JSON |
+| `open-audit-log-dir` | audit-logger | Open audit directory in the file manager |
+| `export-full-audit` | audit-logger | Export all audit logs to a single JSON |
+| `get-audit-entries-before` | audit-logger | Paginated audit log entries (cursor) |
 | `export-log` | exports | JSON save dialog |
 | `export-csv` | exports | CSV save dialog |
 | `generate-report` | exports | HTML report → open in browser |
+| `export-zip` | zip-writer | One-click ZIP session export |
 | `get-agent-database` | process-scanner | Full agent signature database |
-| `get-project-dir` | main | Project root path |
 | `get-custom-agents` | config-manager | User-defined agent list |
 | `save-custom-agents` | config-manager | Persist custom agents |
-| `export-agent-database` | main | Export agents to JSON file |
-| `import-agent-database` | main | Import agents from JSON file |
-| `capture-screenshot` | main | Capture window as PNG |
-| `kill-process` | main | Terminate process by PID |
-| `suspend-process` | main | Suspend process via NtSuspendProcess |
-| `resume-process` | main | Resume process via NtResumeProcess |
-| `get-instance-permissions` | config-manager | Per-instance permission state |
-| `save-instance-permissions` | config-manager | Persist per-instance permissions |
-| `get-audit-entries-before` | audit-logger | Paginated audit log entries |
-| `get-log-stats` | logger | Structured log statistics |
-| `export-full-log` | logger | Export all structured logs |
-| `open-log-dir` | logger | Open log directory in explorer |
-| `test-notification` | main | Trigger test OS notification |
-| `export-config` | config-manager | Export settings to JSON file |
-| `import-config` | config-manager | Import settings from JSON file |
-| `reveal-in-explorer` | main | Open file location in file manager |
-| `get-local-models` | llm-runtime-detector | Local LLM model list |
-| `get-app-version` | main | Current app version string |
-| `export-zip` | zip-writer | One-click ZIP session export |
+| `export-agent-database` | main | Export agents to a JSON file |
+| `import-agent-database` | main | Import agents from a JSON file |
+| `export-config` | config-manager | Export settings to a JSON file |
+| `import-config` | config-manager | Import settings from a JSON file |
+| `kill-process` | platform | Terminate a monitored PID (own-PID guarded) |
+| `suspend-process` | platform | Suspend a monitored PID (own-PID guarded) |
+| `resume-process` | platform | Resume a monitored PID (own-PID guarded) |
+| `rules:getAll` | rule-loader | All loaded rules, serialized |
+| `rules:reload` | rule-loader | Force a reload, returns the new count |
+| `blocklist-add` | blocklist | Add a watchlist entry (alert-only) |
+| `blocklist-remove` | blocklist | Remove a watchlist entry |
+| `blocklist-list` | blocklist | Current watchlist |
 | `get-false-positives` | config-manager | List of false-positive entries |
-| `add-false-positive` | config-manager | Mark process as false positive |
-| `open-external-url` | main | Open URL in default browser |
+| `add-false-positive` | config-manager | Mark a process as a false positive |
+| `reveal-in-explorer` | main | Open a file's location in the file manager |
+| `open-external-url` | main | Open an http/https URL in the default browser |
+| `get-app-version` | main | Current app version string |
+| `test-notification` | main | Trigger a test OS notification |
+
+`kill-process`, `suspend-process` and `resume-process` each refuse AEGIS's own PID and any
+PID not in the current scan result — see the C-01 guards in `ipc-handlers.js`.
 
 ### Send (Renderer → Main, no response)
 
-| Channel | Purpose |
-|---|---|
-| `other-panel-expanded` | Toggle other-agent file scanning |
+None. `preload.js` wraps only `invoke()` and `on()`; it exposes no `ipcRenderer.send`, so
+there is no fire-and-forget path from the renderer.
 
 ### Push (Main → Renderer)
 
+All 9 subscribed via `ipcRenderer.on` in `preload.js`.
+
 | Channel | Purpose |
 |---|---|
-| `scan-results` | Updated agent list (periodic) |
-| `file-access` | New file access events |
+| `scan-batch` | One coalesced payload per scan: agents, stats, resourceUsage, anomalyScores |
+| `file-access` | New file access events (batched, 150ms) |
 | `stats-update` | Updated aggregate stats |
 | `network-update` | Network connections |
 | `resource-usage` | CPU/memory metrics |
-| `baseline-warnings` | Behavioral deviations |
-| `anomaly-scores` | Per-agent anomaly scores (0-100) |
-| `monitoring-paused` | Pause/resume state from tray |
-| `toggle-theme` | Theme toggle from tray menu |
-| `scan-status` | Scanner state (scanning/idle/error) |
+| `token-costs` | Per-agent token usage and cost estimates |
+| `scan-status` | Scanner state (scanning/idle) |
+| `rules:reloaded` | Rule hot-reload landed, with the new count |
+| `toggle-theme` | Theme toggle from the tray menu |
 
 ## Extension Points
 
 ### Adding a New Agent Signature
-Edit `agent-database.json` — add entry with `processPatterns`, `knownDomains`, `configPaths`, and trust/risk metadata. The process scanner, network monitor, and file watcher all consume this database automatically.
+Edit `agent-database.json` — append an entry to the `agents` array. The process-name field is `names` (an array of match strings), **not** `processPatterns`, which appears nowhere in the codebase. Alongside it: `id`, `displayName`, `category`, `knownDomains`, `configPaths`, and trust/risk metadata. The process scanner, network monitor, and file watcher all consume this database automatically.
 
 ### Adding New Sensitive File Rules
 Rules live in `rules/*.yaml` (one file per category), validated against `rules/_schema.json` and loaded by `rule-loader.js` with hot-reload. Add an entry to the ruleset matching the category:
@@ -280,19 +282,26 @@ Rules live in `rules/*.yaml` (one file per category), validated against `rules/_
 2. Wire in `main.js` via dependency injection
 3. Add IPC handler in `registerIpc()` if renderer needs access
 4. Add bridge method in `preload.js`
-5. Add audit logging via `aud.log(type, details)`
+5. Add audit logging via `audit.log(type, details)` (injected as `deps.audit` in `scan-loop.js`)
 
 ### Adding a New UI Panel
-1. Create `src/renderer/src/lib/components/NewPanel.svelte`
+1. Create `src/renderer/lib/components/NewPanel.svelte` (there is no `src/renderer/src/` directory)
 2. Import and place the component in the appropriate tab (e.g., `ShieldTab.svelte`, `ActivityTab.svelte`)
-3. Subscribe to IPC data via Svelte stores in `src/renderer/src/lib/stores/`
+3. Subscribe to IPC data via Svelte stores in `src/renderer/lib/stores/`
 4. Use scoped styles within the `.svelte` file (follows project CSS conventions)
 
 ### Adding Platform Support
-The main process modules abstract OS-specific operations:
-- `process-scanner.js` — Replace `tasklist` with `ps aux` for Unix
-- `file-watcher.js` — chokidar is cross-platform; handle scanning needs `lsof` fallback
-- `network-monitor.js` — Replace `Get-NetTCPConnection` with `ss` or `lsof -i`
+OS-specific operations already live behind `src/main/platform/`, which picks an
+implementation at load time — so this is about filling gaps in an existing abstraction,
+not introducing one. Add to the platform module, never branch on `process.platform` in a
+caller:
+- `platform/win32.js` — `tasklist /FO CSV /NH`, `Get-CimInstance` for parent chains and
+  `startTime`, `Get-NetTCPConnection`, Restart Manager handle detection, suspend/resume
+  via `NtSuspendProcess`/`NtResumeProcess` P/Invoke
+- `platform/darwin.js`, `platform/linux.js` — `listProcesses()` via `ps`, with the shared
+  POSIX pieces (including `SIGSTOP`/`SIGCONT` suspend/resume) in `platform/posix-shared.js`
+- `file-watcher.js` — chokidar is cross-platform; only open-handle detection is
+  platform-specific
 
 ## Privacy Architecture
 

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -6,15 +6,21 @@
 - `feat/short-name` — new features
 - `fix/short-name` — bug fixes
 - `perf/short-name` — performance
+- `chore/short-name` — maintenance, data updates
 - `docs/short-name` — documentation
 
 ## Rules
 
-1. NEVER commit features directly to master
-2. Create branch -> changes -> PR -> CI passes -> squash merge
-3. Keep branches short-lived (1-3 days)
-4. Delete branch after merge
-5. Direct master commits OK ONLY for: typos, version bumps, CI config
+1. Create branch -> changes -> PR -> CI passes -> **merge commit**. Squash and rebase are
+   disabled on the repository, so `gh pr merge <n> --merge --delete-branch` is the only
+   method available and every merge lands as a two-parent commit. Squash the noisy commits
+   on your own branch *before* opening the PR.
+2. Keep branches short-lived (1-3 days)
+3. Branch is deleted on merge (`delete_branch_on_merge` is on)
+4. **Direct commits to master are impossible, for anything — including typos, version bumps
+   and CI config.** `master` requires a pull request plus green `audit` / `build` / `lint` /
+   `svelte-check` / `test`, with admin enforcement on, so the push is rejected. The
+   `.claude/hooks/branch-guard.js` hook refuses edits on master before you get that far.
 
 ## For AI agents (Claude Code)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ npm run dist              # Electron-builder NSIS installer
 ## Critical Rules
 1. Read memory-bank/ai-mistakes.md before ANY code change
 2. Do ONLY what the prompt says — no extra features, no unrequested changes
-3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 632, ipc-handlers.js 498), tests go up to 691. Don't split an existing file just to hit the number; do extract when adding to one that's already over
+3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 654, ipc-handlers.js 498), tests go up to 734. Don't split an existing file just to hit the number; do extract when adding to one that's already over
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Landing: aegisprotect.vercel.app | Demo: aegis-demo-ten.vercel.app
 npm run build:renderer    # Vite build (MUST pass before commit)
 npm run lint              # ESLint
 npm run format            # Prettier
-npm test                  # Vitest (1006 passed / 4 skipped = 1010, 63 files)
+npm test                  # Vitest (1017 passed / 4 skipped = 1021, 64 files)
 npm run dist              # Electron-builder NSIS installer
 
 ## Background Tasks (/loop)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ When maintainers merge the Release PR → version bump + CHANGELOG + GitHub Rele
 - **JSDoc headers on all exported functions** — `@param`, `@returns`, `@since` tags required. Include `@file`, `@module`, `@description` at top of every file.
 - **300 line soft limit per file** — split into focused, single-responsibility modules when exceeding.
 - **`const` over `let`** when the binding doesn't change. Never use `var`.
-- **No external dependencies** without discussion — the project intentionally has only 1 runtime dependency (`chokidar`; `electron` is a devDependency). Adding a dependency requires justification.
+- **No external dependencies** without discussion — the project intentionally keeps `dependencies` to three: `ajv` (rule-schema validation), `chokidar` (file watching) and `js-yaml` (ruleset parsing). `electron` is a devDependency. Adding a dependency requires justification.
 
 ### Naming Conventions
 
@@ -80,7 +80,7 @@ Add an entry to the `agents` array:
 {
   "name": "My Agent",
   "displayName": "My Agent",
-  "processPatterns": ["myagent", "myagent.exe"],
+  "names": ["myagent", "myagent.exe"],
   "icon": "🤖",
   "color": "#FF6B6B",
   "vendor": "My Company",
@@ -96,14 +96,14 @@ Add an entry to the `agents` array:
 
 **Required fields:**
 - `name` / `displayName` — Agent identifier (must be unique)
-- `processPatterns` — Substrings matched against running process names (case-insensitive)
+- `names` — Substrings matched against running process names (case-insensitive). The field is `names`, not `processPatterns`; nothing in the codebase reads a `processPatterns` key
 
 **Important fields:**
 - `knownDomains` — Domains classified as "safe" when this agent connects to them. Without this, the agent's connections will be flagged as unknown.
 - `configPaths` — Directories to monitor for the Hudson Rock config protection feature. These directories are watched for unauthorized access.
 - `defaultTrust` — Initial trust score (0-100). Lower = more suspicious. Affects risk score multiplier.
 - `riskProfile` — `low`, `medium`, or `high`. Affects default permission assignments.
-- `category` — One of: `coding-assistant`, `ai-ide`, `cli-tool`, `autonomous-agent`, `desktop-agent`, `browser-agent`, `agent-framework`, `security-devops`, `ide-extension`, `local-llm-runtime`
+- `category` — One of the 11 in use: `agent-framework`, `ai-ide`, `autonomous-agent`, `browser-agent`, `cli-tool`, `coding-assistant`, `container-runtime`, `desktop-agent`, `ide-extension`, `local-llm-runtime`, `security-devops`
 
 ### Via the UI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Requires Node.js 18+ and Windows 10/11 for full monitoring functionality. The El
 1. **Fork** the repository
 2. **Branch** from `master`: `git checkout -b feature/your-feature`
 3. **Implement** your changes following the code standards below
-4. **Test**: run `npm test` (968 tests across 62 files) and `npm start` — verify no console errors, all tabs render, existing features work
+4. **Test**: run `npm test` (1017 tests across 64 files) and `npm start` — verify no console errors, all tabs render, existing features work
 5. **Commit** with [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 6. **Push** your branch and open a **Pull Request** with a clear description of what changed and why
 
@@ -55,7 +55,7 @@ When maintainers merge the Release PR → version bump + CHANGELOG + GitHub Rele
 ### TypeScript
 
 - **New files should be written in TypeScript** (`.ts`) — existing `.js` files will be migrated incrementally
-- **Main process** (`.js`): uses JSDoc annotations + `checkJs: true` for type safety without converting to `.ts`
+- **Main process** (`.js`): annotated with JSDoc, which editors use for IntelliSense. `checkJs` is **off** in `tsconfig.base.json`, so `tsc` resolves these files but does not type-check their bodies — the annotations document intent, they are not enforced by the typecheck gate
 - **Renderer** (`.ts`/`.svelte`): native TypeScript with ES modules
 - Shared type definitions live in `src/shared/types/` (types across 8 files)
 - Run `npm run typecheck` before opening a PR — zero type errors required. It checks both projects (`tsconfig.main.json` + `tsconfig.renderer.json`); a bare `npx tsc --noEmit` resolves the root solution file and checks nothing

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/antropos17/Aegis/releases/latest"><img src="https://img.shields.io/github/v/release/antropos17/Aegis?include_prereleases&style=flat-square&label=Release" alt="Release"></a>
   <img src="https://img.shields.io/github/actions/workflow/status/antropos17/Aegis/ci.yml?style=flat-square&label=CI" alt="CI">
-  <img src="https://img.shields.io/badge/Tests-968%20passing-brightgreen?style=flat-square" alt="Tests">
+  <img src="https://img.shields.io/badge/Tests-1017%20passing-brightgreen?style=flat-square" alt="Tests">
   <a href="#monitor-first"><img src="https://img.shields.io/badge/Mode-monitor--first-8a2be2?style=flat-square" alt="Monitor-first"></a>
   <img src="https://img.shields.io/badge/License-MIT-blue?style=flat-square" alt="MIT License">
   <img src="https://img.shields.io/badge/Platform-Win%20%7C%20macOS%20%7C%20Linux-lightgrey?style=flat-square" alt="Platform">
@@ -33,7 +33,7 @@
 ## What Does Aegis Monitor?
 
 - **Process Monitoring** — Tracks 110 known AI agent signatures with parent-child tree resolution and IDE host detection.
-- **File System Access** — Watches sensitive directories (`.ssh`, `.aws`, `.gnupg`, `.env`, cloud configs) and 27 AI agent config paths for unauthorized access.
+- **File System Access** — Watches sensitive directories (`.ssh`, `.aws`, `.gnupg`, `.env`, cloud configs) and 35 registered AI agent config paths for unauthorized access.
 - **Network Activity** — Logs outbound TCP connections per agent PID with reverse DNS and known-vs-unknown API endpoint classification.
 - **Behavioral Analysis** — Applies 73 detection rules across 8 categories with rolling 10-session baselines and 4-axis anomaly scoring.
 - **Trust Scoring** — Assigns real-time risk scores with trust grades (A+ through F) using time-decay algorithms and multi-dimensional threat assessment.
@@ -46,8 +46,8 @@
 | **512** | vulnerabilities found in OpenClaw by Kaspersky — autonomous agents ship with real security risks |
 | **0** | open-source EDR tools existed for AI agents before Aegis |
 | **110** | AI agent signatures in the detection database, from Claude Code to AutoGPT |
-| **73** | behavioral detection rules across 8 categories, with hot-reload and custom overrides |
-| **968** | tests passing, 0 failures — the monitoring engine is verified on every commit |
+| **73** | behavioral detection rules across 8 categories, hot-reloaded on edit |
+| **1017** | tests passing, 0 failures — the monitoring engine is verified on every commit |
 | **<2s** | cold boot to full dashboard — lightweight enough to run alongside the agents it monitors |
 
 AI agents now have deep access to your machine — files, commands, network. Every existing AI security tool is enterprise SaaS that monitors what humans send *to* AI. Nobody monitors what AI agents do *on local machines*. Aegis is the open-source answer.
@@ -140,15 +140,15 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
 
 **Export** — JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging (daily rotation, 30-day retention)
 
-**i18n** — Internationalization with English base (110+ strings), community translations welcome
+**i18n** — Internationalization with English base (230 strings in `en.json`), community translations welcome
 
 **CLI** — `--scan-json` for scripting, `--version`, `--help`
 
 ## YAML Rulesets
 
 - 73 detection rules across 8 categories (AI config, secrets, SSH, cloud, browser, devtools, crypto, certificates)
-- JSON Schema validated, hot-reload without restart
-- Extend or override via `rules/custom/` directory
+- Validated against `rules/_schema.json`; editing a ruleset hot-reloads without a restart
+- Extend by adding a `.yaml` to `rules/`. Rule IDs must be unique — a duplicate ID is skipped, not overridden. A newly added file is picked up on the next reload or restart, since the watcher reacts to changes in existing top-level files
 
 ## Screenshots
 
@@ -205,7 +205,7 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
             └─────────────┘    └─────────────┘
 ```
 
-**Stack**: Electron 33, Svelte 5, Vite 7, Vitest (968 tests across 62 files). The monitoring engine is JavaScript (CommonJS); TypeScript is used in the renderer and shared types.
+**Stack**: Electron 33, Svelte 5, Vite 7, Vitest (1017 tests across 64 files). The monitoring engine is JavaScript (CommonJS); TypeScript is used in the renderer and shared types.
 
 ## Agent Database
 
@@ -264,7 +264,7 @@ Aegis ships with 110 agent signatures across five categories: coding assistants 
 
 ### Can I use Aegis in production?
 
-Aegis is currently at v0.10.0-alpha and is recommended for development and testing environments. The core monitoring engine is stable with 968 tests passing, but production deployment features (auto-update, OS-level enforcement) are on the roadmap for v1.0.
+Aegis is currently at v0.10.0-alpha and is recommended for development and testing environments. The core monitoring engine is stable with 1017 tests passing, but production deployment features (auto-update, OS-level enforcement) are on the roadmap for v1.0.
 
 ### Is Aegis free?
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p align="center"><i>Open-source monitor that shows what AI coding agents actually do on your machine — at the OS level, no agent hooks required.</i></p>
 </p>
 
-**AEGIS sees every AI agent on your machine — even ones that don't cooperate.** It is an independent, OS-level observer that watches agent processes, file access, network activity, and behavioral anomalies in real time, regardless of how the agent was launched. Built on a JavaScript (ES modules / CommonJS) monitoring engine, with TypeScript in the renderer and shared types. **Open-source, local, no telemetry** — everything stays on your machine.
+**AEGIS sees every AI agent on your machine — even ones that don't cooperate.** It is an independent, OS-level observer that watches agent processes, file access, network activity, and behavioral anomalies in real time, regardless of how the agent was launched. Built on a CommonJS JavaScript monitoring engine, with TypeScript in the renderer and in the shared types. **Open-source, local, no telemetry** — everything stays on your machine.
 
 > "Kaspersky found 512 bugs in OpenClaw. So we built an EDR to monitor it."
 
@@ -67,7 +67,7 @@ AEGIS sits at a different layer. It is an **independent, OS-level observer**: it
 | Layer | How |
 |-------|-----|
 | **Processes** | 110 known AI agent signatures, parent-child tree resolution, IDE host detection |
-| **Files** | Watches `.ssh`, `.aws`, `.gnupg`, `.env*`, cloud configs, 27 AI agent config dirs |
+| **Files** | Watches `.ssh`, `.aws`, `.gnupg`, `.env*`, cloud configs, 35 registered AI agent config dirs |
 | **Network** | Outbound TCP per agent PID, reverse DNS, known API endpoints vs unknown |
 | **Behavior** | Rolling 10-session baselines, 4-axis anomaly scoring (Network/FS/Process/Baseline) |
 | **Local LLMs** | Ollama, LM Studio, vLLM, llama.cpp runtime detection |
@@ -240,7 +240,7 @@ Everything below is **planned**, not shipped. AEGIS today is monitor-only (see [
 
 ### What is Aegis?
 
-Aegis is an open-source endpoint detection and response (EDR) tool purpose-built for monitoring AI agents. It tracks processes, file access, network activity, and behavioral anomalies in real time, built on Electron 33 and Svelte 5. The monitoring engine is JavaScript (ES modules / CommonJS); TypeScript is used in the renderer and shared type definitions. All data stays local — no telemetry, no cloud dependency.
+Aegis is an open-source endpoint detection and response (EDR) tool purpose-built for monitoring AI agents. It tracks processes, file access, network activity, and behavioral anomalies in real time, built on Electron 33 and Svelte 5. The monitoring engine is CommonJS JavaScript; the renderer is ES modules, and TypeScript is used in the renderer and the shared type definitions. All data stays local — no telemetry, no cloud dependency.
 
 ### Why do AI agents need monitoring?
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,7 +5,7 @@ and IPC architecture specific to this codebase.
 
 ---
 
-## Stack Versions (current as of v0.7.0-alpha)
+## Stack Versions (current as of v0.10.0-alpha)
 
 | Dep | Version | Role |
 |-----|---------|------|
@@ -16,7 +16,9 @@ and IPC architecture specific to this codebase.
 | chokidar | 3.6 | File system watcher (main process only) |
 | prettier | 3.8 | Code formatter — run before committing |
 
-**Runtime deps only:** `electron` + `chokidar`. No other runtime deps without discussion.
+**Runtime deps (package.json `dependencies`) — three:** `ajv`, `chokidar`, `js-yaml`. `electron`
+is a devDependency; it ships as the shell, not as a resolved runtime dep. No further runtime
+deps without discussion.
 
 ---
 
@@ -169,20 +171,28 @@ OS (chokidar + netstat) --> main process
 
 ### Stream channels (pushed from main)
 
+All nine, exactly as subscribed in `preload.js`. There is no `scan-results` or
+`anomaly-scores` channel — anomaly scores ride inside `scan-batch`.
+
 | Channel | Store | Payload |
 |---------|-------|---------|
-| `scan-results` | `agents` | `Agent[]` |
+| `scan-batch` | `agents`, `stats`, `resourceUsage`, `anomalies` | `{ agents, stats, resourceUsage, anomalyScores }` — one coalesced payload per scan |
 | `file-access` | `events` | `FileEvent[]` |
 | `stats-update` | `stats` | `StatsObject` |
 | `network-update` | `network` | `NetworkConnection[]` |
-| `anomaly-scores` | `anomalies` | `{ [agentName]: score }` |
-| `resource-usage` | `resourceUsage` | `{ memMB, heapMB, cpuUser, cpuSystem }` |
+| `token-costs` | `tokenCosts` | `TokenCostRecord[]` |
+| `scan-status` | `scanActive` | `{ scanning: boolean }` |
+| `toggle-theme` | — | consumed directly in `App.svelte`, not via a store |
+| `resource-usage` | — | exposed by `preload.js` but **no renderer subscriber**; metrics arrive via `scan-batch` |
+| `rules:reloaded` | — | exposed by `preload.js` but **no renderer subscriber** |
 
 ### Invoke channels (renderer requests main)
 
 Common ones: `get-stats`, `get-resource-usage`, `get-agent-database`, `get-settings`,
 `save-settings`, `get-all-permissions`, `save-agent-permissions`, `analyze-session`,
-`kill-process`, `get-audit-stats`. Full list in `src/main/preload.js`.
+`kill-process`, `get-audit-entries-before`. All 39 are listed in `src/main/preload.js`; the
+full table with module attribution is in [ARCHITECTURE.md](../ARCHITECTURE.md). Note there
+is no `get-audit-stats` channel — `audit-logger.getStats()` exists but is not wired to IPC.
 
 ### Browser / demo mode guard
 
@@ -245,7 +255,8 @@ npm start              # build:renderer + launch.js (opens Electron with built r
 
 ## Testing
 
-Vitest (not Jest). Tests live in `src/tests/`.
+Vitest (not Jest). Tests live in `tests/` at the repository root — split into three Vitest
+projects (`main`, `renderer`, `components`) by `vitest.config.js`.
 
 ```bash
 npm test               # run all tests once
@@ -285,7 +296,7 @@ Key token namespaces:
 
 ## Conventions
 
-- **200-line soft limit** per file — split by feature, not enforced by linter
+- **300-line soft limit** per file — a target for NEW files, not an invariant; 18 existing `src/` files already exceed it. Not enforced by the linter
 - **JSDoc on all exported functions**: `@param`, `@returns`, `@since`
 - **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `security:`
 - **IPC channel names**: `kebab-case`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19,15 +19,15 @@ npm install
 npm start
 ```
 
-Requires Node.js 18+ and npm 9+. Windows 10/11 recommended. macOS/Linux experimental.
+Building from source requires Node.js 20.19+ or 22.12+ — Vite 7 declares `^20.19.0 || >=22.12.0` and Vitest 4 declares `^20.0.0 || ^22.0.0 || >=24.0.0`, so Node 18 and 19 are excluded. npm 10+. The packaged app ships its own Node runtime inside Electron. Windows 10/11 recommended. macOS/Linux experimental.
 
 ## Features
 
 ### Process Monitoring
-Tracks 110 known AI agent signatures with parent-child tree resolution and IDE host detection. Covers coding assistants (Claude Code, Copilot, Cursor), autonomous agents (OpenClaw, AutoGPT, CrewAI, Devin), desktop AI (Gemini, Apple Intelligence), frameworks (LangChain, AutoGen, MetaGPT), and local LLMs (Ollama, LM Studio, llama.cpp).
+Tracks 110 known AI agents (262 process-name signatures across their `names` arrays) with parent-child tree resolution and IDE host detection. Covers coding assistants (Claude Code, Copilot, Cursor), autonomous agents (OpenClaw, AutoGPT, CrewAI, Devin), desktop AI (Gemini, Apple Intelligence), frameworks (LangChain, AutoGen, MetaGPT), and local LLMs (Ollama, LM Studio, llama.cpp).
 
 ### File System Access
-Watches sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs) and 27 AI agent config paths for unauthorized access.
+Watches sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs) and the 35 AI agent config paths registered in AGENT_CONFIG_PATHS for unauthorized access.
 
 ### Network Activity
 Logs outbound TCP connections per agent PID with reverse DNS and known-vs-unknown API endpoint classification.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -45,7 +45,7 @@ Bento grid layout with RiskRing gauge, sparklines, TrustBadge, agent stats, acti
 JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily rotation and 30-day retention.
 
 ### YAML Rulesets
-73 detection rules, JSON Schema validated, hot-reload without restart. Extend or override via rules/custom/ directory.
+73 detection rules, validated against rules/_schema.json. Editing a ruleset hot-reloads without a restart. Extend by adding a .yaml to rules/; rule IDs must be unique, and a duplicate ID is skipped rather than overriding.
 
 ## Documentation
 
@@ -57,7 +57,7 @@ JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily r
 ## Technical Details
 
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
-- **Tests**: 968 passing, 4 skipped across 62 files (Vitest)
+- **Tests**: 1017 passing, 4 skipped across 64 files (Vitest)
 - **License**: MIT
 - **Version**: 0.10.0-alpha
 - **Platform**: Windows, macOS, Linux

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@
 
 ## Key Features
 
-- Process monitoring with 110 known AI agent signatures and parent-child tree resolution
+- Process monitoring with 110 known AI agents (262 process-name signatures) and parent-child tree resolution
 - File system watching for sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs)
 - Network activity logging with per-agent PID tracking and reverse DNS
 - Behavioral analysis with 73 detection rules across 8 categories
@@ -23,7 +23,7 @@
 ## Technical Details
 
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
-- **Tests**: 968 passing, 4 skipped across 62 files (Vitest)
+- **Tests**: 1017 passing, 4 skipped across 64 files (Vitest)
 - **License**: MIT
 - **Version**: 0.10.0-alpha
 - **Platform**: Windows, macOS, Linux


### PR DESCRIPTION
## What

Every checkable claim in the tracked docs was re-derived from source. 51 drifts corrected
across 13 files, in two commits: counts first, then the structural claims that describe
mechanisms which do not exist.

## How the findings were produced

A 60-agent audit: one reader per doc group (`README`, `AGENTS.md`, `CLAUDE.md`, `llms.*`,
`ARCHITECTURE.md` + `memory-bank/architecture.md`, the dev-workflow docs, the
`aegis-context` skill), then **one adversarial verifier per candidate finding**, prompted to
*refute* it — with instructions to lean toward "refuted" when uncertain, and to consider the
usual escapes: miscounting recursive vs top-level, the separate `.claude/worktrees/`
checkout, historical changelog rows, and two numbers that legitimately count different
things.

53 candidates → **51 confirmed, 2 refuted and dropped.** Each confirmed finding was then
re-derived a third time by hand before being written, because a fix based on an unverified
report is the same failure as the drift it replaces.

## The two that were not just stale numbers

**`ARCHITECTURE.md` documented an IPC surface that largely does not exist.** The invoke table
listed 45 channels; 11 are unreachable from the renderer and 5 real ones were missing.
Ground truth is 39 `ipcMain.handle()` registrations, all exposed in `preload.js` — and a
channel absent from `preload.js` cannot be invoked at all under `contextIsolation`.

| | documented | real |
|---|---|---|
| invoke | 45 (11 nonexistent) | 39 |
| push | 10 (4 nonexistent) | 9 |
| send | 1 channel + a whole table | **0 — `preload.js` has no `ipcRenderer.send`** |

45 − 11 + 5 = 39, matching `preload.js` exactly. Nonexistent invoke channels were
`scan-processes`, `get-agent-permissions`, `get-agent-baseline`, `get-audit-stats`,
`get-project-dir`, `capture-screenshot`, `get-instance-permissions`, `get-log-stats`,
`export-full-log`, `open-log-dir`, `get-local-models`; missing real ones were
`blocklist-add/remove/list`, `rules:getAll`, `rules:reload`. The periodic push channel is
`scan-batch`, not `scan-results`. Note the diagram at the top of the same file already said
"48 channels: 39 invoke + 9 push" — the file contradicted itself.

**The documented risk formula was fiction.** `ARCHITECTURE.md` gave
`Base = min(40, log2(1 + sensitiveFiles) * 8)` and pointed at `src/main/risk-scoring.js`.
There is no such file; risk scoring runs in the **renderer**
(`src/renderer/lib/utils/risk-scoring.js`), and the real formula is six independently capped
terms whose sensitive contribution is deliberately sub-linear:
`min(40, sensitive * 5 * (1 / (1 + sensitive * 0.1)))`. That damping is what stops the score
pinning at 100 on the first burst — `ai-mistakes.md` #10 — so documenting a `log2` formula
hid the one part a reader most needs to understand. Anomaly scoring likewise: 4 weighted
dimensions (`{network: .3, filesystem: .25, process: .25, baseline: .2}`), not "5 weighted
factors" with point values.

## Also corrected

- **"Mac/Linux Support: process scanning is Windows-only"** — wrong twice. `darwin.js` and
  `linux.js` both implement `listProcesses()`, and suspend/resume work on POSIX via
  `posix-shared.js`. Only Restart Manager handle detection is Windows-only. (I nearly
  shipped a *new* false claim here by asserting suspend/resume was Windows-only; checking
  `posix-shared.js` caught it.)
- **`rules/custom/` does not exist** (README, llms-full). `loadRules(rulesDir)` *replaces*
  the default directory and needs its own `_schema.json`; it never overlays a second one, and
  a duplicate rule ID is skipped with a warning — the opposite of overriding. Replaced with
  what works, including that the watcher runs at `depth: 0` on `change` only, so a newly
  added file needs a reload or restart.
- **`processPatterns` does not exist** — the agent-database field is `names`. It appeared in
  `ARCHITECTURE.md`, and in `CONTRIBUTING.md` both as the JSON template and as a documented
  required field, so anyone following the guide would have added a silently-ignored key.
- **`checkJs: true`** — it is `false`. `src/main` JSDoc is documentation, not an enforced gate.
- **Squash merge / direct master commits** (`AGENTS.md`, `BRANCHING.md`) — both operations
  GitHub refuses. `gh api` confirms `squash: false, rebase: false, merge: true` and master
  with `required_pr` + `enforce_admins` + five required checks.
- **9 stale test counts** 968/62 → 1017/64, plus `CLAUDE.md`'s 1006/63.
- 43 CJS modules → 44; 27 config paths → 35; "110 agent signatures" → 110 agents / 262
  signatures (two different numbers reported as one); i18n 110+ → 230 strings; Node 18+ →
  20.19+/22.12+ (Vite 7 and Vitest 4 both exclude 18); 10 agent categories → 11;
  1 runtime dep → 3 (`ajv`, `chokidar`, `js-yaml`); tests in `src/tests/` → `tests/`;
  200-line limit → 300; `v0.7.0-alpha` heading → `v0.10.0-alpha`; audit trail 7 event types
  → 6 emitted; model `claude-sonnet-4-5-20250929` → `claude-haiku-4-5-20251001`;
  `src/renderer/src/lib/...` → `src/renderer/lib/...`; `VisTimeline`/`AgentGraph`/`EventFeed`
  (none exist) → the real component set.

Two drift-proofing changes rather than fresh numbers: `aegis-context`'s "Current Focus" now
points at `memory-bank/progress.md` instead of duplicating it, and `docs/DEVELOPMENT.md`
defers the full channel list to `ARCHITECTURE.md` instead of keeping a second copy.

## Left alone deliberately

`CHANGELOG.md` and the README release table — historical rows correctly describe past
versions. The 2 refuted candidates. And these, each re-derived and confirmed **accurate**:
73 rules / 8 categories, 110 agents, 48 IPC channels, 46 components, 11 stores, 16 utils,
8 type files, 11 skills, 18 files over 300 lines, `tasklist /FO CSV /NH`, `AGENT_CONFIG_PATHS`
usage, and hot-reload itself.

## Found but NOT fixed here — a live bug, not a doc issue

`AuditLog.svelte:13` calls `window.aegis.getAuditStats()`. That method does not exist:
`preload.js` exposes no `getAuditStats`, `ipc-handlers.js` registers no `get-audit-stats`, and
`audit-logger.getStats()` has **zero callers in the entire app**. In a real run the call
throws synchronously inside `$effect` — before `.catch()` is attached — so the Reports tab's
audit panel never renders. It only "works" in demo mode, off the hardcoded `1247`.

Out of scope for a docs PR; the docs now say plainly that the channel does not exist. The fix
belongs with the audit-logger durability work, where the counters need a live surface anyway.

## Verification

- `npm test` — 1017 passed / 4 skipped (64 files)
- `npm run typecheck` — 0 errors · `npm run lint` — 0 errors · `npm run build:renderer` — clean

Docs-only; no source file changed.
