### PR TITLE
feat(renderer): show per-instance CPU and memory on the agent card

### DIFF
--- a/src/renderer/lib/components/AgentCard.svelte
+++ b/src/renderer/lib/components/AgentCard.svelte
@@ -5,7 +5,7 @@
    *   trust badge, spotlight hover, and expandable details. [F2.3]
    * @since v0.5.0
    */
-  import { focusedAgentInstanceId, tokenCosts } from '../stores/ipc.js';
+  import { agentResourceByInstance, focusedAgentInstanceId, tokenCosts } from '../stores/ipc.js';
   import { eventsByInstance } from '../stores/events-index.ts';
   import AgentCardDetails from './AgentCardDetails.svelte';
   import AgentActions from './AgentActions.svelte';
@@ -93,6 +93,28 @@
     $tokenCosts.find((r) =>
       agent.instanceId && r.instanceId ? r.instanceId === agent.instanceId : r.pid === agent.pid,
     ),
+  );
+
+  /**
+   * CPU/RAM sample for THIS instance, from the `agent-resource-usage` push. Looked up
+   * strictly by `instanceId` — no pid fallback, unlike {@link tokenRec}: the resource
+   * push always carries the key when the monitor could resolve one, so a pid match here
+   * would only ever fire for a record that is deliberately unattributed, and would pin a
+   * stranger's CPU onto this card. An agent with no key gets no figures.
+   */
+  let resourceRec = $derived(
+    agent.instanceId ? ($agentResourceByInstance.get(agent.instanceId) ?? null) : null,
+  );
+
+  /**
+   * Formatted figures, or `null` for "no measurement". `null` covers BOTH no record for
+   * this instance and a record whose field the monitor could not read — the two are
+   * indistinguishable to a viewer and both render as absent. A measured zero is a real
+   * reading and formats normally: `0 %` means idle, not missing.
+   */
+  let cpuText = $derived(resourceRec && resourceRec.cpu != null ? `${resourceRec.cpu} %` : null);
+  let memText = $derived(
+    resourceRec && resourceRec.memMb != null ? `${resourceRec.memMb.toLocaleString()} MB` : null,
   );
 
   let lastFile = $derived.by(() => {
@@ -204,6 +226,22 @@
         <span class="stat-value">{agent.networkCount}</span>
       </span>
     {/if}
+    <span class="stat-chip" title={cpuText ? $t('agents.cpu_title') : $t('agents.no_sample_title')}>
+      <span class="stat-label">CPU</span>
+      {#if cpuText}
+        <span class="stat-value">{cpuText}</span>
+      {:else}
+        <span class="stat-absent">{$t('agents.not_sampled')}</span>
+      {/if}
+    </span>
+    <span class="stat-chip" title={memText ? $t('agents.mem_title') : $t('agents.no_sample_title')}>
+      <span class="stat-label">MEM</span>
+      {#if memText}
+        <span class="stat-value">{memText}</span>
+      {:else}
+        <span class="stat-absent">{$t('agents.not_sampled')}</span>
+      {/if}
+    </span>
     {#if tokenRec && tokenRec.totalTokens > 0}
       <span class="stat-chip">
         <span class="stat-label">{$t('agents.tokens')}</span>
@@ -338,6 +376,15 @@
     font-size: calc(11px * var(--aegis-ui-scale));
     font-weight: 600;
     color: var(--fancy-text-1);
+  }
+  /* "No measurement" — deliberately NOT a number and NOT the mono face the figures use,
+     so it cannot be misread as a reading of zero at a glance. */
+  .stat-absent {
+    font-family: var(--fancy-font-body);
+    font-size: calc(10px * var(--aegis-ui-scale));
+    font-weight: 400;
+    color: var(--fancy-text-2);
+    opacity: 0.7;
   }
 
   .activity-hint {

--- a/src/renderer/lib/components/PidList.svelte
+++ b/src/renderer/lib/components/PidList.svelte
@@ -8,6 +8,9 @@
    * @since v0.10.0-alpha
    */
 
+  import { agentResourceByInstance } from '../stores/ipc.js';
+  import { t } from '../i18n/index.js';
+
   /**
    * @type {{
    *   agent: { _instances?: Array<object>, pid: number, process?: string, name?: string },
@@ -22,6 +25,30 @@
    * @type {Array<{ pid: number, process?: string, cwd?: string, parentChain?: string, parentEditor?: string, riskScore?: number }>}
    */
   let instances = $derived(agent._instances?.length ? agent._instances : [agent]);
+
+  /**
+   * One row per instance, each carrying ITS OWN resource sample.
+   *
+   * This is where two instances of the same tool stop sharing a number: the card above
+   * is one per display NAME and shows the representative's figures, so a second Claude
+   * Code in another project would otherwise be invisible. The lookup is strictly by that
+   * instance's `instanceId` — never by pid, which the OS reissues, and never by name,
+   * which is what groups these rows in the first place.
+   *
+   * `cpuText`/`memText` are null for "no measurement", covering both a missing record and
+   * a null field on a present one. A measured zero formats as `0 %` and is NOT absent.
+   * @type {Array<{inst: object, cpuText: string|null, memText: string|null}>}
+   */
+  let rows = $derived(
+    instances.map((inst) => {
+      const rec = inst.instanceId ? ($agentResourceByInstance.get(inst.instanceId) ?? null) : null;
+      return {
+        inst,
+        cpuText: rec && rec.cpu != null ? `${rec.cpu} %` : null,
+        memText: rec && rec.memMb != null ? `${rec.memMb.toLocaleString()} MB` : null,
+      };
+    }),
+  );
 
   /**
    * Compact per-PID intervention buttons — muted, revealed on row hover.
@@ -64,10 +91,21 @@
 </script>
 
 <div class="pid-list">
-  {#each instances as inst (inst.pid)}
+  {#each rows as { inst, cpuText, memText } (inst.pid)}
     <div class="pid-row" title={pidTooltip(inst)}>
       <span class="pid-num">{inst.pid}</span>
       <span class="pid-proc">{inst.process || inst.name || ''}</span>
+      <span class="pid-res">
+        {#if cpuText || memText}
+          <span class="pid-res-val">{cpuText ?? $t('agents.not_sampled')}</span>
+          <span class="pid-res-sep">/</span>
+          <span class="pid-res-val">{memText ?? $t('agents.not_sampled')}</span>
+        {:else}
+          <span class="pid-res-absent" title={$t('agents.no_sample_title')}
+            >{$t('agents.not_sampled')}</span
+          >
+        {/if}
+      </span>
       <div class="pid-acts">
         {#each PID_ACTIONS as act (act.method)}
           <button
@@ -125,6 +163,27 @@
     white-space: nowrap;
     opacity: 0.85;
   }
+  .pid-res {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--aegis-space-1);
+    flex-shrink: 0;
+  }
+  .pid-res-val {
+    font-family: var(--fancy-font-mono);
+    color: var(--md-sys-color-on-surface);
+    opacity: 0.85;
+  }
+  .pid-res-sep {
+    opacity: 0.4;
+  }
+  /* Same rule as the card chips: absent is a word in the body face, never a figure. */
+  .pid-res-absent {
+    font-family: var(--fancy-font-body);
+    color: var(--md-sys-color-on-surface-variant);
+    opacity: 0.7;
+  }
+
   .pid-acts {
     display: flex;
     gap: var(--aegis-space-1);

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -127,7 +127,11 @@
     "stat_proc": "Proc",
     "stat_files": "File Act",
     "stat_net": "Net",
-    "tokens": "TOK"
+    "tokens": "TOK",
+    "not_sampled": "no sample",
+    "cpu_title": "CPU share of the whole machine, sampled per process instance",
+    "mem_title": "Resident memory of this process instance",
+    "no_sample_title": "No resource sample for this instance yet — this is missing data, not a load of zero"
   },
   "timeline": {
     "title": "Event Timeline",

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -103,6 +103,33 @@ interface TokenCostRecord {
   readonly models: string[];
 }
 
+/**
+ * One monitored agent's sampled load, pushed on the `agent-resource-usage` channel.
+ * Mirrors `AgentResourceRecord` in the main process (resource-monitor.js).
+ *
+ * `instanceId` is the KEY and `pid` is display only — the OS reissues pids, so joining
+ * on one can attribute a dead process's load to whatever wears its number next.
+ *
+ * Two different nulls, and they must not be conflated:
+ * - `instanceId: null` — the sample could not be attributed to a keyed instance. Such
+ *   a record keeps its own pid and stays individually distinguishable
+ *   ({@link unattributedAgentResource}); it is never folded into a shared bucket.
+ * - `cpu` / `memMb` / `gpu` null — the process WAS the subject of a sample and the
+ *   figure could not be read (exited, denied, unparseable, or no nvidia-smi for gpu).
+ *   That is "not measured", which is categorically different from a measured zero and
+ *   must never be rendered as one.
+ */
+interface AgentResourceRecord {
+  readonly instanceId: string | null;
+  readonly pid: number;
+  /** 0–100 % of the whole machine, or null when not sampled. */
+  readonly cpu: number | null;
+  /** Resident memory in MB, or null when not sampled. */
+  readonly memMb: number | null;
+  /** GPU memory, or null when nvidia-smi is absent — never a fabricated 0. */
+  readonly gpu: { readonly memMb: number } | null;
+}
+
 /** Minimal type for the window.aegis IPC bridge exposed by preload.js */
 interface AegisIpcBridge {
   onScanBatch(cb: (data: ScanBatchData) => void): void;
@@ -111,6 +138,7 @@ interface AegisIpcBridge {
   onNetworkUpdate(cb: (data: NetworkConnection[]) => void): void;
   onScanStatus(cb: (data: ScanStatusData) => void): void;
   onTokenCosts(cb: (data: TokenCostRecord[]) => void): void;
+  onAgentResourceUsage(cb: (data: AgentResourceRecord[]) => void): void;
   getStats(): Promise<Record<string, unknown>>;
   getAuditStats(): Promise<AuditStats>;
   getResourceUsage(): Promise<MonitorResourceUsage>;
@@ -158,9 +186,10 @@ export const anomaliesByInstance: Writable<Record<string, number>> = writable({}
  * `get-resource-usage`, because those names already mean "the app's own" on the main
  * side and renaming them would churn their tests for nothing. The asymmetry is the
  * price of making the RENDERER side unambiguous — a store called `resourceUsage`
- * sitting next to a channel called `resource-usage` that carries the MONITORED
+ * sitting next to a channel then called `resource-usage` that carries the MONITORED
  * AGENTS' load is exactly how that channel went a release and a half with a bridge
- * method and no subscriber.
+ * method and no subscriber. That channel is now `agent-resource-usage` and lands in
+ * {@link agentResourceUsage}; the two are no longer one rename away from each other.
  */
 export const monitorResourceUsage: Writable<MonitorResourceUsage | null> = writable(null);
 export const falsePositives: Writable<FalsePositiveEntry[]> = writable([]);
@@ -168,6 +197,51 @@ export const scanActive: Writable<boolean> = writable(false);
 
 /** Per process-instance token + cost records, refreshed each scan via the `token-costs` push. */
 export const tokenCosts: Writable<TokenCostRecord[]> = writable([]);
+
+/**
+ * The MONITORED AGENTS' load, exactly as `agent-resource-usage` delivered it — raw and
+ * unindexed. Replaced (not merged) on every push, so a record cannot outlive the
+ * instance it describes.
+ *
+ * An ARRAY rather than a keyed object, and that is the point: keying here would need a
+ * single slot for every record whose `instanceId` is null, and all but the last would
+ * vanish. Read {@link agentResourceByInstance} to look one up and
+ * {@link unattributedAgentResource} for the ones that have no key.
+ */
+export const agentResourceUsage: Writable<AgentResourceRecord[]> = writable([]);
+
+/**
+ * Instance-keyed index over {@link agentResourceUsage} — the lookup a per-agent view
+ * should use. Records with no `instanceId` are ABSENT here by construction; they are not
+ * given a placeholder key, because a placeholder is a bucket and a bucket is how two
+ * unrelated processes end up sharing a number.
+ *
+ * A missing key means "no sample for this instance", which the UI must render as absent
+ * rather than as zero.
+ */
+export const agentResourceByInstance: Readable<Map<string, AgentResourceRecord>> = derived(
+  agentResourceUsage,
+  ($records) => {
+    const byInstance = new Map<string, AgentResourceRecord>();
+    for (const record of $records) {
+      if (typeof record.instanceId === 'string' && record.instanceId !== '') {
+        byInstance.set(record.instanceId, record);
+      }
+    }
+    return byInstance;
+  },
+);
+
+/**
+ * Samples that arrived without an instance key, each keeping its own pid and staying
+ * individually distinguishable. Kept as its own list so that "we sampled a process we
+ * could not identify" stays visible instead of being silently dropped by the index
+ * above — an unattributed measurement is data, not an error.
+ */
+export const unattributedAgentResource: Readable<AgentResourceRecord[]> = derived(
+  agentResourceUsage,
+  ($records) => $records.filter((record) => record.instanceId === null),
+);
 
 /**
  * True once the first scan batch has arrived from the main process. Monotonic
@@ -303,6 +377,11 @@ if (import.meta.env.VITE_DEMO_MODE === 'true') {
   });
   window.aegis!.onScanStatus((data) => scanActive.set(data?.scanning ?? false));
   window.aegis!.onTokenCosts((data) => tokenCosts.set(Array.isArray(data) ? data : []));
+  // Replace, never merge: a record kept past its push would keep drawing a number for an
+  // instance the monitor has stopped reporting.
+  window.aegis!.onAgentResourceUsage((data) =>
+    agentResourceUsage.set(Array.isArray(data) ? data : []),
+  );
 
   // Fetch initial data
   window.aegis!.getStats().then((data) => stats.set(data));

--- a/tests/renderer/components/AgentCard.test.ts
+++ b/tests/renderer/components/AgentCard.test.ts
@@ -73,7 +73,9 @@ describe('AgentCard — per-instance resource figures', () => {
     agentResourceUsage.set([
       { instanceId: '100:1717000000000', pid: 100, cpu: 2.9, memMb: 631, gpu: null },
     ]);
-    const { container } = render(AgentCard, { props: { agent: agent() } });
+    const { container } = render(AgentCard, {
+      props: { agent: agent(), expandedInstanceId: null },
+    });
 
     expect(chipFigure(container, 'CPU')).toBe('2.9 %');
     expect(chipFigure(container, 'MEM')).toBe('631 MB');
@@ -85,7 +87,9 @@ describe('AgentCard — per-instance resource figures', () => {
     agentResourceUsage.set([
       { instanceId: '100:1717000000000', pid: 100, cpu: 0, memMb: 0, gpu: null },
     ]);
-    const { container } = render(AgentCard, { props: { agent: agent() } });
+    const { container } = render(AgentCard, {
+      props: { agent: agent(), expandedInstanceId: null },
+    });
 
     expect(chipFigure(container, 'CPU')).toBe('0 %');
     expect(chipFigure(container, 'MEM')).toBe('0 MB');
@@ -99,7 +103,9 @@ describe('AgentCard — per-instance resource figures', () => {
     agentResourceUsage.set([
       { instanceId: '100:1717000000000', pid: 100, cpu: null, memMb: null, gpu: null },
     ]);
-    const { container } = render(AgentCard, { props: { agent: agent() } });
+    const { container } = render(AgentCard, {
+      props: { agent: agent(), expandedInstanceId: null },
+    });
 
     expect(chipAbsent(container, 'CPU')).toBe('no sample');
     expect(chipAbsent(container, 'MEM')).toBe('no sample');
@@ -111,7 +117,9 @@ describe('AgentCard — per-instance resource figures', () => {
     agentResourceUsage.set([
       { instanceId: '999:1717000000000', pid: 999, cpu: 50, memMb: 900, gpu: null },
     ]);
-    const { container } = render(AgentCard, { props: { agent: agent() } });
+    const { container } = render(AgentCard, {
+      props: { agent: agent(), expandedInstanceId: null },
+    });
 
     expect(chipAbsent(container, 'CPU')).toBe('no sample');
     expect(chipFigure(container, 'CPU')).toBeNull();
@@ -123,7 +131,9 @@ describe('AgentCard — per-instance resource figures', () => {
     agentResourceUsage.set([
       { instanceId: '100:OLD-LIFE', pid: 100, cpu: 77, memMb: 999, gpu: null },
     ]);
-    const { container } = render(AgentCard, { props: { agent: agent() } });
+    const { container } = render(AgentCard, {
+      props: { agent: agent(), expandedInstanceId: null },
+    });
 
     expect(chipAbsent(container, 'CPU')).toBe('no sample');
     expect(container.textContent).not.toContain('77');
@@ -133,7 +143,9 @@ describe('AgentCard — per-instance resource figures', () => {
     agentResourceUsage.set([
       { instanceId: '100:1717000000000', pid: 100, cpu: 2.9, memMb: 631, gpu: null },
     ]);
-    const { container } = render(AgentCard, { props: { agent: agent({ instanceId: null }) } });
+    const { container } = render(AgentCard, {
+      props: { agent: agent({ instanceId: null }), expandedInstanceId: null },
+    });
 
     expect(chipAbsent(container, 'CPU')).toBe('no sample');
   });

--- a/tests/renderer/components/AgentCard.test.ts
+++ b/tests/renderer/components/AgentCard.test.ts
@@ -1,0 +1,187 @@
+/**
+ * AgentCard.test.ts — what the card does with a per-instance resource sample.
+ *
+ * The distinction under test is the one a monitor cannot afford to blur: a MEASURED
+ * zero ("this process is idle") versus NO MEASUREMENT ("we have nothing to say"). The
+ * running app can be made to show the first two states easily; a record whose `cpu` is
+ * null — sampled, unreadable — only shows up when a process exits or denies access
+ * mid-scan, which is why it is pinned here instead.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+/**
+ * `window.aegis` must exist BEFORE `stores/ipc` is evaluated, or that module takes the
+ * demo branch. Same reason as NetworkPanel.test.ts / Timeline.test.ts.
+ */
+const noop = () => {};
+(window as unknown as { aegis: unknown }).aegis = {
+  onScanBatch: noop,
+  onFileAccess: noop,
+  onStatsUpdate: noop,
+  onNetworkUpdate: noop,
+  onScanStatus: noop,
+  onTokenCosts: noop,
+  onAgentResourceUsage: noop,
+  getStats: () => Promise.resolve({}),
+  getResourceUsage: () => Promise.resolve({}),
+  getFalsePositives: () => Promise.resolve([]),
+  getSettings: () => Promise.resolve({}),
+  saveSettings: () => Promise.resolve({}),
+  getAuditEntriesBefore: () => Promise.resolve([]),
+};
+
+const { agentResourceUsage } = await import('../../../src/renderer/lib/stores/ipc.js');
+const AgentCard = (await import('../../../src/renderer/lib/components/AgentCard.svelte')).default;
+
+/** One live agent, shaped as `enrichedAgents` hands it to the card. */
+function agent(over: Record<string, unknown> = {}) {
+  return {
+    name: 'Claude Code',
+    agent: 'Claude Code',
+    process: 'claude.exe',
+    pid: 100,
+    instanceId: '100:1717000000000',
+    category: 'ai',
+    riskScore: 10,
+    ...over,
+  };
+}
+
+/** The CPU or MEM chip's rendered figure, or null when it rendered the absent state. */
+function chipFigure(container: HTMLElement, label: string): string | null {
+  const chip = [...container.querySelectorAll('.stat-chip')].find(
+    (c) => c.querySelector('.stat-label')?.textContent?.trim() === label,
+  );
+  return chip?.querySelector('.stat-value')?.textContent?.trim() ?? null;
+}
+
+/** The absent text of the CPU or MEM chip, or null when it rendered a figure. */
+function chipAbsent(container: HTMLElement, label: string): string | null {
+  const chip = [...container.querySelectorAll('.stat-chip')].find(
+    (c) => c.querySelector('.stat-label')?.textContent?.trim() === label,
+  );
+  return chip?.querySelector('.stat-absent')?.textContent?.trim() ?? null;
+}
+
+describe('AgentCard — per-instance resource figures', () => {
+  beforeEach(() => {
+    agentResourceUsage.set([]);
+  });
+
+  it('renders CPU and memory for the matching instance', () => {
+    agentResourceUsage.set([
+      { instanceId: '100:1717000000000', pid: 100, cpu: 2.9, memMb: 631, gpu: null },
+    ]);
+    const { container } = render(AgentCard, { props: { agent: agent() } });
+
+    expect(chipFigure(container, 'CPU')).toBe('2.9 %');
+    expect(chipFigure(container, 'MEM')).toBe('631 MB');
+  });
+
+  it('renders a MEASURED zero as a figure, never as the absent state', () => {
+    // An idle process is a real observation. Collapsing it into "no sample" would throw
+    // away the very thing the reading proves.
+    agentResourceUsage.set([
+      { instanceId: '100:1717000000000', pid: 100, cpu: 0, memMb: 0, gpu: null },
+    ]);
+    const { container } = render(AgentCard, { props: { agent: agent() } });
+
+    expect(chipFigure(container, 'CPU')).toBe('0 %');
+    expect(chipFigure(container, 'MEM')).toBe('0 MB');
+    expect(chipAbsent(container, 'CPU')).toBeNull();
+    expect(chipAbsent(container, 'MEM')).toBeNull();
+  });
+
+  it('renders the absent state when a sampled field came back null', () => {
+    // The record EXISTS — the process was sampled and the figure could not be read.
+    // Indistinguishable to a viewer from having no record, and rendered the same way.
+    agentResourceUsage.set([
+      { instanceId: '100:1717000000000', pid: 100, cpu: null, memMb: null, gpu: null },
+    ]);
+    const { container } = render(AgentCard, { props: { agent: agent() } });
+
+    expect(chipAbsent(container, 'CPU')).toBe('no sample');
+    expect(chipAbsent(container, 'MEM')).toBe('no sample');
+    expect(chipFigure(container, 'CPU')).toBeNull();
+    expect(chipFigure(container, 'MEM')).toBeNull();
+  });
+
+  it('renders the absent state when no record exists for this instance', () => {
+    agentResourceUsage.set([
+      { instanceId: '999:1717000000000', pid: 999, cpu: 50, memMb: 900, gpu: null },
+    ]);
+    const { container } = render(AgentCard, { props: { agent: agent() } });
+
+    expect(chipAbsent(container, 'CPU')).toBe('no sample');
+    expect(chipFigure(container, 'CPU')).toBeNull();
+  });
+
+  it('never matches on pid: a same-pid record under another key is not this instance', () => {
+    // The failure this guards: pid 100 recycled, the dead instance's sample still in the
+    // last payload, and the new process wearing its CPU figure.
+    agentResourceUsage.set([
+      { instanceId: '100:OLD-LIFE', pid: 100, cpu: 77, memMb: 999, gpu: null },
+    ]);
+    const { container } = render(AgentCard, { props: { agent: agent() } });
+
+    expect(chipAbsent(container, 'CPU')).toBe('no sample');
+    expect(container.textContent).not.toContain('77');
+  });
+
+  it('an agent carrying no instanceId gets no figures', () => {
+    agentResourceUsage.set([
+      { instanceId: '100:1717000000000', pid: 100, cpu: 2.9, memMb: 631, gpu: null },
+    ]);
+    const { container } = render(AgentCard, { props: { agent: agent({ instanceId: null }) } });
+
+    expect(chipAbsent(container, 'CPU')).toBe('no sample');
+  });
+
+  it('two instances of the same tool show independent figures in the PID list', () => {
+    // The card is one per display NAME, so this is where the two are told apart at all.
+    agentResourceUsage.set([
+      { instanceId: '100:aaa', pid: 100, cpu: 2.9, memMb: 631, gpu: null },
+      { instanceId: '200:bbb', pid: 200, cpu: 0, memMb: 430, gpu: null },
+    ]);
+    const grouped = {
+      ...agent({ instanceId: '100:aaa' }),
+      _processCount: 2,
+      _instances: [
+        agent({ instanceId: '100:aaa', pid: 100, cwd: 'X:/projects/one' }),
+        agent({ instanceId: '200:bbb', pid: 200, cwd: 'X:/projects/two' }),
+      ],
+    };
+    const { container } = render(AgentCard, {
+      props: { agent: grouped, expandedInstanceId: '100:aaa' },
+    });
+
+    const rows = [...container.querySelectorAll('.pid-row')].map((row) => ({
+      pid: row.querySelector('.pid-num')?.textContent?.trim(),
+      res: [...row.querySelectorAll('.pid-res-val')].map((el) => el.textContent?.trim()),
+    }));
+    expect(rows).toEqual([
+      { pid: '100', res: ['2.9 %', '631 MB'] },
+      { pid: '200', res: ['0 %', '430 MB'] },
+    ]);
+  });
+
+  it('a PID-list row with no record of its own renders the absent state', () => {
+    agentResourceUsage.set([{ instanceId: '100:aaa', pid: 100, cpu: 2.9, memMb: 631, gpu: null }]);
+    const grouped = {
+      ...agent({ instanceId: '100:aaa' }),
+      _processCount: 2,
+      _instances: [
+        agent({ instanceId: '100:aaa', pid: 100 }),
+        agent({ instanceId: '200:bbb', pid: 200 }),
+      ],
+    };
+    const { container } = render(AgentCard, {
+      props: { agent: grouped, expandedInstanceId: '100:aaa' },
+    });
+
+    const second = [...container.querySelectorAll('.pid-row')][1];
+    expect(second?.querySelector('.pid-res-absent')?.textContent?.trim()).toBe('no sample');
+    expect(second?.querySelector('.pid-res-val')).toBeNull();
+  });
+});

--- a/tests/renderer/components/NetworkPanel.test.ts
+++ b/tests/renderer/components/NetworkPanel.test.ts
@@ -24,6 +24,7 @@ const noop = () => {};
   onNetworkUpdate: noop,
   onScanStatus: noop,
   onTokenCosts: noop,
+  onAgentResourceUsage: noop,
   getStats: () => Promise.resolve({}),
   getResourceUsage: () => Promise.resolve({}),
   getFalsePositives: () => Promise.resolve([]),

--- a/tests/renderer/components/Timeline.test.ts
+++ b/tests/renderer/components/Timeline.test.ts
@@ -34,6 +34,7 @@ const noop = () => {};
   onNetworkUpdate: noop,
   onScanStatus: noop,
   onTokenCosts: noop,
+  onAgentResourceUsage: noop,
   getStats: () => Promise.resolve({}),
   getResourceUsage: () => Promise.resolve({}),
   getFalsePositives: () => Promise.resolve([]),


### PR DESCRIPTION
Block B2 — the renderer half. B1 made the main process emit `agent-resource-usage` with instance-keyed records; this subscribes to it and puts the figures on the agent card.

## Changes

**Store** (`stores/ipc.ts`) — `AgentResourceRecord` type, `onAgentResourceUsage` on `AegisIpcBridge`, and three exports: `agentResourceUsage` (raw array, **replaced** per push so a record cannot outlive the instance it describes), `agentResourceByInstance` (Map over non-empty keys only), `unattributedAgentResource` (the null-key samples, each keeping its own pid).

The index deliberately holds no placeholder key for null: a placeholder is a bucket, and a bucket is how two unrelated processes end up sharing one number. The stale JSDoc naming the old channel is corrected.

**Card** (`AgentCard.svelte`) — CPU and MEM chips, looked up **strictly by `instanceId`, no pid fallback**. Unlike `tokenRec`, which falls back to pid for legacy records, a pid match here could only ever fire for a deliberately unattributed record — and would pin a stranger's load onto this card.

**Absent vs zero.** A missing record and a `null` field render identically: the words "no sample", in the body face, muted (`DM Sans`, `--fancy-text-2`, opacity .7) — never a figure, never a dash that could read as a measurement. A **measured** zero renders as `0 %` in the mono face at full contrast, because an idle process is an observation and folding it into "no data" discards it.

**PID list** (`PidList.svelte`) — the card is one per display **name** (`agent-panel-utils.ts` picks a max-risk representative), so two instances of the same tool would otherwise both show the representative's figures. Each PID row now carries its own sample, keyed by that instance's own `instanceId`.

## Verification

Five gates green: `npm test` 1398 passed / 4 skipped (84 files, +8 new), `tsc -p tsconfig.main.json` 0, `tsc -p tsconfig.renderer.json` 0, `npm run lint` 0 errors (28 pre-existing warnings, none in changed files), `npm run build:renderer` ✓. `npm run build` (electron-builder) ✓. Svelte autofixer: 0 issues on both components.

`npm run typecheck:svelte` was run too — it is a required CI job and is **not** one of the five gates, and it caught six renders in the new test that omit a non-optional prop (`expandedInstanceId`), which vitest and `tsc` both accept. Fixed in the second commit; svelte-check now reports 384 files, 0 errors, 0 warnings.

Sensitivity proven by injection, then reverted:

| Injected fault | Result |
|---|---|
| `resourceRec.cpu` (truthy) instead of `!= null` | red: "renders a MEASURED zero as a figure, never as the absent state" |
| pid fallback added to the lookup | red: "never matches on pid: a same-pid record under another key is not this instance" |

### In the running app

Launched the packaged build under a Playwright `_electron` driver and read the cards:

| Moment | Card | CPU | MEM |
|---|---|---|---|
| before the first push | Claude Code (3 proc) | `no sample` | `no sample` |
| after the first push (t≈12s) | Claude Code | `2.1 %` | `634 MB` |
| after the second push (t≈50s) | Claude Code | `2.9 %` | `631 MB` |

Expanded card, per-PID rows — three instances of the same tool, independent figures. Independence here is per INSTANCE: the lookup uses `instanceId` and `cwd` plays no part in it, so "different projects" is incidental — these three were not checked for their working directories.

```
31448  claude.exe   2.9 % / 631 MB
32776  claude.exe   0 %   / 430 MB     ← a measured zero, rendered as a figure
31728  claude.exe   0.6 % / 605 MB
```

Absent and figure are visually distinct at runtime, read off computed styles: absent = `DM Sans`, `rgb(138,143,152)`, opacity `0.7`; figure = `DM Mono`, `rgb(255,255,255)`, opacity `1`. Console clean: 0 messages, 0 page errors.

## Files outside the stated edit list

- `PidList.svelte` — without it, two instances of one tool cannot show independent figures at all, since the card groups by name. Named here rather than folded in quietly.
- `en.json` — one string plus three tooltips. `CPU`/`MEM` are literals, matching the existing `PID` label; "no sample" is a phrase and goes through i18n like every other one.
- `AgentCard.test.ts` (new) — the `cpu: null` case cannot be produced on demand in a live run (it needs a process to exit or deny access mid-scan), so it is pinned in a test instead of left as a claim.

## Known gaps

- The absent state was observed only in the **pre-first-push** window, where no records exist yet. The steady-state case — one agent without a record while others have one, e.g. a pid-0 synthetic — did not occur on this machine and is covered by test, not by observation.
- The three CPU/MEM chips were seen alongside `Proc` only. A card carrying `Proc + File Act + Net + CPU + MEM + Tokens` at once was never rendered; `stats-row` wraps, so the worst case is an extra line rather than breakage, but the dense layout is unverified.
- The demo build (`demo-data.js`) does not fabricate resource records, so every card in the browser demo shows "no sample". Honest, but worth a decision separately — it was not in scope here.
- `unattributedAgentResource` has no consumer yet. It exists so unattributed samples stay visible rather than being dropped by the index; a view for them is not part of this block.
