### PR TITLE
fix(process-utils): prove the process generation from a fresh OS birth time

### DIFF
--- a/src/main/platform/darwin.js
+++ b/src/main/platform/darwin.js
@@ -145,6 +145,14 @@ async function getProcessCwds(pids) {
 }
 
 module.exports = {
+  /**
+   * `getParentProcessMap` entries carry no `startTime` here — `ps` could supply one
+   * at second resolution, but it is not wired. process-utils reads this flag as "no
+   * generation is observable", which keeps its parent-chain and cwd caches on their
+   * plain TTL contract instead of paying a `ps` spawn every scan tick.
+   * @type {boolean}
+   */
+  providesStartTime: false,
   listProcesses,
   getParentProcessMap,
   getRawTcpConnections,

--- a/src/main/platform/linux.js
+++ b/src/main/platform/linux.js
@@ -243,6 +243,14 @@ async function getProcessCwds(pids) {
 }
 
 module.exports = {
+  /**
+   * `getParentProcessMap` entries carry no `startTime` here — `/proc/<pid>/stat`
+   * field 22 would supply one, but it is not wired. process-utils reads this flag
+   * as "no generation is observable", which keeps its parent-chain and cwd caches
+   * on their plain TTL contract instead of paying a /proc walk every scan tick.
+   * @type {boolean}
+   */
+  providesStartTime: false,
   listProcesses,
   getParentProcessMap,
   getRawTcpConnections,

--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -435,6 +435,15 @@ function getProcessCwds(pids) {
 }
 
 module.exports = {
+  /**
+   * `getParentProcessMap` entries carry `startTime`, the OS process birth time.
+   * process-utils reads it as the GENERATION of a pid: the proof that a cached
+   * parent chain or working directory still belongs to the process living under
+   * that pid. Only win32 supplies it — see the matching `false` in linux.js and
+   * darwin.js, which is why neither pays a per-scan map observation.
+   * @type {boolean}
+   */
+  providesStartTime: true,
   listProcesses,
   getParentProcessMap,
   getRawTcpConnections,

--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -17,15 +17,28 @@ const { EDITORS } = require('../shared/constants');
 
 let _getParentProcessMap = _platform.getParentProcessMap;
 let _getProcessCwds = _platform.getProcessCwds;
-/** @internal Override platform functions (for tests). */
+/**
+ * Whether this platform's `getParentProcessMap` carries an OS birth time. Only
+ * win32 does today (`Win32_Process.CreationDate`); linux and darwin omit it, and
+ * neither may pay a per-scan subprocess or /proc walk to serve a Windows-only
+ * generation check. The flag is what gates the generation proof below.
+ * @type {boolean}
+ */
+let _providesStartTime = _platform.providesStartTime === true;
+/** @internal Override platform functions AND the birth-time capability (for tests). */
 function _setPlatformForTest(overrides) {
   if (overrides.getParentProcessMap) _getParentProcessMap = overrides.getParentProcessMap;
   if (overrides.getProcessCwds) _getProcessCwds = overrides.getProcessCwds;
+  // Explicit boolean, not truthiness: `false` is a value a test must be able to
+  // pin, so both paths are exercised without depending on the CI host's OS.
+  if (typeof overrides.providesStartTime === 'boolean')
+    _providesStartTime = overrides.providesStartTime;
 }
-/** @internal Clear caches (for tests). */
+/** @internal Clear caches and restore the real platform capability (for tests). */
 function _resetForTest() {
   parentChainCache.clear();
   cwdCache.clear();
+  _providesStartTime = _platform.providesStartTime === true;
 }
 
 const parentChainCache = new Map();
@@ -40,10 +53,11 @@ const PARENT_CHAIN_TTL = 60000;
  * the one field `instanceId` is built from. Folding the name in turns a recycled
  * pid that belongs to a different executable into a cache MISS.
  *
- * KNOWN BOUND: a pid recycled by an executable with the SAME name still hits
- * inside the TTL. `forceRefresh` (passed by scan-loop whenever the scanned pid
- * SET changed) covers the common case; the residue is a same-name reuse on a tick
- * where the set is unchanged.
+ * The name is NOT the whole answer: a pid recycled by an executable with the SAME
+ * name produces the same key. What separates those two instances is the GENERATION
+ * — the freshly observed OS birth time, re-read on every enrichment pass. The key
+ * addresses the entry; the generation decides whether the entry is still about the
+ * process running under that pid right now (see {@link enrichWithParentChains}).
  * @param {number} pid
  * @param {string} [name] - OS process name (or display name) observed for that pid.
  * @returns {string}
@@ -66,15 +80,73 @@ function _agentName(agent) {
 }
 
 /**
- * Resolve parent process chains for a list of PIDs via platform adapter.
+ * Drop entries older than their TTL once a cache grows past 500 keys. Shared by
+ * both caches so neither can grow without bound on a long-running scan.
+ * @param {Map<string, {timestamp: number}>} cache
+ * @param {number} ttl
+ * @param {number} now
+ * @returns {void}
+ */
+function _pruneStale(cache, ttl, now) {
+  if (cache.size <= 500) return;
+  for (const [key, entry] of cache) {
+    if (now - entry.timestamp > ttl) cache.delete(key);
+  }
+}
+
+/**
+ * Walk one pid's parent chain inside an already-fetched process map. Depth 6,
+ * cycle-guarded, and it costs nothing: the map is the caller's, so a chain rebuild
+ * never adds a provider call.
+ * @param {Map<number, {name: string, ppid: number}>} procMap
+ * @param {number} pid
+ * @returns {string[]} parent names, nearest first.
+ */
+function _walkChain(procMap, pid) {
+  const chain = [];
+  let cur = pid;
+  const seen = new Set();
+  for (let i = 0; i < 6; i++) {
+    const info = procMap.get(cur);
+    if (!info) break;
+    const pp = info.ppid;
+    if (pp <= 0 || pp === cur || seen.has(pp)) break;
+    seen.add(pp);
+    const parentInfo = procMap.get(pp);
+    if (!parentInfo) break;
+    chain.push(parentInfo.name);
+    cur = pp;
+  }
+  return chain;
+}
+
+/**
+ * The OS birth time (epoch-ms) a process map carries for one pid, or null when the
+ * platform omits it (darwin/linux map entries) or the OS withheld it for this pid.
+ * Null is honest — never a substitute for a number, and never read from a cache.
+ * @param {Map<number, {startTime?: number|null}>} procMap
+ * @param {number} pid
+ * @returns {number|null}
+ */
+function _birthTimeOf(procMap, pid) {
+  const info = procMap.get(pid);
+  return info && typeof info.startTime === 'number' ? info.startTime : null;
+}
+
+/**
+ * Resolve parent process chains for a list of PIDs via platform adapter, TTL-cached.
+ *
+ * This is the chain-only helper: it answers from the cache when it can and fetches
+ * a process map only for the pids it cannot answer. It carries no generation proof
+ * and is not the identity path — {@link enrichWithParentChains} is, and on a
+ * birth-time platform that path observes its own single map instead of calling here.
  * @param {number[]} pids
  * @param {Object} [opts]
  * @param {Map<number, string>} [opts.names] - pid → process name, used to key the
  *   cache (see {@link _cacheKey}). Omitted names key as the empty string, which is
  *   consistent for a caller that never supplies them.
  * @param {boolean} [opts.forceRefresh=false] - when true, ignore cached entries for
- *   the requested pids and re-read the OS process map. Costs one platform call —
- *   the SAME `cim-parent` fetch the scan tick already pays for on win32.
+ *   the requested pids and re-read the OS process map. Costs one platform call.
  * @returns {Promise<Map<number, string[]>>} pid to parent-name chain
  * @since v0.1.0
  */
@@ -86,12 +158,7 @@ async function getParentChains(pids, opts = {}) {
   const keyOf = (pid) => _cacheKey(pid, names ? names.get(pid) : undefined);
 
   const now = Date.now();
-  // Prune stale entries when cache grows too large
-  if (parentChainCache.size > 500) {
-    for (const [key, entry] of parentChainCache) {
-      if (now - entry.timestamp > PARENT_CHAIN_TTL) parentChainCache.delete(key);
-    }
-  }
+  _pruneStale(parentChainCache, PARENT_CHAIN_TTL, now);
   const needLookup = pids.filter((pid) => {
     if (forceRefresh) return true;
     const cached = parentChainCache.get(keyOf(pid));
@@ -123,32 +190,15 @@ async function getParentChains(pids, opts = {}) {
 
   // Walk parent chains in JS for uncached PIDs
   for (const pid of needLookup) {
-    const chain = [];
-    let cur = pid;
-    const seen = new Set();
-    for (let i = 0; i < 6; i++) {
-      const info = procMap.get(cur);
-      if (!info) break;
-      const pp = info.ppid;
-      if (pp <= 0 || pp === cur || seen.has(pp)) break;
-      seen.add(pp);
-      const parentInfo = procMap.get(pp);
-      if (parentInfo) {
-        chain.push(parentInfo.name);
-      } else {
-        break;
-      }
-      cur = pp;
-    }
-    // Capture the OS process birth time (epoch-ms) for the agent's OWN pid from
-    // the same map fetch — zero extra spawn. Only win32 supplies it; darwin/linux
-    // map entries omit startTime, so the typeof guard yields null (honest).
-    // The cache entry is keyed by pid AND process name, so a pid recycled by a
-    // different executable no longer serves this startTime (see _cacheKey for the
-    // residual same-name bound).
-    const ownInfo = procMap.get(pid);
-    const startTime = ownInfo && typeof ownInfo.startTime === 'number' ? ownInfo.startTime : null;
-    parentChainCache.set(keyOf(pid), { chain, startTime, timestamp: now });
+    // The OS birth time (epoch-ms) for the agent's OWN pid comes from the same map
+    // fetch — zero extra spawn. Only win32 supplies it; darwin/linux map entries
+    // omit startTime, so this is null there (honest).
+    const chain = _walkChain(procMap, pid);
+    parentChainCache.set(keyOf(pid), {
+      chain,
+      startTime: _birthTimeOf(procMap, pid),
+      timestamp: now,
+    });
     result.set(pid, chain);
   }
 
@@ -156,13 +206,98 @@ async function getParentChains(pids, opts = {}) {
 }
 
 /**
+ * Stamp `parentChain` and `startTime` from ONE fresh process-map observation, on a
+ * platform that supplies OS birth times. This is the generation proof.
+ *
+ * Exactly one provider call per pass, and that single map serves everything: the
+ * birth time that proves the generation, and every chain rebuild a miss or a
+ * generation change needs. There is never a second fetch in one pass.
+ *
+ * A cached entry survives only while the FRESH birth time equals the one the entry
+ * was written with. Same pid, same executable name, different birth time is a
+ * different process instance, so its chain is rebuilt from this map and its cwd
+ * loses its proof (see {@link annotateWorkingDirs}). `startTime` is always the
+ * freshly observed value — a cached birth time never proves the current instance,
+ * and when the fresh observation withholds it the agent gets null rather than the
+ * stale number, degrading through the `<pid>:u` identity process-identity.js
+ * already defines.
+ *
+ * pid ≤ 0 is not an OS process (the pid-0 synthetics), so there is no generation to
+ * prove for it and the plain TTL contract applies.
+ * @param {Array} agents
+ * @param {boolean} forceRefresh - rebuild every chain from this map regardless of
+ *   what the cache holds.
+ * @returns {Promise<void>}
+ * @since v0.12.0
+ */
+async function _stampFromFreshBirthTimes(agents, forceRefresh) {
+  const procMap = await _getParentProcessMap();
+  const now = Date.now();
+  _pruneStale(parentChainCache, PARENT_CHAIN_TTL, now);
+
+  for (const a of agents) {
+    const key = _cacheKey(a.pid, _agentName(a));
+    const birthTime = _birthTimeOf(procMap, a.pid);
+    const cached = forceRefresh ? undefined : parentChainCache.get(key);
+    const live = cached !== undefined && now - cached.timestamp <= PARENT_CHAIN_TTL;
+    const proven = live && (a.pid <= 0 || (birthTime !== null && cached.startTime === birthTime));
+
+    if (proven) {
+      a.parentChain = cached.chain;
+    } else {
+      const chain = _walkChain(procMap, a.pid);
+      parentChainCache.set(key, { chain, startTime: birthTime, timestamp: now });
+      a.parentChain = chain;
+    }
+    a.startTime = birthTime;
+  }
+}
+
+/**
+ * Stamp `parentChain` and `startTime` on a platform that supplies NO birth time
+ * (linux, darwin). Unchanged behaviour: the TTL-bounded parent-chain cache answers,
+ * and a pass whose pids are all cached costs no provider call at all. Adding a
+ * per-pass process map here would buy nothing — there is no birth time in it to
+ * prove a generation with — and would cost a `ps` spawn or a full /proc walk every
+ * scan tick.
+ * @param {Array} agents
+ * @param {boolean} forceRefresh
+ * @returns {Promise<void>}
+ * @since v0.12.0
+ */
+async function _stampFromCachedChains(agents, forceRefresh) {
+  // pid → name for the cache key. Synthetic agents all share pid 0, so the last
+  // one wins here; harmless because pid 0 is absent from the OS process map (its
+  // startTime is null either way) and identify() reads each agent's OWN name.
+  const names = new Map();
+  for (const a of agents) names.set(a.pid, _agentName(a));
+  const chains = await getParentChains(
+    agents.map((a) => a.pid),
+    { names, forceRefresh },
+  );
+  for (const a of agents) {
+    a.parentChain = chains.get(a.pid) || [];
+    const entry = parentChainCache.get(_cacheKey(a.pid, names.get(a.pid)));
+    a.startTime = entry && typeof entry.startTime === 'number' ? entry.startTime : null;
+  }
+}
+
+/**
  * Attach parent-chain arrays, the OS process start-time AND the process instance
  * key to each agent object.
  *
  * `startTime` (epoch-ms, OS birth time) is distinct from `firstSeen`
- * (AEGIS-observed) and is read from the same cache `getParentChains` populates —
- * after the call every requested pid has an entry under the same key, so the read
- * is safe. Used by the token-feed PID-reuse guard; null on non-Windows or absent pid.
+ * (AEGIS-observed). Used by the token-feed PID-reuse guard; null on a platform that
+ * supplies no birth time, and null for an absent pid.
+ *
+ * WHERE IT COMES FROM decides whether `instanceId` means anything. On a platform
+ * that supplies birth times, every pass makes ONE fresh process-map observation and
+ * the birth time it reads is both the stamped value and the proof that the cached
+ * `parentChain` (and, downstream, the cached cwd) still describes the process living
+ * under that pid — see {@link _stampFromFreshBirthTimes}. Serving a CACHED birth
+ * time was the poisoning bug: a pid Windows had reissued to another process of the
+ * same executable name kept the dead process's birth time, so both instances shared
+ * one `instanceId`, and with it one session, one dedup set and one token ledger.
  *
  * `instanceId` / `instanceIdSource` are derived from that startTime by
  * process-identity.js. This is the ONLY place they are stamped, so it must run
@@ -170,32 +305,36 @@ async function getParentChains(pids, opts = {}) {
  * particular (see scan-loop.js).
  * @param {Array} agents
  * @param {Object} [opts]
- * @param {boolean} [opts.forceRefresh=false] - re-read the OS process map instead of
- *   trusting cached entries. Pass true when the scanned pid set changed: a pid new
- *   to the set must never be identified from a dead process's cached birth time.
+ * @param {boolean} [opts.forceRefresh=false] - rebuild every parent chain from the
+ *   observed map instead of trusting cached entries. The identity stamp no longer
+ *   depends on it: the birth time is re-observed on every pass either way.
  * @returns {Promise<void>}
  * @since v0.1.0
  */
 async function enrichWithParentChains(agents, opts = {}) {
   if (agents.length === 0) return;
-  const pids = agents.map((a) => a.pid);
-  // pid → name for the cache key. Synthetic agents all share pid 0, so the last
-  // one wins here; harmless because pid 0 is absent from the OS process map (its
-  // startTime is null either way) and identify() below reads each agent's OWN name.
-  const names = new Map();
-  for (const a of agents) names.set(a.pid, _agentName(a));
-  const chains = await getParentChains(pids, {
-    names,
-    forceRefresh: opts.forceRefresh === true,
-  });
+  const forceRefresh = opts.forceRefresh === true;
+  if (_providesStartTime) await _stampFromFreshBirthTimes(agents, forceRefresh);
+  else await _stampFromCachedChains(agents, forceRefresh);
   for (const a of agents) {
-    a.parentChain = chains.get(a.pid) || [];
-    const entry = parentChainCache.get(_cacheKey(a.pid, names.get(a.pid)));
-    a.startTime = entry && typeof entry.startTime === 'number' ? entry.startTime : null;
     const identity = identify(a);
     a.instanceId = identity.instanceId;
     a.instanceIdSource = identity.instanceIdSource;
   }
+}
+
+/**
+ * The generation {@link enrichWithParentChains} established for a cache key on this
+ * pass, for consumers that must not observe a birth time themselves.
+ * @param {string} key
+ * @returns {number|null|undefined} epoch-ms when a fresh birth time proved the
+ *   instance; `null` when the fresh observation withheld one (nothing is proven);
+ *   `undefined` when no generation was established for this key at all.
+ */
+function _establishedGeneration(key) {
+  const entry = parentChainCache.get(key);
+  if (entry === undefined) return undefined;
+  return typeof entry.startTime === 'number' ? entry.startTime : null;
 }
 
 /** Map editor host exe names (lowercase) to human-readable labels, derived from EDITORS */
@@ -239,8 +378,20 @@ const CWD_CACHE_TTL = 60000;
  * CWD_CONTAINMENT attribution matches on. Folding the name in turns a recycled
  * pid belonging to a different executable into a cache MISS.
  *
- * KNOWN BOUND: identical to `_cacheKey`'s — a pid recycled by an executable with
- * the SAME name still hits inside the TTL. `opts.forceRefresh` covers that case.
+ * A same-name recycled pid produces the same key, so on a platform that supplies
+ * birth times the entry additionally carries the GENERATION it was fetched under,
+ * and it is served only while that generation is still the one
+ * {@link enrichWithParentChains} proved on this pass. This function performs NO
+ * birth-time lookup of its own — it consumes what the identity stamp already
+ * established, which is why scan-loop must keep running the stamp first.
+ *
+ * Three cases, and the middle one is the honest degradation:
+ *   - a number → the cwd must have been fetched under that same generation;
+ *   - `null` (the fresh observation withheld the birth time) → nothing is proven,
+ *     so the cwd is re-fetched rather than inherited from the old generation;
+ *   - `undefined` (no generation was established for this key — every pid on
+ *     linux/darwin, and any caller that skipped the stamp) → no generation exists
+ *     to check against, and the plain TTL contract applies exactly as before.
  * @param {Array} agents
  * @param {Object} [opts]
  * @param {boolean} [opts.forceRefresh=false] - when true, ignore cached entries and
@@ -256,24 +407,32 @@ async function annotateWorkingDirs(agents, opts = {}) {
 
   const forceRefresh = opts.forceRefresh === true;
   const now = Date.now();
-  // Prune stale entries
-  if (cwdCache.size > 500) {
-    for (const [key, entry] of cwdCache) {
-      if (now - entry.timestamp > CWD_CACHE_TTL) cwdCache.delete(key);
-    }
-  }
+  _pruneStale(cwdCache, CWD_CACHE_TTL, now);
 
   // One cache key per agent, resolved once, via the same `_agentName` the
-  // parent-chain cache keys on.
-  const entries = agents.map((a) => ({ agent: a, key: _cacheKey(a.pid, _agentName(a)) }));
+  // parent-chain cache keys on, plus the generation that key is bound to. pid ≤ 0
+  // is not an OS process, so it has no generation — undefined leaves the synthetics
+  // on the plain TTL contract.
+  const entries = agents.map((a) => {
+    const key = _cacheKey(a.pid, _agentName(a));
+    return {
+      agent: a,
+      key,
+      generation: _providesStartTime && a.pid > 0 ? _establishedGeneration(key) : undefined,
+    };
+  });
 
-  // Pids with no live cache entry. Agents can share a pid (the pid-0 synthetics
-  // all do) while holding distinct keys, so the Set both collects and deduplicates
-  // — one platform lookup per pid, in first-seen order.
+  // Pids with no live, generation-proven cache entry. Agents can share a pid (the
+  // pid-0 synthetics all do) while holding distinct keys, so the Set both collects
+  // and deduplicates — one platform lookup per pid, in first-seen order.
   const uncachedPids = new Set();
   for (const e of entries) {
     const cached = forceRefresh ? null : cwdCache.get(e.key);
-    if (cached && now - cached.timestamp <= CWD_CACHE_TTL) continue;
+    const fresh = cached && now - cached.timestamp <= CWD_CACHE_TTL;
+    const proven =
+      e.generation === undefined ||
+      (e.generation !== null && cached && cached.generation === e.generation);
+    if (fresh && proven) continue;
     uncachedPids.add(e.agent.pid);
   }
 
@@ -285,7 +444,14 @@ async function annotateWorkingDirs(agents, opts = {}) {
   // pass, reading the value just written.
   for (const e of entries) {
     if (batchResults && uncachedPids.has(e.agent.pid)) {
-      cwdCache.set(e.key, { cwd: batchResults.get(e.agent.pid) || null, timestamp: now });
+      cwdCache.set(e.key, {
+        cwd: batchResults.get(e.agent.pid) || null,
+        // The generation this directory was read under. `undefined` (no generation
+        // established) stores as null, which no established generation ever matches
+        // — a value fetched without a proof never becomes one.
+        generation: e.generation === undefined ? null : e.generation,
+        timestamp: now,
+      });
     }
     const cached = cwdCache.get(e.key);
     const cwd = cached ? cached.cwd : null;

--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -324,17 +324,26 @@ async function enrichWithParentChains(agents, opts = {}) {
 }
 
 /**
- * The generation {@link enrichWithParentChains} established for a cache key on this
- * pass, for consumers that must not observe a birth time themselves.
- * @param {string} key
- * @returns {number|null|undefined} epoch-ms when a fresh birth time proved the
- *   instance; `null` when the fresh observation withheld one (nothing is proven);
- *   `undefined` when no generation was established for this key at all.
+ * The generation ONE agent record carries out of its own enrichment pass.
+ *
+ * Read off the record, never out of `parentChainCache`. The cache is keyed by
+ * `pid|name` and is shared by every record that ever used that key, so a lookup
+ * there would answer with a generation some OTHER record established — possibly on
+ * an earlier tick — and a record that never went through enrichment at all would
+ * silently borrow it. `startTime` is written by {@link enrichWithParentChains} on
+ * every observation, so the record itself is the only honest source.
+ * @param {{startTime?: number|null}} agent
+ * @returns {number|null|undefined} epoch-ms when this record's own fresh observation
+ *   produced a usable birth time; `null` when enrichment ran for it and the platform
+ *   withheld one (nothing is proven); `undefined` when this record never passed
+ *   through enrichment, so no generation was established for it either way.
  */
-function _establishedGeneration(key) {
-  const entry = parentChainCache.get(key);
-  if (entry === undefined) return undefined;
-  return typeof entry.startTime === 'number' ? entry.startTime : null;
+function _recordGeneration(agent) {
+  const v = agent.startTime;
+  if (v === undefined) return undefined;
+  // Same usability test process-identity.js applies before building an `os` key, so
+  // a value that cannot identify an instance cannot prove one either.
+  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : null;
 }
 
 /** Map editor host exe names (lowercase) to human-readable labels, derived from EDITORS */
@@ -380,18 +389,20 @@ const CWD_CACHE_TTL = 60000;
  *
  * A same-name recycled pid produces the same key, so on a platform that supplies
  * birth times the entry additionally carries the GENERATION it was fetched under,
- * and it is served only while that generation is still the one
- * {@link enrichWithParentChains} proved on this pass. This function performs NO
- * birth-time lookup of its own — it consumes what the identity stamp already
- * established, which is why scan-loop must keep running the stamp first.
+ * and it is served only while that generation is still the one THIS agent record
+ * carries from its own enrichment pass ({@link _recordGeneration}). This function
+ * performs NO birth-time lookup of its own — it consumes the observation the record
+ * already holds, which is why scan-loop must keep running the identity stamp first.
  *
  * Three cases, and the middle one is the honest degradation:
  *   - a number → the cwd must have been fetched under that same generation;
- *   - `null` (the fresh observation withheld the birth time) → nothing is proven,
- *     so the cwd is re-fetched rather than inherited from the old generation;
- *   - `undefined` (no generation was established for this key — every pid on
- *     linux/darwin, and any caller that skipped the stamp) → no generation exists
- *     to check against, and the plain TTL contract applies exactly as before.
+ *   - `null` (enrichment ran for this record and the fresh observation withheld the
+ *     birth time) → nothing is proven, so the cwd is re-fetched rather than
+ *     inherited from the old generation;
+ *   - `undefined` (this record never passed through enrichment — every pid on
+ *     linux/darwin, pid ≤ 0, and any direct caller that skipped the stamp) → the
+ *     record established no generation, so none is invented for it and the plain
+ *     TTL contract applies exactly as it did before generations existed.
  * @param {Array} agents
  * @param {Object} [opts]
  * @param {boolean} [opts.forceRefresh=false] - when true, ignore cached entries and
@@ -410,17 +421,14 @@ async function annotateWorkingDirs(agents, opts = {}) {
   _pruneStale(cwdCache, CWD_CACHE_TTL, now);
 
   // One cache key per agent, resolved once, via the same `_agentName` the
-  // parent-chain cache keys on, plus the generation that key is bound to. pid ≤ 0
-  // is not an OS process, so it has no generation — undefined leaves the synthetics
-  // on the plain TTL contract.
-  const entries = agents.map((a) => {
-    const key = _cacheKey(a.pid, _agentName(a));
-    return {
-      agent: a,
-      key,
-      generation: _providesStartTime && a.pid > 0 ? _establishedGeneration(key) : undefined,
-    };
-  });
+  // parent-chain cache keys on, plus the generation THAT RECORD carries. pid ≤ 0 is
+  // not an OS process, so it has no generation — undefined leaves the synthetics on
+  // the plain TTL contract.
+  const entries = agents.map((a) => ({
+    agent: a,
+    key: _cacheKey(a.pid, _agentName(a)),
+    generation: _providesStartTime && a.pid > 0 ? _recordGeneration(a) : undefined,
+  }));
 
   // Pids with no live, generation-proven cache entry. Agents can share a pid (the
   // pid-0 synthetics all do) while holding distinct keys, so the Set both collects

--- a/tests/main/process-utils.test.js
+++ b/tests/main/process-utils.test.js
@@ -15,6 +15,10 @@ describe('process-utils', () => {
       getParentProcessMap: mockGetParentProcessMap,
       getProcessCwd: mockGetProcessCwd,
       getProcessCwds: mockGetProcessCwds,
+      // Pinned, never inherited from the CI host: the generation proof only exists
+      // on a platform that supplies an OS birth time. Both settings are exercised
+      // deterministically — see the `providesStartTime: false` describe at the end.
+      providesStartTime: true,
     });
   });
 
@@ -169,42 +173,257 @@ describe('process-utils', () => {
       expect(reused[0].instanceId).not.toBe(dead[0].instanceId);
     });
 
-    it('forceRefresh re-reads the map even for a cached pid + name', async () => {
-      mockGetParentProcessMap.mockResolvedValue(
+    it('forceRefresh rebuilds the chain from the observed map even for a proven generation', async () => {
+      mockGetParentProcessMap.mockResolvedValueOnce(
         new Map([
           [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
-          [200, { name: 'code', ppid: 0 }],
+          [200, { name: 'code.exe', ppid: 0 }],
         ]),
       );
       const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
       await processUtils.enrichWithParentChains(agents);
-      await processUtils.enrichWithParentChains(agents);
-      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1); // cached
+      expect(agents[0].parentChain).toEqual(['code.exe']);
 
+      // Same birth time, so the generation is proven and the cached chain would
+      // normally win. forceRefresh rebuilds it from the map this pass observed —
+      // and that is still ONE call, because it is the only map fetched.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 300, startTime: 1717000000000 }],
+          [300, { name: 'cursor.exe', ppid: 0 }],
+        ]),
+      );
       await processUtils.enrichWithParentChains(agents, { forceRefresh: true });
       expect(mockGetParentProcessMap).toHaveBeenCalledTimes(2);
+      expect(agents[0].parentChain).toEqual(['cursor.exe']);
     });
 
-    it('a same-name reuse inside the TTL is the documented residual bound', async () => {
-      // Honest test of the KNOWN BOUND in _cacheKey: pid + SAME exe name still
-      // hits the cache, so the stale startTime survives until forceRefresh or TTL.
-      mockGetParentProcessMap.mockResolvedValueOnce(
+    it('a same-name reuse sharing one birth-time millisecond is the residual bound', async () => {
+      // What the KNOWN BOUND in _cacheKey used to be — pid + SAME exe name serving
+      // the dead process's startTime until forceRefresh or TTL — is gone: the fresh
+      // birth time separates those instances with forceRefresh false (see the
+      // generation-proof describe above). What is left is genuine indistinguish-
+      // ability: two instances sharing a pid AND the same epoch-ms birth time. That
+      // is the millisecond bound documented in process-identity.js, not a cache
+      // defect, and it degrades to "two instances read as one", never to a wrong
+      // instance.
+      mockGetParentProcessMap.mockResolvedValue(
         new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000000000 }]]),
       );
       const first = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
       await processUtils.enrichWithParentChains(first);
 
+      const second = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(second);
+      expect(second[0].startTime).toBe(1717000000000);
+      expect(second[0].instanceId).toBe(first[0].instanceId);
+    });
+  });
+
+  describe('enrichWithParentChains() — fresh OS birth time as the generation proof', () => {
+    it('a same-name pid reuse with a different birth time is a NEW instance, not the dead one', async () => {
+      // Reproduced on production code: two processes 10.7 s apart, same pid, same
+      // executable name, forceRefresh false — both were stamped with the FIRST
+      // birth time because the cached entry answered without the provider ever
+      // being called.
       mockGetParentProcessMap.mockResolvedValueOnce(
-        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000500000 }]]),
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code.exe', ppid: 0, startTime: 1716999990000 }],
+        ]),
+      );
+      const first = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(first);
+      expect(first[0].startTime).toBe(1717000000000);
+      expect(first[0].instanceId).toBe('100:1717000000000');
+
+      // Windows reissued pid 100 to a new claude.exe 10.7 s later — inside the 60 s TTL.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000010700 }],
+          [200, { name: 'code.exe', ppid: 0, startTime: 1716999990000 }],
+        ]),
       );
       const second = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
       await processUtils.enrichWithParentChains(second);
-      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1); // cache HIT
-      expect(second[0].startTime).toBe(1717000000000); // stale, by design
 
-      // forceRefresh — what scan-loop passes on a changed pid set — clears it.
-      await processUtils.enrichWithParentChains(second, { forceRefresh: true });
-      expect(second[0].startTime).toBe(1717000500000);
+      expect(second[0].startTime).toBe(1717000010700);
+      expect(second[0].instanceId).toBe('100:1717000010700');
+      expect(second[0].instanceId).not.toBe(first[0].instanceId);
+      expect(second[0].instanceIdSource).toBe('os');
+    });
+
+    it('a different birth time gives the new process its OWN parent chain', async () => {
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code.exe', ppid: 0 }],
+        ]),
+      );
+      const first = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(first);
+      expect(first[0].parentChain).toEqual(['code.exe']);
+
+      // Same pid and name, new birth time, launched from a different host.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 300, startTime: 1717000010700 }],
+          [300, { name: 'cursor.exe', ppid: 0 }],
+        ]),
+      );
+      const second = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(second);
+      expect(second[0].parentChain).toEqual(['cursor.exe']);
+    });
+
+    it('a PROVEN same generation keeps the cached parent chain', async () => {
+      // The opposite case, pinned hard: the freshness observation must not turn the
+      // parent-chain cache into decorative code. The second fresh map deliberately
+      // reports a DIFFERENT parent topology under the SAME birth time; the cached
+      // chain must win, because the birth time proves it is the same process.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code.exe', ppid: 0 }],
+        ]),
+      );
+      const first = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(first);
+      expect(first[0].parentChain).toEqual(['code.exe']);
+
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 300, startTime: 1717000000000 }],
+          [300, { name: 'cursor.exe', ppid: 0 }],
+        ]),
+      );
+      const second = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(second);
+
+      expect(second[0].parentChain).toEqual(['code.exe']);
+      expect(second[0].startTime).toBe(1717000000000);
+      expect(second[0].instanceId).toBe('100:1717000000000');
+    });
+
+    it('a withheld fresh birth time never inherits the cached numeric startTime', async () => {
+      // Fail honest: the fresh observation cannot produce a usable birth time for a
+      // pid that previously had one. The stale number must not be served, and the
+      // old generation's cache data must not be treated as proven.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code.exe', ppid: 0 }],
+        ]),
+      );
+      mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
+      const warm = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(warm);
+      await processUtils.annotateWorkingDirs(warm);
+      expect(warm[0].startTime).toBe(1717000000000);
+      expect(warm[0].cwd).toBe('/home/user/project-a');
+
+      // CreationDate withheld on this observation (access/rare) — the entry exists,
+      // the birth time does not.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200 }],
+          [200, { name: 'code.exe', ppid: 0 }],
+        ]),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-b']]));
+      const degraded = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(degraded);
+
+      expect(degraded[0].startTime).toBeNull();
+      expect(degraded[0].instanceId).toBe('100:u');
+      expect(degraded[0].instanceIdSource).toBe('unknown');
+
+      // The generation-bound cwd of the old generation is not proven either.
+      await processUtils.annotateWorkingDirs(degraded);
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(2);
+      expect(degraded[0].cwd).toBe('/home/user/project-b');
+    });
+  });
+
+  describe('enrichWithParentChains() — process-map call cardinality', () => {
+    it('performs exactly one process-map call on the first non-empty enrichment', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code.exe', ppid: 0 }],
+        ]),
+      );
+      await processUtils.enrichWithParentChains([
+        { pid: 100, agent: 'Claude Code', process: 'claude.exe' },
+      ]);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1);
+    });
+
+    it('performs exactly one MORE call on a fully cached same-generation pass', async () => {
+      // The birth time is the generation proof, so it must be freshly observed even
+      // when every other field is cached — one call, never zero, never two.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code.exe', ppid: 0 }],
+        ]),
+      );
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(agents);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1);
+      await processUtils.enrichWithParentChains(agents);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(2);
+      await processUtils.enrichWithParentChains(agents);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(3);
+    });
+
+    it('performs exactly one call — not two — when the generation changed', async () => {
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code.exe', ppid: 0 }],
+        ]),
+      );
+      await processUtils.enrichWithParentChains([
+        { pid: 100, agent: 'Claude Code', process: 'claude.exe' },
+      ]);
+      mockGetParentProcessMap.mockClear();
+
+      // Generation change AND a chain rebuild in the same pass: the fresh map that
+      // proved the change must also serve the rebuild.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 300, startTime: 1717000010700 }],
+          [300, { name: 'cursor.exe', ppid: 0 }],
+        ]),
+      );
+      const second = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(second);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1);
+      expect(second[0].parentChain).toEqual(['cursor.exe']);
+    });
+
+    it('performs exactly one call — not two — for a pid that was never cached', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude.exe', ppid: 200, startTime: 1717000000000 }],
+          [200, { name: 'code.exe', ppid: 0 }],
+          [400, { name: 'cursor.exe', ppid: 200, startTime: 1717000020000 }],
+        ]),
+      );
+      await processUtils.enrichWithParentChains([
+        { pid: 100, agent: 'Claude Code', process: 'claude.exe' },
+      ]);
+      mockGetParentProcessMap.mockClear();
+
+      const mixed = [
+        { pid: 100, agent: 'Claude Code', process: 'claude.exe' },
+        { pid: 400, agent: 'Cursor', process: 'cursor.exe' },
+      ];
+      await processUtils.enrichWithParentChains(mixed);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1);
+      expect(mixed[1].parentChain).toEqual(['code.exe']);
+      expect(mixed[1].instanceId).toBe('400:1717000020000');
     });
   });
 
