### PR TITLE
test(risk): pin the recycled-pid case, correct ai-mistakes entry 23

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Landing: aegisprotect.vercel.app | Demo: aegis-demo-ten.vercel.app
 npm run build:renderer    # Vite build (MUST pass before commit)
 npm run lint              # ESLint
 npm run format            # Prettier
-npm test                  # Vitest (1398 passed / 4 skipped = 1402, 84 files)
+npm test                  # Vitest (1399 passed / 4 skipped = 1403, 84 files)
 npm run dist              # Electron-builder NSIS installer
 
 ## Verification — three different counts, do not merge them

--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -43,11 +43,12 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
 
 ## CI
 23. Regenerates package-lock.json with the LOCAL npm and breaks every CI job. The local
-    npm is 11.x; CI runs Node 20 with npm 10.8.2. npm 11 dedupes entries npm 10 still
+    npm is 11.x; CI runs Node 22, and this repo pins no npm version — never assume the
+    resolver that reads your lockfile is the one that wrote it. npm 11 dedupes entries npm 10 still
     requires — `svelte-check/node_modules/picomatch` was hoisted away, and every job died
     at `npm ci` with "Missing: picomatch@4.0.5 from lock file" (commit `a6dccc7`, fixing
-    `a91f2e1`). The lockfile is CI's input, not yours: rebuild it from master with
-    `npx npm@10.8.2 install`, and verify with `npx npm@10.8.2 ci` exiting 0 before pushing.
+    `a91f2e1`). The lockfile is CI's input, not yours: rebuild it from master, and verify
+    with `npm ci` exiting 0 on Node 22 before pushing.
     A `npm install` that succeeds locally proves nothing about the resolver that will read
     the file.
 

--- a/tests/renderer/risk.test.ts
+++ b/tests/renderer/risk.test.ts
@@ -47,6 +47,12 @@ const CLAUDE_ID = '100:1754380000000';
 const OPENCODE_ID = '200:1754380044000';
 /** A SECOND Claude Code — same name, same executable, different process. The C1 case. */
 const SECOND_CLAUDE_ID = '200:1754380090000';
