### PR TITLE
feat(identity): generation witness gates cache reuse (Block 1, PR-A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ node_modules/
 dist/
 out/
 coverage/
+# Compiled snapshot sidecar — built from sidecar/procsnap, never committed
+build/sidecar/
+# Throwaway mutants written by scripts/verify-witness-gate.mjs (removed in a finally)
+src/main/.mutants/
 # `npx tsc -b` writes one per referenced project, next to the config
 *.tsbuildinfo
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ Landing: aegisprotect.vercel.app | Demo: aegis-demo-ten.vercel.app
 npm run build:renderer    # Vite build (MUST pass before commit)
 npm run lint              # ESLint
 npm run format            # Prettier
-npm test                  # Vitest (1399 passed / 4 skipped = 1403, 84 files)
+npm test                  # Vitest (1477 passed / 4 skipped = 1481, 89 files — measured 2026-08-12)
+npm run verify:gate       # Injection proof: break the witness gate, require the suite to go red
 npm run dist              # Electron-builder NSIS installer
 
 ## Verification — three different counts, do not merge them
@@ -55,7 +56,7 @@ regenerating a lockfile.
 8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` + `npm run typecheck:svelte` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths
-- src/main/ — 47 CommonJS modules (38 top-level + platform/ 7 + token-adapters/ 2)
+- src/main/ — 50 CommonJS modules (38 top-level + platform/ 10 + token-adapters/ 2)
 - src/renderer/ — 46 Svelte 5 components + 11 stores + 16 utils + tokens.css/global.css
 - src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (8 TS files), constants.js (ignore patterns, config paths; SENSITIVE_RULES deprecated)
 - rules/ — 73 active detection rules in 8 YAML files, validated by rules/_schema.json

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "verify:gate": "node scripts/verify-witness-gate.mjs",
     "prepare": "husky"
   },
   "engines": {

--- a/scripts/verify-witness-gate.mjs
+++ b/scripts/verify-witness-gate.mjs
@@ -1,0 +1,205 @@
+/**
+ * @file scripts/verify-witness-gate.mjs
+ * @description Injection proof for the generation-witness gate in
+ *   src/main/process-utils.js.
+ *
+ *   A green suite proves the suite ran, not that it inspected anything
+ *   (memory-bank/ai-mistakes.md #21). This script breaks the gate on purpose — one
+ *   mutant at a time, in a throwaway copy — and requires the witness suite to go
+ *   RED for every mutant. A mutant that survives is reported and the script exits 1.
+ *
+ *   Nothing under version control is modified: each mutant is written to
+ *   `src/main/.mutants/` (gitignored, removed in a finally), and the suite is
+ *   pointed at it through AEGIS_PU_UNDER_TEST. The mutants live inside src/main so
+ *   that a single depth adjustment (`./x` → `../x`) makes every relative require
+ *   resolve; each rewritten path is checked on disk before the run, so a broken
+ *   copy can never be mistaken for a killed mutant.
+ *
+ *   Usage: npm run verify:gate
+ */
+
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE = path.join(ROOT, 'src', 'main', 'process-utils.js');
+const MUTANT_DIR = path.join(ROOT, 'src', 'main', '.mutants');
+const TEST_FILE = path.join('tests', 'main', 'process-utils-witness.test.js');
+const VITEST = path.join(ROOT, 'node_modules', 'vitest', 'vitest.mjs');
+
+/**
+ * Each mutant is a named, surgical breakage of one clause of the gate. `find` must
+ * match exactly once — a mutant that silently changed nothing would "survive" for
+ * the wrong reason.
+ */
+const MUTANTS = [
+  {
+    id: 'm1-gate-ignores-witness',
+    why: 'the parent-chain gate trusts a live TTL entry without comparing the witness',
+    edits: [
+      {
+        find: `    const proven =
+      live &&
+      (a.pid <= 0 ||
+        (witness !== null &&
+          cached.witness === witness.value &&
+          cached.witnessSource === witness.source));`,
+        replace: '    const proven = live;',
+      },
+    ],
+  },
+  {
+    id: 'm2-witness-read-from-cache',
+    why: 'the cwd gate reads the witness out of the shared cache instead of off the record',
+    edits: [
+      {
+        find: '    witness: _providesStartTime && a.pid > 0 ? _recordWitness(a) : undefined,',
+        replace: `    witness:
+      _providesStartTime && a.pid > 0
+        ? (() => {
+            const shared = parentChainCache.get(_cacheKey(a.pid, _agentName(a)));
+            return shared && shared.witness
+              ? { value: shared.witness, source: shared.witnessSource }
+              : null;
+          })()
+        : undefined,`,
+      },
+    ],
+  },
+  {
+    id: 'm3-source-not-compared',
+    why: 'the witness value is compared without its provenance, so two sources can prove each other',
+    edits: [
+      {
+        find: `        (witness !== null &&
+          cached.witness === witness.value &&
+          cached.witnessSource === witness.source));`,
+        replace: `        (witness !== null &&
+          cached.witness === witness.value));`,
+      },
+      {
+        find: `      (e.witness !== null &&
+        cached &&
+        cached.witness === e.witness.value &&
+        cached.witnessSource === e.witness.source);`,
+        replace: `      (e.witness !== null && cached && cached.witness === e.witness.value);`,
+      },
+    ],
+  },
+];
+
+/**
+ * Re-point every relative require one directory deeper, and prove each target
+ * exists.
+ * @param {string} code
+ * @returns {string}
+ */
+function reparentRequires(code) {
+  return code.replace(/require\('(\.[^']*)'\)/g, (_match, specifier) => {
+    const deeper = `../${specifier.startsWith('./') ? specifier.slice(2) : specifier}`;
+    const resolved = path.resolve(MUTANT_DIR, deeper);
+    const exists =
+      fs.existsSync(resolved) ||
+      fs.existsSync(`${resolved}.js`) ||
+      fs.existsSync(path.join(resolved, 'index.js'));
+    if (!exists) {
+      throw new Error(`mutant require rewrite points nowhere: ${specifier} → ${deeper}`);
+    }
+    return `require('${deeper}')`;
+  });
+}
+
+/**
+ * @param {{id: string, edits: Array<{find: string, replace: string}>}} mutant
+ * @param {string} original
+ * @returns {string} the mutated module path.
+ */
+function writeMutant(mutant, original) {
+  let code = original;
+  for (const edit of mutant.edits) {
+    const occurrences = code.split(edit.find).length - 1;
+    if (occurrences !== 1) {
+      throw new Error(
+        `${mutant.id}: expected its target to appear exactly once, found ${occurrences}. ` +
+          'The gate was refactored — update this mutant instead of deleting it.',
+      );
+    }
+    code = code.replace(edit.find, edit.replace);
+  }
+  const file = path.join(MUTANT_DIR, `process-utils.${mutant.id}.js`);
+  fs.writeFileSync(file, reparentRequires(code), 'utf8');
+  return file;
+}
+
+/**
+ * @param {string|null} modulePath - null runs the suite against the real module.
+ * @returns {{code: number, output: string}}
+ */
+function runSuite(modulePath) {
+  const env = { ...process.env };
+  if (modulePath) env.AEGIS_PU_UNDER_TEST = pathToFileURL(modulePath).href;
+  else delete env.AEGIS_PU_UNDER_TEST;
+  const res = spawnSync(process.execPath, [VITEST, 'run', '--project', 'main', TEST_FILE], {
+    cwd: ROOT,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    code: res.status === null ? 1 : res.status,
+    output: `${res.stdout || ''}${res.stderr || ''}`,
+  };
+}
+
+// Newlines are normalised before matching: the repository normalises line endings
+// per checkout (`.gitattributes` text=auto), so a mutant that only matched LF would
+// find nothing on a Windows working tree and report a false "refactored" error.
+const original = fs.readFileSync(SOURCE, 'utf8').replace(/\r\n/g, '\n');
+const results = [];
+let failed = false;
+
+try {
+  fs.mkdirSync(MUTANT_DIR, { recursive: true });
+
+  // The control run: an unmutated module must be GREEN, or a red mutant proves
+  // nothing at all.
+  const control = runSuite(null);
+  results.push({
+    id: 'control (unmutated)',
+    expected: 'green',
+    got: control.code === 0 ? 'green' : 'RED',
+  });
+  if (control.code !== 0) {
+    failed = true;
+    console.error(control.output);
+  }
+
+  for (const mutant of MUTANTS) {
+    const file = writeMutant(mutant, original);
+    const run = runSuite(file);
+    const killed = run.code !== 0;
+    results.push({
+      id: mutant.id,
+      expected: 'RED',
+      got: killed ? 'RED (killed)' : 'green (SURVIVED)',
+    });
+    if (!killed) {
+      failed = true;
+      console.error(`\nMutant SURVIVED: ${mutant.id}\n  ${mutant.why}\n`);
+      console.error(run.output);
+    }
+  }
+} finally {
+  fs.rmSync(MUTANT_DIR, { recursive: true, force: true });
+}
+
+console.log('\nWitness-gate injection proof');
+for (const r of results) {
+  console.log(`  ${r.got.startsWith('green (SURV') ? '✗' : '✓'} ${r.id}: ${r.got}`);
+}
+if (failed) {
+  console.error('\nThe gate is not fully load-bearing — a break in it left the suite green.');
+  process.exit(1);
+}
+console.log('\nEvery mutant was killed: the witness gate is load-bearing.');

--- a/src/main/platform/proc-snapshot-client.js
+++ b/src/main/platform/proc-snapshot-client.js
@@ -1,0 +1,435 @@
+/**
+ * @file platform/proc-snapshot-client.js
+ * @module main/platform/proc-snapshot-client
+ * @description Supervises the process-snapshot sidecar: one long-lived child that
+ *   answers `snap` requests over stdio, with a bounded restart budget and a
+ *   fail-honest surface. Owns NO policy — which provider serves a pass, and what
+ *   happens when this one cannot, is decided by process-snapshot.js.
+ *
+ *   Everything is injectable (`_setInternalsForTest`), because the Windows binary
+ *   is never executed by CI: all five required contexts run on Linux, so the
+ *   supervision logic here is proven against a fake child or it is not proven at
+ *   all.
+ *
+ *   Failure policy, deliberately conservative — a snapshot that arrives late is
+ *   worth nothing, since the caller can read the CIM map in ~1.3 s anyway:
+ *     - one request in flight at a time (the scan loop is single-flight already);
+ *     - a timeout, a crash, a desynchronised stream or a failed write kills the
+ *       child and burns one of {@link MAX_FAILURES_IN_WINDOW} restarts;
+ *     - restarts back off 1 s / 5 s / 30 s, and exhausting the budget disables the
+ *       sidecar for the rest of the session with exactly one warning;
+ *     - a missing binary or an unknown protocol version disables it immediately —
+ *       neither condition fixes itself mid-session, and retrying every scan tick
+ *       would just be a spawn storm behind a silent fallback.
+ *
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const childProcess = require('child_process');
+const logger = require('../logger');
+const { PROTOCOL_VERSION, encodeFrame, createFrameDecoder } = require('./proc-snapshot-protocol');
+
+/** @type {string} Binary name, identical in the repo build dir and in resources/. */
+const EXE_NAME = 'aegis-procsnap.exe';
+
+/**
+ * Default deadline for a handshake or a snapshot. Below the measured CIM p50
+ * (1284 ms, N=32, 486 processes): a sidecar that cannot beat the fallback's median
+ * is not worth waiting for.
+ * @type {number}
+ */
+const DEFAULT_TIMEOUT_MS = 1200;
+
+/** @type {number} Sliding window the restart budget is counted over. */
+const FAILURE_WINDOW_MS = 600000;
+/** @type {number} Failures inside the window before the sidecar is given up on. */
+const MAX_FAILURES_IN_WINDOW = 3;
+/** @type {number[]} Backoff after the 1st, 2nd, … failure in the window. */
+const BACKOFF_MS = [1000, 5000, 30000];
+
+/** @type {readonly string[]} Capability classes a hello may announce. */
+const KNOWN_CLASSES = ['basic', 'class5'];
+
+let _spawn = childProcess.spawn;
+let _now = () => Date.now();
+let _resolveExePath = _defaultExePath;
+
+/** @type {import('child_process').ChildProcess|null} */
+let _child = null;
+/** @type {{class: string, sequence: boolean, topology: boolean}|null} */
+let _caps = null;
+/** @type {Promise<any>|null} */
+let _starting = null;
+/** @type {{id: number, resolve: Function, reject: Function, timer: any}|null} */
+let _pending = null;
+/**
+ * True from the moment a caller asks for a snapshot until that call settles —
+ * INCLUDING the handshake, which `_pending` does not cover. Two callers arriving
+ * during one spawn would otherwise both attach to the same handshake and the second
+ * would overwrite the first's response slot, leaving the first hanging until its
+ * timeout.
+ * @type {boolean}
+ */
+let _inFlight = false;
+/** @type {{resolve: Function, reject: Function, timer: any}|null} */
+let _helloWaiter = null;
+let _nextId = 1;
+/** @type {number[]} Epoch-ms of failures inside the sliding window. */
+let _failures = [];
+let _nextAttemptAt = 0;
+/** @type {string|null} Non-null once the sidecar is given up on for this session. */
+let _sticky = null;
+let _exitHookInstalled = false;
+
+/**
+ * Where the binary lives: packaged next to the app resources, or in the repo
+ * build directory during development. Both paths are FIXED — the executable is
+ * never looked up on PATH, so nothing on PATH can substitute itself for it.
+ * @returns {string|null} the first existing candidate, or null when none exists.
+ */
+function _defaultExePath() {
+  const candidates = [];
+  if (typeof process.resourcesPath === 'string' && process.resourcesPath.length > 0) {
+    candidates.push(path.join(process.resourcesPath, 'sidecar', EXE_NAME));
+  }
+  candidates.push(path.join(__dirname, '..', '..', '..', 'build', 'sidecar', EXE_NAME));
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch (_) {
+      // Unreadable candidate is simply not a candidate.
+    }
+  }
+  return null;
+}
+
+/**
+ * Drop the current child and settle whatever was waiting on it. Idempotent.
+ * @param {string} reason
+ * @returns {void}
+ */
+function _teardown(reason) {
+  const pending = _pending;
+  _pending = null;
+  if (pending) {
+    clearTimeout(pending.timer);
+    pending.reject(new Error(`proc-snapshot: ${reason}`));
+  }
+  const waiter = _helloWaiter;
+  _helloWaiter = null;
+  if (waiter) {
+    clearTimeout(waiter.timer);
+    waiter.reject(new Error(`proc-snapshot: ${reason}`));
+  }
+  const child = _child;
+  _child = null;
+  _caps = null;
+  if (!child) return;
+  try {
+    if (child.stdout) child.stdout.removeAllListeners();
+    if (child.stderr) child.stderr.removeAllListeners();
+    if (child.removeAllListeners) child.removeAllListeners();
+    if (child.stdin && child.stdin.end) child.stdin.end();
+    if (child.kill) child.kill();
+  } catch (_) {
+    // A child that resists teardown is already gone for our purposes.
+  }
+}
+
+/**
+ * Give up on the sidecar for the rest of the session. One warning, never a
+ * per-tick repeat.
+ * @param {string} reason
+ * @returns {void}
+ */
+function _disable(reason) {
+  if (_sticky) return;
+  _sticky = reason;
+  logger.warn(
+    'proc-snapshot',
+    `Snapshot sidecar disabled for this session (${reason}) — the CIM observation serves instead`,
+  );
+  _teardown(reason);
+}
+
+/**
+ * Count one failure against the restart budget and schedule the next attempt.
+ * @param {string} reason
+ * @returns {void}
+ */
+function _recordFailure(reason) {
+  const now = _now();
+  _failures = _failures.filter((t) => now - t < FAILURE_WINDOW_MS);
+  _failures.push(now);
+  logger.debug('proc-snapshot', `Sidecar failure (${reason})`, { failures: _failures.length });
+  _teardown(reason);
+  if (_failures.length >= MAX_FAILURES_IN_WINDOW) {
+    _disable(`restart budget exhausted (${reason})`);
+    return;
+  }
+  _nextAttemptAt = now + BACKOFF_MS[Math.min(_failures.length - 1, BACKOFF_MS.length - 1)];
+}
+
+/**
+ * Validate the capability block a hello carries. The caps ARE the sidecar's
+ * runtime probe result; a hello that omits them tells us nothing about what the
+ * snapshots will contain, so it is rejected rather than guessed at.
+ * @param {*} caps
+ * @returns {{class: string, sequence: boolean, topology: boolean}|null}
+ */
+function _normalizeCaps(caps) {
+  if (caps === null || typeof caps !== 'object') return null;
+  if (!KNOWN_CLASSES.includes(caps.class)) return null;
+  return {
+    class: caps.class,
+    sequence: caps.sequence === true,
+    topology: caps.topology !== false,
+  };
+}
+
+/**
+ * Dispatch one decoded message.
+ * @param {Object} msg
+ * @returns {void}
+ */
+function _onMessage(msg) {
+  if (msg.t === 'hello') {
+    if (!_helloWaiter) {
+      logger.debug('proc-snapshot', 'Ignored an unexpected second hello frame');
+      return;
+    }
+    if (msg.proto !== PROTOCOL_VERSION) {
+      _disable(`protocol version mismatch: sidecar ${msg.proto}, client ${PROTOCOL_VERSION}`);
+      return;
+    }
+    const caps = _normalizeCaps(msg.caps);
+    if (!caps) {
+      _disable('hello carried no usable capability block');
+      return;
+    }
+    _caps = caps;
+    const waiter = _helloWaiter;
+    _helloWaiter = null;
+    clearTimeout(waiter.timer);
+    logger.info('proc-snapshot', 'Snapshot sidecar ready', { caps, pid: msg.pid });
+    waiter.resolve();
+    return;
+  }
+
+  if (msg.t !== 'snap' && msg.t !== 'err') {
+    logger.debug('proc-snapshot', `Ignored unknown frame type "${msg.t}"`);
+    return;
+  }
+  if (!_pending || _pending.id !== msg.id) {
+    logger.debug('proc-snapshot', 'Ignored a response with no matching request', { id: msg.id });
+    return;
+  }
+  const pending = _pending;
+  _pending = null;
+  clearTimeout(pending.timer);
+
+  if (msg.t === 'err') {
+    // The child is alive and said no. That is a provider failure for this pass,
+    // not a supervision failure, so the restart budget is not touched.
+    pending.reject(new Error(`proc-snapshot: sidecar error ${msg.code || 'unknown'}`));
+    return;
+  }
+  if (!Array.isArray(msg.procs) || !KNOWN_CLASSES.includes(msg.source)) {
+    pending.reject(new Error('proc-snapshot: malformed snapshot response'));
+    return;
+  }
+  pending.resolve({ source: msg.source, procs: msg.procs });
+}
+
+/** Install the one process-exit hook that closes the child on app shutdown. */
+function _installExitHook() {
+  if (_exitHookInstalled) return;
+  _exitHookInstalled = true;
+  process.once('exit', () => {
+    try {
+      _teardown('parent exiting');
+    } catch (_) {
+      // Nothing useful can be done from an exit handler.
+    }
+  });
+}
+
+/**
+ * Spawn the sidecar and wait for its hello.
+ * @param {number} timeoutMs
+ * @returns {Promise<import('child_process').ChildProcess>}
+ */
+function _startChild(timeoutMs) {
+  const exePath = _resolveExePath();
+  if (!exePath) {
+    _disable('sidecar binary not found');
+    return Promise.reject(new Error('proc-snapshot: sidecar binary not found'));
+  }
+  let child;
+  try {
+    child = _spawn(exePath, [], { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
+  } catch (err) {
+    _recordFailure(`spawn threw: ${err.message}`);
+    return Promise.reject(new Error(`proc-snapshot: spawn failed — ${err.message}`));
+  }
+  _child = child;
+  const decoder = createFrameDecoder();
+  _installExitHook();
+
+  child.stdout.on('data', (chunk) => {
+    if (_child !== child) return;
+    const { frames, errors, fatal } = decoder.push(chunk);
+    for (const e of errors) logger.warn('proc-snapshot', `Frame error: ${e}`);
+    if (fatal) {
+      _recordFailure('stream desynchronised');
+      return;
+    }
+    for (const frame of frames) _onMessage(frame);
+  });
+  child.stderr.on('data', (chunk) => {
+    const text = String(chunk).trim();
+    if (text) logger.debug('proc-snapshot', `sidecar stderr: ${text}`);
+  });
+  child.on('error', (err) => {
+    if (_child !== child) return;
+    _recordFailure(`child error: ${err.message}`);
+  });
+  child.on('exit', (code, signal) => {
+    if (_child !== child) return;
+    _recordFailure(`child exited (code=${code}, signal=${signal})`);
+  });
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => _recordFailure(`handshake timed out after ${timeoutMs} ms`),
+      timeoutMs,
+    );
+    if (timer.unref) timer.unref();
+    _helloWaiter = { resolve: () => resolve(child), reject, timer };
+  });
+}
+
+/**
+ * The live child, spawning and handshaking it if needed.
+ * @param {number} timeoutMs
+ * @returns {Promise<import('child_process').ChildProcess>}
+ */
+function _ensureChild(timeoutMs) {
+  if (_child && _caps) return Promise.resolve(_child);
+  if (_starting) return _starting;
+  const now = _now();
+  if (now < _nextAttemptAt) {
+    return Promise.reject(new Error(`proc-snapshot: backing off for ${_nextAttemptAt - now} ms`));
+  }
+  const started = _startChild(timeoutMs);
+  _starting = started;
+  const clear = () => {
+    if (_starting === started) _starting = null;
+  };
+  started.then(clear, clear);
+  return started;
+}
+
+/**
+ * Ask the sidecar for one full process snapshot.
+ * @param {Object} [opts]
+ * @param {number} [opts.timeoutMs=1200]
+ * @returns {Promise<{source: string, procs: Array<Object>}>} rejects on every
+ *   failure mode — the caller decides what to fall back to.
+ * @since v0.12.0
+ */
+function requestSnapshot(opts = {}) {
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  if (_sticky) return Promise.reject(new Error(`proc-snapshot: unavailable — ${_sticky}`));
+  if (_inFlight) return Promise.reject(new Error('proc-snapshot: a snapshot is already in flight'));
+
+  _inFlight = true;
+  const settled = (value) => {
+    _inFlight = false;
+    return value;
+  };
+  return _ensureChild(timeoutMs)
+    .then(
+      (child) =>
+        new Promise((resolve, reject) => {
+          const id = _nextId++;
+          const timer = setTimeout(
+            () => _recordFailure(`snapshot timed out after ${timeoutMs} ms`),
+            timeoutMs,
+          );
+          if (timer.unref) timer.unref();
+          _pending = { id, resolve, reject, timer };
+          try {
+            child.stdin.write(encodeFrame({ t: 'snap', id }));
+          } catch (err) {
+            _recordFailure(`stdin write failed: ${err.message}`);
+          }
+        }),
+    )
+    .then(settled, (err) => {
+      settled();
+      throw err;
+    });
+}
+
+/**
+ * Observable supervision state, for the provider chooser's health record.
+ * @returns {{available: boolean, sticky: string|null, connected: boolean,
+ *   caps: {class: string, sequence: boolean, topology: boolean}|null, failures: number}}
+ */
+function getState() {
+  return {
+    available: _sticky === null,
+    sticky: _sticky,
+    connected: _child !== null && _caps !== null,
+    caps: _caps ? { ..._caps } : null,
+    failures: _failures.length,
+  };
+}
+
+/**
+ * Close the child (app shutdown). The sidecar also exits on stdin EOF, so this is
+ * belt and braces rather than the only path.
+ * @returns {void}
+ */
+function shutdown() {
+  _teardown('shutdown');
+}
+
+/** @internal Replace spawn / clock / path resolution (for tests). */
+function _setInternalsForTest(overrides) {
+  if (overrides.spawn) _spawn = overrides.spawn;
+  if (overrides.now) _now = overrides.now;
+  if (overrides.resolveExePath) _resolveExePath = overrides.resolveExePath;
+}
+
+/** @internal Restore the real internals and clear all supervision state. */
+function _resetForTest() {
+  _teardown('reset');
+  _spawn = childProcess.spawn;
+  _now = () => Date.now();
+  _resolveExePath = _defaultExePath;
+  _starting = null;
+  _inFlight = false;
+  _nextId = 1;
+  _failures = [];
+  _nextAttemptAt = 0;
+  _sticky = null;
+}
+
+module.exports = {
+  EXE_NAME,
+  DEFAULT_TIMEOUT_MS,
+  MAX_FAILURES_IN_WINDOW,
+  BACKOFF_MS,
+  requestSnapshot,
+  getState,
+  shutdown,
+  _setInternalsForTest,
+  _resetForTest,
+};

--- a/src/main/platform/proc-snapshot-protocol.js
+++ b/src/main/platform/proc-snapshot-protocol.js
@@ -1,0 +1,147 @@
+/**
+ * @file platform/proc-snapshot-protocol.js
+ * @module main/platform/proc-snapshot-protocol
+ * @description The wire codec for the process-snapshot sidecar: length-prefixed
+ *   frames carrying UTF-8 JSON. Pure — no child process, no fs, no clock — so the
+ *   framing can be proven on any platform, including the Linux CI runners that
+ *   never execute the Windows binary.
+ *
+ *   THE WIRE IS THE STABLE CONTRACT, not the sidecar's implementation language.
+ *   A frame is `uint32 LE payload length` followed by exactly that many bytes of
+ *   UTF-8 JSON; the length does not count itself. The transport (stdio today, a
+ *   named pipe if that ever becomes preferable) is deliberately not part of this
+ *   module.
+ *
+ *   Messages, all of them JSON objects with a `t` discriminator:
+ *     - `{t:'hello', proto, caps:{class, sequence, topology}, pid}` — sent once by
+ *       the sidecar before any request, carrying the result of its runtime
+ *       capability probe. A `proto` this client does not know is a hard stop.
+ *     - `{t:'snap', id}` — the only request: give me every process.
+ *     - `{t:'snap', id, source, procs:[{pid, ppid, name, ct, seq}]}` — the answer.
+ *       `ct` (process creation time in 100 ns ticks) and `seq` (the kernel
+ *       SequenceNumber, absent when the OS does not supply one) are DECIMAL
+ *       STRINGS: both exceed what a JS number holds without losing precision, and
+ *       a witness that silently lost its low digits would compare equal across
+ *       generations.
+ *     - `{t:'err', id, code, ntstatus}` — the sidecar could not answer.
+ *
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+'use strict';
+
+/**
+ * Wire protocol version. Bumped whenever a frame's meaning changes; the client
+ * refuses to talk to a sidecar announcing anything else, because a half-understood
+ * snapshot is worse than no snapshot.
+ * @type {number}
+ */
+const PROTOCOL_VERSION = 1;
+
+/** @type {number} Bytes of the little-endian length prefix. */
+const FRAME_HEADER_BYTES = 4;
+
+/**
+ * Largest payload accepted from the sidecar. A full snapshot of a busy machine is
+ * tens of kilobytes, so 8 MiB is far above any honest frame and exists to bound
+ * what a desynchronised or hostile stream can make this process allocate.
+ * @type {number}
+ */
+const MAX_FRAME_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Encode one message as a frame.
+ * @param {Object} message - JSON-serialisable object.
+ * @returns {Buffer}
+ * @throws {RangeError} when the encoded payload exceeds {@link MAX_FRAME_BYTES} —
+ *   only reachable for a request this process built itself, so it is a bug here,
+ *   not a peer failure.
+ */
+function encodeFrame(message) {
+  const payload = Buffer.from(JSON.stringify(message), 'utf8');
+  if (payload.length > MAX_FRAME_BYTES) {
+    throw new RangeError(`proc-snapshot frame too large to send: ${payload.length}`);
+  }
+  const header = Buffer.allocUnsafe(FRAME_HEADER_BYTES);
+  header.writeUInt32LE(payload.length, 0);
+  return Buffer.concat([header, payload]);
+}
+
+/**
+ * Create a streaming decoder. Bytes arrive in whatever chunks the OS pipe hands
+ * over — a frame split across three reads and three frames in one read are both
+ * normal — so the decoder buffers and yields only complete frames.
+ *
+ * It never throws. Two error classes are reported instead, and they are not the
+ * same kind of problem:
+ *   - a payload that is not a JSON object is a BAD FRAME. Framing is still in
+ *     sync (exactly `len` bytes were consumed), so the frame is dropped and
+ *     decoding continues;
+ *   - a length prefix of zero or above {@link MAX_FRAME_BYTES} means the stream is
+ *     DESYNCHRONISED. Nothing after it can be trusted, so the decoder latches
+ *     `fatal` and the caller must tear the child down rather than resynchronise
+ *     by guesswork.
+ * @returns {{push: function(Buffer): {frames: Object[], errors: string[], fatal: boolean},
+ *   pendingBytes: function(): number, isFatal: function(): boolean}}
+ */
+function createFrameDecoder() {
+  let buffered = Buffer.alloc(0);
+  let fatal = false;
+
+  return {
+    push(chunk) {
+      /** @type {Object[]} */
+      const frames = [];
+      /** @type {string[]} */
+      const errors = [];
+      if (fatal) return { frames, errors: ['decoder-desynchronised'], fatal: true };
+
+      buffered = buffered.length === 0 ? Buffer.from(chunk) : Buffer.concat([buffered, chunk]);
+
+      while (buffered.length >= FRAME_HEADER_BYTES) {
+        const len = buffered.readUInt32LE(0);
+        if (len === 0 || len > MAX_FRAME_BYTES) {
+          errors.push(`frame-length-invalid: ${len}`);
+          fatal = true;
+          buffered = Buffer.alloc(0);
+          break;
+        }
+        if (buffered.length < FRAME_HEADER_BYTES + len) break;
+
+        const payload = buffered.subarray(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + len);
+        buffered = buffered.subarray(FRAME_HEADER_BYTES + len);
+        let parsed;
+        try {
+          parsed = JSON.parse(payload.toString('utf8'));
+        } catch (err) {
+          errors.push(`frame-parse-error: ${err.message}`);
+          continue;
+        }
+        // A bare number, string, array or null is well-formed JSON and still not a
+        // message. Rejecting it here keeps every consumer free of shape guards.
+        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          errors.push('frame-not-an-object');
+          continue;
+        }
+        frames.push(parsed);
+      }
+
+      return { frames, errors, fatal };
+    },
+    pendingBytes() {
+      return buffered.length;
+    },
+    isFatal() {
+      return fatal;
+    },
+  };
+}
+
+module.exports = {
+  PROTOCOL_VERSION,
+  FRAME_HEADER_BYTES,
+  MAX_FRAME_BYTES,
+  encodeFrame,
+  createFrameDecoder,
+};

--- a/src/main/platform/process-snapshot.js
+++ b/src/main/platform/process-snapshot.js
@@ -1,0 +1,261 @@
+/**
+ * @file platform/process-snapshot.js
+ * @module main/platform/process-snapshot
+ * @description Chooses which provider observes the Windows process table on this
+ *   pass, and turns whatever answered into the ONE map shape process-utils.js
+ *   already consumes.
+ *
+ *   The chain, in order:
+ *     1. the snapshot sidecar (one NtQuerySystemInformation call per snapshot);
+ *     2. the existing CIM `Win32_Process` observation — EMERGENCY FALLBACK ONLY,
+ *        passed in by the caller so this module never requires win32.js back and
+ *        closes a require cycle;
+ *     3. nothing — an empty map, which degrades identity to `<pid>:u` and proves
+ *        no cached entry. Never a stale generation inherited from an earlier pass.
+ *
+ *   WHY THE SOURCE IS LOGGED ON EVERY PASS, not on transitions: if the binary is
+ *   missing or its path resolves wrong, `auto` silently serves CIM forever while
+ *   every test stays green and the block looks shipped. One `mod='perf'` line per
+ *   observation naming the source is what makes that visible, and the benchmark
+ *   refuses to report a speedup unless each sample names its own source.
+ *
+ *   Rollout flag `AEGIS_PROC_SNAPSHOT`, read once at load:
+ *     - `auto` (default) — sidecar, then CIM, then nothing;
+ *     - `cim` — kill switch: the sidecar is never spawned, behaviour is exactly
+ *       what it was before this module existed;
+ *     - `strict` — sidecar only, no CIM: fail-honest, so a benchmark or a test can
+ *       prove that what it measured really was the sidecar.
+ *
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+'use strict';
+
+const logger = require('../logger');
+const sensorHealth = require('../sensor-health');
+const defaultClient = require('./proc-snapshot-client');
+
+/** @type {string} Sensor id for the health record this module owns. */
+const SENSOR_ID = 'proc-snapshot';
+
+/** @type {readonly string[]} */
+const MODES = ['auto', 'cim', 'strict'];
+
+/**
+ * Milliseconds between the FILETIME epoch (1601-01-01) and the Unix epoch. The
+ * conversion runs HERE and only here: the sidecar reports raw 100 ns ticks and
+ * never converts, so there is a single place where the `startTime` millisecond
+ * contract is produced.
+ * @type {bigint}
+ */
+const FILETIME_EPOCH_OFFSET_MS = 11644473600000n;
+
+let _client = defaultClient;
+let _mode = _readMode();
+/** @type {import('../sensor-health').SensorHealth} */
+let _health = sensorHealth.createSensorHealth(SENSOR_ID);
+/** @type {string|null} Source that served the previous pass. */
+let _lastSource = null;
+let _sourceTransitions = 0;
+
+/**
+ * @returns {string} the validated rollout mode; an unknown value is not obeyed
+ *   silently — it warns and falls back to `auto`.
+ */
+function _readMode() {
+  const raw = String(process.env.AEGIS_PROC_SNAPSHOT || 'auto')
+    .trim()
+    .toLowerCase();
+  if (MODES.includes(raw)) return raw;
+  logger.warn(
+    'proc-snapshot',
+    `Unknown AEGIS_PROC_SNAPSHOT value "${raw}" — using "auto" (${MODES.join('|')})`,
+  );
+  return 'auto';
+}
+
+/**
+ * Convert a process creation time in 100 ns FILETIME ticks to epoch milliseconds.
+ *
+ * Parsed as BigInt, never as a Number: ticks run around 1.34e17, well past 2^53,
+ * so `Number(ticks)` would already have dropped low digits before any division —
+ * and a witness that lost its low digits compares equal across generations. The
+ * QUOTIENT is small enough to be an exact Number, which is what keeps the frozen
+ * `pid:startTime(ms)` contract intact.
+ * @param {string} ticks - decimal digits, as they arrive on the wire.
+ * @returns {number|null} epoch-ms, or null when the value is unusable (honest).
+ */
+function ticksToEpochMs(ticks) {
+  if (typeof ticks !== 'string' || !/^\d+$/.test(ticks)) return null;
+  const ms = Number(BigInt(ticks) / 10000n - FILETIME_EPOCH_OFFSET_MS);
+  return Number.isFinite(ms) && ms > 0 ? ms : null;
+}
+
+/**
+ * The generation witness for one snapshot record, and where it came from.
+ *
+ * The kernel SequenceNumber wins when the OS supplies it — it is the documented
+ * PID-reuse detector and it separates two instances that share a birth
+ * millisecond. Creation-time ticks are the fallback: still finer than the stored
+ * epoch-ms, so still a stronger proof than the identity key carries.
+ * @param {{seq?: string, ct?: string}} proc
+ * @returns {{witness: string, witnessSource: string}|null}
+ */
+function _witnessOfRecord(proc) {
+  if (typeof proc.seq === 'string' && /^\d+$/.test(proc.seq)) {
+    return { witness: proc.seq, witnessSource: 'sequence' };
+  }
+  if (typeof proc.ct === 'string' && /^\d+$/.test(proc.ct)) {
+    return { witness: proc.ct, witnessSource: 'createTime100ns' };
+  }
+  return null;
+}
+
+/**
+ * Turn a sidecar snapshot into the parent-process map shape.
+ * @param {Array<Object>} procs
+ * @returns {Map<number, {name: string, ppid: number, startTime: number|null,
+ *   witness: string|null, witnessSource: string|null}>}
+ */
+function _mapFromSnapshot(procs) {
+  const map = new Map();
+  for (const proc of procs) {
+    if (!proc || !Number.isInteger(proc.pid) || proc.pid <= 0) continue;
+    const witness = _witnessOfRecord(proc);
+    map.set(proc.pid, {
+      name: typeof proc.name === 'string' ? proc.name : '',
+      ppid: Number.isInteger(proc.ppid) ? proc.ppid : 0,
+      startTime: ticksToEpochMs(proc.ct),
+      witness: witness ? witness.witness : null,
+      witnessSource: witness ? witness.witnessSource : null,
+    });
+  }
+  return map;
+}
+
+/**
+ * Record which provider served this pass, and make a change of provider visible.
+ * A flapping sidecar invalidates every cached witness on each flip — the right,
+ * fail-safe direction, but expensive — so the count exists to make that legible
+ * instead of mysterious.
+ * @param {string} source
+ * @returns {void}
+ */
+function _trackSource(source) {
+  if (_lastSource !== null && _lastSource !== source) {
+    _sourceTransitions++;
+    logger.info('proc-snapshot', `Snapshot source changed ${_lastSource} → ${source}`, {
+      transitions: _sourceTransitions,
+    });
+  }
+  _lastSource = source;
+}
+
+/**
+ * Observe the process table once, through the best provider available.
+ * @param {Object} [opts]
+ * @param {function(): Promise<Map<number, Object>>} [opts.cimFallback] - the
+ *   emergency CIM observation. Injected by win32.js; its entries carry no witness,
+ *   and process-utils derives one from the epoch-ms birth time instead.
+ * @param {number} [opts.timeoutMs] - deadline for the sidecar request.
+ * @returns {Promise<Map<number, Object>>} pid → {name, ppid, startTime, …}. Empty
+ *   when nothing could observe — never a remembered map.
+ * @since v0.12.0
+ */
+async function getParentProcessMap(opts = {}) {
+  const cimFallback = typeof opts.cimFallback === 'function' ? opts.cimFallback : null;
+  const t0 = performance.now();
+  let map = null;
+  let source = 'none';
+  let sidecarError = null;
+
+  if (_mode !== 'cim') {
+    try {
+      const res = await _client.requestSnapshot({ timeoutMs: opts.timeoutMs });
+      map = _mapFromSnapshot(res.procs);
+      source = res.source;
+    } catch (err) {
+      sidecarError = err.message;
+      map = null;
+    }
+  }
+
+  if (map === null && _mode !== 'strict' && cimFallback) {
+    map = await cimFallback();
+    source = 'cim';
+  }
+  if (map === null) {
+    map = new Map();
+    source = 'none';
+  }
+
+  const now = Date.now();
+  if (map.size === 0) {
+    // A machine always has processes, so an empty map is a failed observation,
+    // whichever provider produced it. The CIM path resolves empty on error too.
+    _health = sensorHealth.markFailed(_health, now, {
+      error: sidecarError || 'no provider produced a process map',
+      detail: source,
+    });
+  } else if (source === 'cim') {
+    _health = sensorHealth.markDegraded(_health, now, {
+      error: sidecarError || 'sidecar not used',
+      detail: 'cim-fallback',
+    });
+  } else {
+    _health = sensorHealth.markHealthy(_health, now, { detail: source });
+  }
+
+  _trackSource(source);
+  logger.debug('perf', 'snapshot', {
+    source,
+    ms: Math.round(performance.now() - t0),
+    procs: map.size,
+    mode: _mode,
+  });
+  return map;
+}
+
+/**
+ * @returns {import('../sensor-health').SensorHealth} plain health record. Not on
+ *   IPC in this block — read by tests and by the operational log.
+ */
+function getSnapshotHealth() {
+  return sensorHealth.toPlain(_health);
+}
+
+/** @returns {string} the active rollout mode. */
+function getMode() {
+  return _mode;
+}
+
+/** @returns {{lastSource: string|null, transitions: number}} */
+function getSourceStats() {
+  return { lastSource: _lastSource, transitions: _sourceTransitions };
+}
+
+/** @internal Swap the sidecar client (for tests). */
+function _setClientForTest(client) {
+  _client = client;
+}
+
+/** @internal Restore the real client and re-read the rollout flag. */
+function _resetForTest() {
+  _client = defaultClient;
+  _mode = _readMode();
+  _health = sensorHealth.createSensorHealth(SENSOR_ID);
+  _lastSource = null;
+  _sourceTransitions = 0;
+}
+
+module.exports = {
+  SENSOR_ID,
+  ticksToEpochMs,
+  getParentProcessMap,
+  getSnapshotHealth,
+  getMode,
+  getSourceStats,
+  _setClientForTest,
+  _resetForTest,
+};

--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -8,6 +8,7 @@
 const { execFile } = require('child_process');
 const logger = require('../logger');
 const restartManager = require('./restart-manager');
+const snapshot = require('./process-snapshot');
 
 /**
  * Whether the handle.exe/handle64.exe binary is on PATH — the LEGACY read-detect
@@ -81,9 +82,16 @@ function listProcesses() {
  * CreationDate as a System.DateTime (Kind=Local), NOT a DMTF string (that is the
  * legacy Get-WmiObject shape) — so the [DateTimeOffset] cast is a direct, correct
  * UTC-epoch conversion. Null when the OS withholds CreationDate (rare/access).
+ *
+ * EMERGENCY FALLBACK ONLY since v0.12.0. This is the observation whose cost was
+ * measured at p50 1284 / p95 1459 / max 1657 ms (N=32, 486 processes, one machine
+ * and one sample) — the tax the snapshot sidecar exists to remove. It stays because
+ * a sidecar that is missing, incompatible or dead must not take identity down with
+ * it; it is not the hot path any more. Entries carry no generation witness, so
+ * process-utils derives one from `startTime` (see its `_witnessOf`).
  * @returns {Promise<Map<number, {name: string, ppid: number, startTime: number|null}>>}
  */
-function getParentProcessMap() {
+function cimParentProcessMap() {
   return new Promise((resolve) => {
     const psScript = [
       '$ErrorActionPreference="SilentlyContinue"',
@@ -118,6 +126,25 @@ function getParentProcessMap() {
       },
     );
   });
+}
+
+/**
+ * The ONE process-table observation a scan pass makes on Windows.
+ *
+ * Delegates the provider choice to process-snapshot.js — sidecar first, this
+ * module's CIM call as the emergency fallback, an empty map when neither can
+ * observe. The CIM function is passed IN rather than imported there, so the
+ * platform module stays the only place that knows how to talk to PowerShell and no
+ * require cycle (win32 → process-snapshot → win32) is created.
+ *
+ * The returned entries keep the shape callers already consume and may additionally
+ * carry `witness` / `witnessSource` when the sidecar served the pass.
+ * @returns {Promise<Map<number, {name: string, ppid: number, startTime: number|null,
+ *   witness?: string|null, witnessSource?: string|null}>>}
+ * @since v0.3.0
+ */
+function getParentProcessMap() {
+  return snapshot.getParentProcessMap({ cimFallback: cimParentProcessMap });
 }
 
 /**
@@ -436,16 +463,18 @@ function getProcessCwds(pids) {
 
 module.exports = {
   /**
-   * `getParentProcessMap` entries carry `startTime`, the OS process birth time.
-   * process-utils reads it as the GENERATION of a pid: the proof that a cached
-   * parent chain or working directory still belongs to the process living under
-   * that pid. Only win32 supplies it — see the matching `false` in linux.js and
-   * darwin.js, which is why neither pays a per-scan map observation.
+   * `getParentProcessMap` entries carry `startTime`, the OS process birth time,
+   * and — when the snapshot sidecar served the pass — a stronger `witness`.
+   * process-utils reads the witness as the GENERATION of a pid: the proof that a
+   * cached parent chain or working directory still belongs to the process living
+   * under that pid. Only win32 supplies either — see the matching `false` in
+   * linux.js and darwin.js, which is why neither pays a per-scan map observation.
    * @type {boolean}
    */
   providesStartTime: true,
   listProcesses,
   getParentProcessMap,
+  cimParentProcessMap,
   getRawTcpConnections,
   getFileHandles,
   getSensitiveHolders: restartManager.getSensitiveHolders,

--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -55,9 +55,10 @@ const PARENT_CHAIN_TTL = 60000;
  *
  * The name is NOT the whole answer: a pid recycled by an executable with the SAME
  * name produces the same key. What separates those two instances is the GENERATION
- * — the freshly observed OS birth time, re-read on every enrichment pass. The key
- * addresses the entry; the generation decides whether the entry is still about the
- * process running under that pid right now (see {@link enrichWithParentChains}).
+ * WITNESS — freshly observed on every enrichment pass and never read back out of a
+ * cache. The key addresses the entry; the witness decides whether the entry is
+ * still about the process running under that pid right now (see
+ * {@link enrichWithParentChains} and {@link _witnessOf}).
  * @param {number} pid
  * @param {string} [name] - OS process name (or display name) observed for that pid.
  * @returns {string}
@@ -134,12 +135,63 @@ function _birthTimeOf(procMap, pid) {
 }
 
 /**
+ * The GENERATION WITNESS a process map carries for one pid: the strongest proof
+ * THIS observation can offer that a cached entry still describes the process
+ * living under that pid right now.
+ *
+ * Ordered, and the order is the whole point:
+ *   1. `entry.witness` — what the snapshot sidecar observed: the kernel
+ *      SequenceNumber where Windows supplies it (Microsoft documents it as the
+ *      PID-reuse detector), otherwise the creation time in 100 ns ticks. Always a
+ *      STRING. Both are 64-bit values a JS number cannot hold without dropping low
+ *      digits, and a witness that lost its low digits compares EQUAL across two
+ *      generations — precisely the failure it exists to prevent.
+ *   2. the epoch-ms birth time, stringified, source `startTimeMs` — what the
+ *      emergency CIM observation and every pre-sidecar map entry can offer. This is
+ *      the same proof PR #206 shipped, carried in the new shape, which is why
+ *      linux/darwin and the existing behaviour are untouched by the change.
+ *   3. null — nothing observable, so nothing proven. Never a substitute for a
+ *      value, and never taken from a cache.
+ *
+ * The SOURCE travels with the value and is compared alongside it, so two witnesses
+ * of different provenance are never equal by accident: a provider change can only
+ * invalidate cache entries, never falsely prove one.
+ * @param {Map<number, {startTime?: number|null, witness?: string|null,
+ *   witnessSource?: string|null}>} procMap
+ * @param {number} pid
+ * @returns {{value: string, source: string}|null}
+ * @since v0.12.0
+ */
+function _witnessOf(procMap, pid) {
+  const info = procMap.get(pid);
+  if (!info) return null;
+  if (
+    typeof info.witness === 'string' &&
+    info.witness.length > 0 &&
+    typeof info.witnessSource === 'string' &&
+    info.witnessSource.length > 0
+  ) {
+    return { value: info.witness, source: info.witnessSource };
+  }
+  const birthTime = _birthTimeOf(procMap, pid);
+  // The same usability test process-identity.js applies before building an `os`
+  // key: a value that cannot identify an instance cannot prove one either.
+  if (!Number.isFinite(birthTime) || birthTime <= 0) return null;
+  return { value: String(birthTime), source: 'startTimeMs' };
+}
+
+/**
  * Resolve parent process chains for a list of PIDs via platform adapter, TTL-cached.
  *
  * This is the chain-only helper: it answers from the cache when it can and fetches
  * a process map only for the pids it cannot answer. It carries no generation proof
  * and is not the identity path — {@link enrichWithParentChains} is, and on a
  * birth-time platform that path observes its own single map instead of calling here.
+ *
+ * The entries it writes therefore carry no witness. Nothing on win32 calls this
+ * today; if something did, those entries would simply never be proven and would be
+ * rebuilt — safe, only wasteful. An entry may never be reused on the strength of a
+ * proof it does not hold.
  * @param {number[]} pids
  * @param {Object} [opts]
  * @param {Map<number, string>} [opts.names] - pid → process name, used to key the
@@ -206,21 +258,27 @@ async function getParentChains(pids, opts = {}) {
 }
 
 /**
- * Stamp `parentChain` and `startTime` from ONE fresh process-map observation, on a
- * platform that supplies OS birth times. This is the generation proof.
+ * Stamp `parentChain`, `startTime` and the generation witness from ONE fresh
+ * process-map observation, on a platform that supplies OS birth times. This is the
+ * generation proof.
  *
  * Exactly one provider call per pass, and that single map serves everything: the
- * birth time that proves the generation, and every chain rebuild a miss or a
- * generation change needs. There is never a second fetch in one pass.
+ * witness that proves the generation, the birth time the identity is built from,
+ * and every chain rebuild a miss or a generation change needs. There is never a
+ * second fetch in one pass.
  *
- * A cached entry survives only while the FRESH birth time equals the one the entry
- * was written with. Same pid, same executable name, different birth time is a
- * different process instance, so its chain is rebuilt from this map and its cwd
- * loses its proof (see {@link annotateWorkingDirs}). `startTime` is always the
- * freshly observed value — a cached birth time never proves the current instance,
- * and when the fresh observation withholds it the agent gets null rather than the
- * stale number, degrading through the `<pid>:u` identity process-identity.js
- * already defines.
+ * A cached entry survives only while the FRESH witness — value AND source — equals
+ * the one the entry was written with. Same pid, same executable name, different
+ * witness is a different process instance, so its chain is rebuilt from this map
+ * and its cwd loses its proof (see {@link annotateWorkingDirs}).
+ *
+ * The witness gates the CACHE; it is not the identity. `startTime` is still the
+ * freshly observed epoch-ms and still the only input to `instanceId` — a cached
+ * birth time never proves the current instance, and when the fresh observation
+ * withholds it the agent gets null rather than the stale number, degrading through
+ * the `<pid>:u` identity process-identity.js already defines. A pid whose witness
+ * is readable while its birth time is not therefore keeps a working cache gate AND
+ * an honest `unknown` identity; the two answer different questions.
  *
  * pid ≤ 0 is not an OS process (the pid-0 synthetics), so there is no generation to
  * prove for it and the plain TTL contract applies.
@@ -238,18 +296,32 @@ async function _stampFromFreshBirthTimes(agents, forceRefresh) {
   for (const a of agents) {
     const key = _cacheKey(a.pid, _agentName(a));
     const birthTime = _birthTimeOf(procMap, a.pid);
+    const witness = _witnessOf(procMap, a.pid);
     const cached = forceRefresh ? undefined : parentChainCache.get(key);
     const live = cached !== undefined && now - cached.timestamp <= PARENT_CHAIN_TTL;
-    const proven = live && (a.pid <= 0 || (birthTime !== null && cached.startTime === birthTime));
+    const proven =
+      live &&
+      (a.pid <= 0 ||
+        (witness !== null &&
+          cached.witness === witness.value &&
+          cached.witnessSource === witness.source));
 
     if (proven) {
       a.parentChain = cached.chain;
     } else {
       const chain = _walkChain(procMap, a.pid);
-      parentChainCache.set(key, { chain, startTime: birthTime, timestamp: now });
+      parentChainCache.set(key, {
+        chain,
+        startTime: birthTime,
+        witness: witness ? witness.value : null,
+        witnessSource: witness ? witness.source : null,
+        timestamp: now,
+      });
       a.parentChain = chain;
     }
     a.startTime = birthTime;
+    a.generationWitness = witness ? witness.value : null;
+    a.generationWitnessSource = witness ? witness.source : null;
   }
 }
 
@@ -260,6 +332,11 @@ async function _stampFromFreshBirthTimes(agents, forceRefresh) {
  * per-pass process map here would buy nothing — there is no birth time in it to
  * prove a generation with — and would cost a `ps` spawn or a full /proc walk every
  * scan tick.
+ *
+ * No generation witness is stamped here, deliberately: the field stays `undefined`,
+ * which {@link annotateWorkingDirs} reads as "this record established no
+ * generation" and answers with the plain TTL contract. An invented witness would be
+ * a fabricated proof.
  * @param {Array} agents
  * @param {boolean} forceRefresh
  * @returns {Promise<void>}
@@ -291,13 +368,20 @@ async function _stampFromCachedChains(agents, forceRefresh) {
  * supplies no birth time, and null for an absent pid.
  *
  * WHERE IT COMES FROM decides whether `instanceId` means anything. On a platform
- * that supplies birth times, every pass makes ONE fresh process-map observation and
- * the birth time it reads is both the stamped value and the proof that the cached
- * `parentChain` (and, downstream, the cached cwd) still describes the process living
- * under that pid — see {@link _stampFromFreshBirthTimes}. Serving a CACHED birth
+ * that supplies birth times, every pass makes ONE fresh process-map observation:
+ * the birth time it reads is the stamped value, and the GENERATION WITNESS it reads
+ * alongside is the proof that the cached `parentChain` (and, downstream, the cached
+ * cwd) still describes the process living under that pid — see
+ * {@link _stampFromFreshBirthTimes} and {@link _witnessOf}. Serving a CACHED birth
  * time was the poisoning bug: a pid Windows had reissued to another process of the
  * same executable name kept the dead process's birth time, so both instances shared
  * one `instanceId`, and with it one session, one dedup set and one token ledger.
+ *
+ * `generationWitness` / `generationWitnessSource` are stamped here too. They gate
+ * cache reuse and NOTHING else: the `instanceId` format stays `pid:startTime(ms)`,
+ * so two instances that share a pid and a birth millisecond still collide on the
+ * identity even when a stronger witness can tell them apart. That bound is
+ * documented, not eliminated (process-identity.js TIME RESOLUTION).
  *
  * `instanceId` / `instanceIdSource` are derived from that startTime by
  * process-identity.js. This is the ONLY place they are stamped, so it must run
@@ -324,26 +408,28 @@ async function enrichWithParentChains(agents, opts = {}) {
 }
 
 /**
- * The generation ONE agent record carries out of its own enrichment pass.
+ * The generation witness ONE agent record carries out of its own enrichment pass.
  *
  * Read off the record, never out of `parentChainCache`. The cache is keyed by
  * `pid|name` and is shared by every record that ever used that key, so a lookup
  * there would answer with a generation some OTHER record established — possibly on
  * an earlier tick — and a record that never went through enrichment at all would
- * silently borrow it. `startTime` is written by {@link enrichWithParentChains} on
+ * silently borrow it. The witness is written by {@link enrichWithParentChains} on
  * every observation, so the record itself is the only honest source.
- * @param {{startTime?: number|null}} agent
- * @returns {number|null|undefined} epoch-ms when this record's own fresh observation
- *   produced a usable birth time; `null` when enrichment ran for it and the platform
- *   withheld one (nothing is proven); `undefined` when this record never passed
- *   through enrichment, so no generation was established for it either way.
+ * @param {{generationWitness?: string|null, generationWitnessSource?: string|null}} agent
+ * @returns {{value: string, source: string}|null|undefined} the pair when this
+ *   record's own fresh observation produced a witness; `null` when enrichment ran
+ *   for it and the observation produced none (nothing is proven); `undefined` when
+ *   this record never passed through enrichment, so no generation was established
+ *   for it either way.
+ * @since v0.12.0
  */
-function _recordGeneration(agent) {
-  const v = agent.startTime;
-  if (v === undefined) return undefined;
-  // Same usability test process-identity.js applies before building an `os` key, so
-  // a value that cannot identify an instance cannot prove one either.
-  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : null;
+function _recordWitness(agent) {
+  const value = agent.generationWitness;
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const source = agent.generationWitnessSource;
+  return typeof source === 'string' && source.length > 0 ? { value, source } : null;
 }
 
 /** Map editor host exe names (lowercase) to human-readable labels, derived from EDITORS */
@@ -388,16 +474,17 @@ const CWD_CACHE_TTL = 60000;
  * pid belonging to a different executable into a cache MISS.
  *
  * A same-name recycled pid produces the same key, so on a platform that supplies
- * birth times the entry additionally carries the GENERATION it was fetched under,
- * and it is served only while that generation is still the one THIS agent record
- * carries from its own enrichment pass ({@link _recordGeneration}). This function
- * performs NO birth-time lookup of its own — it consumes the observation the record
- * already holds, which is why scan-loop must keep running the identity stamp first.
+ * birth times the entry additionally carries the GENERATION WITNESS it was fetched
+ * under, and it is served only while that witness is still the one THIS agent record
+ * carries from its own enrichment pass ({@link _recordWitness}). This function
+ * performs NO observation of its own — it consumes the one the record already holds,
+ * which is why scan-loop must keep running the identity stamp first.
  *
  * Three cases, and the middle one is the honest degradation:
- *   - a number → the cwd must have been fetched under that same generation;
- *   - `null` (enrichment ran for this record and the fresh observation withheld the
- *     birth time) → nothing is proven, so the cwd is re-fetched rather than
+ *   - a witness pair → the cwd must have been fetched under that same value AND
+ *     source;
+ *   - `null` (enrichment ran for this record and the fresh observation produced no
+ *     witness) → nothing is proven, so the cwd is re-fetched rather than
  *     inherited from the old generation;
  *   - `undefined` (this record never passed through enrichment — every pid on
  *     linux/darwin, pid ≤ 0, and any direct caller that skipped the stamp) → the
@@ -421,13 +508,13 @@ async function annotateWorkingDirs(agents, opts = {}) {
   _pruneStale(cwdCache, CWD_CACHE_TTL, now);
 
   // One cache key per agent, resolved once, via the same `_agentName` the
-  // parent-chain cache keys on, plus the generation THAT RECORD carries. pid ≤ 0 is
+  // parent-chain cache keys on, plus the witness THAT RECORD carries. pid ≤ 0 is
   // not an OS process, so it has no generation — undefined leaves the synthetics on
   // the plain TTL contract.
   const entries = agents.map((a) => ({
     agent: a,
     key: _cacheKey(a.pid, _agentName(a)),
-    generation: _providesStartTime && a.pid > 0 ? _recordGeneration(a) : undefined,
+    witness: _providesStartTime && a.pid > 0 ? _recordWitness(a) : undefined,
   }));
 
   // Pids with no live, generation-proven cache entry. Agents can share a pid (the
@@ -438,8 +525,11 @@ async function annotateWorkingDirs(agents, opts = {}) {
     const cached = forceRefresh ? null : cwdCache.get(e.key);
     const fresh = cached && now - cached.timestamp <= CWD_CACHE_TTL;
     const proven =
-      e.generation === undefined ||
-      (e.generation !== null && cached && cached.generation === e.generation);
+      e.witness === undefined ||
+      (e.witness !== null &&
+        cached &&
+        cached.witness === e.witness.value &&
+        cached.witnessSource === e.witness.source);
     if (fresh && proven) continue;
     uncachedPids.add(e.agent.pid);
   }
@@ -454,10 +544,11 @@ async function annotateWorkingDirs(agents, opts = {}) {
     if (batchResults && uncachedPids.has(e.agent.pid)) {
       cwdCache.set(e.key, {
         cwd: batchResults.get(e.agent.pid) || null,
-        // The generation this directory was read under. `undefined` (no generation
-        // established) stores as null, which no established generation ever matches
+        // The witness this directory was read under. `undefined` (no generation
+        // established) stores as null, which no established witness ever matches
         // — a value fetched without a proof never becomes one.
-        generation: e.generation === undefined ? null : e.generation,
+        witness: e.witness ? e.witness.value : null,
+        witnessSource: e.witness ? e.witness.source : null,
         timestamp: now,
       });
     }

--- a/src/shared/types/process.ts
+++ b/src/shared/types/process.ts
@@ -10,7 +10,16 @@ export interface ProcessInfo {
   readonly pid: number;
 }
 
-/** Parent process info from Win32_Process CIM instance */
+/**
+ * Where a generation witness came from. `sequence` = the kernel SequenceNumber
+ * (Microsoft's documented PID-reuse detector); `createTime100ns` = process creation
+ * time in 100 ns ticks; `startTimeMs` = the epoch-ms birth time, stringified — what
+ * the emergency CIM observation can offer. The source is compared alongside the
+ * value, so witnesses of different provenance are never equal.
+ */
+export type GenerationWitnessSource = 'sequence' | 'createTime100ns' | 'startTimeMs';
+
+/** Parent process info from a snapshot observation (sidecar, or CIM fallback) */
 export interface ParentProcessInfo {
   readonly name: string;
   readonly ppid: number;
@@ -19,6 +28,15 @@ export interface ParentProcessInfo {
    * entries omit it, so the field is null there.
    */
   readonly startTime?: number | null;
+  /**
+   * Generation witness for this pid, always a string — 64-bit values that a JS
+   * number cannot hold without losing low digits. Present only when the snapshot
+   * sidecar served the observation; the CIM fallback omits it and process-utils
+   * derives a `startTimeMs` witness instead.
+   */
+  readonly witness?: string | null;
+  /** Provenance of {@link ParentProcessInfo.witness}. */
+  readonly witnessSource?: GenerationWitnessSource | null;
 }
 
 /**
@@ -67,6 +85,21 @@ export interface DetectedAgent {
   readonly instanceId?: string;
   /** Where {@link DetectedAgent.instanceId} came from. */
   readonly instanceIdSource?: InstanceIdSource;
+  /**
+   * Generation witness from THIS record's own enrichment pass — the proof that a
+   * cached parent chain or working directory still belongs to the process living
+   * under this pid. Gates cache reuse and nothing else: it is deliberately NOT part
+   * of {@link DetectedAgent.instanceId}, so two instances sharing a pid and a birth
+   * millisecond still collide on the identity even when the witness separates them.
+   *
+   * `null` = enrichment ran and the observation produced no witness (nothing is
+   * proven); absent = this record never passed through enrichment, so no generation
+   * was established for it either way. Never read from a cache — a cache entry is
+   * shared by every record that ever used its key.
+   */
+  readonly generationWitness?: string | null;
+  /** Provenance of {@link DetectedAgent.generationWitness}. */
+  readonly generationWitnessSource?: GenerationWitnessSource | null;
   /**
    * `true` only on records fabricated by the browser demo engine
    * (renderer/lib/stores/demo-data.js). ABSENT on everything the main process

--- a/tests/main/platform/proc-snapshot-client.test.js
+++ b/tests/main/platform/proc-snapshot-client.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import client from '../../../src/main/platform/proc-snapshot-client.js';
+import protocol from '../../../src/main/platform/proc-snapshot-protocol.js';
+
+const { encodeFrame, PROTOCOL_VERSION } = protocol;
+
+/**
+ * A stand-in for the sidecar process. The Windows binary is never executed by CI —
+ * all five required contexts run on Linux — so the supervision logic is proven
+ * against this fake or it is not proven at all.
+ * @returns {Object}
+ */
+function makeFakeChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.written = [];
+  child.stdinEnded = false;
+  child.killed = false;
+  child.stdin = {
+    write: (buf) => {
+      child.written.push(buf);
+      return true;
+    },
+    end: () => {
+      child.stdinEnded = true;
+    },
+  };
+  child.kill = () => {
+    child.killed = true;
+  };
+  return child;
+}
+
+/** Let queued microtasks and immediates run. */
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+const HELLO = {
+  t: 'hello',
+  proto: PROTOCOL_VERSION,
+  caps: { class: 'class5', sequence: false, topology: true },
+  pid: 4242,
+};
+
+describe('platform/proc-snapshot-client', () => {
+  let children;
+  let spawnCalls;
+  let clock;
+
+  /**
+   * Drive one full request: send it, hand over the hello, let the request frame be
+   * written, then let the caller answer.
+   * @param {Object} [opts]
+   * @returns {Promise<{promise: Promise<any>, child: Object}>}
+   */
+  async function startRequest(opts = {}) {
+    const promise = client.requestSnapshot({ timeoutMs: 60, ...opts });
+    const child = children[children.length - 1];
+    child.stdout.emit('data', encodeFrame(HELLO));
+    await flush();
+    return { promise, child };
+  }
+
+  beforeEach(() => {
+    children = [];
+    spawnCalls = [];
+    clock = 1000;
+    client._resetForTest();
+    client._setInternalsForTest({
+      spawn: (exePath, args, opts) => {
+        spawnCalls.push({ exePath, args, opts });
+        const child = makeFakeChild();
+        children.push(child);
+        return child;
+      },
+      resolveExePath: () => 'C:\\fake\\aegis-procsnap.exe',
+      now: () => clock,
+    });
+  });
+
+  afterEach(() => {
+    client._resetForTest();
+  });
+
+  it('spawns the resolved binary with piped stdio and no shell', async () => {
+    const { promise, child } = await startRequest();
+    child.stdout.emit(
+      'data',
+      encodeFrame({ t: 'snap', id: 1, source: 'class5', procs: [{ pid: 7 }] }),
+    );
+    await expect(promise).resolves.toEqual({ source: 'class5', procs: [{ pid: 7 }] });
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].exePath).toBe('C:\\fake\\aegis-procsnap.exe');
+    expect(spawnCalls[0].args).toEqual([]);
+    expect(spawnCalls[0].opts).toEqual({ stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
+    expect(spawnCalls[0].opts.shell).toBeUndefined();
+  });
+
+  it('sends exactly one snap frame per request and reuses the same child', async () => {
+    const first = await startRequest();
+    first.child.stdout.emit('data', encodeFrame({ t: 'snap', id: 1, source: 'basic', procs: [] }));
+    await first.promise;
+
+    const second = client.requestSnapshot({ timeoutMs: 60 });
+    await flush();
+    first.child.stdout.emit('data', encodeFrame({ t: 'snap', id: 2, source: 'basic', procs: [] }));
+    await second;
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(first.child.written).toHaveLength(2);
+    expect(client.getState().connected).toBe(true);
+  });
+
+  it('reports the capability block the hello announced', async () => {
+    const { promise, child } = await startRequest();
+    child.stdout.emit('data', encodeFrame({ t: 'snap', id: 1, source: 'class5', procs: [] }));
+    await promise;
+    expect(client.getState().caps).toEqual({ class: 'class5', sequence: false, topology: true });
+  });
+
+  it('ignores a response whose id matches no request, then answers the real one', async () => {
+    const { promise, child } = await startRequest();
+    child.stdout.emit(
+      'data',
+      encodeFrame({ t: 'snap', id: 99, source: 'class5', procs: [{ pid: 1 }] }),
+    );
+    child.stdout.emit(
+      'data',
+      encodeFrame({ t: 'snap', id: 1, source: 'class5', procs: [{ pid: 2 }] }),
+    );
+    await expect(promise).resolves.toEqual({ source: 'class5', procs: [{ pid: 2 }] });
+  });
+
+  it('rejects a malformed snapshot response', async () => {
+    const { promise, child } = await startRequest();
+    child.stdout.emit('data', encodeFrame({ t: 'snap', id: 1, source: 'class5', procs: 'nope' }));
+    await expect(promise).rejects.toThrow(/malformed snapshot response/);
+  });
+
+  it('rejects a second request while one is in flight', async () => {
+    const { promise, child } = await startRequest();
+    await expect(client.requestSnapshot({ timeoutMs: 60 })).rejects.toThrow(/already in flight/);
+    child.stdout.emit('data', encodeFrame({ t: 'snap', id: 1, source: 'class5', procs: [] }));
+    await promise;
+  });
+
+  describe('fail-honest supervision', () => {
+    it('disables itself for the session when no binary exists — and never spawns', async () => {
+      client._setInternalsForTest({ resolveExePath: () => null });
+      await expect(client.requestSnapshot({ timeoutMs: 60 })).rejects.toThrow(/binary not found/);
+      await expect(client.requestSnapshot({ timeoutMs: 60 })).rejects.toThrow(/unavailable/);
+      expect(spawnCalls).toHaveLength(0);
+      expect(client.getState().available).toBe(false);
+      expect(client.getState().sticky).toMatch(/binary not found/);
+    });
+
+    it('disables itself on a protocol version it does not know', async () => {
+      const promise = client.requestSnapshot({ timeoutMs: 60 });
+      children[0].stdout.emit('data', encodeFrame({ ...HELLO, proto: PROTOCOL_VERSION + 1 }));
+      await expect(promise).rejects.toThrow(/protocol version mismatch/);
+      expect(client.getState().sticky).toMatch(/protocol version mismatch/);
+      await expect(client.requestSnapshot({ timeoutMs: 60 })).rejects.toThrow(/unavailable/);
+      expect(spawnCalls).toHaveLength(1);
+    });
+
+    it('disables itself on a hello with no usable capability block', async () => {
+      const promise = client.requestSnapshot({ timeoutMs: 60 });
+      children[0].stdout.emit('data', encodeFrame({ t: 'hello', proto: PROTOCOL_VERSION }));
+      await expect(promise).rejects.toThrow(/capability block/);
+      expect(client.getState().available).toBe(false);
+    });
+
+    it('kills the child and backs off when a snapshot times out', async () => {
+      const { promise, child } = await startRequest({ timeoutMs: 20 });
+      await expect(promise).rejects.toThrow(/timed out/);
+      expect(child.killed).toBe(true);
+      expect(client.getState().failures).toBe(1);
+      await expect(client.requestSnapshot({ timeoutMs: 20 })).rejects.toThrow(/backing off/);
+      expect(spawnCalls).toHaveLength(1);
+    });
+
+    it('respawns once the backoff has elapsed', async () => {
+      const { promise, child } = await startRequest();
+      child.emit('exit', 1, null);
+      await expect(promise).rejects.toThrow(/child exited/);
+
+      clock += 1001;
+      const retry = await startRequest();
+      retry.child.stdout.emit(
+        'data',
+        encodeFrame({ t: 'snap', id: 2, source: 'basic', procs: [] }),
+      );
+      await expect(retry.promise).resolves.toEqual({ source: 'basic', procs: [] });
+      expect(spawnCalls).toHaveLength(2);
+    });
+
+    it('gives up for the session once the restart budget is exhausted', async () => {
+      const backoffs = [0, 1001, 5001];
+      for (const step of backoffs) {
+        clock += step;
+        const promise = client.requestSnapshot({ timeoutMs: 60 });
+        children[children.length - 1].emit('exit', 1, null);
+        await expect(promise).rejects.toThrow(/child exited/);
+      }
+      expect(spawnCalls).toHaveLength(3);
+      expect(client.getState().available).toBe(false);
+      expect(client.getState().sticky).toMatch(/restart budget exhausted/);
+      await expect(client.requestSnapshot({ timeoutMs: 60 })).rejects.toThrow(/unavailable/);
+      expect(spawnCalls).toHaveLength(3);
+    });
+
+    it('treats a desynchronised stream as a failure and tears the child down', async () => {
+      const { promise, child } = await startRequest();
+      const bogus = Buffer.alloc(8);
+      bogus.writeUInt32LE(0, 0);
+      child.stdout.emit('data', bogus);
+      await expect(promise).rejects.toThrow(/desynchronised/);
+      expect(child.killed).toBe(true);
+      expect(client.getState().failures).toBe(1);
+    });
+
+    it('rejects the pass on an err frame WITHOUT spending a restart', async () => {
+      const { promise, child } = await startRequest();
+      child.stdout.emit(
+        'data',
+        encodeFrame({ t: 'err', id: 1, code: 'nt-status', ntstatus: '0xC0000004' }),
+      );
+      await expect(promise).rejects.toThrow(/sidecar error nt-status/);
+      // The child answered, so it is healthy: no kill, no failure counted, and the
+      // next pass reuses it rather than paying a respawn.
+      expect(child.killed).toBe(false);
+      expect(client.getState().failures).toBe(0);
+      expect(client.getState().connected).toBe(true);
+    });
+  });
+
+  it('closes stdin and kills the child on shutdown', async () => {
+    const { promise, child } = await startRequest();
+    child.stdout.emit('data', encodeFrame({ t: 'snap', id: 1, source: 'class5', procs: [] }));
+    await promise;
+
+    client.shutdown();
+    expect(child.stdinEnded).toBe(true);
+    expect(child.killed).toBe(true);
+    expect(client.getState().connected).toBe(false);
+  });
+
+  it('forwards sidecar stderr to the debug log without failing the pass', async () => {
+    const { promise, child } = await startRequest();
+    expect(() => child.stderr.emit('data', Buffer.from('probe: class5\n'))).not.toThrow();
+    child.stdout.emit('data', encodeFrame({ t: 'snap', id: 1, source: 'class5', procs: [] }));
+    await expect(promise).resolves.toBeTruthy();
+  });
+
+  it('rejects a caller that arrives DURING the handshake, before any request slot exists', async () => {
+    // The busy guard has to cover the spawn window too. Two callers attaching to one
+    // handshake would both write a request, the second would take over the response
+    // slot, and the first would hang until its own timeout.
+    const first = client.requestSnapshot({ timeoutMs: 60 });
+    await expect(client.requestSnapshot({ timeoutMs: 60 })).rejects.toThrow(/already in flight/);
+    expect(spawnCalls).toHaveLength(1);
+
+    children[0].stdout.emit('data', encodeFrame(HELLO));
+    await flush();
+    expect(children[0].written).toHaveLength(1);
+    children[0].stdout.emit('data', encodeFrame({ t: 'snap', id: 1, source: 'basic', procs: [] }));
+    await expect(first).resolves.toEqual({ source: 'basic', procs: [] });
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it('is silent about a stale child that exits after teardown', async () => {
+    const { promise, child } = await startRequest();
+    child.stdout.emit('data', encodeFrame({ t: 'snap', id: 1, source: 'class5', procs: [] }));
+    await promise;
+    client.shutdown();
+    child.emit('exit', 0, null);
+    expect(client.getState().failures).toBe(0);
+    expect(client.getState().available).toBe(true);
+  });
+});

--- a/tests/main/platform/proc-snapshot-protocol.test.js
+++ b/tests/main/platform/proc-snapshot-protocol.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import protocol from '../../../src/main/platform/proc-snapshot-protocol.js';
+
+const { encodeFrame, createFrameDecoder, MAX_FRAME_BYTES, PROTOCOL_VERSION } = protocol;
+
+/**
+ * Build a frame by hand so the decoder is tested against BYTES, not against
+ * whatever encodeFrame happens to produce.
+ * @param {number} len - the length prefix to write (may deliberately lie).
+ * @param {string} payload
+ * @returns {Buffer}
+ */
+function rawFrame(len, payload) {
+  const body = Buffer.from(payload, 'utf8');
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(len, 0);
+  return Buffer.concat([header, body]);
+}
+
+describe('platform/proc-snapshot-protocol', () => {
+  it('exposes the protocol version the client negotiates on', () => {
+    expect(PROTOCOL_VERSION).toBe(1);
+  });
+
+  describe('encodeFrame', () => {
+    it('round-trips a message through the decoder', () => {
+      const decoder = createFrameDecoder();
+      const { frames, errors, fatal } = decoder.push(encodeFrame({ t: 'snap', id: 3 }));
+      expect(frames).toEqual([{ t: 'snap', id: 3 }]);
+      expect(errors).toEqual([]);
+      expect(fatal).toBe(false);
+    });
+
+    it('writes the payload length, not counting the header', () => {
+      const frame = encodeFrame({ t: 'snap', id: 1 });
+      expect(frame.readUInt32LE(0)).toBe(frame.length - 4);
+    });
+
+    it('refuses to send a payload above the frame ceiling', () => {
+      const huge = { t: 'snap', pad: 'x'.repeat(MAX_FRAME_BYTES + 1) };
+      expect(() => encodeFrame(huge)).toThrow(RangeError);
+    });
+  });
+
+  describe('createFrameDecoder', () => {
+    it('reassembles a frame split across three chunks', () => {
+      const frame = encodeFrame({ t: 'hello', proto: 1 });
+      const decoder = createFrameDecoder();
+
+      expect(decoder.push(frame.subarray(0, 2)).frames).toEqual([]);
+      expect(decoder.pendingBytes()).toBe(2);
+      expect(decoder.push(frame.subarray(2, 7)).frames).toEqual([]);
+      const last = decoder.push(frame.subarray(7));
+
+      expect(last.frames).toEqual([{ t: 'hello', proto: 1 }]);
+      expect(decoder.pendingBytes()).toBe(0);
+    });
+
+    it('decodes two frames delivered in one chunk', () => {
+      const decoder = createFrameDecoder();
+      const chunk = Buffer.concat([encodeFrame({ t: 'a' }), encodeFrame({ t: 'b' })]);
+      expect(decoder.push(chunk).frames).toEqual([{ t: 'a' }, { t: 'b' }]);
+    });
+
+    it('keeps the tail of an incomplete second frame buffered', () => {
+      const decoder = createFrameDecoder();
+      const second = encodeFrame({ t: 'b' });
+      const chunk = Buffer.concat([encodeFrame({ t: 'a' }), second.subarray(0, 3)]);
+      const result = decoder.push(chunk);
+      expect(result.frames).toEqual([{ t: 'a' }]);
+      expect(decoder.pendingBytes()).toBe(3);
+      expect(decoder.push(second.subarray(3)).frames).toEqual([{ t: 'b' }]);
+    });
+
+    it('reports a bad payload and keeps decoding — framing is still in sync', () => {
+      const decoder = createFrameDecoder();
+      const chunk = Buffer.concat([rawFrame(7, 'not-json'.slice(0, 7)), encodeFrame({ t: 'b' })]);
+      const result = decoder.push(chunk);
+      expect(result.errors[0]).toMatch(/frame-parse-error/);
+      expect(result.fatal).toBe(false);
+      expect(result.frames).toEqual([{ t: 'b' }]);
+    });
+
+    it('rejects well-formed JSON that is not a message object', () => {
+      const decoder = createFrameDecoder();
+      const payload = '[1,2]';
+      const result = decoder.push(rawFrame(payload.length, payload));
+      expect(result.errors).toEqual(['frame-not-an-object']);
+      expect(result.frames).toEqual([]);
+      expect(result.fatal).toBe(false);
+    });
+
+    it('treats an oversized length prefix as desynchronisation, not as a big frame', () => {
+      const decoder = createFrameDecoder();
+      const result = decoder.push(rawFrame(MAX_FRAME_BYTES + 1, 'x'));
+      expect(result.fatal).toBe(true);
+      expect(result.frames).toEqual([]);
+      expect(result.errors[0]).toMatch(/frame-length-invalid/);
+    });
+
+    it('treats a zero length prefix as desynchronisation', () => {
+      const decoder = createFrameDecoder();
+      expect(decoder.push(rawFrame(0, '')).fatal).toBe(true);
+    });
+
+    it('stays fatal once desynchronised — a resynchronised guess is not offered', () => {
+      const decoder = createFrameDecoder();
+      decoder.push(rawFrame(0, ''));
+      const after = decoder.push(encodeFrame({ t: 'snap', id: 1 }));
+      expect(after.fatal).toBe(true);
+      expect(after.frames).toEqual([]);
+      expect(decoder.isFatal()).toBe(true);
+    });
+  });
+});

--- a/tests/main/platform/process-snapshot.test.js
+++ b/tests/main/platform/process-snapshot.test.js
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import Module from 'module';
+
+/** Operational-log lines the module under test emitted, newest last. */
+let logLines = [];
+const fakeLogger = {
+  debug: (mod, message, meta) => logLines.push({ level: 'debug', mod, message, meta }),
+  info: (mod, message, meta) => logLines.push({ level: 'info', mod, message, meta }),
+  warn: (mod, message, meta) => logLines.push({ level: 'warn', mod, message, meta }),
+  error: (mod, message, meta) => logLines.push({ level: 'error', mod, message, meta }),
+};
+
+// The module under test is CommonJS and holds its logger by reference, so the
+// substitution has to happen at require time — spying on an ESM default import
+// patches a different object and records nothing.
+const originalLoad = Module._load;
+Module._load = function (request, _parent, _isMain) {
+  if (request === '../logger') return fakeLogger;
+  return originalLoad.apply(this, arguments);
+};
+
+afterAll(() => {
+  Module._load = originalLoad;
+});
+
+/** 1717000000000 epoch-ms expressed in 100 ns FILETIME ticks. */
+const TICKS = '133614736000000000';
+
+/**
+ * @param {Array<Object>} procs
+ * @param {string} [source]
+ * @returns {{requestSnapshot: Function}}
+ */
+function clientReturning(procs, source = 'basic') {
+  return { requestSnapshot: vi.fn().mockResolvedValue({ source, procs }) };
+}
+
+/**
+ * @param {string} message
+ * @returns {{requestSnapshot: Function}}
+ */
+function clientFailing(message) {
+  return { requestSnapshot: vi.fn().mockRejectedValue(new Error(message)) };
+}
+
+describe('platform/process-snapshot', () => {
+  const originalMode = process.env.AEGIS_PROC_SNAPSHOT;
+  /** @type {any} */
+  let snapshot;
+
+  /**
+   * Reload the module so the rollout flag is read afresh.
+   * @returns {Promise<void>}
+   */
+  async function loadModule() {
+    vi.resetModules();
+    const mod = await import('../../../src/main/platform/process-snapshot.js');
+    snapshot = mod.default;
+  }
+
+  beforeEach(async () => {
+    logLines = [];
+    delete process.env.AEGIS_PROC_SNAPSHOT;
+    await loadModule();
+  });
+
+  afterEach(() => {
+    if (originalMode === undefined) delete process.env.AEGIS_PROC_SNAPSHOT;
+    else process.env.AEGIS_PROC_SNAPSHOT = originalMode;
+  });
+
+  describe('ticksToEpochMs', () => {
+    it('converts FILETIME ticks to the frozen epoch-millisecond contract', () => {
+      expect(snapshot.ticksToEpochMs(TICKS)).toBe(1717000000000);
+    });
+
+    it('keeps every low digit — the naive Number path is off by a millisecond here', () => {
+      // 2^53 is 9.0e15; ticks run at 1.3e17, so Number() rounds to the nearest
+      // multiple of 16 BEFORE any division, and on this value that rounding crosses
+      // a millisecond boundary. A witness that lost its low digits would compare
+      // EQUAL across two generations — the exact failure this guards against.
+      const ticks = '133614736000009999';
+      expect(snapshot.ticksToEpochMs(ticks)).toBe(1717000000000);
+      expect(Math.floor(Number(ticks) / 10000) - 11644473600000).toBe(1717000000001);
+    });
+
+    it('is honest about a value it cannot use', () => {
+      expect(snapshot.ticksToEpochMs('')).toBeNull();
+      expect(snapshot.ticksToEpochMs('12abc')).toBeNull();
+      expect(snapshot.ticksToEpochMs('1')).toBeNull();
+      expect(snapshot.ticksToEpochMs(undefined)).toBeNull();
+      expect(snapshot.ticksToEpochMs(Number(TICKS))).toBeNull();
+    });
+  });
+
+  describe('sidecar path', () => {
+    it('prefers the kernel SequenceNumber as the witness', async () => {
+      snapshot._setClientForTest(
+        clientReturning([{ pid: 100, ppid: 4, name: 'claude.exe', ct: TICKS, seq: '918273' }]),
+      );
+      const map = await snapshot.getParentProcessMap();
+      expect(map.get(100)).toEqual({
+        name: 'claude.exe',
+        ppid: 4,
+        startTime: 1717000000000,
+        witness: '918273',
+        witnessSource: 'sequence',
+      });
+      expect(snapshot.getSnapshotHealth().state).toBe('HEALTHY');
+    });
+
+    it('falls back to creation-time ticks when the OS supplies no sequence number', async () => {
+      snapshot._setClientForTest(
+        clientReturning([{ pid: 100, ppid: 4, name: 'claude.exe', ct: TICKS }], 'class5'),
+      );
+      const map = await snapshot.getParentProcessMap();
+      expect(map.get(100).witness).toBe(TICKS);
+      expect(map.get(100).witnessSource).toBe('createTime100ns');
+    });
+
+    it('keeps a readable witness even when the birth time is unusable', async () => {
+      snapshot._setClientForTest(
+        clientReturning([{ pid: 100, ppid: 4, name: 'claude.exe', ct: 'nope', seq: '7' }]),
+      );
+      const map = await snapshot.getParentProcessMap();
+      expect(map.get(100).startTime).toBeNull();
+      expect(map.get(100).witness).toBe('7');
+    });
+
+    it('drops records that carry no usable pid', async () => {
+      snapshot._setClientForTest(
+        clientReturning([
+          { pid: 0, name: 'idle', ct: TICKS },
+          { pid: -1, name: 'bogus', ct: TICKS },
+          { pid: 1.5, name: 'bogus', ct: TICKS },
+          { pid: 100, ppid: 4, name: 'claude.exe', ct: TICKS },
+        ]),
+      );
+      const map = await snapshot.getParentProcessMap();
+      expect([...map.keys()]).toEqual([100]);
+    });
+  });
+
+  describe('fallback chain', () => {
+    it('serves the CIM observation when the sidecar cannot, and marks itself DEGRADED', async () => {
+      snapshot._setClientForTest(clientFailing('binary not found'));
+      const cimMap = new Map([[100, { name: 'claude.exe', ppid: 4, startTime: 1717000000000 }]]);
+      const cimFallback = vi.fn().mockResolvedValue(cimMap);
+
+      const map = await snapshot.getParentProcessMap({ cimFallback });
+      expect(cimFallback).toHaveBeenCalledTimes(1);
+      // Passed through untouched: the CIM entry carries no witness, and
+      // process-utils derives a `startTimeMs` one from the birth time instead.
+      expect(map.get(100)).toEqual({ name: 'claude.exe', ppid: 4, startTime: 1717000000000 });
+      const health = snapshot.getSnapshotHealth();
+      expect(health.state).toBe('DEGRADED');
+      expect(health.lastError).toMatch(/binary not found/);
+    });
+
+    it('never spawns the sidecar under the cim kill switch', async () => {
+      process.env.AEGIS_PROC_SNAPSHOT = 'cim';
+      await loadModule();
+      const client = clientReturning([{ pid: 100, ppid: 4, name: 'claude.exe', ct: TICKS }]);
+      snapshot._setClientForTest(client);
+      const cimFallback = vi
+        .fn()
+        .mockResolvedValue(new Map([[100, { name: 'claude.exe', ppid: 4, startTime: 1 }]]));
+
+      const map = await snapshot.getParentProcessMap({ cimFallback });
+      expect(snapshot.getMode()).toBe('cim');
+      expect(client.requestSnapshot).not.toHaveBeenCalled();
+      expect(cimFallback).toHaveBeenCalledTimes(1);
+      expect(map.get(100).witness).toBeUndefined();
+    });
+
+    it('refuses the CIM fallback under strict — so a measurement cannot be mistaken', async () => {
+      process.env.AEGIS_PROC_SNAPSHOT = 'strict';
+      await loadModule();
+      snapshot._setClientForTest(clientFailing('timed out'));
+      const cimFallback = vi.fn();
+
+      const map = await snapshot.getParentProcessMap({ cimFallback });
+      expect(cimFallback).not.toHaveBeenCalled();
+      expect(map.size).toBe(0);
+      expect(snapshot.getSnapshotHealth().state).toBe('FAILED');
+    });
+
+    it('returns an empty map — never a remembered one — when nothing can observe', async () => {
+      snapshot._setClientForTest(clientFailing('dead'));
+      const map = await snapshot.getParentProcessMap({ cimFallback: async () => new Map() });
+      expect(map.size).toBe(0);
+      expect(snapshot.getSnapshotHealth().state).toBe('FAILED');
+    });
+
+    it('does not obey an unknown rollout value', async () => {
+      process.env.AEGIS_PROC_SNAPSHOT = 'turbo';
+      await loadModule();
+      expect(snapshot.getMode()).toBe('auto');
+      expect(
+        logLines.some((l) => l.level === 'warn' && /Unknown AEGIS_PROC_SNAPSHOT/.test(l.message)),
+      ).toBe(true);
+    });
+  });
+
+  describe('source visibility', () => {
+    it('names the serving source on EVERY pass, not only when it changes', async () => {
+      snapshot._setClientForTest(
+        clientReturning([{ pid: 100, ppid: 4, name: 'claude.exe', ct: TICKS }], 'class5'),
+      );
+
+      await snapshot.getParentProcessMap();
+      await snapshot.getParentProcessMap();
+
+      const perfLines = logLines.filter((l) => l.mod === 'perf' && l.message === 'snapshot');
+      expect(perfLines).toHaveLength(2);
+      for (const line of perfLines) {
+        expect(line.meta.source).toBe('class5');
+        expect(line.meta.procs).toBe(1);
+        expect(line.meta.mode).toBe('auto');
+        expect(typeof line.meta.ms).toBe('number');
+      }
+    });
+
+    it('counts a provider change, because each one invalidates every cached witness', async () => {
+      snapshot._setClientForTest(
+        clientReturning([{ pid: 100, ppid: 4, name: 'claude.exe', ct: TICKS }], 'class5'),
+      );
+      await snapshot.getParentProcessMap();
+      expect(snapshot.getSourceStats()).toEqual({ lastSource: 'class5', transitions: 0 });
+
+      snapshot._setClientForTest(clientFailing('died'));
+      await snapshot.getParentProcessMap({
+        cimFallback: async () => new Map([[100, { name: 'claude.exe', ppid: 4, startTime: 1 }]]),
+      });
+      expect(snapshot.getSourceStats()).toEqual({ lastSource: 'cim', transitions: 1 });
+    });
+  });
+});

--- a/tests/main/process-utils-witness.test.js
+++ b/tests/main/process-utils-witness.test.js
@@ -1,0 +1,452 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * The module path is overridable so `scripts/verify-witness-gate.mjs` can point
+ * this suite at a deliberately broken copy and prove the gate is load-bearing.
+ * ai-mistakes #21: a passing command proves the command ran, not that it inspected
+ * anything.
+ */
+const MODULE_UNDER_TEST =
+  process.env.AEGIS_PU_UNDER_TEST ||
+  new URL('../../src/main/process-utils.js', import.meta.url).href;
+const processUtils = (await import(/* @vite-ignore */ MODULE_UNDER_TEST)).default;
+
+/** One epoch-millisecond, shared by every generation below on purpose. */
+const MS = 1717000000000;
+/** The same instant in 100 ns FILETIME ticks. */
+const TICKS = '133614736000000000';
+
+describe('process-utils — generation witness', () => {
+  let mockGetParentProcessMap;
+  let mockGetProcessCwds;
+
+  beforeEach(() => {
+    mockGetParentProcessMap = vi.fn();
+    mockGetProcessCwds = vi.fn();
+    processUtils._resetForTest();
+    processUtils._setPlatformForTest({
+      getParentProcessMap: mockGetParentProcessMap,
+      getProcessCwds: mockGetProcessCwds,
+      // Pinned, never inherited from the CI host: the witness only exists on a
+      // platform that observes the process table per pass.
+      providesStartTime: true,
+    });
+  });
+
+  /**
+   * @param {Object} own - map entry for pid 100.
+   * @param {Object} [parent] - map entry for the parent pid it points at.
+   * @returns {Map<number, Object>}
+   */
+  function mapWith(own, parent) {
+    const entries = [[100, own]];
+    if (parent) entries.push([own.ppid, parent]);
+    return new Map(entries);
+  }
+
+  /** @returns {Array<Object>} a fresh single-agent batch (never reused across passes). */
+  function batch() {
+    return [{ pid: 100, agent: 'Claude Code', process: 'claude.exe' }];
+  }
+
+  describe('what the witness buys that the birth time could not', () => {
+    it('separates two instances that share a pid AND a birth millisecond', async () => {
+      // RESEARCH-BASELINE §4, verbatim: "Generation witness is authoritative for
+      // cache-generation validation but does not change the current `instanceId`
+      // format. Therefore same-PID + same-millisecond distinct generations remain a
+      // known downstream identity bound even when a stronger witness can distinguish
+      // them. Generation v2 must not claim to eliminate that bound."
+      //
+      // So: the CACHES must separate these two, and the IDENTITY must not pretend to.
+      // Do not "fix" the instanceId assertion below — it is the contract.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 200,
+            startTime: MS,
+            witness: '11',
+            witnessSource: 'sequence',
+          },
+          { name: 'code.exe', ppid: 0 },
+        ),
+      );
+      mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
+      const genA = batch();
+      await processUtils.enrichWithParentChains(genA);
+      await processUtils.annotateWorkingDirs(genA);
+      expect(genA[0].parentChain).toEqual(['code.exe']);
+      expect(genA[0].cwd).toBe('/home/user/project-a');
+
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 300,
+            startTime: MS,
+            witness: '12',
+            witnessSource: 'sequence',
+          },
+          { name: 'cursor.exe', ppid: 0 },
+        ),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-b']]));
+      const genB = batch();
+      await processUtils.enrichWithParentChains(genB);
+      await processUtils.annotateWorkingDirs(genB);
+
+      expect(genB[0].parentChain).toEqual(['cursor.exe']);
+      expect(genB[0].cwd).toBe('/home/user/project-b');
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(2);
+
+      expect(genB[0].generationWitness).toBe('12');
+      expect(genB[0].generationWitnessSource).toBe('sequence');
+      // The identity is deliberately UNCHANGED across the two generations.
+      expect(genB[0].instanceId).toBe(genA[0].instanceId);
+      expect(genB[0].instanceId).toBe('100:1717000000000');
+      expect(genB[0].instanceIdSource).toBe('os');
+    });
+
+    it('keeps the caches when the witness is unchanged — they are not decorative', async () => {
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 200,
+            startTime: MS,
+            witness: '11',
+            witnessSource: 'sequence',
+          },
+          { name: 'code.exe', ppid: 0 },
+        ),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-a']]));
+      const first = batch();
+      await processUtils.enrichWithParentChains(first);
+      await processUtils.annotateWorkingDirs(first);
+
+      // Same witness, DIFFERENT parent topology reported: the cached chain must win,
+      // because the witness proves it is the same process.
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 300,
+            startTime: MS,
+            witness: '11',
+            witnessSource: 'sequence',
+          },
+          { name: 'cursor.exe', ppid: 0 },
+        ),
+      );
+      const second = batch();
+      await processUtils.enrichWithParentChains(second);
+      await processUtils.annotateWorkingDirs(second);
+
+      expect(second[0].parentChain).toEqual(['code.exe']);
+      expect(second[0].cwd).toBe('/home/user/project-a');
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(1);
+    });
+
+    it('never lets two witnesses of different provenance prove each other', async () => {
+      // The value strings are byte-identical; only the source differs. A provider
+      // change must be able to invalidate a cache entry, never to confirm one.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        mapWith({ name: 'claude.exe', ppid: 200, startTime: MS }, { name: 'code.exe', ppid: 0 }),
+      );
+      mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
+      const viaCim = batch();
+      await processUtils.enrichWithParentChains(viaCim);
+      await processUtils.annotateWorkingDirs(viaCim);
+      expect(viaCim[0].generationWitnessSource).toBe('startTimeMs');
+      expect(viaCim[0].generationWitness).toBe(String(MS));
+
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 300,
+            startTime: MS,
+            witness: String(MS),
+            witnessSource: 'sequence',
+          },
+          { name: 'cursor.exe', ppid: 0 },
+        ),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-b']]));
+      const viaSidecar = batch();
+      await processUtils.enrichWithParentChains(viaSidecar);
+      await processUtils.annotateWorkingDirs(viaSidecar);
+
+      expect(viaSidecar[0].parentChain).toEqual(['cursor.exe']);
+      expect(viaSidecar[0].cwd).toBe('/home/user/project-b');
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('the witness is not the identity', () => {
+    it('gates the cache off a sequence number while the identity degrades honestly', async () => {
+      // Creation time unreadable, SequenceNumber readable: `<pid>:u` is the honest
+      // identity, and the cache gate still has a real proof to work with.
+      const entry = {
+        name: 'claude.exe',
+        ppid: 200,
+        witness: '918273',
+        witnessSource: 'sequence',
+      };
+      mockGetParentProcessMap.mockResolvedValue(mapWith(entry, { name: 'code.exe', ppid: 0 }));
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-a']]));
+
+      const first = batch();
+      await processUtils.enrichWithParentChains(first);
+      await processUtils.annotateWorkingDirs(first);
+      expect(first[0].startTime).toBeNull();
+      expect(first[0].instanceId).toBe('100:u');
+      expect(first[0].instanceIdSource).toBe('unknown');
+
+      const second = batch();
+      await processUtils.enrichWithParentChains(second);
+      await processUtils.annotateWorkingDirs(second);
+      expect(second[0].parentChain).toEqual(['code.exe']);
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(1);
+    });
+
+    it('still builds the os identity from the birth time, not from the witness', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith({
+          name: 'claude.exe',
+          ppid: 0,
+          startTime: MS,
+          witness: TICKS,
+          witnessSource: 'createTime100ns',
+        }),
+      );
+      const agents = batch();
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].instanceId).toBe('100:1717000000000');
+      expect(agents[0].instanceIdSource).toBe('os');
+      expect(agents[0].generationWitness).toBe(TICKS);
+    });
+  });
+
+  describe('fail honest', () => {
+    it('proves nothing when the observation produced no witness at all', async () => {
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 200,
+            startTime: MS,
+            witness: '11',
+            witnessSource: 'sequence',
+          },
+          { name: 'code.exe', ppid: 0 },
+        ),
+      );
+      mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
+      const warm = batch();
+      await processUtils.enrichWithParentChains(warm);
+      await processUtils.annotateWorkingDirs(warm);
+
+      // Neither a witness nor a birth time on this pass.
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith({ name: 'claude.exe', ppid: 200 }, { name: 'code.exe', ppid: 0 }),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-b']]));
+      const degraded = batch();
+      await processUtils.enrichWithParentChains(degraded);
+      await processUtils.annotateWorkingDirs(degraded);
+
+      // The old witness is not inherited, and the old generation's cwd is not served.
+      expect(degraded[0].generationWitness).toBeNull();
+      expect(degraded[0].generationWitnessSource).toBeNull();
+      expect(degraded[0].instanceId).toBe('100:u');
+      expect(degraded[0].cwd).toBe('/home/user/project-b');
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores a witness that arrives without a source, or with an empty value', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith({ name: 'claude.exe', ppid: 0, witness: '918273' }),
+      );
+      const noSource = batch();
+      await processUtils.enrichWithParentChains(noSource);
+      expect(noSource[0].generationWitness).toBeNull();
+
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith({ name: 'claude.exe', ppid: 0, witness: '', witnessSource: 'sequence' }),
+      );
+      const emptyValue = batch();
+      await processUtils.enrichWithParentChains(emptyValue);
+      expect(emptyValue[0].generationWitness).toBeNull();
+    });
+
+    it('refuses to derive a witness from an unusable birth time', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith({ name: 'claude.exe', ppid: 0, startTime: 0 }),
+      );
+      const agents = batch();
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].generationWitness).toBeNull();
+      expect(agents[0].instanceId).toBe('100:u');
+    });
+  });
+
+  describe('cross-record contamination', () => {
+    it('never lets a record borrow a witness another record established', async () => {
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        mapWith({
+          name: 'claude.exe',
+          ppid: 0,
+          startTime: MS,
+          witness: '11',
+          witnessSource: 'sequence',
+        }),
+      );
+      mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
+      const enriched = batch();
+      await processUtils.enrichWithParentChains(enriched);
+      await processUtils.annotateWorkingDirs(enriched);
+
+      // Another record moves the shared module cache on to witness 12.
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith({
+          name: 'claude.exe',
+          ppid: 0,
+          startTime: MS,
+          witness: '12',
+          witnessSource: 'sequence',
+        }),
+      );
+      const other = batch();
+      await processUtils.enrichWithParentChains(other);
+      expect(other[0].generationWitness).toBe('12');
+
+      // This one never passed through enrichment: it carries no witness of its own,
+      // so it gets the plain TTL contract — not somebody else's proof.
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-b']]));
+      const unenriched = batch();
+      await processUtils.annotateWorkingDirs(unenriched);
+      expect(unenriched[0].generationWitness).toBeUndefined();
+      expect(unenriched[0].cwd).toBe('/home/user/project-a');
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unchanged contracts', () => {
+    it('derives a startTimeMs witness from a legacy map entry, exactly as before', async () => {
+      // What the emergency CIM observation produces: a birth time and nothing else.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        mapWith({ name: 'claude.exe', ppid: 200, startTime: MS }, { name: 'code.exe', ppid: 0 }),
+      );
+      mockGetProcessCwds.mockResolvedValueOnce(new Map([[100, '/home/user/project-a']]));
+      const first = batch();
+      await processUtils.enrichWithParentChains(first);
+      await processUtils.annotateWorkingDirs(first);
+      expect(first[0].generationWitness).toBe('1717000000000');
+      expect(first[0].generationWitnessSource).toBe('startTimeMs');
+
+      // A different birth millisecond is still a different generation.
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith(
+          { name: 'claude.exe', ppid: 300, startTime: MS + 10700 },
+          { name: 'cursor.exe', ppid: 0 },
+        ),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-b']]));
+      const second = batch();
+      await processUtils.enrichWithParentChains(second);
+      await processUtils.annotateWorkingDirs(second);
+      expect(second[0].parentChain).toEqual(['cursor.exe']);
+      expect(second[0].cwd).toBe('/home/user/project-b');
+      expect(second[0].instanceId).toBe('100:1717000010700');
+    });
+
+    it('leaves the pid-0 synthetics on the plain TTL contract', async () => {
+      mockGetParentProcessMap.mockResolvedValue(new Map());
+      mockGetProcessCwds.mockResolvedValue(new Map());
+      const agents = [
+        { pid: 0, agent: 'Ollama', process: 'ollama' },
+        { pid: 0, agent: 'LM Studio', process: 'lm-studio' },
+      ];
+      await processUtils.enrichWithParentChains(agents);
+      await processUtils.annotateWorkingDirs(agents);
+      expect(agents[0].generationWitness).toBeNull();
+      expect(agents[0].instanceId).toBe('0:ollama');
+      expect(agents[1].instanceId).toBe('0:lm-studio');
+      expect(mockGetProcessCwds).toHaveBeenCalledWith([0]);
+    });
+
+    it('still observes exactly one process map per non-empty pass', async () => {
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 200,
+            startTime: MS,
+            witness: '11',
+            witnessSource: 'sequence',
+          },
+          { name: 'code.exe', ppid: 0 },
+        ),
+      );
+      const agents = batch();
+      await processUtils.enrichWithParentChains(agents);
+      await processUtils.enrichWithParentChains(agents);
+      await processUtils.enrichWithParentChains(agents);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(3);
+    });
+
+    it('still rebuilds the chain under forceRefresh even when the witness proves it', async () => {
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 200,
+            startTime: MS,
+            witness: '11',
+            witnessSource: 'sequence',
+          },
+          { name: 'code.exe', ppid: 0 },
+        ),
+      );
+      const agents = batch();
+      await processUtils.enrichWithParentChains(agents);
+      expect(agents[0].parentChain).toEqual(['code.exe']);
+
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith(
+          {
+            name: 'claude.exe',
+            ppid: 300,
+            startTime: MS,
+            witness: '11',
+            witnessSource: 'sequence',
+          },
+          { name: 'cursor.exe', ppid: 0 },
+        ),
+      );
+      await processUtils.enrichWithParentChains(agents, { forceRefresh: true });
+      expect(agents[0].parentChain).toEqual(['cursor.exe']);
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(2);
+    });
+
+    it('stamps no witness at all on a platform with no per-pass observation', async () => {
+      processUtils._setPlatformForTest({ providesStartTime: false });
+      mockGetParentProcessMap.mockResolvedValue(
+        mapWith({ name: 'claude', ppid: 200 }, { name: 'bash', ppid: 0 }),
+      );
+      mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-a']]));
+      const agents = [{ pid: 100, agent: 'Claude Code', process: 'claude' }];
+
+      for (let i = 0; i < 3; i++) {
+        await processUtils.enrichWithParentChains(agents);
+        await processUtils.annotateWorkingDirs(agents);
+      }
+      expect(agents[0].generationWitness).toBeUndefined();
+      expect(agents[0].instanceId).toBe('100:u');
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1);
+      expect(mockGetProcessCwds).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Block 1 (Generation v2), part A — all JavaScript. The sidecar binary lands in PR-B; until it
exists this branch changes no behaviour at all.

## What it does

- **Generation witness `(value, source)` replaces the epoch-ms birth time as the proof token** for
  parent-chain and CWD cache reuse. The witness is derived from the process-map entry in one place:
  what the snapshot sidecar observed, else the epoch-ms birth time stringified as `startTimeMs`,
  else null. Value and source are compared together, so two witnesses of different provenance can
  never prove each other — a provider change can only invalidate a cache entry, never confirm one.
- **Provider chooser** (`platform/process-snapshot.js`): sidecar first, the existing CIM
  observation as the emergency fallback, an empty map when neither can observe. The CIM function is
  passed in rather than imported, so no require cycle forms. Rollout flag `AEGIS_PROC_SNAPSHOT`:
  `auto` (default) / `cim` (kill switch) / `strict` (sidecar only, so a measurement cannot silently
  be a measurement of something else).
- **Frame codec and supervised client** for the sidecar: `uint32 LE` length prefix plus UTF-8 JSON,
  64-bit values (creation-time ticks, kernel SequenceNumber) as decimal strings. One request in
  flight, a 1200 ms deadline below the measured CIM p50, backoff 1 s / 5 s / 30 s, a three-restart
  budget, then the sidecar is given up on for the session with a single warning.

## What it does NOT do

- `instanceId = pid:startTime(ms)` is frozen and untouched; `startTime` stays epoch milliseconds.
- No change to the call order in `scan-loop.js` — the identity stamp still precedes reconcile, and
  the cwd annotation still runs before the pid-0 synthetics are pushed.
- Per RESEARCH-BASELINE section 4: the witness is authoritative for cache-generation validation and
  does not change the identity format, so two instances sharing a pid AND a birth millisecond
  remain indistinguishable to `instanceId` even when the SequenceNumber separates them. That bound
  is documented, not eliminated.

## Verification

- 1477 passed / 4 skipped over 89 files (measured today); 58 of those tests are new.
- The centrepiece test: same pid, same image name, **same epoch-millisecond**, different
  SequenceNumber — the chain is rebuilt and the cwd re-fetched, and `instanceId` is asserted
  byte-identical with source `os`.
- `npm run verify:gate` breaks the gate three ways in a throwaway copy and requires the witness
  suite to go red for each: the gate ignoring the witness, the cwd gate reading the witness out of
  the shared cache instead of off the record, and the value compared without its provenance. All
  three mutants are killed; a control run on the unmutated module is green first.
- End-to-end on Windows with no binary present: source `cim`, health `DEGRADED` with the reason
  `sidecar binary not found`, `instanceId 44788:1786591434819` source `os`, witness
  `1786591434819` / `startTimeMs`, stable across passes. Exactly the pre-change behaviour, with the
  degradation now visible in the log.

## Honest limits

- **CI never executes the Windows binary** — all five required contexts run on `ubuntu-latest`. The
  frames, the client state machine, the gate and the provider selection are proven by injection;
  no test is skipped by platform.
- `verify:gate` is not yet wired into CI (it is a step inside the `test` job in PR-B).
- `vitest.config.js` lists coverage files by name and does not yet include the three new modules
  (PR-B).
- `platform/proc-snapshot-client.js` is 435 lines against the 300-line target for new files
  (284 lines of code, the rest JSDoc); splitting one supervision state machine across two files
  would cost more than it buys.
