### PR TITLE
chore(lint): guard require() of .ts paths, and make the gate walk tests/

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -191,6 +191,36 @@ export default [
     },
   },
   {
+    // The lint gate walks tests/ and scripts/ so the require-of-.ts rule above
+    // reaches the directory the historical offender lived in. Both directories
+    // carry pre-existing violations that are properties of their role, not
+    // defects: script entrypoints (.mjs/.cjs) run without a declared globals
+    // set, and a test fixture deliberately embeds control characters. Scoped
+    // here only — src/ keeps both rules at full strength.
+    files: ['tests/**/*.{js,mjs,cjs,ts}', 'scripts/**/*.{js,mjs,cjs,ts}'],
+    rules: {
+      'no-undef': 'off',
+      'no-control-regex': 'off',
+    },
+  },
+  {
+    // TypeScript strictness is calibrated for src/. Tests and scripts keep the
+    // unused-vars signal as a warning, matching the plain no-unused-vars level
+    // the .js blocks above already use for these directories.
+    files: ['tests/**/*.ts', 'scripts/**/*.ts'],
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  {
     ignores: ['dist/', 'node_modules/', '*.config.js', '*.config.mjs', '.claude/'],
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -131,6 +131,23 @@ export default [
     },
   },
   {
+    // Node 22 strips TypeScript types by default, so a require() of a .ts path
+    // resolves silently instead of throwing the way it did on Node 20. Lint is
+    // the only gate left that can catch it.
+    files: ['**/*.js'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'CallExpression[callee.name="require"][arguments.0.type="Literal"][arguments.0.value=/\\.tsx?$/]',
+          message:
+            'require() of a .ts/.tsx path in a JavaScript file — use an ESM import instead. Node 22 type stripping makes this pass silently at runtime.',
+        },
+      ],
+    },
+  },
+  {
     files: ['src/renderer/**/*.ts'],
     languageOptions: {
       globals: { ...globals.browser },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist": "electron-builder --publish never",
     "format": "prettier --write 'src/**/*.{js,ts,svelte,css,html}' '*.{js,ts,json}'",
     "format:check": "prettier --check 'src/**/*.{js,ts,svelte,css,html}' '*.{js,ts,json}'",
-    "lint": "npx eslint src/",
+    "lint": "npx eslint src/ tests/ scripts/",
     "typecheck": "tsc --noEmit -p tsconfig.main.json && tsc --noEmit -p tsconfig.renderer.json",
     "typecheck:main": "tsc --noEmit -p tsconfig.main.json",
     "typecheck:renderer": "tsc --noEmit -p tsconfig.renderer.json",


### PR DESCRIPTION
## Why

CI moved from Node 20 to Node 22, which strips TypeScript types by default. A `require()` of a `.ts` file used to throw loudly on CI; now it resolves silently. The guard that caught that defect class is gone — lint is the only gate left that can catch it.

## What

**`eslint.config.mjs`** — a rules-only block scoped to `**/*.js` (+17 lines):

```js
'no-restricted-syntax': [
  'error',
  {
    selector:
      'CallExpression[callee.name="require"][arguments.0.type="Literal"][arguments.0.value=/\.tsx?$/]',
    message:
      'require() of a .ts/.tsx path in a JavaScript file — use an ESM import instead. Node 22 type stripping makes this pass silently at runtime.',
  },
],
```

**`package.json`** — `"lint": "npx eslint src/"` → `"npx eslint src/ tests/ scripts/"`. The rule was defined for `**/*.js`, but the gate only walked `src/`, while the historical offender lived in `tests/shared/instance-key.test.js`. Linted files: 142 → 231 (src 142, tests 84, scripts 5).

**`eslint.config.mjs`** — two scoped blocks (+30 lines) so widening the gate does not turn pre-existing violations red. For `tests/**` and `scripts/**` only: `no-undef` off (script entrypoints `.mjs`/`.cjs` run without a declared globals set), `no-control-regex` off (`tests/main/ai-analysis.test.js` embeds `\x00`/`\x01` in a fixture on purpose), and for their `.ts` files `explicit-function-return-type` off plus `@typescript-eslint/no-unused-vars` down to `warn` — the level plain `no-unused-vars` already had for these directories. No source file under `tests/`, `scripts/` or `src/` was edited, and `src/` keeps every rule at full strength.

## Verification

Positive, through the widened gate — scratch file `tests/scratch-require-ts.js` (created, run, deleted), `npm run lint`:

```
X:\Future\ESCAPE\AEGIS\tests\scratch-require-ts.js
  4:16  error  require() of a .ts/.tsx path in a JavaScript file — use an ESM import instead. Node 22 type stripping makes this pass silently at runtime  no-restricted-syntax
  5:16  error  require() of a .ts/.tsx path in a JavaScript file — use an ESM import instead. Node 22 type stripping makes this pass silently at runtime  no-restricted-syntax

✖ 30 problems (2 errors, 28 warnings)
```

Negative — the same file requiring `./something.js` and `./data.json`: exit 0, no output. The rule discriminates on the extension, not on `require` itself.

Clean repo — `npm run lint` over all 231 files: `✖ 28 problems (0 errors, 28 warnings)`, exit 0.

Gates: `lint` ✅ · `typecheck` ✅ · `test` ✅ (1376 passed / 4 skipped, 83 files) · `build:renderer` ✅ · `format:check` red on the local CRLF checkout only — `prettier --check --end-of-line auto` over the same globs passes on all 145 files, and CI's LF checkout runs it green.
