### PR TITLE
feat(main): emit per-agent resource records keyed by instanceId

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -254,7 +254,7 @@ All 9 subscribed via `ipcRenderer.on` in `preload.js`.
 | `file-access` | New file access events (batched, 150ms) |
 | `stats-update` | Updated aggregate stats |
 | `network-update` | Network connections |
-| `resource-usage` | CPU/memory metrics |
+| `agent-resource-usage` | Per-agent CPU/RAM/GPU, one record per instance (keyed by `instanceId`, never pid). Distinct from `scan-batch.resourceUsage`, which is AEGIS's own load |
 | `token-costs` | Per-agent token usage and cost estimates |
 | `scan-status` | Scanner state (scanning/idle) |
 | `rules:reloaded` | Rule hot-reload landed, with the new count |

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -84,11 +84,14 @@ contextBridge.exposeInMainWorld('aegis', {
     ipcRenderer.on('scan-status', handler);
     return () => ipcRenderer.removeListener('scan-status', handler);
   },
-  // ── Per-PID resource usage + token costs (main → renderer push) ──
-  onResourceUsage: (cb) => {
+  // ── Per-agent resource usage + token costs (main → renderer push) ──
+  // `agent-resource-usage` carries the MONITORED AGENTS' load, keyed by instanceId.
+  // AEGIS's own load is a different measurement and travels separately, via
+  // `get-resource-usage` and the `resourceUsage` field of `scan-batch`.
+  onAgentResourceUsage: (cb) => {
     const handler = (_e, data) => cb(data);
-    ipcRenderer.on('resource-usage', handler);
-    return () => ipcRenderer.removeListener('resource-usage', handler);
+    ipcRenderer.on('agent-resource-usage', handler);
+    return () => ipcRenderer.removeListener('agent-resource-usage', handler);
   },
   onTokenCosts: (cb) => {
     const handler = (_e, data) => cb(data);

--- a/src/main/resource-monitor.js
+++ b/src/main/resource-monitor.js
@@ -2,7 +2,10 @@
  * @file resource-monitor.js
  * @module main/resource-monitor
  * @description Per-PID CPU/RAM (and optional NVIDIA GPU memory) sampling for
- *   detected AI-agent processes. Self-contained: spawns its own metrics queries
+ *   detected AI-agent processes. The OS is queried BY PID — that is the only handle
+ *   it offers — but every sample is requested, cached and returned under the caller's
+ *   `instanceId`, so a recycled pid can never inherit the previous holder's numbers.
+ *   Self-contained: spawns its own metrics queries
  *   via execFile (NOT the platform dispatcher) so integration can be wired later.
  *   CPU is normalized to 0–100 % of total machine per-PID (C-01). GPU memory is
  *   reported ONLY when nvidia-smi exists — else gpu:null + a one-time warning
@@ -22,6 +25,22 @@ const logger = require('./logger');
 
 /** @typedef {{ pid: number, cpu: number|null, memMb: number|null, gpu: {memMb: number}|null }} Resource */
 /** @typedef {{ cpuRaw: number, memMb: number|null }} CpuMem */
+/**
+ * What to sample, and WHO it belongs to. `instanceId` is the caller's stamped
+ * process-instance key for that pid on the tick it built this target — never
+ * re-resolved here, which would be a second lookup able to straddle a pid recycle.
+ * `null` is the honest value for a process the caller could not key.
+ * @typedef {{ pid: number, instanceId: string|null }} ResourceTarget
+ */
+/**
+ * One sampled process, carrying the identity it was requested under.
+ *
+ * `instanceId` is the KEY; `pid` rides alongside for display and diagnostics and must
+ * not be used to key anything downstream — the OS reissues it. A record with
+ * `instanceId: null` is an unattributed sample: it keeps its own pid and stays
+ * individually distinguishable, never merged with other null-key records.
+ * @typedef {{ instanceId: string|null, pid: number, cpu: number|null, memMb: number|null, gpu: {memMb: number}|null }} AgentResourceRecord
+ */
 
 /** ms — short on purpose: CPU is volatile, but this keeps spawns off the per-tick path. */
 const RESOURCE_CACHE_TTL = 5000;
@@ -34,7 +53,21 @@ let _gpuAvailable = null;
 let _gpuWarned = false;
 let _gpuProbePromise = null; // memoizes the one-time probe
 
-/** @type {Map<number, {resource: Resource, timestamp: number}>} TTL cache, keyed by PID. */
+/**
+ * TTL cache, keyed by `instanceId` — NOT by pid.
+ *
+ * A pid is not an identity: Windows reissues it, so a pid-keyed hit can hand a sample
+ * taken under the previous holder of that pid to the process now wearing it, and the
+ * two would silently disagree about whose CPU that was. `instanceId` binds the pid to
+ * the OS birth time (process-identity.js), so a hit belongs to the instance that asked
+ * for it or to nothing.
+ *
+ * A target with `instanceId: null` is NEITHER read from NOR written to this map: with
+ * no key there is no way to prove the pid still names the same process, so it is
+ * resampled every call. That costs a spawn on a path that is already spawn-bound and
+ * off the critical path — cheaper than inventing distinguishability we do not have.
+ * @type {Map<string, {record: AgentResourceRecord, timestamp: number}>}
+ */
 const _cache = new Map();
 
 /**
@@ -224,64 +257,111 @@ function _fetchGpu() {
  */
 function _pruneCache(now) {
   if (_cache.size <= 500) return;
-  for (const [pid, entry] of _cache) {
-    if (now - entry.timestamp > RESOURCE_CACHE_TTL) _cache.delete(pid);
+  for (const [instanceId, entry] of _cache) {
+    if (now - entry.timestamp > RESOURCE_CACHE_TTL) _cache.delete(instanceId);
   }
 }
 
 /**
- * Resolve CPU/RAM/GPU for a set of PIDs, batched and TTL-cached. Fresh cache
- * hits are served without spawning; only stale/missing PIDs trigger one query.
- * @param {number[]} pids
- * @returns {Promise<Map<number, Resource>>}
+ * Drop anything that is not a sampleable target, and collapse exact duplicates.
+ *
+ * Dedup is on the (instanceId, pid) PAIR, not on pid alone: two agents sharing a pid
+ * under different keys are two requests and both are answered. An exact repeat of the
+ * same pair is one process named twice, and nothing distinguishes the two — collapsing
+ * it is what the old pid-level `new Set` did and it stays correct.
+ * @param {unknown} targets
+ * @returns {ResourceTarget[]}
+ */
+function _normalizeTargets(targets) {
+  if (!Array.isArray(targets)) return [];
+  const seen = new Set();
+  /** @type {ResourceTarget[]} */
+  const out = [];
+  for (const t of targets) {
+    if (!t || typeof t !== 'object') continue;
+    const pid = Number(/** @type {{pid: unknown}} */ (t).pid);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    const raw = /** @type {{instanceId: unknown}} */ (t).instanceId;
+    const instanceId = typeof raw === 'string' && raw !== '' ? raw : null;
+    const dedupKey = `${instanceId ?? ''} ${pid}`;
+    if (seen.has(dedupKey)) continue;
+    seen.add(dedupKey);
+    out.push({ pid, instanceId });
+  }
+  return out;
+}
+
+/**
+ * Resolve CPU/RAM/GPU for a set of {pid, instanceId} targets, batched and TTL-cached
+ * BY INSTANCE. Fresh cache hits are served without spawning; unkeyed targets and stale
+ * or missing instances trigger one batched query for their pids.
+ *
+ * Returns an ARRAY, not a Map, and that is load-bearing: a Map keyed on `instanceId`
+ * would put every unattributed record under one `null` key and lose all but the last,
+ * while a Map keyed on pid would reintroduce the pid-as-identity the cache migration
+ * exists to remove. The array preserves one record per requested target, in request
+ * order.
+ * @param {ResourceTarget[]} targets
+ * @returns {Promise<AgentResourceRecord[]>}
  * @since v0.10.0
  */
-async function getResourcesForPids(pids) {
-  const result = new Map();
-  if (!Array.isArray(pids) || pids.length === 0) return result;
-  const valid = [...new Set(pids.map(Number).filter((p) => Number.isInteger(p) && p > 0))];
-  if (valid.length === 0) return result;
+async function getResourcesForPids(targets) {
+  const wanted = _normalizeTargets(targets);
+  if (wanted.length === 0) return [];
 
   const now = Date.now();
   _pruneCache(now);
 
-  const stale = [];
-  for (const pid of valid) {
-    const cached = _cache.get(pid);
-    if (cached && now - cached.timestamp <= RESOURCE_CACHE_TTL) result.set(pid, cached.resource);
-    else stale.push(pid);
+  /** @type {Map<ResourceTarget, AgentResourceRecord>} */
+  const resolved = new Map();
+  /** @type {ResourceTarget[]} */
+  const needSample = [];
+  for (const target of wanted) {
+    const cached = target.instanceId ? _cache.get(target.instanceId) : undefined;
+    if (cached && now - cached.timestamp <= RESOURCE_CACHE_TTL) resolved.set(target, cached.record);
+    else needSample.push(target);
   }
-  if (stale.length === 0) return result;
 
-  await probeGpu(); // one-time; memoized no-op after first call
-  const [cpuMem, gpu] = await Promise.all([_fetchCpuMem(stale), _fetchGpu()]);
+  if (needSample.length > 0) {
+    await probeGpu(); // one-time; memoized no-op after first call
+    const pids = [...new Set(needSample.map((t) => t.pid))];
+    const [cpuMem, gpu] = await Promise.all([_fetchCpuMem(pids), _fetchGpu()]);
 
-  for (const pid of stale) {
-    const cm = cpuMem.get(pid);
-    const gpuMb = gpu.get(pid);
-    /** @type {Resource} */
-    const resource = {
-      pid,
-      cpu: cm ? _normalizeCpu(cm.cpuRaw, LOGICAL_CORES) : null,
-      memMb: cm ? cm.memMb : null,
-      gpu: gpuMb !== undefined ? { memMb: gpuMb } : null,
-    };
-    _cache.set(pid, { resource, timestamp: now });
-    result.set(pid, resource);
+    for (const target of needSample) {
+      const cm = cpuMem.get(target.pid);
+      const gpuMb = gpu.get(target.pid);
+      /** @type {AgentResourceRecord} */
+      const record = {
+        instanceId: target.instanceId,
+        pid: target.pid,
+        cpu: cm ? _normalizeCpu(cm.cpuRaw, LOGICAL_CORES) : null,
+        memMb: cm ? cm.memMb : null,
+        gpu: gpuMb !== undefined ? { memMb: gpuMb } : null,
+      };
+      // Unkeyed samples are never stored: see the `_cache` note.
+      if (target.instanceId) _cache.set(target.instanceId, { record, timestamp: now });
+      resolved.set(target, record);
+    }
   }
-  return result;
+
+  return wanted.map((t) => /** @type {AgentResourceRecord} */ (resolved.get(t)));
 }
 
 /**
  * Resolve CPU/RAM/GPU for a single PID. Returns an all-null resource when the
  * PID cannot be sampled (exited, denied, or unparseable).
+ *
+ * Unchanged contract: a bare pid in, a pid-shaped {@link Resource} out. It carries no
+ * instance key, so — like every unkeyed target — it never reads or writes the cache and
+ * samples afresh on each call.
  * @param {number} pid
  * @returns {Promise<Resource>}
  * @since v0.10.0
  */
 async function getResourcesByPid(pid) {
-  const map = await getResourcesForPids([pid]);
-  return map.get(Number(pid)) || { pid: Number(pid), cpu: null, memMb: null, gpu: null };
+  const [record] = await getResourcesForPids([{ pid: Number(pid), instanceId: null }]);
+  if (!record) return { pid: Number(pid), cpu: null, memMb: null, gpu: null };
+  return { pid: record.pid, cpu: record.cpu, memMb: record.memMb, gpu: record.gpu };
 }
 
 module.exports = {

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -415,13 +415,29 @@ async function doProcessScan() {
     await collectTokenCosts(agents);
     sendToRenderer('token-costs', tokenTracker.getAllCosts());
 
-    // Per-PID CPU/RAM/GPU is fetched fire-and-forget AFTER the batch so its
+    // Per-agent CPU/RAM/GPU is fetched fire-and-forget AFTER the batch so its
     // spawn (~0.4–8s, 5s-cached) never delays getting agents on screen. The
-    // result is pushed on its own `resource-usage` channel, keyed by pid (C-01).
-    const resourcePids = agents.map((a) => a.pid).filter((p) => Number.isInteger(p) && p > 0);
+    // result is pushed on its own `agent-resource-usage` channel — named apart from
+    // the app's OWN load, which rides `scan-batch.resourceUsage` and is a different
+    // measurement entirely.
+    //
+    // The pid → instanceId pairing is read off THIS tick's `agents`, which the identity
+    // stamp above (procUtil.enrichWithParentChains) has already filled, and is captured
+    // here rather than re-resolved when the sample lands: a second lookup could straddle
+    // a pid recycle and label one process's load with another's key (ai-mistakes #19).
+    // pid ≤ 0 is dropped because the OS has nothing to sample for a synthetic agent, not
+    // because it lacks a key. An agent whose stamp is missing rides along with
+    // `instanceId: null` — unattributed, and kept distinct from every other such record
+    // rather than pooled under one key.
+    const resourceTargets = agents
+      .filter((a) => Number.isInteger(a.pid) && a.pid > 0)
+      .map((a) => ({
+        pid: a.pid,
+        instanceId: typeof a.instanceId === 'string' && a.instanceId !== '' ? a.instanceId : null,
+      }));
     resourceMonitor
-      .getResourcesForPids(resourcePids)
-      .then((resourceMap) => sendToRenderer('resource-usage', [...resourceMap.values()]))
+      .getResourcesForPids(resourceTargets)
+      .then((records) => sendToRenderer('agent-resource-usage', records))
       .catch((err) => logger.error('main', 'Resource usage scan failed', { error: err.message }));
 
     if (result.changed && Date.now() - _lastTriggeredNetScan > 15000) {

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -41,14 +41,23 @@ export type IpcInvokeChannel =
   | 'add-false-positive'
   | 'open-external-url';
 
-/** IPC event channel names (main -> renderer, push) */
+/**
+ * IPC event channel names (main -> renderer, push).
+ *
+ * Documentation, not enforcement: `sendToRenderer` is called from main-process `.js`
+ * under `checkJs: false`, so nothing is typechecked against this union. `token-costs`
+ * predates it and is still missing — listed here so its absence reads as a known gap
+ * rather than as proof the channel does not exist.
+ */
 export type IpcEventChannel =
   | 'file-access'
   | 'stats-update'
   | 'network-update'
   | 'toggle-theme'
   | 'scan-batch'
-  | 'scan-status';
+  | 'scan-status'
+  /** Per-agent CPU/RAM/GPU records, keyed by `instanceId`. NOT AEGIS's own load. */
+  | 'agent-resource-usage';
 
 /** Payload for save-instance-permissions invoke */
 export interface SaveInstancePermissionsPayload {

--- a/tests/main/resource-monitor.test.js
+++ b/tests/main/resource-monitor.test.js
@@ -47,6 +47,46 @@ function makeExec({ gpu = true } = {}) {
   });
 }
 
+const BYTES_PER_MB = 1048576;
+
+/**
+ * An exec whose CPU/RAM answer CHANGES on every sampling call, so a returned figure
+ * proves which call produced it. Without this, a cached record and a fresh one are
+ * indistinguishable and a cache-key test asserts nothing.
+ *
+ * Call 1 reports pid 100 at 1 MB, call 2 at 2 MB, and so on.
+ * @returns {Function}
+ */
+function makeVaryingExec() {
+  let sample = 0;
+  return vi.fn((cmd) => {
+    if (cmd === 'nvidia-smi') {
+      return Promise.reject(Object.assign(new Error('not found'), { code: 'ENOENT' }));
+    }
+    if (cmd === 'powershell.exe') {
+      sample++;
+      return Promise.resolve(
+        JSON.stringify([
+          { IDProcess: 100, PercentProcessorTime: sample, WorkingSet: sample * BYTES_PER_MB },
+          { IDProcess: 200, PercentProcessorTime: sample, WorkingSet: sample * BYTES_PER_MB },
+        ]),
+      );
+    }
+    if (cmd === 'ps') {
+      sample++;
+      return Promise.resolve(
+        `100 ${sample}.0 ${sample * 1024}\n200 ${sample}.0 ${sample * 1024}\n`,
+      );
+    }
+    return Promise.resolve('');
+  });
+}
+
+/** Count of CPU/RAM sampling spawns — the thing a cache hit is supposed to avoid. */
+function sampleCalls(exec) {
+  return exec.mock.calls.filter(([cmd]) => cmd === 'powershell.exe' || cmd === 'ps').length;
+}
+
 describe('resource-monitor', () => {
   beforeEach(() => {
     _resetForTest();
@@ -138,18 +178,116 @@ describe('resource-monitor', () => {
     });
   });
 
-  describe('TTL cache', () => {
-    it('serves a second call within TTL without re-spawning the CPU/RAM query', async () => {
+  describe('TTL cache — keyed by instanceId, never by pid', () => {
+    it('serves a second call for the SAME instance within TTL without re-spawning', async () => {
       const exec = makeExec({ gpu: true });
       _setExecForTest(exec);
 
-      await getResourcesForPids([100]);
-      await getResourcesForPids([100]);
+      await getResourcesForPids([{ pid: 100, instanceId: '100:aaa' }]);
+      await getResourcesForPids([{ pid: 100, instanceId: '100:aaa' }]);
 
-      const cpuMemCalls = exec.mock.calls.filter(
-        ([cmd]) => cmd === 'powershell.exe' || cmd === 'ps',
-      ).length;
-      expect(cpuMemCalls).toBe(1);
+      expect(sampleCalls(exec)).toBe(1);
+    });
+
+    it('a recycled pid under a NEW instanceId gets a fresh sample, not the dead one’s', async () => {
+      // The whole point of the key migration (ai-mistakes #19). Same pid, two lives:
+      // the second must not be served the first's cached numbers. The varying exec makes
+      // the two answers distinguishable — 1 MB on the first sample, 2 MB on the second.
+      const exec = makeVaryingExec();
+      _setExecForTest(exec);
+
+      const [first] = await getResourcesForPids([{ pid: 100, instanceId: '100:lifeA' }]);
+      const [second] = await getResourcesForPids([{ pid: 100, instanceId: '100:lifeB' }]);
+
+      expect(first.memMb).toBe(1);
+      expect(second.memMb).toBe(2); // a pid-keyed cache would have replayed 1 here
+      expect(second.instanceId).toBe('100:lifeB');
+      expect(sampleCalls(exec)).toBe(2);
+    });
+
+    it('an unkeyed target is never cached — every call resamples', async () => {
+      // With instanceId null there is no proof the pid still names the same process,
+      // so a cache hit would be a guess. It resamples instead.
+      const exec = makeVaryingExec();
+      _setExecForTest(exec);
+
+      const [first] = await getResourcesForPids([{ pid: 100, instanceId: null }]);
+      const [second] = await getResourcesForPids([{ pid: 100, instanceId: null }]);
+
+      expect(first.memMb).toBe(1);
+      expect(second.memMb).toBe(2);
+      expect(sampleCalls(exec)).toBe(2);
+    });
+
+    it('an unkeyed target does not poison the cache for a keyed one on the same pid', async () => {
+      const exec = makeVaryingExec();
+      _setExecForTest(exec);
+
+      await getResourcesForPids([{ pid: 100, instanceId: null }]);
+      const [keyed] = await getResourcesForPids([{ pid: 100, instanceId: '100:aaa' }]);
+
+      expect(keyed.memMb).toBe(2); // its own sample, not the unkeyed call's
+      expect(keyed.instanceId).toBe('100:aaa');
+    });
+  });
+
+  describe('record shape and identity', () => {
+    it('returns one record per requested target, in request order, each with its key', async () => {
+      _setExecForTest(makeExec({ gpu: true }));
+
+      const records = await getResourcesForPids([
+        { pid: 200, instanceId: '200:bbb' },
+        { pid: 100, instanceId: '100:aaa' },
+      ]);
+
+      expect(records).toHaveLength(2);
+      expect(records.map((r) => r.instanceId)).toEqual(['200:bbb', '100:aaa']);
+      expect(records.map((r) => r.pid)).toEqual([200, 100]);
+      expect(records[1]).toEqual({
+        instanceId: '100:aaa',
+        pid: 100,
+        cpu: expect.any(Number),
+        memMb: 72,
+        gpu: { memMb: 512 },
+      });
+    });
+
+    it('two unattributed targets stay distinct instead of collapsing into one bucket', async () => {
+      _setExecForTest(makeExec({ gpu: true }));
+
+      const records = await getResourcesForPids([
+        { pid: 100, instanceId: null },
+        { pid: 200, instanceId: null },
+      ]);
+
+      expect(records).toHaveLength(2);
+      expect(records.map((r) => r.pid)).toEqual([100, 200]);
+      expect(records.every((r) => r.instanceId === null)).toBe(true);
+      // Distinct measurements, not one shared row: pid 200 is the 1 MB process.
+      expect(records[0].memMb).toBe(72);
+      expect(records[1].memMb).toBe(1);
+    });
+
+    it('two agents sharing a pid under different keys both get a record', async () => {
+      _setExecForTest(makeExec({ gpu: true }));
+
+      const records = await getResourcesForPids([
+        { pid: 100, instanceId: '100:aaa' },
+        { pid: 100, instanceId: '100:bbb' },
+      ]);
+
+      expect(records.map((r) => r.instanceId)).toEqual(['100:aaa', '100:bbb']);
+    });
+
+    it('collapses an exact repeat of the same (pid, instanceId) pair', async () => {
+      _setExecForTest(makeExec({ gpu: true }));
+
+      const records = await getResourcesForPids([
+        { pid: 100, instanceId: '100:aaa' },
+        { pid: 100, instanceId: '100:aaa' },
+      ]);
+
+      expect(records).toHaveLength(1);
     });
   });
 
@@ -158,6 +296,38 @@ describe('resource-monitor', () => {
       _setExecForTest(makeExec({ gpu: true }));
       const r = await getResourcesByPid(-1);
       expect(r).toEqual({ pid: -1, cpu: null, memMb: null, gpu: null });
+    });
+
+    it('drops unsampleable targets and keeps the rest', async () => {
+      _setExecForTest(makeExec({ gpu: true }));
+
+      const records = await getResourcesForPids([
+        null,
+        { pid: 0, instanceId: '0:Kilo Code' }, // synthetic: no OS process to sample
+        { pid: -1, instanceId: 'x' },
+        { pid: 'nope', instanceId: 'y' },
+        { pid: 100, instanceId: '100:aaa' },
+      ]);
+
+      expect(records).toHaveLength(1);
+      expect(records[0].instanceId).toBe('100:aaa');
+    });
+
+    it('returns an empty array for a non-array or empty input', async () => {
+      _setExecForTest(makeExec({ gpu: true }));
+      expect(await getResourcesForPids([])).toEqual([]);
+      expect(await getResourcesForPids(undefined)).toEqual([]);
+    });
+
+    it('treats an empty-string instanceId as unattributed, not as a key', async () => {
+      const exec = makeVaryingExec();
+      _setExecForTest(exec);
+
+      const [first] = await getResourcesForPids([{ pid: 100, instanceId: '' }]);
+      const [second] = await getResourcesForPids([{ pid: 100, instanceId: '' }]);
+
+      expect(first.instanceId).toBeNull();
+      expect(second.memMb).toBe(2); // resampled — an empty string never became a cache key
     });
   });
 });

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -1142,4 +1142,212 @@ describe('scan-loop', () => {
       expect(alert[1].pid).toBeNull();
     });
   });
+
+  // ── per-agent resource push (`agent-resource-usage`) ──
+
+  describe('agent-resource-usage push', () => {
+    const MB = 1048576;
+
+    /**
+     * An exec whose CPU/RAM answer changes on every sampling call, so a figure in the
+     * payload proves WHICH sample produced it — the only way a cached record and a
+     * fresh one can be told apart. Sample n reports every pid at n MB. GPU absent.
+     * @returns {Function}
+     */
+    function makeVaryingExec() {
+      let sample = 0;
+      return vi.fn((cmd) => {
+        if (cmd === 'nvidia-smi') {
+          return Promise.reject(Object.assign(new Error('not found'), { code: 'ENOENT' }));
+        }
+        if (cmd === 'powershell.exe') {
+          sample++;
+          return Promise.resolve(
+            JSON.stringify(
+              [100, 200, 300, 400].map((pid) => ({
+                IDProcess: pid,
+                PercentProcessorTime: sample,
+                WorkingSet: sample * MB,
+              })),
+            ),
+          );
+        }
+        if (cmd === 'ps') {
+          sample++;
+          return Promise.resolve(
+            [100, 200, 300, 400].map((pid) => `${pid} ${sample}.0 ${sample * 1024}`).join('\n'),
+          );
+        }
+        return Promise.resolve('');
+      });
+    }
+
+    /**
+     * scan-loop requires resource-monitor at module scope, and the CJS cache hands both
+     * the same instance — so injecting here injects into the module under test. Returns
+     * the module so the test can reset it.
+     * @param {Function} exec
+     * @returns {Object}
+     */
+    function stubResourceMonitor(exec) {
+      const rm = require_('../../src/main/resource-monitor.js');
+      rm._resetForTest();
+      rm._setLoggerForTest({ warn: vi.fn() });
+      rm._setExecForTest(exec);
+      return rm;
+    }
+
+    afterEach(() => {
+      const rm = require_('../../src/main/resource-monitor.js');
+      rm._resetForTest();
+      // Leave an inert exec behind: the module survives this file's CJS cache clearing,
+      // and a real spawn from a later test would be a live process query in CI.
+      rm._setExecForTest(() => Promise.resolve(''));
+    });
+
+    /**
+     * Deps whose enrich stamps identity through the real `identify()`, over a fresh
+     * agent array per tick — `scanProcesses` is driven by the supplied factory so a
+     * test can change what the SECOND tick sees.
+     * @param {Function} sendToRenderer
+     * @param {Function} agentsForTick - () => Array, called once per scan
+     * @returns {Object}
+     */
+    function makeStampingDeps(sendToRenderer, agentsForTick) {
+      const { identify } = require_('../../src/main/process-identity.js');
+      return makeDeps({
+        scanner: {
+          scanProcesses: vi.fn().mockImplementation(async () => ({
+            agents: agentsForTick(),
+            changed: false,
+          })),
+        },
+        procUtil: {
+          enrichWithParentChains: vi.fn(async (agents) => {
+            for (const a of agents) {
+              const id = identify(a);
+              a.instanceId = id.instanceId;
+              a.instanceIdSource = id.instanceIdSource;
+            }
+          }),
+          annotateHostApps: vi.fn(),
+          annotateWorkingDirs: vi.fn().mockResolvedValue(),
+        },
+        sendToRenderer,
+      });
+    }
+
+    /** Every `agent-resource-usage` payload sent so far, oldest first. */
+    function pushes(sendToRenderer) {
+      return sendToRenderer.mock.calls
+        .filter((c) => c[0] === 'agent-resource-usage')
+        .map((c) => c[1]);
+    }
+
+    it('every emitted record carries the instanceId stamped on that same tick', async () => {
+      stubResourceMonitor(makeVaryingExec());
+      const sendToRenderer = vi.fn();
+      const deps = makeStampingDeps(sendToRenderer, () => [
+        { agent: 'Claude Code', process: 'claude.exe', pid: 100, startTime: 1717000000000 },
+        { agent: 'Cursor', process: 'cursor.exe', pid: 200, startTime: 1717000100000 },
+      ]);
+      scanLoop.init(deps);
+      scanLoop.startScanIntervals(1000);
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(0); // let the fire-and-forget push settle
+
+      const batch = sendToRenderer.mock.calls.find((c) => c[0] === 'scan-batch')[1];
+      const [records] = pushes(sendToRenderer);
+      expect(records).toBeTruthy();
+
+      // The keys in the payload are the keys the very same batch carries — not
+      // re-resolved, not name-matched.
+      const batchKeys = new Map(
+        batch.agents.filter((a) => a.pid > 0).map((a) => [a.pid, a.instanceId]),
+      );
+      expect(records.length).toBe(batchKeys.size);
+      for (const r of records) {
+        expect(r.instanceId).toBe(batchKeys.get(r.pid));
+        expect(typeof r.instanceId).toBe('string');
+      }
+    });
+
+    it('a recycled pid does not inherit the previous instance’s cached sample', async () => {
+      stubResourceMonitor(makeVaryingExec());
+      const sendToRenderer = vi.fn();
+      let tick = 0;
+      const deps = makeStampingDeps(sendToRenderer, () => {
+        tick++;
+        // Same pid, two lives: tick 2 is a DIFFERENT process wearing pid 100.
+        return [
+          {
+            agent: 'Claude Code',
+            process: 'claude.exe',
+            pid: 100,
+            startTime: tick === 1 ? 1717000000000 : 1717000999000,
+          },
+        ];
+      });
+      scanLoop.init(deps);
+      // 1s apart, well inside the 5s resource TTL — so a pid-keyed cache WOULD hit.
+      scanLoop.startScanIntervals(1000);
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const [first, second] = pushes(sendToRenderer);
+      expect(first[0].instanceId).toBe('100:1717000000000');
+      expect(second[0].instanceId).toBe('100:1717000999000');
+      // Distinct measurements: the second life was sampled afresh (2 MB), not served
+      // the first life's cached 1 MB.
+      expect(first[0].memMb).toBe(1);
+      expect(second[0].memMb).toBe(2);
+    });
+
+    it('unstamped agents ride along as separate null-key records, not one bucket', async () => {
+      stubResourceMonitor(makeVaryingExec());
+      const sendToRenderer = vi.fn();
+      // Default deps: enrichWithParentChains is inert, so nothing is stamped — the
+      // defensive case the payload shape has to survive.
+      const deps = makeDeps({
+        scanner: {
+          scanProcesses: vi.fn().mockImplementation(async () => ({
+            agents: [
+              { agent: 'Claude Code', process: 'claude.exe', pid: 300 },
+              { agent: 'Cursor', process: 'cursor.exe', pid: 400 },
+            ],
+            changed: false,
+          })),
+        },
+        sendToRenderer,
+      });
+      scanLoop.init(deps);
+      scanLoop.startScanIntervals(1000);
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const [records] = pushes(sendToRenderer);
+      const unkeyed = records.filter((r) => r.instanceId === null);
+      expect(unkeyed.map((r) => r.pid).sort()).toEqual([300, 400]);
+      expect(unkeyed).toHaveLength(2); // two rows, each keeping its own pid
+    });
+
+    it('synthetic pid-0 agents are not sampled — the OS has nothing to answer for them', async () => {
+      stubResourceMonitor(makeVaryingExec());
+      const sendToRenderer = vi.fn();
+      const deps = makeStampingDeps(sendToRenderer, () => [
+        { agent: 'Claude Code', process: 'claude.exe', pid: 100, startTime: 1717000000000 },
+        { agent: 'Kilo Code', process: 'code.exe', pid: 0 },
+      ]);
+      scanLoop.init(deps);
+      scanLoop.startScanIntervals(1000);
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const [records] = pushes(sendToRenderer);
+      expect(records.every((r) => r.pid > 0)).toBe(true);
+      expect(records.some((r) => r.pid === 100)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Block B1 of the resource-usage split — main side only. The renderer subscriber and the agent-card display are B2.

## What was wrong

`resource-monitor` sampled per-PID CPU/RAM/GPU and pushed it on `resource-usage` with **pid as the only identity**, while its TTL cache was also pid-keyed. A pid is not an identity — Windows reissues it — so a cache hit inside the 5s window could hand a sample taken under the previous holder of a pid to the process now wearing it. That is ai-mistakes #19 in the one place it had not been swept yet. The channel name also sat one hyphen from `resourceUsage` (AEGIS's own load), which is how it went a release and a half with a bridge method and no subscriber.

## Changes

**Cache key → instanceId.** `getResourcesForPids` takes `{pid, instanceId}` pairs and returns an **array** of records instead of a pid-keyed `Map`. The array is load-bearing: a Map keyed on `instanceId` would put every unattributed record under one `null` key and lose all but the last; a Map keyed on pid would reintroduce exactly what this migration removes.

Targets with no key are **neither read from nor written to** the cache. With `instanceId: null` there is no proof the pid still names the same process, so a hit would be a guess — they resample instead. `getResourcesByPid` keeps its bare-pid contract untouched (and, being unkeyed, now samples afresh each call).

**Payload.** `AgentResourceRecord` = `{instanceId, pid, cpu, memMb, gpu}`. `instanceId` is the key; `pid` rides alongside for display and diagnostics. A null-key record keeps its own pid and stays distinct from every other null-key record.

**Same-tick pairing.** `scan-loop` builds the pid → instanceId pairs from that tick's own `agents` array, inside the existing closure — never re-resolved when the sample lands, which could straddle a pid recycle. pid ≤ 0 is dropped because the OS has nothing to sample for a synthetic agent, not because it lacks a key.

**Channel.** `resource-usage` → `agent-resource-usage`; bridge method `onResourceUsage` → `onAgentResourceUsage`; `agent-resource-usage` added to `IpcEventChannel` (documented there as documentation, not enforcement — `sendToRenderer` is called from `checkJs: false` JS, so nothing typechecks against that union; the pre-existing `token-costs` gap is noted, not fixed).

## Verification

Five gates green: `npm test` 1390 passed / 4 skipped (83 files, +14 new), `tsc -p tsconfig.main.json` 0, `tsc -p tsconfig.renderer.json` 0, `npm run lint` 0 errors (28 pre-existing warnings, none in changed files), `npm run build:renderer` ✓.

Gate sensitivity was proven by injection, not assumed (ai-mistakes #21) — each injected, observed red, then reverted:

| Injected fault | Result |
|---|---|
| cache key back to `pid` | **5 red**, incl. the scan-loop integration case "a recycled pid does not inherit the previous instance's cached sample" |
| `instanceId: null` in the scan-loop target build | **2 red**, incl. "every emitted record carries the instanceId stamped on that same tick" |
| channel name back to `resource-usage` | **4 red** — all of the new push tests |

The cache tests use an exec whose answer changes per sampling call (1 MB, 2 MB, …), so a cached record and a fresh one are actually distinguishable; without that, the assertions would pass either way.

### preload.js has no automated gate

Nothing in the suite loads `preload.js` — `lint` only proves it parses. So the wiring was checked by running the real app under a Playwright `_electron` driver and subscribing through the bridge exactly as a renderer store will, with no renderer source touched:

- `typeof window.aegis.onAgentResourceUsage` → `"function"`; `window.aegis.onResourceUsage` → `undefined` (old method gone, not shadowed)
- 2 payloads received, at t=5s and t=41s — matching `staggeredStartup` + `startWarmup` (first scan at 3s, then `scanIntervalSec × 3` for the first minute, `scan-loop.js:606-620`)
- 10 records total, **10 with a string `instanceId`**, 0 missing the field, 0 duplicate keys within a payload
- Real values, e.g. `{instanceId: "19808:1786458875512", pid: 19808, cpu: 2.2, memMb: 437, gpu: null}` (`gpu: null` = no nvidia-smi on this machine, the honest degraded value)
- Console clean: 0 messages, 0 page errors

That boot schedule incidentally explains the open observation left in #197 — the footer MEM figure moving once and then holding was the 30s warm-up interval, not a stuck store.

## Known gaps

- `src/renderer/lib/stores/ipc.ts:161` still describes the channel by its old name in a JSDoc note. Renderer files were explicitly out of scope for this block; B2 edits that file anyway and should correct the line.
- No test asserts the preload surface. The check above is a manual run, reproducible but not a gate.
