### PR TITLE
refactor(renderer): rename resourceUsage store to monitorResourceUsage

### DIFF
--- a/src/renderer/lib/components/Footer.svelte
+++ b/src/renderer/lib/components/Footer.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { resourceUsage, stats, tokenCosts } from '../stores/ipc.js';
+  import { monitorResourceUsage, stats, tokenCosts } from '../stores/ipc.js';
   import { t } from '../i18n/index.js';
   import FooterMiniCharts from './FooterMiniCharts.svelte';
   import { tick, startTick } from '../stores/tick.ts';
@@ -22,7 +22,7 @@
   });
 
   $effect(() => {
-    const u = $resourceUsage;
+    const u = $monitorResourceUsage;
     if (!u || !u.cpuUser) return;
     heapMB = u.heapMB ?? '--';
   });

--- a/src/renderer/lib/components/FooterMiniCharts.svelte
+++ b/src/renderer/lib/components/FooterMiniCharts.svelte
@@ -4,16 +4,10 @@
   Reuses Sparkline.svelte (F2.1) at compact size.
 -->
 <script lang="ts">
-  import { resourceUsage } from '../stores/ipc.js';
+  import { monitorResourceUsage } from '../stores/ipc.js';
   import Sparkline from './Sparkline.svelte';
   import { createRingBuffer } from '../utils/ring-buffer';
   import { tick, startTick } from '../stores/tick';
-
-  interface ResourceUsageData {
-    cpuUser: number;
-    cpuSystem: number;
-    memMB: number;
-  }
 
   /** Ring buffers: 60 data points = 60 seconds of history */
   const HISTORY_SIZE = 60;
