### PR TITLE
docs: state the gate set honestly and unstale audit-check step 7

### DIFF
--- a/.agents/skills/audit-check/SKILL.md
+++ b/.agents/skills/audit-check/SKILL.md
@@ -15,7 +15,7 @@ description: AEGIS-specific pre-push / pre-release repo audit. Runs format:check
 4. node -e "const d=require('./src/shared/agent-database.json');console.log('Agents:', d.agents.length)" — agent count
 5. grep -c "agent" README.md — verify README references
 6. git status — clean working tree?
-7. git ls-files | grep -E "^memory-bank/|^\.agent/" — no must-stay-untracked internals tracked? (.Codex/agents/, .Codex/skills/, .mcp.json are intentionally tracked — do NOT flag them)
+7. git ls-files | grep -E "^\.agent/" — no must-stay-untracked internals tracked? (.Codex/agents/, .Codex/skills/, .mcp.json are intentionally tracked — do NOT flag them; memory-bank/ is intentionally tracked too, since e7ba29d)
 8. Report pass/fail for each check
 
 ## Trigger

--- a/.claude/skills/audit-check/SKILL.md
+++ b/.claude/skills/audit-check/SKILL.md
@@ -15,7 +15,7 @@ description: AEGIS-specific pre-push / pre-release repo audit. Runs format:check
 4. node -e "const d=require('./src/shared/agent-database.json');console.log('Agents:', d.agents.length)" — agent count
 5. grep -c "agent" README.md — verify README references
 6. git status — clean working tree?
-7. git ls-files | grep -E "^memory-bank/|^\.agent/" — no must-stay-untracked internals tracked? (.claude/agents/, .claude/skills/, .mcp.json are intentionally tracked — do NOT flag them)
+7. git ls-files | grep -E "^\.agent/" — no must-stay-untracked internals tracked? (.claude/agents/, .claude/skills/, .mcp.json are intentionally tracked — do NOT flag them; memory-bank/ is intentionally tracked too, since e7ba29d)
 8. Report pass/fail for each check
 
 ## Trigger

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,20 @@ Key modules:
 
 ```sh
 npm install
-npm test              # Vitest — all tests must pass
-npm run build:renderer # Vite build — must succeed
-npm run format:check  # Prettier — must be clean
+npm run build:renderer   # Vite build — must succeed
+npm run format:check     # Prettier — must be clean
+npm run lint             # ESLint — no errors
+npm run typecheck        # tsc, both projects
+npm run typecheck:svelte # svelte-check — a bare typecheck does NOT cover it
+npm test                 # Vitest — all tests must pass
 ```
 
-CI runs all three on every push and PR (`.github/workflows/ci.yml`).
+Six gates, not three. `.github/workflows/ci.yml` spreads them over five required jobs:
+`build` (build:renderer), `lint` (format:check + lint), `svelte-check` (typecheck +
+typecheck:svelte), `test` (test:coverage), and `audit`
+(`npm audit --audit-level=high --omit=dev`, dependency-scoped, no local diff equivalent).
+All five are required status checks on `master`, so skipping `typecheck:svelte` locally
+does not skip it — it just moves the failure to CI.
 
 ## Code conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,21 +30,32 @@ Key modules:
 ## Build & test
 
 ```sh
-npm install
+npm ci                   # what CI installs with — NOT npm install, see the lockfile note below
 npm run build:renderer   # Vite build — must succeed
-npm run format:check     # Prettier — must be clean
+npm run format:check     # Prettier — must be clean (the WRITING variant is npm run format)
 npm run lint             # ESLint — no errors
-npm run typecheck        # tsc, both projects
-npm run typecheck:svelte # svelte-check — a bare typecheck does NOT cover it
-npm test                 # Vitest — all tests must pass
+npm run typecheck        # one command, two tsc projects: tsconfig.main.json && tsconfig.renderer.json
+npm run typecheck:svelte # svelte-check — reads .svelte templates, which tsc never does
+npm run test:coverage    # vitest run --coverage — this, not npm test, is what CI runs
+npm audit --audit-level=high --omit=dev   # production dependencies only
 ```
 
