### PR TITLE
chore(ci): call the installer build from release-please, bump it to Node 22

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -3,6 +3,18 @@ name: Build Windows Installer
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build and upload the installer for (e.g. aegis-v0.11.0-alpha)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to build and upload the installer for'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,11 +23,19 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
+      # `inputs` is null on a `release` event, so this falls through to the released tag.
+      - name: Resolve release tag
+        id: tag
+        shell: bash
+        run: echo "name=${{ inputs.tag || github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.tag.outputs.name }}
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci
@@ -33,4 +53,4 @@ jobs:
         run: |
           EXE=$(ls dist/*.exe)
           echo "Found installer: $EXE"
-          gh release upload "${{ github.event.release.tag_name }}" "$EXE" --clobber
+          gh release upload "${{ steps.tag.outputs.name }}" "$EXE" --clobber

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,23 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # The Release is created with GITHUB_TOKEN, and `release: published` events raised by
+  # that token never start a workflow — so the installer build is called directly here
+  # instead of waiting for a cascade that cannot happen.
+  build-installer:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-build.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
`release: published` events created with `GITHUB_TOKEN` never start a workflow, so `release-build.yml` has not run once since it was added in June — `aegis-v0.11.0-alpha` and every release before it shipped without an installer.

- `release-please.yml` now calls `release-build.yml` as a reusable workflow (`workflow_call`) in the same run, gated on `release_created`, passing the released tag. No PAT needed, no cascade involved.
- `release-build.yml` gains `workflow_dispatch` with a `tag` input, so a build can be run manually against any tag, and checks out that tag instead of the default branch.
- `release: published` is kept for releases created by a human.
- Node 20 -> 22, matching `engines.node`.

A `push: tags` trigger was deliberately not added: release-please pushes the tag with the same `GITHUB_TOKEN`, so it would not fire either.