### PR TITLE
refactor(renderer): drop the unread unattributedAgentResource store

### DIFF
--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -112,8 +112,8 @@ interface TokenCostRecord {
  *
  * Two different nulls, and they must not be conflated:
  * - `instanceId: null` — the sample could not be attributed to a keyed instance. Such
- *   a record keeps its own pid and stays individually distinguishable
- *   ({@link unattributedAgentResource}); it is never folded into a shared bucket.
+ *   a record keeps its own pid and stays individually distinguishable in
+ *   {@link agentResourceUsage}; it is never folded into a shared bucket.
  * - `cpu` / `memMb` / `gpu` null — the process WAS the subject of a sample and the
  *   figure could not be read (exited, denied, unparseable, or no nvidia-smi for gpu).
  *   That is "not measured", which is categorically different from a measured zero and
@@ -205,8 +205,8 @@ export const tokenCosts: Writable<TokenCostRecord[]> = writable([]);
  *
  * An ARRAY rather than a keyed object, and that is the point: keying here would need a
  * single slot for every record whose `instanceId` is null, and all but the last would
- * vanish. Read {@link agentResourceByInstance} to look one up and
- * {@link unattributedAgentResource} for the ones that have no key.
+ * vanish. Read {@link agentResourceByInstance} to look a keyed instance up; the records
+ * that have no key stay here, reachable by filtering on `instanceId === null`.
  */
 export const agentResourceUsage: Writable<AgentResourceRecord[]> = writable([]);
 
@@ -230,17 +230,6 @@ export const agentResourceByInstance: Readable<Map<string, AgentResourceRecord>>
     }
     return byInstance;
   },
-);
-
-/**
- * Samples that arrived without an instance key, each keeping its own pid and staying
- * individually distinguishable. Kept as its own list so that "we sampled a process we
- * could not identify" stays visible instead of being silently dropped by the index
- * above — an unattributed measurement is data, not an error.
- */
-export const unattributedAgentResource: Readable<AgentResourceRecord[]> = derived(
-  agentResourceUsage,
-  ($records) => $records.filter((record) => record.instanceId === null),
 );
 
 /**


### PR DESCRIPTION
## Why

`unattributedAgentResource` landed in #200 with **no reader**. Verified across the whole tree (excluding `node_modules`): no component imports it, no test touches it, and the only references anywhere are two JSDoc `{@link}` tags inside the same file. Its siblings are genuinely consumed — `agentResourceByInstance` by `AgentCard.svelte:106` and `PidList.svelte:44`, `agentResourceUsage` by `AgentCard.test.ts` and the `agent-resource-usage` push handler.

A field with no consumer is a dead index waiting to happen, so it goes now.

## Nothing is lost

`agentResourceUsage` still carries every record, unattributed ones included. The store was a one-line filter:

```ts
$records.filter((record) => record.instanceId === null)
```

That line can come back at the point where something actually needs it, with the consumer visible in the same change.

## JSDoc

Both `{@link unattributedAgentResource}` references are rewritten to name `agentResourceUsage`. A dangling `@link` to a deleted export is the exact class logged as `ai-mistakes` entry 20 — documentation naming a thing that does not exist — so it was not left behind.

## Gates

All six, locally:

| gate | result |
|---|---|
| `build:renderer` | pass |
| `format:check` | pass — see note |
| `lint` | pass (28 pre-existing warnings, 0 errors) |
| `typecheck` | pass |
| `typecheck:svelte` | pass — 384 files, 0 errors |
| `test` | 1398 passed / 4 skipped, 84 files |

Note on `format:check`: the local run exits 1 flagging **144 files**, i.e. nearly the whole tree, including files this branch never touches. That is the known CRLF working-copy artifact. Verified by checking the LF form from the index instead — `git show :<file> | npx prettier --check --stdin-filepath <file>` returns 0 for the changed file **and** for an untouched control file, under the same method.