-Six gates, not three. `.github/workflows/ci.yml` spreads them over five required jobs:
-`build` (build:renderer), `lint` (format:check + lint), `svelte-check` (typecheck +
-typecheck:svelte), `test` (test:coverage), and `audit`
-(`npm audit --audit-level=high --omit=dev`, dependency-scoped, no local diff equivalent).
-All five are required status checks on `master`, so skipping `typecheck:svelte` locally
-does not skip it — it just moves the failure to CI.
+Three counts, deliberately kept apart:
+
+- **5 required status contexts** — `build`, `lint`, `svelte-check`, `test`, `audit`. This is
+  what GitHub blocks a merge on, proven by
+  `gh api repos/antropos17/Aegis/branches/master/protection --jq '.required_status_checks'`
+  (`strict: true`, so the branch must also be up to date). `/rulesets` and
+  `/rules/branches/master` both return `[]` — nothing else is enforced.
+- **7 verification commands** inside those 5 jobs. The counts differ because `lint` runs
+  `format:check` then `lint`, and `svelte-check` runs `typecheck` then `typecheck:svelte`.
+  `format:check` is a step, not a job, and has no status context of its own.
+- **7 local pre-merge commands** — the block above, one per verification command.
+
+`npm test` (`vitest run`) is a convenience alias, not a gate: CI runs `npm run test:coverage`
+(`vitest run --coverage`). Same suite, plus v8 instrumentation and an lcov artifact. No
+coverage thresholds are configured in `vitest.config.js`, so coverage cannot fail a run that
+`npm test` would pass — but document what CI executes, not what is close to it.
 
 ## Code conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,17 @@ npm run format            # Prettier
 npm test                  # Vitest (1398 passed / 4 skipped = 1402, 84 files)
 npm run dist              # Electron-builder NSIS installer
 
+## Gates — SIX, not five (run all before commit)
+npm run build:renderer    # Vite build
+npm run format:check      # Prettier
+npm run lint              # ESLint
+npm run typecheck         # tsc, both projects
+npm run typecheck:svelte  # svelte-check — NOT covered by typecheck, the one usually skipped
+npm test                  # Vitest
+Each is a required CI job step on master, so skipping one locally only moves the red to CI.
+A seventh required check, `npm audit --audit-level=high --omit=dev`, scans dependencies
+rather than your diff and has no local pre-commit equivalent.
+
 ## Background Tasks (/loop)
 - /loop 30m — PR triage (pr-monitor skill)
 - /loop 2m — CI watcher post-push (ci-monitor skill)
@@ -22,7 +33,7 @@ npm run dist              # Electron-builder NSIS installer
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
 7. Git: powershell.exe -NoProfile -Command "cd 'X:\Future\ESCAPE\AEGIS'; git ..."