@@ -341,9 +560,11 @@ describe('process-utils', () => {
       expect(agents[0].projectName).toBe('project-b');
     });
 
-    it('a same-name reuse inside the TTL is the documented residual bound', async () => {
-      // Honest test of the KNOWN BOUND shared with _cacheKey: pid + SAME exe name
-      // still hits the cache, so the stale cwd survives until forceRefresh or TTL.
+    it('serves the TTL cache when no generation was established for the key', async () => {
+      // enrichWithParentChains never ran here, so there is no established
+      // generation to check the entry against and the plain TTL contract applies —
+      // the same contract linux and darwin keep. In the scan loop the identity
+      // stamp always runs first, and the generation describe above covers that.
       mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
       const first = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
       await processUtils.annotateWorkingDirs(first);
@@ -352,11 +573,67 @@ describe('process-utils', () => {
       const second = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
       await processUtils.annotateWorkingDirs(second);
       expect(mockGetProcessCwds).toHaveBeenCalledTimes(1); // cache HIT
-      expect(second[0].cwd).toBe('/home/user/project-a'); // stale, by design
+      expect(second[0].cwd).toBe('/home/user/project-a'); // the live TTL entry
 
       // forceRefresh — what a changed pid set warrants — clears it.
       await processUtils.annotateWorkingDirs(second, { forceRefresh: true });
       expect(second[0].cwd).toBe('/home/user/project-b');
+    });
+
+    it('does not serve the dead generation cwd to the instance that replaced it', async () => {
+      // pid 100, claude.exe, birth time A with cwd A, then birth time B with cwd B,
+      // forceRefresh false throughout. Once enrichWithParentChains has established
+      // B, the A-generation cwd is no longer proven.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000000000 }]]),
+      );
+      mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
+      const genA = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(genA);
+      await processUtils.annotateWorkingDirs(genA);
+      expect(genA[0].cwd).toBe('/home/user/project-a');
+
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000010700 }]]),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-b']]));
+      const genB = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(genB);
+      await processUtils.annotateWorkingDirs(genB);
+
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(2);
+      expect(genB[0].cwd).toBe('/home/user/project-b');
+      expect(genB[0].projectName).toBe('project-b');
+    });
+
+    it('keeps the cwd cached across repeated observations of the same proven generation', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000000000 }]]),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-a']]));
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      for (let i = 0; i < 3; i++) {
+        await processUtils.enrichWithParentChains(agents);
+        await processUtils.annotateWorkingDirs(agents);
+      }
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(1);
+      expect(agents[0].cwd).toBe('/home/user/project-a');
+    });
+
+    it('performs no process-map lookup of its own', async () => {
+      // The generation is consumed from what enrichWithParentChains established —
+      // annotateWorkingDirs never observes a birth time itself.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000000000 }]]),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-a']]));
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(agents);
+      mockGetParentProcessMap.mockClear();
+
+      await processUtils.annotateWorkingDirs(agents);
+      await processUtils.annotateWorkingDirs(agents, { forceRefresh: true });
+      expect(mockGetParentProcessMap).not.toHaveBeenCalled();
     });
 
     it('deduplicates a pid shared by several agents in the batched platform call', async () => {
@@ -371,6 +648,49 @@ describe('process-utils', () => {
       expect(mockGetProcessCwds).toHaveBeenCalledWith([0]);
       expect(agents[0].cwd).toBeNull();
       expect(agents[1].cwd).toBeNull();
+    });
+  });
+
+  describe('a platform that supplies no OS birth time (linux / darwin shape)', () => {
+    beforeEach(() => {
+      // Pinned false, so this suite proves the no-startTime behaviour on ANY host.
+      processUtils._setPlatformForTest({ providesStartTime: false });
+    });
+
+    it('keeps the parent-chain cache and adds no per-pass process-map fetch', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [100, { name: 'claude', ppid: 200 }],
+          [200, { name: 'bash', ppid: 0 }],
+        ]),
+      );
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude' }];
+      await processUtils.enrichWithParentChains(agents);
+      await processUtils.enrichWithParentChains(agents);
+      await processUtils.enrichWithParentChains(agents);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1);
+      expect(agents[0].parentChain).toEqual(['bash']);
+    });
+
+    it('stamps the honest unknown identity with a null startTime', async () => {
+      mockGetParentProcessMap.mockResolvedValue(new Map([[100, { name: 'claude', ppid: 0 }]]));
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude' }];
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].startTime).toBeNull();
+      expect(agents[0].instanceId).toBe('100:u');
+      expect(agents[0].instanceIdSource).toBe('unknown');
+    });
+
+    it('keeps the cwd cache — there is no generation to gate it on', async () => {
+      mockGetParentProcessMap.mockResolvedValue(new Map([[100, { name: 'claude', ppid: 0 }]]));
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-a']]));
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude' }];
+      for (let i = 0; i < 3; i++) {
+        await processUtils.enrichWithParentChains(agents);
+        await processUtils.annotateWorkingDirs(agents);
+      }
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(1);
+      expect(agents[0].cwd).toBe('/home/user/project-a');
     });
   });
 });

