### PR TITLE
docs: correct the src/main module count and log why counters drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Landing: aegisprotect.vercel.app | Demo: aegis-demo-ten.vercel.app
 npm run build:renderer    # Vite build (MUST pass before commit)
 npm run lint              # ESLint
 npm run format            # Prettier
-npm test                  # Vitest (1182 passed / 4 skipped = 1186, 71 files)
+npm test                  # Vitest (1398 passed / 4 skipped = 1402, 84 files)
 npm run dist              # Electron-builder NSIS installer
 
 ## Background Tasks (/loop)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ npm run dist              # Electron-builder NSIS installer
 8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths
-- src/main/ — 46 CommonJS modules (37 top-level + platform/ 7 + token-adapters/ 2)
+- src/main/ — 47 CommonJS modules (38 top-level + platform/ 7 + token-adapters/ 2)
 - src/renderer/ — 46 Svelte 5 components + 11 stores + 16 utils + tokens.css/global.css
 - src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (8 TS files), constants.js (ignore patterns, config paths; SENSITIVE_RULES deprecated)
 - rules/ — 73 active detection rules in 8 YAML files, validated by rules/_schema.json

--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -28,6 +28,15 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
 ## Documentation
 16. Leaves outdated agent counts in README badges, CLAUDE.md and architecture docs
 17. Does not sync agent counts between README badges, CLAUDE.md and agent-database.json
+24. Repeats a hand-maintained counter instead of deriving it. No CI check computes these figures
+    from the tree — the `audit-check` skill derives the agent count and nothing else, and only when
+    someone runs it — so a count is true only until the next merge and NOTHING goes red when it
+    stops being true. `src/main/` was documented as 46 CJS modules (37 top-level); adding
+    `sensor-health.js` in `273dedc` (2026-08-09) made it 47/38, and the dead figure sat in EIGHT
+    files — CLAUDE.md, the aegis-context and electron-main SKILL.md under BOTH `.claude/skills/`
+    and `.agents/skills/`, memory-bank/architecture.md, STATE-RECON.md, and CORRECTNESS-AUDIT.md,
+    which had audited the number and recorded "match". Derive before quoting
+    (`git ls-files 'src/main/*.js'`), and assume the figure you were sent to fix has siblings.
 
 ## PowerShell
 18. Uses && in PowerShell commands instead of ; or powershell.exe -NoProfile -Command wrapper


### PR DESCRIPTION
## What

`CLAUDE.md:28` documented `src/main/` as **46 CJS modules (37 top-level)**. The tree has **47 (38 top-level + platform/ 7 + token-adapters/ 2)**.

## Evidence

- `git ls-files ''src/main/*.js''` → 47 tracked, 38 top-level; filesystem agrees; no untracked files in `src/main/`.
- The figure was **correct** at `fe601cb` (2026-08-04, the last edit to that line): `git ls-tree` there gives 46 = 37 + 7 + 2.
- It went stale at `273dedc` (2026-08-09). `git diff --name-status fe601cb..HEAD -- src/main` shows exactly one `A` and no `D`: `src/main/sensor-health.js`.

## Also

Adds `ai-mistakes.md` entry **24** for the class this belongs to: no CI job derives these figures from the tree, so a count is true only until the next merge and nothing goes red when it stops being true.

## Deliberately NOT in this PR

The same stale figure lives in seven other files (`.claude/skills/` and `.agents/skills/` aegis-context + electron-main, `memory-bank/architecture.md`, `STATE-RECON.md`, `CORRECTNESS-AUDIT.md`). They are a separate branch by request.