### PR TITLE
docs: sync IPC and test counts after the audit-stats channel landed

### DIFF
--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -24,12 +24,12 @@ Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs
 ## Architecture
 - Main process (Node.js): src/main/ — 44 CJS modules (35 top-level + 7 platform/ + 2 token-adapters/)
 - Renderer (Svelte 5): src/renderer/ — 46 components + 11 stores + 16 utils via IPC bridge
-- Bridge: src/main/preload.js — contextBridge, 39 invoke + 9 push = 48 channels
+- Bridge: src/main/preload.js — contextBridge, 40 invoke + 9 push = 49 channels
 - Data: src/shared/agent-database.json (110 agents / 262 name signatures)
 - Rules: rules/*.yaml — 73 active rules across 8 categories, validated against rules/_schema.json
 - Rule loader: src/main/rule-loader.js — loadRules() + categoryIndex Map exposed via getRulesByCategory(); built and tested, but no production caller consumes it yet (C-16)
 - Types: src/shared/types/ — 8 .ts files
-- Tests: 1017 pass, 4 skip (1021 total) across 64 files (Vitest, all ESM)
+- Tests: 1034 pass, 4 skip (1038 total) across 65 files (Vitest, all ESM)
 
 ## Key Components (Fancy UI — complete)
 - ShieldTab: bento grid with SummaryCards, RiskRing, ActivityFeed

--- a/.claude/skills/electron-main/SKILL.md
+++ b/.claude/skills/electron-main/SKILL.md
@@ -7,7 +7,7 @@ description: Electron main process patterns for Aegis. CJS modules, platform abs
 ## Architecture
 - 44 CJS modules loaded directly by Node.js (35 top-level + 7 platform/ + 2 token-adapters/, NO build step)
 - Platform dispatcher: src/main/platform/index.js → win32|darwin|linux
-- IPC: 39 invoke + 9 push = 48 channels, scan-batch consolidation
+- IPC: 40 invoke + 9 push = 49 channels, scan-batch consolidation
 - File watcher: chokidar 3.6, function-form ignored (NOT glob)
 
 ## Rules

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -6,7 +6,7 @@ description: Vitest testing patterns for Aegis. ESM imports, mocking, test struc
 
 ## Stack
 - Vitest 4 + esbuild transform
-- 64 test files, 1017 pass, 4 skip (1021 total)
+- 65 test files, 1034 pass, 4 skip (1038 total)
 
 ## Structure
 - tests/ directory mirrors src/ structure

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 │  └───────────────┬──────────────┘     └──────────────┬───────────────┘  │
 │                  │          preload.js                │                  │
 │                  └─────── (IPC bridge) ───────────────┘                  │
-│              contextBridge API (48 channels: 39 invoke + 9 push)        │
+│              contextBridge API (49 channels: 40 invoke + 9 push)        │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -189,7 +189,7 @@ Process Scan (every Ns)
 
 ### Invoke (Renderer → Main → Response)
 
-All 39 registered in `src/main/ipc-handlers.js` and exposed through `src/main/preload.js`. A
+All 40 registered in `src/main/ipc-handlers.js` and exposed through `src/main/preload.js`. A
 channel absent from `preload.js` is unreachable from the renderer under `contextIsolation`,
 so this table is the complete surface — nothing else can be invoked.
 
@@ -206,6 +206,7 @@ so this table is the complete surface — nothing else can be invoked.
 | `analyze-agent` | ai-analysis | Per-agent AI threat analysis |
 | `analyze-session` | ai-analysis | Full session AI threat analysis |
 | `open-threat-report` | main | Write HTML to temp + open in browser |
+| `get-audit-stats` | audit-logger | Entry counts, durability counters, size, date range |
 | `open-audit-log-dir` | audit-logger | Open audit directory in the file manager |
 | `export-full-audit` | audit-logger | Export all audit logs to a single JSON |
 | `get-audit-entries-before` | audit-logger | Paginated audit log entries (cursor) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Landing: aegisprotect.vercel.app | Demo: aegis-demo-ten.vercel.app
 npm run build:renderer    # Vite build (MUST pass before commit)
 npm run lint              # ESLint
 npm run format            # Prettier
-npm test                  # Vitest (1017 passed / 4 skipped = 1021, 64 files)
+npm test                  # Vitest (1034 passed / 4 skipped = 1038, 65 files)
 npm run dist              # Electron-builder NSIS installer
 
 ## Background Tasks (/loop)
@@ -31,7 +31,7 @@ npm run dist              # Electron-builder NSIS installer
 - rules/ — 73 active detection rules in 8 YAML files, validated by rules/_schema.json
 - memory-bank/ — ai-mistakes.md (READ FIRST), progress.md, architecture.md
 - .claude/skills/ — 11 skills: aegis-context, design-system, electron-main, svelte-patterns, testing, ship, pr-monitor, ci-monitor, prompt-craft, audit-check, commit-and-track
-- IPC: preload.js — 39 invoke + 9 push = 48 channels via contextBridge
+- IPC: preload.js — 40 invoke + 9 push = 49 channels via contextBridge
 
 ## MCP & Skills
 - Context7 MCP: проверяй доку ПЕРЕД решениями | Svelte MCP: autofixer на .svelte

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Requires Node.js 18+ and Windows 10/11 for full monitoring functionality. The El
 1. **Fork** the repository
 2. **Branch** from `master`: `git checkout -b feature/your-feature`
 3. **Implement** your changes following the code standards below
-4. **Test**: run `npm test` (1017 tests across 64 files) and `npm start` — verify no console errors, all tabs render, existing features work
+4. **Test**: run `npm test` (1034 tests across 65 files) and `npm start` — verify no console errors, all tabs render, existing features work
 5. **Commit** with [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 6. **Push** your branch and open a **Pull Request** with a clear description of what changed and why
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/antropos17/Aegis/releases/latest"><img src="https://img.shields.io/github/v/release/antropos17/Aegis?include_prereleases&style=flat-square&label=Release" alt="Release"></a>
   <img src="https://img.shields.io/github/actions/workflow/status/antropos17/Aegis/ci.yml?style=flat-square&label=CI" alt="CI">
-  <img src="https://img.shields.io/badge/Tests-1017%20passing-brightgreen?style=flat-square" alt="Tests">
+  <img src="https://img.shields.io/badge/Tests-1034%20passing-brightgreen?style=flat-square" alt="Tests">
   <a href="#monitor-first"><img src="https://img.shields.io/badge/Mode-monitor--first-8a2be2?style=flat-square" alt="Monitor-first"></a>
   <img src="https://img.shields.io/badge/License-MIT-blue?style=flat-square" alt="MIT License">
   <img src="https://img.shields.io/badge/Platform-Win%20%7C%20macOS%20%7C%20Linux-lightgrey?style=flat-square" alt="Platform">
@@ -47,7 +47,7 @@
 | **0** | open-source EDR tools existed for AI agents before Aegis |
 | **110** | AI agent signatures in the detection database, from Claude Code to AutoGPT |
 | **73** | behavioral detection rules across 8 categories, hot-reloaded on edit |
-| **1017** | tests passing, 0 failures — the monitoring engine is verified on every commit |
+| **1034** | tests passing, 0 failures — the monitoring engine is verified on every commit |
 | **<2s** | cold boot to full dashboard — lightweight enough to run alongside the agents it monitors |
 
 AI agents now have deep access to your machine — files, commands, network. Every existing AI security tool is enterprise SaaS that monitors what humans send *to* AI. Nobody monitors what AI agents do *on local machines*. Aegis is the open-source answer.
@@ -205,7 +205,7 @@ Pre-built `.exe` installer is coming in a future release. Track progress in [Rel
             └─────────────┘    └─────────────┘
 ```
 
-**Stack**: Electron 33, Svelte 5, Vite 7, Vitest (1017 tests across 64 files). The monitoring engine is JavaScript (CommonJS); TypeScript is used in the renderer and shared types.
+**Stack**: Electron 33, Svelte 5, Vite 7, Vitest (1034 tests across 65 files). The monitoring engine is JavaScript (CommonJS); TypeScript is used in the renderer and shared types.
 
 ## Agent Database
 
@@ -264,7 +264,7 @@ Aegis ships with 110 agent signatures across five categories: coding assistants 
 
 ### Can I use Aegis in production?
 
-Aegis is currently at v0.10.0-alpha and is recommended for development and testing environments. The core monitoring engine is stable with 1017 tests passing, but production deployment features (auto-update, OS-level enforcement) are on the roadmap for v1.0.
+Aegis is currently at v0.10.0-alpha and is recommended for development and testing environments. The core monitoring engine is stable with 1034 tests passing, but production deployment features (auto-update, OS-level enforcement) are on the roadmap for v1.0.
 
 ### Is Aegis free?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,7 @@ AEGIS follows Electron security best practices:
 
 - **Context isolation:** Enabled. The renderer process cannot access Node.js APIs.
 - **Node integration:** Disabled in the renderer.
-- **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (48 channels: 39 invoke + 9 push). No arbitrary IPC.
+- **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (49 channels: 40 invoke + 9 push). No arbitrary IPC.
 - **Content Security Policy:** Strict `default-src 'self'` policy, no external font loading.
 - **No remote content:** The app loads only local files. No external URLs in the renderer.
 - **Input sanitization:** All user-visible strings pass through `escapeHtml()` before DOM insertion. Template literals are used for HTML generation, not `innerHTML` with raw strings.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -190,9 +190,8 @@ All nine, exactly as subscribed in `preload.js`. There is no `scan-results` or
 
 Common ones: `get-stats`, `get-resource-usage`, `get-agent-database`, `get-settings`,
 `save-settings`, `get-all-permissions`, `save-agent-permissions`, `analyze-session`,
-`kill-process`, `get-audit-entries-before`. All 39 are listed in `src/main/preload.js`; the
-full table with module attribution is in [ARCHITECTURE.md](../ARCHITECTURE.md). Note there
-is no `get-audit-stats` channel — `audit-logger.getStats()` exists but is not wired to IPC.
+`kill-process`, `get-audit-entries-before`. All 40 are listed in `src/main/preload.js`; the
+full table with module attribution is in [ARCHITECTURE.md](../ARCHITECTURE.md).
 
 ### Browser / demo mode guard
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -57,7 +57,7 @@ JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily r
 ## Technical Details
 
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
-- **Tests**: 1017 passing, 4 skipped across 64 files (Vitest)
+- **Tests**: 1034 passing, 4 skipped across 65 files (Vitest)
 - **License**: MIT
 - **Version**: 0.10.0-alpha
 - **Platform**: Windows, macOS, Linux

--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@
 ## Technical Details
 
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
-- **Tests**: 1017 passing, 4 skipped across 64 files (Vitest)
+- **Tests**: 1034 passing, 4 skipped across 65 files (Vitest)
 - **License**: MIT
 - **Version**: 0.10.0-alpha
 - **Platform**: Windows, macOS, Linux


### PR DESCRIPTION
PR #186 added the `get-audit-stats` channel and 17 tests, invalidating numbers PR #185 had just corrected. Fixing it in the same session rather than leaving it — this is ai-mistakes.md #17, and the counts were accurate for about one merge.

**IPC 48 -> 49** (39+9 -> 40+9), re-derived from `preload.js` rather than incremented by hand. Six places carried it: ARCHITECTURE.md (diagram **and** table intro), CLAUDE.md, SECURITY.md, and the aegis-context + electron-main skills. ARCHITECTURE.md's invoke table gains the `get-audit-stats` row, and docs/DEVELOPMENT.md drops its note saying the channel does not exist — it does now.

**Tests 1017/64 -> 1034/65** in ten places: README (badge, stats table, Stack line, FAQ), llms.txt, llms-full.txt, CONTRIBUTING.md, CLAUDE.md, and the testing + aegis-context skills.

Verified no residual stale reference remains:
```
grep -rn '1017|1021 total|across 64|39 invoke|48 channels' --include=*.md --include=*.txt . | grep -v CHANGELOG
# empty
```

Docs-only; no source file changed.

## The pattern worth fixing

Any PR that adds an IPC channel or a test file silently falsifies 10-16 doc lines, and **nothing in CI notices**. Two doc-sync PRs in one session is the symptom. A check that *derives* these counts from source and fails when a doc disagrees would end the whole class — worth doing before the next release, since README and SECURITY.md are the public-facing ones.