--- a/tests/main/process-utils.test.js
+++ b/tests/main/process-utils.test.js
@@ -198,15 +198,20 @@ describe('process-utils', () => {
       expect(agents[0].parentChain).toEqual(['cursor.exe']);
     });
 
-    it('a same-name reuse sharing one birth-time millisecond is the residual bound', async () => {
+    it('a same-name reuse sharing one birth-time millisecond stays indistinguishable', async () => {
       // What the KNOWN BOUND in _cacheKey used to be — pid + SAME exe name serving
       // the dead process's startTime until forceRefresh or TTL — is gone: the fresh
       // birth time separates those instances with forceRefresh false (see the
-      // generation-proof describe above). What is left is genuine indistinguish-
-      // ability: two instances sharing a pid AND the same epoch-ms birth time. That
-      // is the millisecond bound documented in process-identity.js, not a cache
-      // defect, and it degrades to "two instances read as one", never to a wrong
-      // instance.
+      // generation-proof describe above).
+      //
+      // What remains is the millisecond resolution bound documented in
+      // process-identity.js. Two instances that share a pid AND an epoch-ms birth
+      // time collide on the generation token itself, so a generation-bound
+      // parentChain or cwd entry cannot tell them apart either and the first
+      // instance's cached data CAN be served to the second. That is observational
+      // indistinguishability at the resolution AEGIS reads, not a proof that stale
+      // instance data is impossible. It is out of scope here and the identity format
+      // is deliberately unchanged.
       mockGetParentProcessMap.mockResolvedValue(
         new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000000000 }]]),
       );
