### PR TITLE
feat(bench): Bench V1 run skeleton and gate coverage for bench/ (B2.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ out/
 coverage/
 # Compiled snapshot sidecar — built from sidecar/procsnap, never committed
 build/sidecar/
+# Bench run artefacts — machine-specific measurements, written by bench/run.js.
+# The committed record of a run is a hand-written file in docs/bench/, never this.
+bench/runs/
 # Throwaway mutants written by scripts/verify-witness-gate.mjs (removed in a finally)
 src/main/.mutants/
 # `npx tsc -b` writes one per referenced project, next to the config

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,8 @@ package-lock.json
 *.ico
 *.icns
 *.md
+
+# Bench run artefacts are generated measurements, not source. The format:check
+# glob covers bench/**/*.{js,json} so the harness is gated; without this line a
+# single local run would put machine-written JSON in front of the formatter.
+bench/runs

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,119 @@
+# Bench V1
+
+Bench exists so AEGIS can state accuracy numbers that a third party can reproduce.
+Until it exists, no numeric confidence or accuracy figure may be published anywhere in
+the project (`memory-bank/RESEARCH-BASELINE.md` §3, §10).
+
+## Method
+
+For each scenario the bench **generates an expected-event catalogue as a by-product of
+running a deterministic script**, then confirms every row of that catalogue against an
+independent oracle (Sysmon, Procmon), and only afterwards compares it with what the AEGIS
+sensor recorded.
+
+Two rules are non-negotiable and are the reason the harness is shaped this way:
+
+- **Never diff two live streams.** The catalogue is the fixed point; both the oracle and
+  the sensor are scored against it, never against each other.
+- **A sensor is never its own oracle.** Nothing under `bench/` imports from `src/`. Where a
+  scenario needs ground truth about process identity, that truth comes from Sysmon EID 1
+  ordinality — never from the process-snapshot provider AEGIS itself reads.
+
+The actor's catalogue states intent and the fact of execution. It never confirms itself:
+every row it writes is confirmed by an oracle before any metric counts it.
+
+## Windows-only
+
+Sysmon, Procmon, the Restart Manager path and `reg query` are all Windows facilities. The
+bench does not run on Linux or macOS and does not pretend to: on another platform the
+manifest records each Windows fact as **absent with a reason**, rather than substituting a
+plausible value.
+
+Nested virtualisation is unsupported on GitHub runners and the required contexts all run on
+`ubuntu-latest`, so **the bench never runs in CI**. What CI does cover is `bench/` source
+quality: `npm run lint` and `npm run format:check` both walk this tree.
+
+## Numbers from a development machine are not accuracy figures
+
+**No number produced by a run on a development machine may be published as an AEGIS
+accuracy figure.** The condition for publishing is a run on a Hyper-V Gen2 gold image with a
+pinned Windows build (§10: "Hyper-V Gen2 gold image first"). Building the harness on a
+workstation is fine — a harness is not a claim; a number is. A development machine cannot
+pin its build: it updates.
+
+Committed run records live in `docs/bench/`, written by hand from a run's output so the
+prose around the numbers survives a re-run — the precedent is
+`docs/bench/generation-v2-2026-08-12.md`.
+
+## Running
+
+```
+npm run bench:run                                        # defaults: no-scenario, arm A
+npm run bench:run -- --scenario S1-agent-lifecycle --arm A
+```
+
+The `--` is required; without it npm keeps the flags.
+
+Arms, from §10 — a run is one scenario in one arm:
+
+| arm | what runs | measures |
+|---|---|---|
+| A | sensor + Sysmon | coverage and latency |
+| B | Sysmon + Procmon, no sensor | oracle calibration |
+| C | sensor alone | overhead |
+
+Arm B is what makes arm A's scoring legitimate: B establishes that the catalogue is faithful
+for a given deterministic scenario, and only then does A score the sensor against it.
+
+## Layout
+
+Present today (sub-block B2.1):
+
+```
+bench/
+  run.js              # create a run directory, write its manifest
+  lib/manifest.js     # environment snapshot; absent facts stay absent
+  runs/               # run artefacts — gitignored, created on first run
+  README.md
+```
+
+Arriving with later sub-blocks, listed so the tree's shape is legible, not so it reads as
+built — nothing below exists yet:
+
+| path | sub-block |
+|---|---|
+| `bench/scenario.schema.json`, `bench/scenarios/<id>/scenario.json`, `bench/lib/actor.js`, `bench/lib/catalogue.js` | B2.2 |
+| `bench/lib/oracles/sysmon.js`, `bench/oracles/sysmon-bench.xml` | B2.3 |
+| `bench/lib/sut-capture.js` | B2.4 |
+| `bench/score.js`, `bench/lib/join.js`, `bench/lib/metrics.js` | B2.5 |
+| `bench/lib/oracles/procmon.js`, `bench/oracles/procmon-bench.pmc` | B2.6 |
+| `bench/report.js` | B2.9 |
+
+## Run artefacts
+
+One run is one directory under `bench/runs/`, named `<UTC instant>-<scenario>-<arm>`. The
+directory is created fresh and never written into twice, so a re-run cannot blend two
+machines' artefacts into one record.
+
+`manifest.json` is written today. The remaining files arrive with the sub-blocks that
+produce them: `expected.ndjson` (catalogue), `oracle-sysmon.ndjson`, `oracle-procmon.ndjson`,
+`oracle-loss.json`, `sut.ndjson`, `matched.ndjson`, `metrics.json`.
+
+### Absent, never guessed
+
+Every manifest field is `{value, source}` when the probe succeeded and
+`{value: null, unavailable: <reason>, source}` when it did not. That distinction is the
+point: "this machine reported build 26200" and "we could not read the build" must not
+collapse into the same record. `run.js` prints the absent facts at the end of a run so a
+degraded environment is visible at the moment of measurement rather than at analysis time.
+
+Two fields worth knowing about:
+
+- **`host.windowsBuild`** comes from `reg query`, not `os.release()`, because the UBR — the
+  component that separates two machines both calling themselves 26200 — exists only in the
+  registry. `productName` is recorded verbatim even when it disagrees with `os.version()`
+  (Windows 11 machines routinely report `Windows 10 <edition>` under that key). The manifest
+  records what each source said and never reconciles two sources into one invented answer.
+- **`sensor.workingTreeDirty`** means the measured sensor is not exactly the commit named in
+  `sensor.gitSha`. It is recorded, not refused: running against uncommitted work is
+  legitimate while building the harness, and dishonest only if left unsaid.

--- a/bench/lib/manifest.js
+++ b/bench/lib/manifest.js
@@ -1,0 +1,245 @@
+/**
+ * @file bench/lib/manifest.js
+ * @module bench/lib/manifest
+ * @description Environment snapshot for one bench run.
+ *
+ *   A bench number is worth nothing without the machine it was measured on, so
+ *   every run directory opens with a manifest. The rule this file is built
+ *   around: **an absent fact is recorded as absent, never guessed.** Every
+ *   entry is `{value, source}` when the probe succeeded and
+ *   `{value: null, unavailable: <reason>, source}` when it did not — so a
+ *   reader can tell "this machine reported build 26200" from "we could not
+ *   read the build", which a bare `null` or a plausible default would merge.
+ *
+ *   Nothing here is imported from `src/`. The bench observes the sensor from
+ *   outside; a shared module would make AEGIS a contributor to its own
+ *   measurement record.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.11.0
+ */
+'use strict';
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+/** @type {string} Repository root — this file is `bench/lib/`, two levels down. */
+const ROOT = path.resolve(__dirname, '..', '..');
+
+/** @type {number} Manifest shape version. Bump when a field changes meaning. */
+const MANIFEST_SCHEMA_VERSION = 1;
+
+/**
+ * The three run separations of RESEARCH-BASELINE section 10. Kept here rather
+ * than in the CLI so every consumer of a manifest reads the same closed set.
+ * @type {ReadonlyArray<string>}
+ */
+const ARMS = Object.freeze(['A', 'B', 'C']);
+
+/**
+ * What each arm runs. Written into the manifest so a run directory explains
+ * itself without the reader holding the canon open.
+ * @type {Readonly<Object<string, string>>}
+ */
+const ARM_DESCRIPTIONS = Object.freeze({
+  A: 'sensor + Sysmon — coverage and latency',
+  B: 'Sysmon + Procmon without the sensor — oracle calibration',
+  C: 'sensor alone — overhead',
+});
+
+/**
+ * Run one environment probe and wrap the outcome so absence stays visible.
+ * @param {string} source - How the value was obtained, verbatim (a command
+ *   line, a registry key, a Node API). Recorded whether or not the probe won.
+ * @param {function(): *} fn - The probe. Returning `null`/`undefined` counts as
+ *   an absent fact, not as a value.
+ * @returns {{value: *, source: string, unavailable?: string}}
+ */
+function probe(source, fn) {
+  try {
+    const value = fn();
+    if (value === undefined || value === null) {
+      return { value: null, source, unavailable: 'probe produced no value' };
+    }
+    return { value, source };
+  } catch (err) {
+    return { value: null, source, unavailable: String((err && err.message) || err) };
+  }
+}
+
+/**
+ * Read named values out of one registry key with a single `reg query`.
+ *
+ * `reg query` separates name, type and data with runs of four spaces, and the
+ * data may itself contain spaces (`Windows 10 Home`) — hence the greedy tail.
+ * A name that is not in the output is simply absent from the result: the
+ * caller decides what that means, and no default is substituted here.
+ * @param {string} keyPath - e.g. `HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion`
+ * @param {string[]} names - Value names to keep.
+ * @returns {Object<string, string|number>} REG_DWORD parsed as a number (the
+ *   data is printed in hex), every other type kept as a trimmed string.
+ */
+function readRegistryValues(keyPath, names) {
+  const out = execFileSync('reg', ['query', keyPath], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  const wanted = new Set(names);
+  /** @type {Object<string, string|number>} */
+  const found = {};
+  for (const line of out.split(/\r?\n/)) {
+    const m = line.match(/^\s{4}(\S+)\s{4}(REG_\w+)\s{4}(.*)$/);
+    if (!m) continue;
+    const [, name, type, raw] = m;
+    if (!wanted.has(name)) continue;
+    found[name] = type === 'REG_DWORD' ? Number.parseInt(raw, 16) : raw.trim();
+  }
+  return found;
+}
+
+/**
+ * Run a git command in the repository root and return its trimmed stdout.
+ * @param {string[]} args
+ * @returns {string}
+ */
+function git(args) {
+  return execFileSync('git', args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    windowsHide: true,
+  }).trim();
+}
+
+/**
+ * Windows build identity, from the registry rather than `os.release()`.
+ *
+ * `os.release()` gives `10.0.26200` and stops there; the UBR — the fourth
+ * component that actually distinguishes two machines both calling themselves
+ * 26200 — exists only in the registry. `productName` is recorded verbatim even
+ * when it disagrees with `os.version()` (Windows 11 machines routinely report
+ * `Windows 10 <edition>` under this key): the manifest records what each
+ * source said, and never reconciles two sources into one invented answer.
+ * @returns {{value: Object|null, source: string, unavailable?: string}}
+ */
+function windowsBuild() {
+  const key = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion';
+  return probe(`reg query "${key}"`, () => {
+    if (process.platform !== 'win32') return null;
+    const v = readRegistryValues(key, ['CurrentBuild', 'UBR', 'DisplayVersion', 'ProductName']);
+    if (Object.keys(v).length === 0) return null;
+    return {
+      currentBuild: v.CurrentBuild ?? null,
+      ubr: v.UBR ?? null,
+      displayVersion: v.DisplayVersion ?? null,
+      productName: v.ProductName ?? null,
+    };
+  });
+}
+
+/**
+ * How many processes were on the machine when the run started.
+ *
+ * `tasklist` is the same enumerator `process-scanner.js` uses, but it is
+ * spawned here directly rather than imported: the count is context for reading
+ * the numbers (provider cost scales with it — see
+ * docs/bench/generation-v2-2026-08-12.md), not evidence about the sensor, and
+ * the bench must not depend on the module under measurement.
+ * @returns {{value: number|null, source: string, unavailable?: string}}
+ */
+function processCount() {
+  return probe('tasklist /FO CSV /NH', () => {
+    if (process.platform !== 'win32') return null;
+    const out = execFileSync('tasklist', ['/FO', 'CSV', '/NH'], {
+      encoding: 'utf8',
+      windowsHide: true,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return out.split(/\r?\n/).filter((l) => l.trim().length > 0).length;
+  });
+}
+
+/**
+ * Placeholder oracle block. B2.3 fills `sysmon`, B2.6 fills `procmon` — each
+ * with a version, the config path and that config's SHA-256, so a run can be
+ * re-created. Until then the fields are present and explicitly null, because a
+ * key that is simply missing reads as "we forgot" rather than "not yet wired".
+ * @returns {Object}
+ */
+function oraclePlaceholders() {
+  return {
+    sysmon: {
+      version: null,
+      configPath: null,
+      configSha256: null,
+      unavailable: 'oracle adapter not implemented — arrives in sub-block B2.3',
+    },
+    procmon: {
+      version: null,
+      configPath: null,
+      configSha256: null,
+      unavailable: 'oracle adapter not implemented — arrives in sub-block B2.6',
+    },
+  };
+}
+
+/**
+ * Collect the manifest for one run.
+ * @param {Object} opts
+ * @param {string} opts.runId - Directory name of the run.
+ * @param {string} opts.scenario - Scenario id, or the no-scenario placeholder.
+ * @param {string} opts.arm - One of {@link ARMS}.
+ * @param {string} opts.startedAt - UTC ISO timestamp of the run start.
+ * @returns {Object} The manifest, ready to serialize.
+ */
+function collect(opts) {
+  return {
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    runId: opts.runId,
+    scenario: opts.scenario,
+    arm: opts.arm,
+    armDescription: ARM_DESCRIPTIONS[opts.arm] ?? null,
+    startedAt: opts.startedAt,
+    host: {
+      platform: probe('process.platform', () => process.platform),
+      osRelease: probe('os.release()', () => os.release()),
+      osVersion: probe('os.version()', () => os.version()),
+      windowsBuild: windowsBuild(),
+      cpuModel: probe('os.cpus()[0].model', () => os.cpus()[0].model),
+      cpuCount: probe('os.cpus().length', () => os.cpus().length),
+      totalMemBytes: probe('os.totalmem()', () => os.totalmem()),
+      uptimeSec: probe('os.uptime()', () => Math.round(os.uptime())),
+      nodeVersion: probe('process.version', () => process.version),
+    },
+    sensor: {
+      packageVersion: probe('package.json version', () => {
+        const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+        return pkg.version;
+      }),
+      gitSha: probe('git rev-parse HEAD', () => git(['rev-parse', 'HEAD'])),
+      gitBranch: probe('git rev-parse --abbrev-ref HEAD', () =>
+        git(['rev-parse', '--abbrev-ref', 'HEAD']),
+      ),
+      // A dirty tree means the measured sensor is not the commit named above.
+      // Recorded, not refused: a run against uncommitted work is legitimate
+      // while building the harness, and dishonest only if left unsaid.
+      workingTreeDirty: probe(
+        'git status --porcelain',
+        () => git(['status', '--porcelain']).length > 0,
+      ),
+    },
+    processCountAtStart: processCount(),
+    oracles: oraclePlaceholders(),
+  };
+}
+
+module.exports = {
+  ARMS,
+  ARM_DESCRIPTIONS,
+  MANIFEST_SCHEMA_VERSION,
+  ROOT,
+  collect,
+  probe,
+  readRegistryValues,
+};

--- a/bench/run.js
+++ b/bench/run.js
@@ -91,8 +91,9 @@ function parseArgs(argv) {
  * The timestamp keeps ISO-8601 ordering (run directories sort chronologically
  * as plain text) with `:` replaced, since it is illegal in a Windows path, and
  * the milliseconds dropped so two runs a second apart stay readable. Two runs
- * inside the same second collide — {@link createRunDir} refuses rather than
- * writing into an existing directory.
+ * of the same scenario and arm inside one second therefore build the same id —
+ * {@link createRunDir} refuses that, and {@link main} turns the refusal into
+ * the same exit 2 every other bad input gets.
  * @param {Date} now
  * @param {string} scenario
  * @param {string} arm
@@ -141,7 +142,21 @@ function main(argv) {
 
   const now = new Date();
   const runId = buildRunId(now, args.scenario, args.arm);
-  const dir = createRunDir(runId);
+  let dir;
+  try {
+    dir = createRunDir(runId);
+  } catch (err) {
+    // The likely case is EEXIST: the same scenario and arm inside one second.
+    // It fails legibly and with the same exit 2 as a bad flag — a bench loop
+    // must not end in a Node stack trace, and it must never be tempting to
+    // "fix" this by writing into a directory another run already owns.
+    console.error(
+      err.code === 'EEXIST'
+        ? `bench: run directory ${runId} already exists — a run never writes into one it did not create`
+        : `bench: could not create the run directory: ${err.message}`,
+    );
+    return 2;
+  }
   const record = manifest.collect({
     runId,
     scenario: args.scenario,

--- a/bench/run.js
+++ b/bench/run.js
@@ -1,0 +1,179 @@
+/**
+ * @file bench/run.js
+ * @description Bench V1 run entrypoint. Creates one run directory and writes
+ *   its environment manifest.
+ *
+ *   Sub-block B2.1 stops here on purpose: the scenario format (B2.2), the
+ *   oracle adapters (B2.3, B2.6) and the SUT capture (B2.4) are separate
+ *   blocks. What this file establishes is the run directory — the thing every
+ *   later artefact is written into, and the reason a bench number can be traced
+ *   back to a machine.
+ *
+ *   Usage:
+ *     npm run bench:run
+ *     npm run bench:run -- --scenario S1-agent-lifecycle --arm A
+ *
+ *   The `--` is not optional: without it npm keeps the flags for itself.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.11.0
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const manifest = require('./lib/manifest');
+
+/** @type {string} Where run directories are created. Gitignored. */
+const RUNS_DIR = path.join(manifest.ROOT, 'bench', 'runs');
+
+/**
+ * Scenario label used when none was named. Deliberately not `smoke` or
+ * `default`: no scenario machinery exists until B2.2, and a name that sounds
+ * like a scenario would document something that was never built.
+ * @type {string}
+ */
+const NO_SCENARIO = 'no-scenario';
+
+/** @type {RegExp} A label safe to use as one path segment. */
+const SAFE_LABEL = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+const USAGE = `bench/run.js — create a Bench V1 run directory and write its manifest
+
+Usage:  node bench/run.js [--scenario <id>] [--arm A|B|C]
+
+  --scenario <id>  Scenario label for the run directory. Default: ${NO_SCENARIO}
+                   (no scenario machinery exists before sub-block B2.2).
+  --arm <A|B|C>    A = sensor + Sysmon · B = Sysmon + Procmon, no sensor
+                   · C = sensor alone. Default: A.
+  --help           Show this message.`;
+
+/**
+ * Parse `--key value` pairs. Unknown flags are an error rather than a silent
+ * no-op: a typo in a bench invocation must not produce a run directory whose
+ * name says something the run did not do.
+ * @param {string[]} argv - Arguments after the script path.
+ * @returns {{scenario: string, arm: string, help: boolean}}
+ * @throws {Error} On an unknown flag, a missing value, or an invalid value.
+ */
+function parseArgs(argv) {
+  const parsed = { scenario: NO_SCENARIO, arm: 'A', help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    if (arg !== '--scenario' && arg !== '--arm') {
+      throw new Error(`unknown argument "${arg}"`);
+    }
+    const value = argv[++i];
+    if (value === undefined) throw new Error(`${arg} needs a value`);
+    if (arg === '--scenario') {
+      if (!SAFE_LABEL.test(value)) {
+        throw new Error(`--scenario "${value}" is not a safe directory-name segment`);
+      }
+      parsed.scenario = value;
+    } else {
+      if (!manifest.ARMS.includes(value)) {
+        throw new Error(`--arm "${value}" is not one of ${manifest.ARMS.join(', ')}`);
+      }
+      parsed.arm = value;
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Build the run id: UTC instant, scenario, arm.
+ *
+ * The timestamp keeps ISO-8601 ordering (run directories sort chronologically
+ * as plain text) with `:` replaced, since it is illegal in a Windows path, and
+ * the milliseconds dropped so two runs a second apart stay readable. Two runs
+ * inside the same second collide — {@link createRunDir} refuses rather than
+ * writing into an existing directory.
+ * @param {Date} now
+ * @param {string} scenario
+ * @param {string} arm
+ * @returns {string}
+ */
+function buildRunId(now, scenario, arm) {
+  const stamp = now
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z')
+    .replace(/:/g, '-');
+  return `${stamp}-${scenario}-${arm}`;
+}
+
+/**
+ * Create the run directory. Refuses an existing one — a bench run never writes
+ * into a directory it did not create, or a re-run would silently blend two
+ * machines' artefacts into one record.
+ * @param {string} runId
+ * @returns {string} Absolute path to the new directory.
+ * @throws {Error} When the directory already exists.
+ */
+function createRunDir(runId) {
+  const dir = path.join(RUNS_DIR, runId);
+  fs.mkdirSync(RUNS_DIR, { recursive: true });
+  fs.mkdirSync(dir); // no recursive — an existing directory must throw EEXIST
+  return dir;
+}
+
+/**
+ * @param {string[]} argv - `process.argv.slice(2)`
+ * @returns {number} Process exit code.
+ */
+function main(argv) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    console.error(`bench: ${err.message}\n`);
+    console.error(USAGE);
+    return 2;
+  }
+  if (args.help) {
+    console.log(USAGE);
+    return 0;
+  }
+
+  const now = new Date();
+  const runId = buildRunId(now, args.scenario, args.arm);
+  const dir = createRunDir(runId);
+  const record = manifest.collect({
+    runId,
+    scenario: args.scenario,
+    arm: args.arm,
+    startedAt: now.toISOString(),
+  });
+  const manifestPath = path.join(dir, 'manifest.json');
+  fs.writeFileSync(manifestPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+
+  const absent = [];
+  for (const [group, fields] of Object.entries({ host: record.host, sensor: record.sensor })) {
+    for (const [name, entry] of Object.entries(fields)) {
+      if (entry && entry.unavailable) absent.push(`${group}.${name}: ${entry.unavailable}`);
+    }
+  }
+  if (record.processCountAtStart.unavailable) {
+    absent.push(`processCountAtStart: ${record.processCountAtStart.unavailable}`);
+  }
+
+  console.log(`run     ${runId}`);
+  console.log(`arm     ${args.arm} — ${manifest.ARM_DESCRIPTIONS[args.arm]}`);
+  console.log(`dir     ${dir}`);
+  console.log(`written ${manifestPath}`);
+  if (absent.length > 0) {
+    console.log(`\n${absent.length} fact(s) recorded as ABSENT, not guessed:`);
+    for (const line of absent) console.log(`  - ${line}`);
+  }
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main(process.argv.slice(2));
+}
+
+module.exports = { NO_SCENARIO, RUNS_DIR, buildRunId, createRunDir, main, parseArgs };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,6 +111,30 @@ export default [
     },
   },
   {
+    // The bench harness is a Node CLI, same shape as scripts/: CommonJS, and
+    // stdout IS its interface, so no-console stays off. Nothing here may import
+    // from src/ — a sensor must not contribute to its own measurement record —
+    // which is a review rule, not something ESLint can enforce.
+    files: ['bench/**/*.js'],
+    languageOptions: {
+      globals: { ...globals.node },
+      sourceType: 'commonjs',
+    },
+    rules: {
+      'no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+      'no-console': 'off',
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-useless-escape': 'off',
+    },
+  },
+  {
     files: ['tests/**/*.js'],
     languageOptions: {
       globals: { ...globals.node },

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "build:demo": "vite build --mode demo",
     "build": "electron-builder --publish never",
     "dist": "electron-builder --publish never",
-    "format": "prettier --write 'src/**/*.{js,ts,svelte,css,html}' '*.{js,ts,json}'",
-    "format:check": "prettier --check 'src/**/*.{js,ts,svelte,css,html}' '*.{js,ts,json}'",
-    "lint": "npx eslint src/ tests/ scripts/",
+    "format": "prettier --write 'src/**/*.{js,ts,svelte,css,html}' 'bench/**/*.{js,json}' '*.{js,ts,json}'",
+    "format:check": "prettier --check 'src/**/*.{js,ts,svelte,css,html}' 'bench/**/*.{js,json}' '*.{js,ts,json}'",
+    "lint": "npx eslint src/ tests/ scripts/ bench/",
     "typecheck": "tsc --noEmit -p tsconfig.main.json && tsc --noEmit -p tsconfig.renderer.json",
     "typecheck:main": "tsc --noEmit -p tsconfig.main.json",
     "typecheck:renderer": "tsc --noEmit -p tsconfig.renderer.json",
@@ -23,6 +23,7 @@
     "verify:gate": "node scripts/verify-witness-gate.mjs",
     "build:sidecar": "node scripts/build-sidecar.js",
     "bench:generation": "node scripts/bench-generation.js",
+    "bench:run": "node bench/run.js",
     "prepare": "husky"
   },
   "engines": {


### PR DESCRIPTION
Sub-block B2.1 of Bench V1. Establishes the run directory every later bench artefact is written into, and closes the gap where a new top-level tree would have been invisible to both quality gates. No scenario format, no oracle adapters, no SUT capture — those are B2.2 onward.

## What lands

**`bench/run.js`** (179 lines) creates `bench/runs/<UTC instant>-<scenario>-<arm>/` and writes `manifest.json` into it. The directory is created non-recursively, so a re-run inside the same second fails rather than blending two machines' artefacts into one record. Unknown flags are rejected instead of ignored: a typo must not produce a run directory whose name says something the run did not do. `--scenario` defaults to `no-scenario`, not `smoke` or `default` — no scenario machinery exists until B2.2, and a name that sounds like a scenario would document something that was never built.

**`bench/lib/manifest.js`** (245 lines) snapshots the environment under one rule: **an absent fact is recorded as absent, never guessed.** Every entry is `{value, source}`, or `{value: null, unavailable: <reason>, source}` when the probe failed, so "this machine reported build 26200" cannot collapse into "we could not read the build". `run.js` prints the absent facts at the end of a run, so a degraded environment is visible at measurement time rather than at analysis time.

Two probe decisions worth noting:

- Windows build identity comes from `reg query`, not `os.release()`. `os.release()` stops at `10.0.26200`; the UBR — the component that separates two machines both calling themselves 26200 — exists only in the registry. `ProductName` is recorded verbatim even where it disagrees with `os.version()` (Windows 11 machines routinely report `Windows 10 <edition>` under that key). The manifest records what each source said and never reconciles two sources into one invented answer.
- Nothing under `bench/` imports from `src/`. `tasklist` is spawned directly rather than reached through `process-scanner.js`: a sensor must not contribute to its own measurement record.

Oracle fields are present and explicitly null, naming the sub-block that wires them (B2.3 Sysmon, B2.6 Procmon) — a key that is simply missing reads as "we forgot" rather than "not yet wired".

**`bench/README.md`** states what Bench is for, that it is Windows-only, that the bench never runs in CI, and that no number from a development-machine run may be published as an AEGIS accuracy figure — the gold image with a pinned Windows build is the condition for that.

## Gate coverage, and the evidence for it

`lint` walked `src/ tests/ scripts/` and `format:check` globbed `src/**` plus top-level files, so **neither saw `bench/`**. Both now do. `bench/runs` is added to `.prettierignore`: run artefacts are generated measurements, not source, and without that line one local run would put machine-written JSON in front of the formatter.

A gate that merely goes green proves nothing about what it inspected, so both were measured and both were broken on purpose:

| gate | files it now inspects under `bench/` | deliberate violation | result |
|---|---|---|---|
| `npm run lint` | 2 (`bench/lib/manifest.js`, `bench/run.js`), 0 errors 0 warnings | `require('./gate-proof.ts')` | `no-restricted-syntax` **error**, exit 1, file named |
| `npm run format:check` | the same 2 (`bench/runs` excluded) | misformatted object literal | exit 1, file named |

Both violations were removed and both gates returned to exit 0. The lint failure came from the repo-wide `**/*.js` rule, which confirms `bench/` is reached by the whole config and not only by its own block.

The new `bench/**/*.js` config block was measured the same way rather than assumed: with the block removed, `npx eslint bench/` reports **27 `no-undef` errors** on `require`, `module`, `process` and `console`. Restored, it reports 0. The block is load-bearing, not decoration.

`npm run format:check` is red locally on 139 files, all of them pre-existing: `core.autocrlf=true` gives this working tree CRLF endings and Prettier's `endOfLine` default is `lf`. The count is identical with and without the bench glob, no bench file appears among them, and CI checks out LF — which is why the same command is green on master today.

## Run output

```
run     2026-08-13T07-40-36Z-no-scenario-A
arm     A — sensor + Sysmon — coverage and latency
dir     X:\Future\ESCAPE\AEGIS\bench\runs\2026-08-13T07-40-36Z-no-scenario-A
written .../manifest.json
```

Every field populated from real observation: build 26200 UBR 8655 (25H2), 22 cores, 324 processes at start, git SHA and branch, `workingTreeDirty: true`. That last field means the measured sensor is not exactly the commit named beside it — recorded rather than refused, because running against uncommitted work is legitimate while building the harness and dishonest only if left unsaid.

## `--user-data-dir`, measured for B2.4

B2.4 needs the SUT to write its audit log somewhere the bench owns. Probed with a throwaway Electron script, control arm and switch arm:

- `--user-data-dir=<path>` sets `app.getPath('userData')` to that path **verbatim** — no app-name segment appended.
- It is already in effect **at module scope**, before `whenReady`. That covers `main.js:23`, which reads `settings.json` out of `userData` before Electron is ready, so B2.4 can pre-seed a settings file in the run directory with no production-code change.
- `logs` and `sessionData` derive from it, so `logger.init` and `audit.init` (`main.js:430`, `:455`) both land inside the bench directory — and `audit-logger.js:99` puts the audit JSONL at `<userData>/audit-logs`.
- The switch wins regardless of `app.name`: in the switch arm `app.name` changed from `Electron` to `Aegis` and the path did not move.

The control arm ran the probe script, not the repository entrypoint, so it establishes nothing about where the real app writes when the switch is absent. That was not the question B2.4 asks.

## Second commit: an uncaught refusal

`createRunDir` refuses an existing directory on purpose, but `main()` did not catch it, so the refusal surfaced as an uncaught Node stack trace rather than the exit 2 every other bad input already produced. The run id drops milliseconds, so two runs of the same scenario and arm inside one second build the same id — which the scenario loops in B2.7 and B2.8 will do. Reproduced both ways: two `--scenario collision-probe --arm C` runs in one second now print the reason and exit 2. The refusal itself stays.

## `lint-staged` already covers bench/

Worth recording because it is not obvious from reading `package.json`: the `*.{js,ts,json}` lint-staged pattern is matched against basenames, not only top-level paths. In the first commit it processed 3 files out of 7 staged — `package.json` plus both `bench/*.js` — and in the second it processed `bench/run.js`. So a `bench/` file is formatted at commit time, not first flagged at CI. No change was needed.

## Not in this PR

The bench never runs in CI. The required contexts run on `ubuntu-latest`; the bench needs Sysmon, Procmon and admin rights, and nested virtualisation is unsupported on GitHub runners. Unit tests for the pure bench modules arrive in B2.9, inside the existing `test` job, adding no required context.
