### PR TITLE
feat(audit): bound the write buffer and make the loss it causes visible

### DIFF
--- a/src/main/audit-drop-tracker.js
+++ b/src/main/audit-drop-tracker.js
@@ -1,0 +1,141 @@
+/**
+ * @file audit-drop-tracker.js
+ * @module main/audit-drop-tracker
+ * @description Bookkeeping for audit entries evicted from the write buffer, and the
+ *   marker record that makes the loss visible on disk.
+ *
+ *   Why a marker record exists at all: the hash chain in audit-hashchain.js proves that
+ *   no surviving record was EDITED. It cannot prove that none was LOST, because an entry
+ *   dropped before it was ever written leaves no gap — seq numbers are assigned at flush
+ *   time, so the file that remains is a perfectly valid chain that is simply missing
+ *   events. Without a marker, an operator reading the JSONL cannot tell a complete file
+ *   from a silently truncated one. The marker is the minimum signal that lets the file
+ *   describe its own incompleteness.
+ *
+ *   Two counters, deliberately distinct:
+ *   - `pending` — drops since the last SUCCESSFUL flush. This is what the next marker
+ *     reports, and it survives a failed flush so the marker written on recovery covers
+ *     every drop across all failed attempts rather than only the last batch.
+ *   - `total` — every drop in this process lifetime. Surfaced via getStats() and reset
+ *     on restart; the durable cross-restart record is the marker on disk, not this
+ *     number.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.11.0
+ */
+
+'use strict';
+
+/**
+ * Record `type` for the loss marker. A reader filters on this to separate
+ * internally-generated bookkeeping from real agent activity.
+ * @type {string}
+ * @since v0.11.0
+ */
+const MARKER_TYPE = 'buffer-overflow-drop';
+
+/** @type {number} Cumulative evictions this process lifetime. */
+let _total = 0;
+/** @type {number} Evictions since the last successful flush — what the next marker reports. */
+let _pending = 0;
+/** @type {string|null} Timestamp of the first entry evicted in the pending window. */
+let _firstTs = null;
+/** @type {string|null} Timestamp of the most recent entry evicted in the pending window. */
+let _lastTs = null;
+
+/**
+ * Clear all drop state. Called from audit-logger's `init()` so a new session starts at
+ * zero — drop counts describe the current process, never a previous one.
+ * @returns {void}
+ * @since v0.11.0
+ */
+function reset() {
+  _total = 0;
+  _pending = 0;
+  _firstTs = null;
+  _lastTs = null;
+}
+
+/**
+ * Record one evicted entry.
+ * @param {string} timestamp - The evicted entry's own ISO timestamp, so the reported
+ *   loss window describes when the events HAPPENED, not when they were dropped.
+ * @returns {void}
+ * @since v0.11.0
+ */
+function record(timestamp) {
+  _total += 1;
+  _pending += 1;
+  if (_firstTs === null) _firstTs = timestamp;
+  _lastTs = timestamp;
+}
+
+/**
+ * Drops awaiting a marker. `flush()` gates on this in addition to buffer emptiness, so a
+ * pending marker is never swallowed by an early return.
+ * @returns {number}
+ * @since v0.11.0
+ */
+function pendingCount() {
+  return _pending;
+}
+
+/**
+ * Cumulative evictions this process lifetime.
+ * @returns {number}
+ * @since v0.11.0
+ */
+function totalDropped() {
+  return _total;
+}
+
+/**
+ * Build the marker record for the pending window. Field set is IDENTICAL to a normal
+ * audit entry so the canonical hash and every reader see one consistent shape.
+ *
+ * `agent` is `''` and there is no pid: no agent owns this record, and substituting one
+ * would attribute a bookkeeping event to real software (C-01).
+ * @param {string} nowIso - ISO timestamp for the marker itself.
+ * @returns {Object} Marker record WITHOUT seq/hash — the caller chains it like any entry.
+ * @since v0.11.0
+ */
+function buildMarker(nowIso) {
+  return {
+    timestamp: nowIso,
+    type: MARKER_TYPE,
+    agent: '',
+    action: '',
+    path: '',
+    severity: 'high',
+    riskScore: 0,
+    details: {
+      droppedCount: _pending,
+      firstDropTs: _firstTs,
+      lastDropTs: _lastTs,
+      reason: 'buffer-cap-exceeded',
+    },
+  };
+}
+
+/**
+ * Clear the pending window after a marker has been durably written. `total` is NOT
+ * cleared — it counts the whole session. Call this ONLY after a successful write, or the
+ * loss it describes becomes invisible.
+ * @returns {void}
+ * @since v0.11.0
+ */
+function clearPending() {
+  _pending = 0;
+  _firstTs = null;
+  _lastTs = null;
+}
+
+module.exports = {
+  MARKER_TYPE,
+  reset,
+  record,
+  pendingCount,
+  totalDropped,
+  buildMarker,
+  clearPending,
+};