@@ -601,9 +606,45 @@ describe('process-utils', () => {
       await processUtils.enrichWithParentChains(genB);
       await processUtils.annotateWorkingDirs(genB);
 
+      expect(genB[0].startTime).toBe(1717000010700); // the generation this record carries
       expect(mockGetProcessCwds).toHaveBeenCalledTimes(2);
       expect(genB[0].cwd).toBe('/home/user/project-b');
       expect(genB[0].projectName).toBe('project-b');
+    });
+
+    it('never lets a generation established for another record stand in for an unenriched one', async () => {
+      // The generation must come from the observation the annotated record ITSELF
+      // carries, not from whatever the module cache happens to hold under the same
+      // pid|name key — that cache is shared by every record that ever used the key.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000000000 }]]),
+      );
+      mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
+      const enriched = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(enriched);
+      await processUtils.annotateWorkingDirs(enriched);
+      expect(enriched[0].cwd).toBe('/home/user/project-a');
+
+      // A later enrichment of a DIFFERENT record moves the module cache on to
+      // generation B. No cwd pass follows it.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([[100, { name: 'claude.exe', ppid: 0, startTime: 1717000010700 }]]),
+      );
+      const other = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.enrichWithParentChains(other);
+      expect(other[0].startTime).toBe(1717000010700);
+
+      // This record never passed through enrichment, so it carries no generation of
+      // its own — neither a proof nor an honest null. It gets exactly the TTL
+      // contract direct callers had before generations existed, and is NOT judged by
+      // a generation some other record established.
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-b']]));
+      const unenriched = [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+      await processUtils.annotateWorkingDirs(unenriched);
+
+      expect(unenriched[0].startTime).toBeUndefined();
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(1);
+      expect(unenriched[0].cwd).toBe('/home/user/project-a');
     });
 
     it('keeps the cwd cached across repeated observations of the same proven generation', async () => {


### PR DESCRIPTION
## The defect

`process-utils.js` cached `parentChain` and `startTime` under `pid|processName` for
60 seconds. When Windows reissued a pid to a new process with the **same** executable
name and `forceRefresh` was false, the provider was never called at all and
`enrichWithParentChains` served the dead process's `startTime` — the one field
`instanceId` is built from.

Reproduced on production code: two processes 10.7 s apart both stamped
`4242:1786569860438`. One `instanceId` means one session, one dedup set and one token
ledger for two different processes.

`cwdCache` uses the same key and the same 60 s bound, so a stale working directory
rode the same failure into `CWD_CONTAINMENT` attribution and the renderer's instance
key.

The clock-precision hypothesis is not the cause and is not touched here:
`Win32_Process.CreationDate` carries microseconds, AEGIS truncates to epoch
milliseconds on purpose, and that is sufficient. No `GetProcessTimes` is introduced.

## The fix

A **fresh** OS birth-time observation is now the generation proof for process-instance
caches, on the platform that supplies one.

- Platform providers declare `providesStartTime` — `true` on win32, `false` on linux
  and darwin (which supply no birth time today).
- On the capable path, every non-empty `enrichWithParentChains` pass makes **exactly
  one** process-map observation, and that single map serves both the generation proof
  and any chain rebuild a cache miss or a generation change requires. There is never a
  second provider call in a pass.
- A cached `parentChain` survives only while the freshly observed birth time equals
  the one the entry was written with. A same generation keeps the cached chain even
  when the fresh map shows a different parent topology — the cache is still a cache.
- The cwd entry records the generation it was fetched under. `annotateWorkingDirs`
  **consumes** the generation carried by the agent record it is annotating — the
  `startTime` the identity stamp wrote on that record — and performs no birth-time
  lookup of its own. It is never read back out of the shared `pid|name` cache, where
  it would belong to whichever record enriched last; a record that never passed
  through enrichment establishes no generation and keeps the pre-generation TTL
  contract.
- **Fail honest.** When the fresh observation withholds a birth time for a pid that
  previously had one, `startTime` is `null`, the generation-bound `parentChain` and
  cwd data are not treated as proven, and identity degrades through the existing
  `<pid>:u` unknown semantics. The stale number is never inherited and no surrogate
  identity is invented.
- linux and darwin keep their current TTL cache behaviour exactly — no new per-scan
  subprocess, no new /proc walk.
- `startTime` stays epoch milliseconds; the OS-backed `instanceId` stays
  `pid:startTime`.

## Provider-call cardinality (mocked)

| pass | `getParentProcessMap` calls |
|---|---|
| first non-empty win32 enrichment | 1 |
| fully cached, same generation | 1 more (the birth time must still be observed) |
| generation changed + chain rebuild | 1, not 2 |
| never-cached pid alongside a cached one | 1, not 2 |
| `annotateWorkingDirs` | 0 |
| linux/darwin shape, three passes | 1 total (unchanged) |

Confirmed against the real win32 provider by counting PowerShell spawns:
`enrich → [cim-parent]`, `cwd → [cim-cwd]`, then `[cim-parent] / []`, `[cim-parent] / []`.

## Windows cost

Production `getParentProcessMap`, 32 sequential calls, 486 processes, all carrying a
birth time:

| N | p50 | p95 | max |
|---|---|---|---|
| 32 | 1284 ms | 1459 ms | 1657 ms |

Steady state: a fully cached default 10 s scan tick previously paid **zero**
`cim-parent` spawns and now pays **exactly one** — about 1.3 s of provider work per
tick, and no second birth-time or process-map spawn. A tick with a changed pid set
already paid that call before this change.

## Tests

The old same-name reuse test asserted the stale `startTime` as documented residual
behaviour — it documented the bug instead of preventing it. It is replaced by a
regression that asserts on `instanceId`, plus the opposite case, the fail-honest case,
the cwd generation cases (including one proving that a generation established for
another record never stands in for an unenriched one) and the cardinality cases. The birth-time capability is
pinned through the existing test injection seam in both directions, so both platform
paths are exercised deterministically regardless of the CI host OS.

All three targeted mutations bite: restoring cached-`startTime` serving fails the
`instanceId` regression (5 tests), disabling parentChain generation invalidation fails
the parentChain regression (2 tests), disabling cwd generation invalidation fails the
cwd regression (2 tests).

## Verification

`build:renderer`, `lint`, `typecheck`, `typecheck:svelte`, `test:coverage`
(1419 passed / 4 skipped, 85 files), `npm audit --audit-level=high --omit=dev`
(0 vulnerabilities) — all green. Repo-wide `format:check` is red from the pre-existing
Windows CRLF checkout baseline (140 files, none of them touched here); Prettier on the
five changed files reports "All matched files use Prettier code style".

## Known stale comment left in place

`scan-loop.js:294` still says "No new spawn: on win32 this is the same `cim-parent`
fetch the tick already pays" — with the per-pass observation that is now wrong for a
cached tick. `scan-loop.js` is outside this change's scope and belongs to the
documentation block.