-8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
+8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` + `npm run typecheck:svelte` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths
 - src/main/ — 47 CommonJS modules (38 top-level + platform/ 7 + token-adapters/ 2)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,35 @@ npm run format            # Prettier
 npm test                  # Vitest (1398 passed / 4 skipped = 1402, 84 files)
 npm run dist              # Electron-builder NSIS installer
 
-## Gates — SIX, not five (run all before commit)
-npm run build:renderer    # Vite build
-npm run format:check      # Prettier
-npm run lint              # ESLint
-npm run typecheck         # tsc, both projects
-npm run typecheck:svelte  # svelte-check — NOT covered by typecheck, the one usually skipped
-npm test                  # Vitest
-Each is a required CI job step on master, so skipping one locally only moves the red to CI.
-A seventh required check, `npm audit --audit-level=high --omit=dev`, scans dependencies
-rather than your diff and has no local pre-commit equivalent.
+## Verification — three different counts, do not merge them
+**5 required status contexts** are what GitHub enforces on master. Proven with
+`gh api repos/antropos17/Aegis/branches/master/protection --jq '.required_status_checks'`
+→ contexts `[build, lint, svelte-check, test, audit]`, `strict: true` (branch must be up to
+date before merge). No rulesets add more: `/rulesets` and `/rules/branches/master` return `[]`.
+A context is a JOB, not a command — `lint` and `svelte-check` run two commands each.
+
+**7 verification commands** live inside those 5 jobs (`.github/workflows/ci.yml`):
+
+| required context | commands the job runs, after `npm ci` |
+|---|---|
+| build | `npm run build:renderer` |
+| lint | `npm run format:check`, then `npm run lint` |
+| svelte-check | `npm run typecheck`, then `npm run typecheck:svelte` |
+| test | `npm run test:coverage` |
+| audit | `npm audit --audit-level=high --omit=dev` |
+
+`format:check` is a STEP of `lint`, not a job and not a context of its own.
+
+## Local pre-merge set — the same 7 commands
+npm run build:renderer
+npm run format:check      # the checker; `npm run format` WRITES and is not a gate
+npm run lint
+npm run typecheck         # ONE command, TWO tsc projects: main.json && renderer.json
+npm run typecheck:svelte  # svelte-check; tsc never reads .svelte templates
+npm run test:coverage     # what CI runs — `npm test` (vitest run) is NOT the CI command
+npm audit --audit-level=high --omit=dev   # production deps only, not your diff
+Every job also runs `npm ci`, which is not `npm install` — see ai-mistakes 23 before
+regenerating a lockfile.
 
 ## Background Tasks (/loop)
 - /loop 30m — PR triage (pr-monitor skill)


### PR DESCRIPTION
## Gates: six, not five — and not three

`AGENTS.md` listed three commands and asserted **"CI runs all three"**. That is false. `.github/workflows/ci.yml` runs six code gates spread over five required jobs:

| gate | CI job |
|---|---|
| `npm run build:renderer` | `build` |
| `npm run format:check` | `lint` |
| `npm run lint` | `lint` |
| `npm run typecheck` | `svelte-check` |
| `npm run typecheck:svelte` | `svelte-check` |
| `npm run test:coverage` | `test` |

Plus `audit` — `npm audit --audit-level=high --omit=dev` — which scans dependencies rather than the diff, so it has no local pre-commit equivalent.

`typecheck:svelte` is the one that keeps getting skipped locally, and it is exactly the gate a bare `typecheck` does **not** cover: `svelte-check` reads the `.svelte` templates that `tsc` never sees. All five jobs are required status checks on `master`, so skipping it locally does not skip it — it moves the red to CI.

Changes:
- `CLAUDE.md` — new explicit six-gate block; rule 8 now names `typecheck:svelte` next to `typecheck`.
- `AGENTS.md` — the Build & test block lists all six and maps each to its enforcing job; the "all three" claim is gone.

## audit-check step 7 was checking for a condition the repo deliberately left

Step 7 read:

```
git ls-files | grep -E "^memory-bank/|^\.agent/"
```

`memory-bank/` stopped being a must-stay-untracked internal at `e7ba29d` (2026-08-04, *"track the project log in git"*), which removed it from `.gitignore` on purpose. The check was therefore guaranteed to fire on a perfectly healthy repo — a permanently red audit step trains people to ignore audit steps.

The whole alternative is removed, **pipe included**. Dropping only the pattern would leave `grep -E "|^\.agent/"`, and an empty alternative matches every line: verified, that flags all **383** tracked files. After the fix the check returns 0 hits, which is the correct answer for this repo.

Fixed in both copies — `.claude/skills/` and the `.agents/skills/` mirror — each keeping its own parenthetical (`.claude/…` vs `.Codex/…`). Both now record *why* `memory-bank/` is exempt, so it does not get re-added.

## Gates for this PR

Markdown only. No gate consumes `.md`: the prettier globs are `src/**/*.{js,ts,svelte,css,html}` and `*.{js,ts,json}`, `lint` runs eslint over `src/ tests/ scripts/`, both typechecks are TS-only, and grepping `tests/` for `CLAUDE.md`, `AGENTS.md` or `audit-check` returns nothing. Rather than claim green on gates that do not read these files, the honest statement is that CI is the authority here.