--- a/src/main/audit-hashchain.js
+++ b/src/main/audit-hashchain.js
@@ -66,6 +66,22 @@ function computeHash(prevHash, event) {
  *
  * Detects in-place edits, insertions, and deletions of interior lines; does NOT
  * detect truncation of trailing lines (valid prefix remains a valid chain).
+ *
+ * The verdict is asymmetric in BOTH directions, and neither direction is about intent:
+ *
+ * A `valid: true` verdict proves no surviving record was ALTERED. It does NOT prove the
+ * file is COMPLETE. An entry evicted from the write buffer under a full disk was never
+ * assigned a seq, so its absence leaves no gap and the remaining records still chain
+ * perfectly. Records of type `buffer-overflow-drop` (see audit-drop-tracker.js) document
+ * the loss windows that are known; loss during a session that never recovered leaves no
+ * record at all.
+ *
+ * A `valid: false` verdict does NOT prove tampering. A write interrupted partway — the
+ * disk filling mid-append, or the process dying during one — leaves a truncated line and,
+ * once the retry re-appends the batch, a repeated seq range. Both produce exactly the
+ * signal an edit would. Treat an invalid verdict as "this file is not trustworthy",
+ * never as "someone changed this file". The exposure scales with batch size, so it is
+ * largest precisely when flushes have been failing and the buffer has filled.
  * @param {string} filePath - Path to an aegis-audit-YYYY-MM-DD.json file.
  * @returns {{valid: boolean, brokenAtSeq: number|null, reason: string}}
  *   On failure, brokenAtSeq is the 0-based line position where the chain breaks.

--- a/src/main/audit-logger.js
+++ b/src/main/audit-logger.js
@@ -15,6 +15,7 @@
 const fs = require('fs');
 const path = require('path');
 const hashchain = require('./audit-hashchain');
+const dropTracker = require('./audit-drop-tracker');
 
 let _logDir = '';
 let _buffer = [];
@@ -23,6 +24,22 @@ let _onFlushError = null;
 const FLUSH_INTERVAL = 5000;
 const FLUSH_THRESHOLD = 50;
 const RETENTION_DAYS = 30;
+
+/**
+ * Hard ceiling on buffered entries. A permanently unwritable disk (full, or permissions
+ * revoked) makes every flush fail and re-queue, so without a cap the buffer grows until
+ * the process dies — the failure this replaces.
+ *
+ * 500 is 10x FLUSH_THRESHOLD, which makes it a safety valve rather than an operating
+ * mode: a healthy disk flushes at 50 and never comes near it. It is a COUNT, not a byte
+ * budget — a caller that puts a large blob in `details` can push real memory past the
+ * ~140 KB a full buffer of ordinary entries occupies.
+ * @type {number}
+ */
+const BUFFER_CAP = 500;
+
+/** @type {number} Effective cap; overridable via init({ bufferCap }) so tests can evict with a handful of entries. */
+let _bufferCap = BUFFER_CAP;
 
 /** Injectable clock — overridable via init({ now }) so day rotation is testable. */
 let _now = () => new Date();
@@ -38,18 +55,32 @@ let _firstEntry = /** @type {string|null} */ (null);
 let _lastEntry = /** @type {string|null} */ (null);
 
 /**
+ * Entries CONFIRMED written to disk. Distinct from `_totalEntries`, which counts every
+ * event handed to {@link log} and therefore includes entries still buffered — or evicted
+ * before they were ever written. The gap between the two is the honest measure of how
+ * much of the audit trail is not yet durable.
+ * @type {number}
+ */
+let _persistedEntries = 0;
+
+/**
  * Initialise audit logger. Creates audit-logs directory if needed, starts flush timer,
  * and cleans up old log files.
  * @param {Object} opts
  * @param {string} opts.userDataPath - Electron app.getPath('userData')
  * @param {function} [opts.onFlushError] - Called with the Error when a flush write fails
  * @param {function} [opts.now] - Test seam: returns the current Date (defaults to real clock)
+ * @param {number} [opts.bufferCap] - Test seam: max buffered entries before drop-oldest
+ *   eviction (defaults to {@link BUFFER_CAP})
  * @returns {void}
  * @since v0.2.0
  */
 function init(opts) {
   _onFlushError = opts.onFlushError || null;
   if (opts.now) _now = opts.now;
+  _bufferCap = opts.bufferCap != null ? opts.bufferCap : BUFFER_CAP;
+  // Drop counts describe THIS session — a new init must not inherit a previous one's.
+  dropTracker.reset();
   _logDir = path.join(opts.userDataPath, 'audit-logs');
   try {
     if (!fs.existsSync(_logDir)) fs.mkdirSync(_logDir, { recursive: true });
@@ -67,6 +98,7 @@ function init(opts) {
  */
 function _seedCounters() {
   _totalEntries = 0;
+  _persistedEntries = 0;
   _firstEntry = null;
   _lastEntry = null;
   if (!_logDir) return;
@@ -79,13 +111,23 @@ function _seedCounters() {
       const fp = path.join(_logDir, f);
       const content = fs.readFileSync(fp, 'utf-8');
       const lines = content.split('\n').filter((l) => l.trim().length > 0);
-      _totalEntries += lines.length;
       for (const line of lines) {
         try {
           const entry = JSON.parse(line);
-          if (entry.timestamp) {
-            if (!_firstEntry || entry.timestamp < _firstEntry) _firstEntry = entry.timestamp;
-            if (!_lastEntry || entry.timestamp > _lastEntry) _lastEntry = entry.timestamp;
+          // Count inside the try, so a malformed line that JSON.parse rejects is not
+          // counted as an entry — the previous `+= lines.length` counted it anyway.
+          // Loss markers are internal bookkeeping, not audit events, so they are excluded
+          // from both counters or every recovered drop would inflate the totals.
+          // A marker's timestamp is the wall-clock time of the flush that recovered it,
+          // not an event time, so it is excluded from the observed range too — otherwise
+          // the date range shown in the UI would extend past the last real event.
+          if (entry.type !== dropTracker.MARKER_TYPE) {
+            _totalEntries += 1;
+            _persistedEntries += 1;
+            if (entry.timestamp) {
+              if (!_firstEntry || entry.timestamp < _firstEntry) _firstEntry = entry.timestamp;
+              if (!_lastEntry || entry.timestamp > _lastEntry) _lastEntry = entry.timestamp;
+            }
           }
         } catch (_) {
           /* skip malformed line */
@@ -118,6 +160,15 @@ function getTodayLogPath() {
 
 /**
  * Log an audit event. Buffered — writes are flushed every 5s or at 50 events.
+ *
+ * The buffer is bounded at {@link BUFFER_CAP} entries; past that the OLDEST buffered
+ * entry is evicted, which only happens when flushes are failing. Eviction is counted in
+ * `getStats().droppedEntries`, and a `buffer-overflow-drop` marker records it on disk at
+ * the next successful flush *if one happens before the process exits* — if the disk never
+ * recovers, no on-disk trace of the loss exists and the file verifies as valid.
+ *
+ * Calling this NEVER guarantees durability — compare `totalEntries` against
+ * `persistedEntries` for what actually reached disk.
  * @param {string} type - Event type (file-access, network-connection, anomaly-alert, permission-deny, agent-enter, agent-exit, config-access)
  * @param {Object} details - Event details
  * @param {string} [details.agent] - Agent name
@@ -140,11 +191,38 @@ function log(type, details) {
     riskScore: details.riskScore || 0,
     details: details.extra || null,
   };
+  // Whether the buffer was ALREADY at the cap before this push. Once it is, the
+  // FLUSH_THRESHOLD auto-flush is suppressed and only the 5s timer drives writes:
+  // at the cap every log() would otherwise re-hash the whole buffer, so a broken disk
+  // would turn each event into hundreds of wasted SHA-256 computations.
+  const atCapBefore = _buffer.length >= _bufferCap;
+
   _buffer.push(entry);
   _totalEntries++;
   if (!_firstEntry || entry.timestamp < _firstEntry) _firstEntry = entry.timestamp;
   if (!_lastEntry || entry.timestamp > _lastEntry) _lastEntry = entry.timestamp;
-  if (_buffer.length >= FLUSH_THRESHOLD) flush();
+  _trimToCap();
+  if (!atCapBefore && _buffer.length >= FLUSH_THRESHOLD) flush();
+}
+
+/**
+ * Enforce {@link BUFFER_CAP} by evicting from the FRONT of the buffer (drop-oldest).
+ *
+ * Both policies are chain-safe — seq is assigned in {@link flush}, so nothing in the
+ * buffer owns a seq yet. The choice is operational: AEGIS is a monitor, and when the disk
+ * is failing the useful records are the ones describing what an agent is doing NOW.
+ * Drop-newest would preserve stale history while silencing live anomaly alerts.
+ *
+ * Called from {@link log} after a push, and from {@link flush}'s failure path after the
+ * pristine batch is re-queued.
+ * @returns {void}
+ * @since v0.11.0
+ */
+function _trimToCap() {
+  while (_buffer.length > _bufferCap) {
+    const evicted = _buffer.shift();
+    dropTracker.record(evicted.timestamp);
+  }
 }
 
 /**
@@ -155,11 +233,17 @@ function log(type, details) {
  * _chainDate) advances ONLY after a successful write, so a failed flush re-queues
  * the pristine entries without consuming seq numbers — the next flush renumbers
  * from the same point, keeping the chain gap-free (C-03 recovery).
+ *
+ * If entries were evicted since the last successful flush, a `buffer-overflow-drop`
+ * marker leads the batch and is chained like any record. See audit-drop-tracker.js for
+ * why the file needs it and why it is best-effort.
  * @returns {void}
  * @since v0.2.0
  */
 function flush() {
-  if (_buffer.length === 0 || !_logDir) return;
+  // Gate on pending drops too: after eviction the buffer can be empty while a marker is
+  // still owed, and returning early there would discard the only record of the loss.
+  if ((_buffer.length === 0 && dropTracker.pendingCount() === 0) || !_logDir) return;
   const entries = _buffer.splice(0);
   const fp = getTodayLogPath();
   const todayDate = _todayDateStr();
@@ -178,6 +262,23 @@ function flush() {
   }
 
   const out = [];
+
+  // A loss marker leads the batch so it sits at the START of the window whose records
+  // are missing. It is deliberately NOT pushed into `entries`: that array must stay
+  // pristine for the C-03 re-queue below, and a marker baked into it would be written
+  // twice once the disk recovered.
+  //
+  // Best-effort by construction: the marker is only written by the NEXT SUCCESSFUL
+  // flush. If the disk never recovers and the process exits, it never reaches disk and
+  // the file verifies clean with no on-disk trace of the loss.
+  if (dropTracker.pendingCount() > 0) {
+    const marker = dropTracker.buildMarker(_now().toISOString());
+    const markerHash = hashchain.computeHash(prevHash, marker);
+    out.push(JSON.stringify({ ...marker, seq, hash: markerHash }));
+    prevHash = markerHash;
+    seq += 1;
+  }
+
   for (const e of entries) {
     const hash = hashchain.computeHash(prevHash, e);
     out.push(JSON.stringify({ ...e, seq, hash }));
@@ -190,15 +291,20 @@ function flush() {
     _prevHash = prevHash;
     _seq = seq;
     _chainDate = todayDate;
+    // Only now is anything durable. `entries.length`, not `out.length` — the marker is
+    // bookkeeping, not an audit event.
+    _persistedEntries += entries.length;
+    dropTracker.clearPending();
   } catch (err) {
     if (_onFlushError) _onFlushError(err);
-    // TODO(C-03-followup): unbounded buffer growth — if the disk is permanently
-    // broken (full / no perms), re-queuing on every failed flush grows _buffer
-    // without bound (OOM). Add a cap (drop-oldest beyond a limit) in a follow-up;
-    // out of scope for this PR.
     // Re-queue PRISTINE entries (no seq/hash baked in) and leave chain state
-    // unadvanced so the retry produces an unbroken chain.
+    // unadvanced so the retry produces an unbroken chain. Pending drops are
+    // deliberately NOT cleared: the marker written on recovery must cover every drop
+    // across all failed attempts, not just the last batch.
     _buffer = entries.concat(_buffer);
+    // The onFlushError callback runs before this and may itself call log(), so the
+    // concatenation can exceed the cap. A no-op in the normal case.
+    _trimToCap();
   }
 }
 
@@ -233,13 +339,42 @@ function cleanOldLogs() {
 }
 
 /**
- * Get audit log statistics.
- * @returns {{totalEntries: number, totalSize: number, currentSize: number, firstEntry: string, lastEntry: string}}
+ * Get audit log statistics, including durability counters.
+ *
+ * The counters answer different questions and are meant to be read together. The one that
+ * matters when something is wrong is `droppedEntries + bufferDepth`: that is how many
+ * events would be missing from the audit file if the process stopped right now. Buffered
+ * entries are only "pending" while the disk is writable — under a full disk they are just
+ * as lost as evicted ones, they simply have not been counted as lost yet.
+ *
+ * `firstEntry`/`lastEntry` are the earliest and latest timestamps OBSERVED this session,
+ * including entries still buffered and entries evicted before they reached disk — so they
+ * are not necessarily the bounds of what the files contain.
+ * @returns {{totalEntries: number, persistedEntries: number, droppedEntries: number,
+ *   bufferDepth: number, totalSize: number, currentSize: number, firstEntry: string|null,
+ *   lastEntry: string|null}}
+ *   `totalEntries` — events handed to {@link log} this session plus records found on disk
+ *   at init. It counts entries still in the buffer AND entries evicted under a full
+ *   buffer that will never reach disk, so under overflow it permanently exceeds the real
+ *   record count by `droppedEntries`; it is not a measure of what was retained.
+ *   `persistedEntries` — entries confirmed written (markers excluded). `droppedEntries` —
+ *   evictions this session, reset on restart; the cross-restart record is the on-disk
+ *   marker, which is best-effort and absent if the process exited with the disk still
+ *   full. `bufferDepth` — entries buffered right now.
  * @since v0.2.0
  */
 function getStats() {
   if (!_logDir)
-    return { totalEntries: 0, totalSize: 0, currentSize: 0, firstEntry: null, lastEntry: null };
+    return {
+      totalEntries: 0,
+      persistedEntries: 0,
+      droppedEntries: 0,
+      bufferDepth: 0,
+      totalSize: 0,
+      currentSize: 0,
+      firstEntry: null,
+      lastEntry: null,
+    };
   let totalSize = 0;
   let currentSize = 0;
   try {
@@ -258,6 +393,9 @@ function getStats() {
   }
   return {
     totalEntries: _totalEntries,
+    persistedEntries: _persistedEntries,
+    droppedEntries: dropTracker.totalDropped(),
+    bufferDepth: _buffer.length,
     totalSize,
     currentSize,
     firstEntry: _firstEntry,
@@ -375,7 +513,15 @@ function getEntriesBefore(beforeTs, limit = 100) {
       readLinesReverse(fp, (line) => {
         try {
           const entry = JSON.parse(line);
-          if (entry.timestamp && entry.timestamp < beforeTs) {
+          // Loss markers are excluded here — this feeds the paginated activity view,
+          // which shows agent events. exportAll() keeps them: a forensic export must
+          // carry the evidence that records are missing, and verifyChain needs every
+          // line to replay the chain.
+          if (
+            entry.timestamp &&
+            entry.timestamp < beforeTs &&
+            entry.type !== dropTracker.MARKER_TYPE
+          ) {
             results.push(entry);
             if (results.length >= limit) return false;
           }

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -264,6 +264,11 @@ ${findingsHtml}${recsHtml}
   });
 
   // ── Audit ──
+  // AuditLog.svelte has always called window.aegis.getAuditStats(); until this handler
+  // existed the method was undefined, so the call threw synchronously inside $effect —
+  // before .catch() was attached — and the panel never left its loading state outside
+  // demo mode.
+  ipcMain.handle('get-audit-stats', () => audit.getStats());
   ipcMain.handle('get-audit-entries-before', (_e, beforeTs, limit) =>
     audit.getEntriesBefore(beforeTs, limit),
   );

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -53,6 +53,7 @@ contextBridge.exposeInMainWorld('aegis', {
   saveCustomAgents: (agents) => ipcRenderer.invoke('save-custom-agents', agents),
   exportAgentDatabase: () => ipcRenderer.invoke('export-agent-database'),
   importAgentDatabase: () => ipcRenderer.invoke('import-agent-database'),
+  getAuditStats: () => ipcRenderer.invoke('get-audit-stats'),
   getAuditEntriesBefore: (beforeTs, limit) =>
     ipcRenderer.invoke('get-audit-entries-before', beforeTs, limit),
   openAuditLogDir: () => ipcRenderer.invoke('open-audit-log-dir'),

--- a/src/renderer/lib/components/AuditLog.svelte
+++ b/src/renderer/lib/components/AuditLog.svelte
@@ -62,6 +62,15 @@
         <span class="audit-value">{dateRange}</span>
         <span class="audit-label">{$t('reports.audit.date_range')}</span>
       </div>
+      {#if auditStats.droppedEntries > 0}
+        <!-- Only rendered when the audit trail is actually incomplete: entries were
+             evicted from the write buffer because the disk could not be written. Silence
+             here means nothing was lost, not that nothing is being counted. -->
+        <div class="audit-card">
+          <span class="audit-value">{auditStats.droppedEntries.toLocaleString()}</span>
+          <span class="audit-label">{$t('reports.audit.dropped_entries')}</span>
+        </div>
+      {/if}
     </div>
   {:else}
     <span class="audit-loading">{$t('reports.audit.no_data')}</span>

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -283,6 +283,7 @@
       "loading": "Loading audit data...",
       "no_data": "No audit data available",
       "total_entries": "Total Entries",
+      "dropped_entries": "Dropped (Not Written)",
       "log_size": "Log Size",
       "date_range": "Date Range",
       "view_logs": "View Logs Directory",

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -28,6 +28,25 @@ interface ProcessActionResult {
   readonly error?: string;
 }
 
+/**
+ * Audit-log statistics from `get-audit-stats`.
+ *
+ * The counts are not interchangeable: `totalEntries` counts everything the logger was
+ * handed — including entries evicted and gone for good — `persistedEntries` only what
+ * reached disk, `droppedEntries` what was evicted, and `bufferDepth` what is waiting.
+ * `droppedEntries + bufferDepth` is how much would be missing if the process stopped now.
+ */
+interface AuditStats {
+  readonly totalEntries: number;
+  readonly persistedEntries: number;
+  readonly droppedEntries: number;
+  readonly bufferDepth: number;
+  readonly totalSize: number;
+  readonly currentSize: number;
+  readonly firstEntry: string | null;
+  readonly lastEntry: string | null;
+}
+
 /** Result of an alert-only watchlist add from the main process */
 interface WatchlistAddResult {
   readonly success: boolean;
@@ -62,6 +81,7 @@ interface AegisIpcBridge {
   onScanStatus(cb: (data: ScanStatusData) => void): void;
   onTokenCosts(cb: (data: TokenCostRecord[]) => void): void;
   getStats(): Promise<Record<string, unknown>>;
+  getAuditStats(): Promise<AuditStats>;
   getResourceUsage(): Promise<Record<string, unknown>>;
   getFalsePositives(): Promise<FalsePositiveEntry[]>;
   killProcess(pid: number): Promise<ProcessActionResult>;

--- a/tests/main/audit-logger-bounded.test.js
+++ b/tests/main/audit-logger-bounded.test.js
@@ -1,0 +1,280 @@
+/**
+ * @file audit-logger-bounded.test.js
+ * @description Bounded write buffer, drop-oldest eviction, and the durability counters
+ *   that make the loss visible. Split from audit-logger.test.js the way the file-watcher
+ *   suites are split, so the buffer-cap concern reads on its own.
+ *
+ *   `init({ bufferCap })` is what makes these tests cheap: without the seam, provoking an
+ *   eviction would need 500+ log() calls and hundreds of wasted SHA-256 computations.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('audit-logger bounded buffer', () => {
+  let auditLogger;
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-audit-cap-'));
+    vi.resetModules();
+    const mod = await import('../../src/main/audit-logger.js');
+    auditLogger = mod.default;
+  });
+
+  afterEach(() => {
+    auditLogger.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const auditDir = () => path.join(tmpDir, 'audit-logs');
+
+  /** @returns {string} Path to today's log file. */
+  function todayFile() {
+    const name = fs.readdirSync(auditDir()).find((f) => f.endsWith('.json'));
+    return path.join(auditDir(), name);
+  }
+
+  /** @returns {Object[]} Every line of today's file, parsed, in write order. */
+  function readLines() {
+    return fs
+      .readFileSync(todayFile(), 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l));
+  }
+
+  const MARKER = 'buffer-overflow-drop';
+
+  it('evicts the OLDEST buffered entry when the cap is exceeded', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 3 });
+    for (const agent of ['A', 'B', 'C', 'D']) auditLogger.log('t', { agent });
+    auditLogger.flush();
+
+    const lines = readLines();
+    // 1 marker + the 3 survivors.
+    expect(lines).toHaveLength(4);
+    // Identity matters, not just the count: 'A' was oldest, so 'A' is the one gone.
+    expect(lines.filter((l) => l.type !== MARKER).map((l) => l.agent)).toEqual(['B', 'C', 'D']);
+  });
+
+  it('counts one drop per evicted entry', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2 });
+    for (let i = 0; i < 5; i++) auditLogger.log('t', { agent: `a${i}` });
+    expect(auditLogger.getStats().droppedEntries).toBe(3);
+  });
+
+  it('persistedEntries counts only what reached disk, excluding the marker', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 10 });
+    auditLogger.log('t', { agent: 'A' });
+    auditLogger.log('t', { agent: 'B' });
+    auditLogger.log('t', { agent: 'C' });
+    auditLogger.flush();
+    // Two more stay in the buffer — logged, but not durable.
+    auditLogger.log('t', { agent: 'D' });
+    auditLogger.log('t', { agent: 'E' });
+
+    const stats = auditLogger.getStats();
+    expect(stats.persistedEntries).toBe(3);
+    expect(stats.totalEntries).toBe(5);
+    expect(stats.droppedEntries).toBe(0);
+  });
+
+  it('keeps the hash chain valid through a marker record', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2 });
+    for (const agent of ['A', 'B', 'C']) auditLogger.log('t', { agent });
+    auditLogger.flush();
+
+    expect(auditLogger.verifyChain(todayFile())).toEqual({
+      valid: true,
+      brokenAtSeq: null,
+      reason: 'ok',
+    });
+  });
+
+  it('numbers the marker in sequence with the surviving entries — no gap', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2 });
+    for (const agent of ['A', 'B', 'C']) auditLogger.log('t', { agent });
+    auditLogger.flush();
+
+    const lines = readLines();
+    expect(lines.map((l) => l.seq)).toEqual([0, 1, 2]);
+    // The marker leads: it sits at the start of the window whose records are missing.
+    expect(lines[0].type).toBe(MARKER);
+  });
+
+  it('accumulates the drop count across eviction cycles before any flush', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2 });
+    // First two fill the buffer without evicting; each of the next four evicts one.
+    for (let i = 0; i < 6; i++) auditLogger.log('t', { agent: `a${i}` });
+    auditLogger.flush();
+
+    const marker = readLines().find((l) => l.type === MARKER);
+    expect(marker.details.droppedCount).toBe(4);
+    expect(auditLogger.getStats().droppedEntries).toBe(4);
+  });
+
+  it('reports both ends of the loss window in the marker', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2 });
+    for (const agent of ['A', 'B', 'C', 'D']) auditLogger.log('t', { agent });
+    auditLogger.flush();
+
+    const { details } = readLines().find((l) => l.type === MARKER);
+    expect(details.reason).toBe('buffer-cap-exceeded');
+    // Timestamps come from the EVICTED entries, so they describe when the lost events
+    // happened rather than when the marker was written.
+    expect(Number.isNaN(Date.parse(details.firstDropTs))).toBe(false);
+    expect(Number.isNaN(Date.parse(details.lastDropTs))).toBe(false);
+    expect(Date.parse(details.firstDropTs)).toBeLessThanOrEqual(Date.parse(details.lastDropTs));
+  });
+
+  it('holds the pending drop across a failed flush and reports it once on recovery', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2, onFlushError: vi.fn() });
+    for (const agent of ['A', 'B', 'C']) auditLogger.log('t', { agent });
+
+    fs.rmSync(auditDir(), { recursive: true, force: true });
+    auditLogger.flush(); // fails; drop bookkeeping must NOT be cleared
+    fs.mkdirSync(auditDir(), { recursive: true });
+    auditLogger.flush(); // succeeds
+
+    const lines = readLines();
+    const markers = lines.filter((l) => l.type === MARKER);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].details.droppedCount).toBe(1);
+    // Written exactly once — the pristine re-queue must not duplicate it.
+    expect(lines.filter((l) => l.type !== MARKER).map((l) => l.agent)).toEqual(['B', 'C']);
+    expect(auditLogger.verifyChain(todayFile()).valid).toBe(true);
+  });
+
+  it('keeps the re-queued batch within the cap', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 3, onFlushError: vi.fn() });
+    for (const agent of ['A', 'B', 'C']) auditLogger.log('t', { agent });
+
+    fs.rmSync(auditDir(), { recursive: true, force: true });
+    auditLogger.flush(); // fails; [A,B,C] re-queued, exactly at cap
+    fs.mkdirSync(auditDir(), { recursive: true });
+    auditLogger.log('t', { agent: 'D' }); // pushes to 4 -> evicts A
+    auditLogger.flush();
+
+    const lines = readLines();
+    expect(lines.filter((l) => l.type !== MARKER).map((l) => l.agent)).toEqual(['B', 'C', 'D']);
+    expect(auditLogger.getStats().droppedEntries).toBe(1);
+    expect(auditLogger.verifyChain(todayFile()).valid).toBe(true);
+  });
+
+  it('hides markers from the paginated view but keeps them in a full export', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2 });
+    for (const agent of ['A', 'B', 'C']) auditLogger.log('t', { agent });
+    auditLogger.flush();
+
+    const paginated = auditLogger.getEntriesBefore('9999-01-01T00:00:00.000Z', 100);
+    expect(paginated).toHaveLength(2);
+    expect(paginated.some((e) => e.type === MARKER)).toBe(false);
+
+    // The forensic export must carry the evidence that records are missing.
+    const all = auditLogger.exportAll();
+    expect(all).toHaveLength(3);
+    expect(all.some((e) => e.type === MARKER)).toBe(true);
+  });
+
+  it('does not count markers or malformed lines when seeding from disk', async () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2 });
+    for (const agent of ['A', 'B', 'C']) auditLogger.log('t', { agent });
+    auditLogger.flush(); // marker + 2 user records on disk
+    auditLogger.shutdown();
+
+    // A truncated write leaves a line JSON.parse cannot read; it must not be counted.
+    fs.appendFileSync(todayFile(), '{"timestamp":"broken', 'utf-8');
+
+    vi.resetModules();
+    const mod = await import('../../src/main/audit-logger.js');
+    auditLogger = mod.default;
+    auditLogger.init({ userDataPath: tmpDir });
+
+    const stats = auditLogger.getStats();
+    expect(stats.totalEntries).toBe(2);
+    expect(stats.persistedEntries).toBe(2);
+    // Drop counts are session-scoped: the durable record of loss is the on-disk marker.
+    expect(stats.droppedEntries).toBe(0);
+  });
+
+  it('writes nothing when the buffer is empty and no drop is pending', () => {
+    auditLogger.init({ userDataPath: tmpDir });
+    auditLogger.flush();
+    expect(fs.readdirSync(auditDir()).filter((f) => f.endsWith('.json'))).toHaveLength(0);
+  });
+
+  it('reports how many entries are still waiting', () => {
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 10 });
+    auditLogger.log('t', { agent: 'A' });
+    auditLogger.log('t', { agent: 'B' });
+    expect(auditLogger.getStats().bufferDepth).toBe(2);
+    auditLogger.flush();
+    expect(auditLogger.getStats().bufferDepth).toBe(0);
+  });
+
+  it('accounts for every unwritten entry as dropped + buffered', () => {
+    // The number that matters during an outage: buffered entries are only "pending"
+    // while the disk is writable. If the process dies here they are as lost as the
+    // evicted ones, so droppedEntries alone understates the damage.
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 3, onFlushError: vi.fn() });
+    fs.rmSync(auditDir(), { recursive: true, force: true });
+    for (let i = 0; i < 5; i++) {
+      auditLogger.log('t', { agent: `a${i}` });
+      auditLogger.flush(); // every one fails
+    }
+
+    const s = auditLogger.getStats();
+    expect(s.persistedEntries).toBe(0);
+    expect(s.droppedEntries).toBe(2);
+    expect(s.bufferDepth).toBe(3);
+    expect(s.droppedEntries + s.bufferDepth).toBe(s.totalEntries);
+  });
+
+  it('writes a pending marker when a READ triggers the flush', () => {
+    // exportAll() and getEntriesBefore() both flush first, so opening the export dialog
+    // is enough to land the marker — it is not only the 5s timer that writes it.
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2 });
+    for (const agent of ['A', 'B', 'C']) auditLogger.log('t', { agent });
+
+    const all = auditLogger.exportAll();
+    expect(all.some((e) => e.type === MARKER)).toBe(true);
+    expect(auditLogger.verifyChain(todayFile()).valid).toBe(true);
+  });
+
+  it('does not let a marker timestamp widen the observed date range', async () => {
+    // A marker is stamped with the wall-clock time of the flush that recovered it, which
+    // can be long after the last real event. Counting it would push the date range shown
+    // in the UI past the newest actual record.
+    const future = new Date('2099-06-01T12:00:00.000Z');
+    auditLogger.init({ userDataPath: tmpDir, bufferCap: 2, now: () => future });
+    for (const agent of ['A', 'B', 'C']) auditLogger.log('t', { agent });
+    auditLogger.flush();
+    auditLogger.shutdown();
+
+    vi.resetModules();
+    const mod = await import('../../src/main/audit-logger.js');
+    auditLogger = mod.default;
+    auditLogger.init({ userDataPath: tmpDir, now: () => future });
+
+    const { lastEntry } = auditLogger.getStats();
+    expect(lastEntry).not.toBe(future.toISOString());
+    expect(new Date(lastEntry).getUTCFullYear()).toBeLessThan(2099);
+  });
+
+  it('leaves the default cap far above the flush threshold, so healthy runs never evict', () => {
+    // 60 entries is above FLUSH_THRESHOLD (50) but far below BUFFER_CAP (500): the
+    // threshold flush fires and nothing is dropped. Guards against a future cap value
+    // that would silently start discarding audit data during normal operation.
+    auditLogger.init({ userDataPath: tmpDir });
+    for (let i = 0; i < 60; i++) auditLogger.log('t', { agent: `a${i}` });
+    auditLogger.flush();
+
+    const stats = auditLogger.getStats();
+    expect(stats.droppedEntries).toBe(0);
+    expect(stats.persistedEntries).toBe(60);
+    expect(readLines().some((l) => l.type === MARKER)).toBe(false);
+    expect(auditLogger.verifyChain(todayFile()).valid).toBe(true);
+  });
+});