+/**
+ * pid 100 AGAIN, after the OS freed it and handed it to a new process — the C6 case.
+ * Same pid and same name as {@link CLAUDE_ID}; only the birth-time segment differs, which
+ * is the whole point of binding the key to `startTime` (main/process-identity.js space 1).
+ */
+const RECYCLED_CLAUDE_ID = '100:1754380500000';
 
 /** A confirmed, non-sensitive file event owned by Claude Code (pid 100). */
 function fileEvent(over: Record<string, unknown> = {}) {
@@ -324,6 +330,83 @@ describe('risk store — two instances of one agent (C1)', () => {
     // (IDENTITY-RECON.md §6 step 6).
     expect(instanceA.instanceKey).toBe('Claude Code');
     expect(instanceB.instanceKey).toBe('Claude Code');
+  });
+});
+
+describe('risk store — a recycled pid (C6)', () => {
+  // C6's RISK-STORE half. The suite at the bottom of this file pins `eventsByInstance`,
+  // the index; this pins the same claim one level up, on the enriched object AgentCard
+  // actually renders — those are two stores and C6 names both (IDENTITY-RECON §5 C6).
+  //
+  // The fixture is deliberately degenerate: same pid, same display name, same null cwd and
+  // null parentEditor. Nothing derivable from the record tells the two processes apart —
+  // the ONLY discriminator is the `startTime` segment of the stamped `instanceId`. So this
+  // test goes red for a key collapsed back to the name AND for one collapsed back to the
+  // pid, which is stricter than C1: there the pids still differed and a pid-keyed store
+  // would have passed.
+  it('C6: same pid, different startTime → two instanceIds, two risk histories', () => {
+    inputs.agents.set([
+      {
+        agent: 'Claude Code',
+        pid: 100,
+        instanceId: CLAUDE_ID,
+        cwd: null,
+        parentEditor: null,
+        category: 'ai',
+      },
+      // The process that inherited pid 100 after the first one exited.
+      {
+        agent: 'Claude Code',
+        pid: 100,
+        instanceId: RECYCLED_CLAUDE_ID,
+        cwd: null,
+        parentEditor: null,
+        category: 'ai',
+      },
+    ]);
+    // DISTINCT file paths, and that is load-bearing: under a collapsed key both events land
+    // in one bucket, where the 30s same-path dedup (risk.ts `seen`) would silently eat the
+    // second one and the test could go green for the wrong reason. Both carry `timestamp:
+    // NOW` — the differing birth time belongs inside the instanceId string and nowhere
+    // else, or `getTimeDecayWeight` would decay the older event toward 0 and do this
+    // test's work for it.
+    inputs.events.set([
+      [
+        fileEvent({
+          pid: 100,
+          instanceId: CLAUDE_ID,
+          file: '/home/user/project-a/.ssh/id_rsa',
+          sensitive: true,
+          reason: 'SSH keys/config',
+        }),
+        fileEvent({
+          pid: 100,
+          instanceId: RECYCLED_CLAUDE_ID,
+          file: '/home/user/project-b/src/main.js',
+        }),
+      ],
+    ]);
+
+    const enriched = get(enrichedAgents);
+    // Setup invariants. If one fails, the assertions below prove nothing.
+    expect(enriched).toHaveLength(2);
+    const [dead, recycled] = enriched;
+    expect(dead.pid).toBe(100);
+    expect(recycled.pid).toBe(100);
+    expect(dead.instanceId).toBe(CLAUDE_ID);
+    expect(recycled.instanceId).toBe(RECYCLED_CLAUDE_ID);
+    expect(dead.sensitiveFiles).toBeGreaterThan(0);
+    expect(dead.riskScore).toBeGreaterThan(0);
+
+    // Soft, so one run reports every collapsed site rather than aborting on the first.
+    expect.soft(recycled.instanceId).not.toBe(dead.instanceId);
+    // The recycled process never touched a key, so it inherits none of that score.
+    expect.soft(recycled.sensitiveFiles).toBe(0);
+    expect.soft(recycled.riskScore).toBe(0);
+    expect.soft(recycled.trustGrade).toBe('A+');
+    // …and separation is not emptiness: it still has its OWN event. Without this the two
+    // assertions above would also pass for a store that simply dropped the recycled pid.
+    expect.soft(recycled.fileCount).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## What this is

Three separate concerns, one commit each.

### `354c4c8` — test(risk): the recycled-pid case on the enriched agent store

C6's risk-store half had no coverage. The existing recycled-pid test pins
`eventsByInstance` — the index — while `enrichedAgents`, the object `AgentCard`
actually renders, was asserted only by C1, where the two pids still differed. A
pid-keyed store would have passed C1.

The new fixture is degenerate on purpose: same pid, same display name, `cwd` and
`parentEditor` both null, so the `startTime` segment of the stamped `instanceId`
is the only discriminator left.

Verified by breaking the key twice and reverting each time (`risk.ts` is
byte-identical to master in this branch — it needed no change):

| deliberate break | result |
|---|---|
| key collapsed to `ev.agent` | 3 failed — C6, C1, and the null-instanceId test |
| key collapsed to `String(ev.pid)` | **1 failed — C6 only**; C1 passes, its pids differ |

The second run is the point: this test is strictly stronger than C1.

### `1a5a821` — docs(ai-mistakes): entry 23 to Node 22, npm pin dropped

The entry claimed CI runs Node 20 with npm 10.8.2 and prescribed
`npx npm@10.8.2 install`. Both were wrong:

- `ci.yml` pins `node-version: '22'` in all five jobs, `release-build.yml` too;
  `engines.node` is `22.x`; `.nvmrc` reads `22`.
- No npm version is pinned anywhere in this repository — no `.npmrc`, no
  `packageManager`, no `engines.npm`, and no workflow installs one.
  `memory-bank/progress.md:361` records it directly: *"no npm pin exists in any
  workflow so the 10.8.2-via-Node-20 pin was auto-untouched"* — the figure had
  been inferred from the Node 20 distribution, never read off the repo.

The npm 11 vs 10 dedupe account and the picomatch incident stay verbatim; that
is the lesson. Only the stale Node claim and the fabricated pin are gone.

### `d5ad03a` — docs: vitest counter refresh

The new test made `CLAUDE.md:9` stale on landing — ai-mistakes #24. Measured on
this branch: 84 files, 1399 passed, 4 skipped, 1403 total. A grep for the old
figures (`1398`/`1402`) returns that one line only, so it has no siblings.

## Known follow-up, NOT closed here

`tsconfig.renderer.json` includes `tests/renderer/components/**/*` but not
`tests/renderer/*.test.ts`, so `npm run typecheck` does not inspect the
top-level renderer test files — including the one this PR adds.

Expanding the include to `tests/renderer/**/*` was measured and **reverted**.
Against a 0-error baseline it exposed **26 errors in 6 files**, all pre-existing
debt in previously-unchecked test files:

| file | errors |
|---|---|
| `tests/renderer/agent-selection.test.ts` | 11 |
| `tests/renderer/agent-action-keys.test.ts` | 10 |
| `tests/renderer/summary-metrics.test.ts` | 2 |
| `tests/renderer/timeline-utils.test.ts` | 1 |
| `tests/renderer/fleet-risk.test.ts` | 1 |
| `tests/renderer/agent-panel-utils.test.ts` | 1 |

Two classes: **TS5097 x6** — imports ending in a `.ts` extension without
`allowImportingTsExtensions`; **TS2353 / TS2559 / TS2339 x20** — fixtures passing
wider object literals than the narrow parameter types accept.

`tests/renderer/risk.test.ts` produced zero errors under the expanded include,
on the gate's own `compilerOptions`. The gap is real and stays open: this PR
does not close it, and the 26 errors are the scope of a separate block.

## Verification

`build:renderer`, `lint`, `typecheck`, `typecheck:svelte`, `test:coverage`
(84 files, 1399 passed / 4 skipped), `npm audit --audit-level=high --omit=dev`
— all green locally. `format:check` fails on 144 files on a Windows checkout,
identical to the pre-change baseline and unrelated to this diff: `.prettierignore`
excludes `*.md` and the command's glob covers `src/**` plus root files only, so
neither `tests/**` nor `memory-bank/**` can contribute to it.