@@ -40,7 +34,7 @@
 
   $effect(() => {
     $tick; // subscribe — triggers each second
-    const u = $resourceUsage as unknown as ResourceUsageData;
+    const u = $monitorResourceUsage;
     if (!u || !u.cpuUser) return;
 
     // CPU percentage (delta-based)

--- a/src/renderer/lib/stores/demo-data.js
+++ b/src/renderer/lib/stores/demo-data.js
@@ -63,7 +63,7 @@ export function buildAnomalies({ activeAgents, scenario }) {
 // ═══ Main engine ═══
 
 /** Starts demo mode scenario engine. Populates stores with simulated data. @returns {() => void} cleanup */
-export function startDemoMode({ agents, events, stats, network, anomalies, resourceUsage }) {
+export function startDemoMode({ agents, events, stats, network, anomalies, monitorResourceUsage }) {
   const intervals = [];
   let scenarioIndex = 0;
   let totalFiles = 142;
@@ -91,7 +91,7 @@ export function startDemoMode({ agents, events, stats, network, anomalies, resou
     stats.set(
       buildStats({ activeAgents: activeAgents(), totalFiles, totalSensitive, monitoringStarted }),
     );
-    resourceUsage.set({ memMB: 148, heapMB: 102, cpuUser: 31200, cpuSystem: 8400 });
+    monitorResourceUsage.set({ memMB: 148, heapMB: 102, cpuUser: 31200, cpuSystem: 8400 });
     raf(() => {
       anomalies.set(buildAnomalies({ activeAgents: activeAgents(), scenario: currentScenario() }));
     });
@@ -215,7 +215,7 @@ export function startDemoMode({ agents, events, stats, network, anomalies, resou
     // Resource usage — every 5s
     intervals.push(
       setInterval(() => {
-        resourceUsage.set({
+        monitorResourceUsage.set({
           memMB: _deps.randInt(120, 180),
           heapMB: _deps.randInt(80, 130),
           cpuUser: _deps.randInt(18000, 52000),

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -9,11 +9,33 @@ import type {
   FalsePositiveEntry,
 } from '../../../shared/types';
 
+/**
+ * AEGIS's OWN main-process load, exactly as `getResourceUsage()` builds it
+ * (src/main/main.js) — `process.memoryUsage()` / `process.cpuUsage()`. It says
+ * nothing about the monitored agents.
+ *
+ * `cpuUser` / `cpuSystem` are CUMULATIVE microseconds since process start, not a
+ * percentage: a reader has to difference two samples over elapsed time to get a
+ * rate. That is what FooterMiniCharts does, and it is why the shape must not be
+ * "cleaned up" into a percentage here — the delta needs the running totals.
+ */
+interface MonitorResourceUsage {
+  /** Resident set size of the main process, MB. */
+  readonly memMB: number;
+  /** V8 `heapUsed` of the main process, MB. */
+  readonly heapMB: number;
+  /** Cumulative user CPU time since process start, microseconds. */
+  readonly cpuUser: number;
+  /** Cumulative system CPU time since process start, microseconds. */
+  readonly cpuSystem: number;
+}
+
 /** Payload shape for the scan-batch IPC push channel */
 interface ScanBatchData {
   readonly agents?: DetectedAgent[];
   readonly stats?: Record<string, unknown>;
-  readonly resourceUsage?: Record<string, unknown>;
+  /** AEGIS's own load — see {@link MonitorResourceUsage}. Not the agents'. */
+  readonly resourceUsage?: MonitorResourceUsage;
   /**
    * Per-display-name anomaly scores (max over that name's live instances).
    * Consumed by App.svelte toasts and SummaryCards — not by live risk correlation.
@@ -91,7 +113,7 @@ interface AegisIpcBridge {
   onTokenCosts(cb: (data: TokenCostRecord[]) => void): void;
   getStats(): Promise<Record<string, unknown>>;
   getAuditStats(): Promise<AuditStats>;
-  getResourceUsage(): Promise<Record<string, unknown>>;
+  getResourceUsage(): Promise<MonitorResourceUsage>;
   getFalsePositives(): Promise<FalsePositiveEntry[]>;
   killProcess(pid: number): Promise<ProcessActionResult>;
   suspendProcess(pid: number): Promise<ProcessActionResult>;
@@ -125,7 +147,22 @@ export const anomalies: Writable<Record<string, number>> = writable({});
  * Missing keys and null-identity agents contribute 0 in risk.ts — never a name lookup.
  */
 export const anomaliesByInstance: Writable<Record<string, number>> = writable({});
-export const resourceUsage: Writable<Record<string, unknown>> = writable({});
+/**
+ * AEGIS's OWN process load — the figures the footer draws (HEAP, and CPU/MEM via
+ * FooterMiniCharts). Filled from `scan-batch.resourceUsage` and the
+ * `get-resource-usage` seed, both of which originate in `getResourceUsage()`
+ * (src/main/main.js). `null` until the first payload lands.
+ *
+ * The name is deliberately NOT `resourceUsage` any more, and deliberately does not
+ * match the wire: the IPC field stays `resourceUsage` and the invoke channel stays
+ * `get-resource-usage`, because those names already mean "the app's own" on the main
+ * side and renaming them would churn their tests for nothing. The asymmetry is the
+ * price of making the RENDERER side unambiguous — a store called `resourceUsage`
+ * sitting next to a channel called `resource-usage` that carries the MONITORED
+ * AGENTS' load is exactly how that channel went a release and a half with a bridge
+ * method and no subscriber.
+ */
+export const monitorResourceUsage: Writable<MonitorResourceUsage | null> = writable(null);
 export const falsePositives: Writable<FalsePositiveEntry[]> = writable([]);
 export const scanActive: Writable<boolean> = writable(false);
 
@@ -223,7 +260,14 @@ if (import.meta.env.VITE_DEMO_MODE === 'true') {
   // latch needed. The import costs one microtask before the first paint of data, which
   // the demo's own 2s emitter delay already dwarfs.
   import('./demo-data.js').then(({ startDemoMode }) => {
-    const cleanupDemo = startDemoMode({ agents, events, stats, network, anomalies, resourceUsage });
+    const cleanupDemo = startDemoMode({
+      agents,
+      events,
+      stats,
+      network,
+      anomalies,
+      monitorResourceUsage,
+    });
     if (import.meta.hot) {
       import.meta.hot.dispose(() => cleanupDemo());
     }
@@ -235,7 +279,7 @@ if (import.meta.env.VITE_DEMO_MODE === 'true') {
     queueMicrotask(() => {
       if (data.agents) agents.set(data.agents);
       if (data.stats) stats.set(data.stats);
-      if (data.resourceUsage) resourceUsage.set(data.resourceUsage);
+      if (data.resourceUsage) monitorResourceUsage.set(data.resourceUsage);
       if (data.anomalyScores) anomalies.set(data.anomalyScores);
       // Per-instance map rides the same batch; replace (not merge) so a dead instance
       // does not keep a stale score after it leaves the agent list.
@@ -262,7 +306,7 @@ if (import.meta.env.VITE_DEMO_MODE === 'true') {
 
   // Fetch initial data
   window.aegis!.getStats().then((data) => stats.set(data));
-  window.aegis!.getResourceUsage().then((data) => resourceUsage.set(data));
+  window.aegis!.getResourceUsage().then((data) => monitorResourceUsage.set(data));
   window.aegis!.getFalsePositives().then((data) => falsePositives.set(data || []));
 }
 // No third branch: a production build with no preload bridge wires nothing and seeds

--- a/tests/renderer/demo-data.test.js
+++ b/tests/renderer/demo-data.test.js
@@ -20,7 +20,7 @@ function makeStores() {
     stats: writable({}),
     network: writable([]),
     anomalies: writable({}),
-    resourceUsage: writable({}),
+    monitorResourceUsage: writable(null),
   };
 }
 

--- a/tests/renderer/demo-data.test.js
+++ b/tests/renderer/demo-data.test.js
@@ -20,7 +20,7 @@ function makeStores() {
     stats: writable({}),
     network: writable([]),
     anomalies: writable({}),
-    monitorResourceUsage: writable(null),
+    monitorResourceUsage: writable({}),
   };
 }
 


### PR DESCRIPTION
Block A of the resource-usage split. Rename only — zero behaviour change.

## Why

The renderer store `resourceUsage` holds **AEGIS's own main-process load** (`memMB` / `heapMB` / `cpuUser` / `cpuSystem`, built by `getResourceUsage()` in `src/main/main.js:124-133`). The push channel `resource-usage` carries something entirely different — **per-PID load of the monitored agents** (`src/main/resource-monitor.js:23`, sent at `src/main/scan-loop.js:424`). The two names differ by one hyphen, and that channel has had a bridge method (`preload.js:88-92`) and no renderer subscriber for a release and a half. Naming the store for what it actually holds is the precondition for wiring the agent channel in Block B.

## What changed

- `stores/ipc.ts` — store `resourceUsage` → `monitorResourceUsage`, typed `MonitorResourceUsage | null` instead of `Record<string, unknown>`; new `MonitorResourceUsage` interface documents that `cpuUser`/`cpuSystem` are **cumulative microseconds**, which is why the shape must not be "simplified" into a percentage — FooterMiniCharts needs the running totals for its delta.
- `FooterMiniCharts.svelte` — reads the typed store; the `as unknown as ResourceUsageData` cast and its local duplicate interface are gone.
- `Footer.svelte`, `stores/demo-data.js`, `tests/renderer/demo-data.test.js` — follow the rename.

Deliberately **not** renamed: the `scan-batch.resourceUsage` payload field and the `get-resource-usage` invoke channel. On the main side those names already mean "the app's own", and renaming them would churn `ipc-handlers.test.js` and `scan-loop.test.js` for no gain. The resulting asymmetry between wire name and store name is documented in the store's JSDoc.

## Verification

Five gates, all green:

| Gate | Result |
|---|---|
| `npm test` | 1376 passed / 4 skipped, 83 files |
| `tsc -p tsconfig.main.json` | 0 errors |
| `tsc -p tsconfig.renderer.json` | 0 errors |
| `npm run lint` | 0 errors (28 pre-existing warnings, none in the changed files) |
| `npm run build:renderer` | built in 1.76s |

Gate sensitivity confirmed rather than assumed (ai-mistakes #21), by injecting the failure and watching it go red, then reverting:

- Reverted the key in `demo-data.test.js` → `demo-data.test.js` failed 9 of 21 tests.
- Reverted the import in `Footer.svelte` → `vite build` exited 1 with `"resourceUsage" is not exported by "src/renderer/lib/stores/ipc.ts"`. This matters because **no test covers Footer.svelte** — `build:renderer` is its only gate.

`npm run build` (electron-builder NSIS) completed, exit 0. The app was then launched via a Playwright `_electron` driver against that production renderer build — same binary and the same `ELECTRON_RUN_AS_NODE` deletion `scripts/launch.js` does, chosen over `npm start` so the readings are machine-readable rather than eyeballed. Footer sampled every 2s for 40s, then the identical run repeated against unmodified master:

|  | HEAP | MEM | CPU | console |
|---|---|---|---|---|
| this branch | 7 → 35 MB | 97 → 179 MB | 0% throughout | 0 messages, 0 page errors |
| master | 7 → 41 MB | 100 → 186 MB | 0% throughout | 0 messages, 0 page errors |

No `undefined`, `NaN` or stuck `--` reading in either run, and both figures move — so neither is frozen at its initial value. Two pre-existing oddities, **identical on master**, are therefore not caused by this PR and are left alone:

- **CPU flat at 0%** — explained: `FooterMiniCharts` recomputes each 1s tick while the payload only changes every `scanIntervalSec` (10s), so the delta is 0 on nine ticks out of ten, and an idle process rounds to 0 on the tenth.
- **MEM moved once, then held for 34s** — *not* explained by the above (it is a direct read, no delta). Either RSS is genuinely stable to the megabyte at idle, or the store stops receiving after the first batch. Not investigated; recorded as an observation, not a diagnosis.

## Known gaps in this verification

- The store's initial value changes `{}` → `null` (required by the `| null` type). Both consumers guard with `if (!u || …)`, so they cannot tell the two apart — but **no test asserts on it**: `production-no-demo.test.ts`, the no-bridge suite, never references this store. Unasserted, not proven.
- `getResourceUsage()` on the bridge interface is now `Promise<MonitorResourceUsage>`, while the mocks in `NetworkPanel.test.ts:28` and `Timeline.test.ts` still resolve `{}`. They typecheck only because the mock object is assigned through `as unknown`. Nothing breaks — consumers guard on `cpuUser` — but the seed path can set a `{}` under a type claiming four required numbers in those two files.

## Follow-up

Block B (agent channel end-to-end: `agent-resource-usage`, instanceId-keyed records, cache-key migration, CPU/MEM on the agent card) is a separate PR.