--- a/tests/main/ipc-handlers.test.js
+++ b/tests/main/ipc-handlers.test.js
@@ -259,6 +259,7 @@ describe('ipc-handlers', () => {
     expect(registeredChannels).toContain('save-custom-agents');
     expect(registeredChannels).toContain('export-agent-database');
     expect(registeredChannels).toContain('import-agent-database');
+    expect(registeredChannels).toContain('get-audit-stats');
     expect(registeredChannels).toContain('open-audit-log-dir');
     expect(registeredChannels).toContain('export-full-audit');
     expect(registeredChannels).toContain('export-config');


### PR DESCRIPTION
## What

Closes the `TODO(C-03-followup)` admitted at `audit-logger.js:195`: with the disk
permanently unwritable, every flush failed and re-queued its batch, so `_buffer` grew
without bound until the process died.

Bounding it means deliberately discarding audit records. For a tamper-evident audit trail
that is only acceptable if the discard is impossible to miss, so most of this PR is the
second half.

## The bound

`BUFFER_CAP = 500` entries — 10× `FLUSH_THRESHOLD`, so it is a safety valve, not an
operating mode: a healthy disk flushes at 50 and never approaches it. ~140 KB when full.
It is a **count**, therefore a proxy for memory: a caller that puts a large blob in
`details` can exceed the estimate, and the JSDoc says so rather than implying a hard
ceiling. `init({ bufferCap })` joins the existing `now` / `onFlushError` seams so tests
provoke eviction with a handful of entries instead of 500.

**Drop-oldest.** Nothing in the buffer owns a seq yet — seq is assigned in `flush()` — so
both policies are chain-safe and the choice is operational. AEGIS is a monitor: when the
disk is failing, the records worth keeping describe what an agent is doing *now*.
Drop-newest would preserve stale history while silencing live anomaly alerts.

## Making the loss visible — the harder half

An evicted entry never received a seq, so its absence leaves **no gap** and `verifyChain`
still reports the file valid. A silently truncated audit file would be indistinguishable
from a complete one.

New `src/main/audit-drop-tracker.js` owns the accounting and builds a
`buffer-overflow-drop` marker that leads the next flushed batch, chained like any record,
carrying `droppedCount` plus both ends of the lost window.

It is **best-effort by construction** — written by the next *successful* flush, so if the
disk never recovers it never lands. Every JSDoc mentioning it says exactly that; the word
"durable" was removed from the wording after review flagged it as the overclaim.

`getStats()` gains three fields:

| field | question it answers |
|---|---|
| `persistedEntries` | how much actually reached disk |
| `droppedEntries` | how much was evicted and is gone |
| `bufferDepth` | how much is still waiting |

`bufferDepth` exists because `droppedEntries` alone **understates** the damage: during an
outage buffered entries are only "pending" while the disk is writable — if the process is
killed they are as lost as the evicted ones. `droppedEntries + bufferDepth` is what would
be missing if the process stopped right now, and there is a test asserting exactly that.

`totalEntries` keeps its meaning (the test at `audit-logger.test.js:92` depends on it, and
a number that shrinks as events accumulate is worse UX), but its JSDoc now states that
under overflow it permanently exceeds the real record count.

## A dead path the counters exposed

The counters had nowhere to appear. `AuditLog.svelte:13` has always called
`window.aegis.getAuditStats()` — and that method did not exist:

- `preload.js` exposed no `getAuditStats`
- `ipc-handlers.js` registered no `get-audit-stats`
- `audit-logger.getStats()` had **zero callers anywhere in the app**

The call therefore threw *synchronously* inside `$effect`, before `.catch()` was attached,
so outside demo mode the Reports tab's audit panel never left its loading state. It only
ever "worked" against the hardcoded `1247` in the demo branch.

Channel + handler + `AegisIpcBridge` typing are added here, plus a
"Dropped (Not Written)" card that renders **only** when `droppedEntries > 0`, reusing the
existing card markup so no new styling is introduced. Without this the new counters would
have been dead code — `ai-mistakes.md` #14.

## Two pre-existing bugs fixed alongside

- `_seedCounters()` did `_totalEntries += lines.length`, counting lines that `JSON.parse`
  then rejected. Counting moved inside the `try`.
- `flush()`'s early return gated only on an empty buffer. After an eviction the buffer can
  be empty while a marker is still owed — that path would have discarded the only record of
  the loss. It now also gates on the pending drop count.

Markers are excluded from `_firstEntry`/`_lastEntry` as well as the counters: a marker is
stamped with the flush wall-clock time, not an event time, so counting it would push the
date range shown in the UI past the newest real record. They are filtered from
`getEntriesBefore()` (the paginated activity view) and kept in `exportAll()`, which is
forensic and must carry the evidence that records are missing.

`verifyChain`'s JSDoc now documents the asymmetry in **both** directions. It said nothing
about completeness before; it now also says an INVALID verdict does not prove tampering,
because a write interrupted by ENOSPC leaves a truncated line and, on retry, a repeated seq
range — the same signal an edit produces.

## Deliberately not done

Chunking each append into ≤ `FLUSH_THRESHOLD` slices would shrink that false-invalid
window. Rejected here: partial-write corruption is pre-existing, and this change *bounds*
the exposure rather than creating it — the previous behaviour was an unbounded batch.
Chunking also means committing some slices while chain state stays unadvanced, which
reworks the C-03 re-queue invariant. That is its own change; documented rather than
smuggled in.

## How the design was produced

Three independent designs (chain-integrity / honesty / simplicity) scored by a judge, then
three adversarial reviewers (chain / honesty / regression) instructed to break the
synthesis and to report nothing without a concrete triggering scenario.

Chain and regression lenses returned `implementable-as-is`. The honesty lens raised three
findings — `bufferDepth`, the `totalEntries` wording, and the `verifyChain` false-invalid
disclosure — all applied. Its fourth suggestion (chunked appends) is the one rejected
above, with reasoning.

Reviewers also flagged that `exportAll()` and `getEntriesBefore()` both call `flush()`, so
opening the export dialog can write the marker as a side effect of a *read* — now covered
by a test.

## Verification

- `npm test` — **1034 passed / 4 skipped (65 files)**, up from 1017/4 (64) by 17 new tests
- `npm run typecheck` — 0 · `npm run typecheck:svelte` — 370 files, 0 · `npm run lint` — 0 errors (23 pre-existing warnings) · `npm run build:renderer` — clean
- Svelte MCP autofixer on `AuditLog.svelte` — 0 issues
- Re-ran after commit, since `lint-staged` rewrites staged files after the gate

`audit-logger.js` goes 407 → 552 lines. The cohesive piece was extracted to
`audit-drop-tracker.js` (141) per the "extract when adding to a file already over 300"
rule, rather than splitting to chase the number.
