### PR TITLE
feat(bench): scenario format, schema and the actor that emits the catalogue

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -50,9 +50,15 @@ prose around the numbers survives a re-run — the precedent is
 ```
 npm run bench:run                                        # defaults: no-scenario, arm A
 npm run bench:run -- --scenario S1-agent-lifecycle --arm A
+npm run bench:s1                                         # the line above, without the -- trap
 ```
 
 The `--` is required; without it npm keeps the flags.
+
+Exit codes: **0** the run completed · **1** a step failed to execute · **2** the invocation or the
+scenario was wrong and nothing ran. A scenario is loaded and validated *before* the run directory
+exists, so a wrong scenario leaves no empty run behind; a step that fails happens after, and leaves
+the directory holding the catalogue of everything that did happen first.
 
 Arms, from §10 — a run is one scenario in one arm:
 
@@ -67,13 +73,17 @@ for a given deterministic scenario, and only then does A score the sensor agains
 
 ## Layout
 
-Present today (sub-block B2.1):
+Present today (sub-blocks B2.1 and B2.2):
 
 ```
 bench/
-  run.js              # create a run directory, write its manifest
-  lib/manifest.js     # environment snapshot; absent facts stay absent
-  runs/               # run artefacts — gitignored, created on first run
+  run.js                                    # create a run directory, execute a scenario
+  scenario.schema.json                      # draft-07; the shape of a scenario
+  lib/manifest.js                           # environment snapshot; absent facts stay absent
+  lib/actor.js                              # executes steps, captures what happened
+  lib/catalogue.js                          # writes expected.ndjson; refuses a line it did not observe
+  scenarios/S1-agent-lifecycle/scenario.json
+  runs/                                     # run artefacts — gitignored, created on first run
   README.md
 ```
 
@@ -82,12 +92,100 @@ built — nothing below exists yet:
 
 | path | sub-block |
 |---|---|
-| `bench/scenario.schema.json`, `bench/scenarios/<id>/scenario.json`, `bench/lib/actor.js`, `bench/lib/catalogue.js` | B2.2 |
 | `bench/lib/oracles/sysmon.js`, `bench/oracles/sysmon-bench.xml` | B2.3 |
 | `bench/lib/sut-capture.js` | B2.4 |
 | `bench/score.js`, `bench/lib/join.js`, `bench/lib/metrics.js` | B2.5 |
 | `bench/lib/oracles/procmon.js`, `bench/oracles/procmon-bench.pmc` | B2.6 |
 | `bench/report.js` | B2.9 |
+
+## Scenarios
+
+One scenario is one directory under `bench/scenarios/`, holding a `scenario.json` validated against
+`bench/scenario.schema.json` before a run starts. The schema is draft-07 because the repository pins
+`ajv ^6`, which understands no later draft — the same version and the same precedent as
+`rules/_schema.json`.
+
+| field | what it is |
+|---|---|
+| `id` | must equal the directory name, or a run directory would misname what was run |
+| `title` | one line a reader can hold in their head |
+| `arms` | which of A/B/C the scenario is meaningful in; `--arm` outside that set is refused |
+| `oracles` | which independent sources must confirm the catalogue (adapters: B2.3, B2.6) |
+| `proves` | what a passing run establishes, so a number cannot later be read as answering a question the scenario never asked |
+| `expect` | the observable events the scenario intends to produce, each with an id, a category and a type |
+| `steps` | declarative steps, executed in order |
+
+A step is `{id, kind, expect, with}` — a named kind with named parameters, never a script, because
+the catalogue has to be derivable from what the step did. `expect` names one entry of the `expect`
+block, and the actor refuses to run a step whose kind emits a different category or type from the
+expectation it claims. Every expectation must be claimed by a step and every emitting step must
+claim one: an expectation nothing produces is a promise the run never keeps.
+
+### Step kinds
+
+The closed set lives in `bench/lib/actor.js`, **not** in the schema. Only the actor can execute a
+kind, so only the actor can say which kinds exist; a kind it does not implement fails the run by
+name before any step runs, and is never skipped. What the schema owns is the shape of each known
+kind's parameters — and a unit test asserts the two lists stay identical, so a kind added to one and
+forgotten in the other cannot go unvalidated.
+
+| kind | parameters | emits |
+|---|---|---|
+| `copy-binary` | `from` (`%VAR%` expanded), `agentId`, `agentName` | `file.creation` |
+| `spawn-process` | `fromStep` (a `copy-binary` step), `args` | `process.start` |
+| `wait` | `ms` | nothing |
+| `terminate-process` | `fromStep` (a `spawn-process` step) | `process.end` |
+| `delete-file` | `fromStep` (a `copy-binary` step) | `file.deletion` |
+
+`wait` emits nothing on purpose: no oracle can confirm the passage of time, and a catalogue row
+nothing can reach is decoration.
+
+`copy-binary` does not take the agent name on trust. `agentName` must be one of the names
+`src/shared/agent-database.json` gives `agentId`, or the run fails — the stimulus is *drawn from*
+the database rather than resembling it. That file is read as an input datum and never as evidence:
+no claim about what happened comes from anything AEGIS ships.
+
+### S1 — agent lifecycle
+
+`ping.exe` is copied to `claude.exe` inside the run's own `stage/` directory, spawned against the
+loopback interface, left alive for 35 s — the default scan interval is 10 s, so at least three ticks
+see it present rather than only its start and its end — then terminated and deleted. It is harmless
+by construction: 45 KB, loopback only, and its `-n` count bounds its own lifetime if the actor dies
+before the terminate step.
+
+## The catalogue
+
+`expected.ndjson` is written by the actor **as a by-product of executing the steps**, one line per
+event, never ahead of the run. Each line is built from what was captured at the moment the step
+ran — the pid the OS handed out, the absolute path the copy landed on, the instant read off the
+clock. A hand-written catalogue is a guess about a machine, and a guess is not a basis for scoring.
+
+The field names are the minimal ECS subset the plan calls for: `@timestamp`, `event.kind`,
+`event.category`, `event.type`, `event.action`, then `process.*` or `file.*`, then a `bench` block
+naming the scenario, the step and the expectation the step claimed.
+
+Three rules the catalogue enforces in code rather than by convention:
+
+- **It refuses a line it did not observe.** A missing pid, a pid that is not a positive integer, a
+  timestamp that is not a real UTC instant, an empty path — each throws, naming the field and the
+  step, instead of becoming a plausible-looking row a later metric would count.
+- **A field that was not observed is omitted, not set to `null`.** This is the opposite convention
+  from `manifest.json` on purpose: a manifest entry is a slot that exists whether or not the probe
+  won, so absence has to be spelled out, while an ECS document is a bag of observed fields and a
+  `null` in one reads as a measured null.
+- **Nothing reconstructed is written as if observed.** `process.args` is recorded because it is
+  exactly the argv the actor handed `CreateProcess`; `process.command_line` is absent because the
+  actor never saw the string the OS assembled, and a re-quoted guess at it could be mistaken for an
+  observation by the join in B2.5. Where Node reports a terminating signal instead of an exit code
+  — which is what a `kill()` on Windows produces — the signal is recorded under
+  `bench.terminationSignal`, because ECS 8.11 has `process.exit_code` and no field for it.
+
+A step that fails to execute is recorded as failed, the remaining steps are skipped, and the run
+fails. It emits nothing: the catalogue must never contain a row that reads as if a step had
+succeeded. The catalogue that survives a failed run holds exactly the events that did happen.
+
+Everything above is still only intent plus the fact of execution. The catalogue never confirms
+itself — every row is confirmed against an independent oracle before any metric counts it.
 
 ## Run artefacts
 
@@ -95,9 +193,11 @@ One run is one directory under `bench/runs/`, named `<UTC instant>-<scenario>-<a
 directory is created fresh and never written into twice, so a re-run cannot blend two
 machines' artefacts into one record.
 
-`manifest.json` is written today. The remaining files arrive with the sub-blocks that
-produce them: `expected.ndjson` (catalogue), `oracle-sysmon.ndjson`, `oracle-procmon.ndjson`,
-`oracle-loss.json`, `sut.ndjson`, `matched.ndjson`, `metrics.json`.
+`manifest.json` is written today, and `expected.ndjson` plus a `stage/` directory whenever a
+scenario was named. `stage/` holds the binaries the scenario copied; S1 deletes its own, so the
+directory is normally left empty. The remaining files arrive with the sub-blocks that produce them:
+`oracle-sysmon.ndjson`, `oracle-procmon.ndjson`, `oracle-loss.json`, `sut.ndjson`,
+`matched.ndjson`, `metrics.json`.
 
 ### Absent, never guessed
 

--- a/bench/lib/actor.js
+++ b/bench/lib/actor.js
@@ -1,0 +1,523 @@
+/**
+ * @file bench/lib/actor.js
+ * @module bench/lib/actor
+ * @description Executes a scenario's steps and emits the expected-event
+ *   catalogue as a by-product.
+ *
+ *   The catalogue is never written ahead of a run. Each step is executed, what
+ *   actually happened is captured at that moment — the pid the OS handed out,
+ *   the absolute path the copy landed on, the instant read off the clock — and
+ *   only then is a line built from it. A hand-written catalogue would be a
+ *   guess about a machine, and a guess is not a basis for scoring anything.
+ *
+ *   What the catalogue asserts is still only intent plus the fact of execution.
+ *   It is never the confirmation of what it asserts: every row is confirmed
+ *   against an independent oracle before any metric counts it (B2.3, B2.6).
+ *
+ *   Two failure modes are kept apart on purpose:
+ *
+ *   - **The scenario is wrong** — bad shape, a step kind nobody implements, a
+ *     reference to a step that does not exist. Caught before the run directory
+ *     is created, named field by field, exit 2.
+ *   - **A step did not execute** — the source binary is missing, the spawn
+ *     failed, the process was already gone. Recorded as failed, the remaining
+ *     steps are skipped, the run fails. A step that did not execute emits
+ *     nothing: the catalogue must not contain a row that reads as if it had.
+ *
+ *   Nothing here imports from `src/`. `src/shared/agent-database.json` is read
+ *   as a file because the scenario draws its stimulus from it — which name to
+ *   give a fake agent. It is a stimulus, never evidence: no claim about what
+ *   happened is taken from anything AEGIS ships.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.11.0
+ */
+'use strict';
+
+const { spawn } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const Ajv = require('ajv');
+
+const catalogue = require('./catalogue');
+const manifest = require('./manifest');
+
+/** @type {string} Where scenario directories live. */
+const SCENARIOS_DIR = path.join(manifest.ROOT, 'bench', 'scenarios');
+
+/** @type {string} The draft-07 schema every scenario is validated against. */
+const SCHEMA_PATH = path.join(manifest.ROOT, 'bench', 'scenario.schema.json');
+
+/** @type {string} Agent signatures — the source of the names a scenario stages. */
+const AGENT_DATABASE_PATH = path.join(manifest.ROOT, 'src', 'shared', 'agent-database.json');
+
+/** @type {string} Subdirectory of a run holding the binaries it stages. */
+const STAGE_DIRNAME = 'stage';
+
+/** @type {number} How long a terminated process is given to actually exit. */
+const EXIT_TIMEOUT_MS = 10000;
+
+/**
+ * The closed set of step kinds, mapped to the catalogue shape each emits.
+ * `null` means the kind emits nothing — nothing can confirm the passage of
+ * time, and a catalogue row no oracle can reach is decoration.
+ * @type {Readonly<Object<string, string|null>>}
+ */
+const STEP_KINDS = Object.freeze({
+  'copy-binary': 'file.creation',
+  'spawn-process': 'process.start',
+  wait: null,
+  'terminate-process': 'process.end',
+  'delete-file': 'file.deletion',
+});
+
+/** @type {ReadonlyArray<string>} Implemented kinds, in declaration order. */
+const KIND_NAMES = Object.freeze(Object.keys(STEP_KINDS));
+
+/**
+ * Which kind a step's `with.fromStep` has to name. A kind absent from this map
+ * takes no back-reference.
+ * @type {Readonly<Object<string, string>>}
+ */
+const FROM_STEP_KIND = Object.freeze({
+  'spawn-process': 'copy-binary',
+  'terminate-process': 'spawn-process',
+  'delete-file': 'copy-binary',
+});
+
+/** @type {import('ajv').ValidateFunction | null} Compiled once per process. */
+let validateFn = null;
+
+/**
+ * Expand `%VAR%` against the environment.
+ * @param {string} value
+ * @returns {string}
+ * @throws {Error} When a named variable is not set — a bench must not resolve
+ *   an unset variable to an empty path segment and copy from somewhere else.
+ */
+function expandEnv(value) {
+  return value.replace(/%([^%]+)%/g, (_match, name) => {
+    const resolved = process.env[name];
+    if (resolved === undefined) {
+      throw new Error(
+        `environment variable %${name}% is not set, so "${value}" cannot be resolved`,
+      );
+    }
+    return resolved;
+  });
+}
+
+/**
+ * SHA-256 of a file on disk.
+ * @param {string} file
+ * @returns {string} Lowercase hex.
+ */
+function sha256File(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+/**
+ * Load a scenario by id.
+ * @param {string} id - Directory name under `bench/scenarios/`.
+ * @returns {{dir: string, file: string, scenario: Object}}
+ * @throws {Error} When the directory, the file, or the JSON is not there.
+ */
+function loadScenario(id) {
+  const dir = path.join(SCENARIOS_DIR, id);
+  const file = path.join(dir, 'scenario.json');
+  if (!fs.existsSync(file)) {
+    throw new Error(`no scenario "${id}" — expected ${file}`);
+  }
+  let scenario;
+  try {
+    scenario = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    throw new Error(`${file} is not valid JSON: ${err.message}`, { cause: err });
+  }
+  if (scenario && scenario.id !== id) {
+    throw new Error(
+      `${file} declares id "${scenario.id}" but lives in "${id}" — a run directory named after ` +
+        'one of the two would misname what was run',
+    );
+  }
+  return { dir, file, scenario };
+}
+
+/**
+ * Validate a scenario's shape against `bench/scenario.schema.json`.
+ * @param {Object} scenario
+ * @param {string} [schemaPath] - Override, for tests.
+ * @throws {Error} Naming every field that is wrong.
+ */
+function validateScenario(scenario, schemaPath) {
+  let validate;
+  if (schemaPath) {
+    validate = compileSchema(schemaPath);
+  } else {
+    if (!validateFn) validateFn = compileSchema(SCHEMA_PATH);
+    validate = validateFn;
+  }
+  if (validate(scenario)) return;
+  throw new Error(formatSchemaErrors(validate.errors));
+}
+
+/**
+ * Compile one draft-07 schema. ajv is pinned at ^6, which understands draft-07
+ * and no later draft — the same version and the same precedent as
+ * `rules/_schema.json`.
+ * @param {string} schemaPath
+ * @returns {import('ajv').ValidateFunction}
+ */
+function compileSchema(schemaPath) {
+  return new Ajv({ allErrors: true }).compile(JSON.parse(fs.readFileSync(schemaPath, 'utf8')));
+}
+
+/**
+ * Turn ajv 6 errors into a message that names the field.
+ * @param {Array<Object>|null|undefined} errors
+ * @returns {string}
+ */
+function formatSchemaErrors(errors) {
+  const lines = (errors ?? []).map((e) => {
+    const where = e.dataPath || '<root>';
+    const params = e.params ?? {};
+    // ajv 6 leaves the offending key out of `message` for these two keywords;
+    // without it "should NOT have additional properties" names no field at all.
+    let detail = '';
+    if (params.additionalProperty) detail = ` — "${params.additionalProperty}"`;
+    else if (params.allowedValues) detail = ` — allowed: ${params.allowedValues.join(', ')}`;
+    return `  ${where} ${e.message}${detail}`;
+  });
+  return `scenario does not match bench/scenario.schema.json:\n${lines.join('\n')}`;
+}
+
+/**
+ * Validate what only the actor can: which kinds exist, which emit, and whether
+ * the references between steps and expectations lead anywhere.
+ * @param {Object} scenario - Already through {@link validateScenario}.
+ * @throws {Error} On the first problem, named.
+ */
+function validateSteps(scenario) {
+  const expectations = new Map();
+  for (const e of scenario.expect) {
+    if (expectations.has(e.id)) throw new Error(`expectation "${e.id}" is declared twice`);
+    expectations.set(e.id, e);
+  }
+  const claimed = new Set();
+  const seen = new Map();
+  for (const step of scenario.steps) {
+    if (seen.has(step.id)) throw new Error(`step id "${step.id}" is used twice`);
+    if (!Object.prototype.hasOwnProperty.call(STEP_KINDS, step.kind)) {
+      throw new Error(
+        `step "${step.id}" uses step kind "${step.kind}", which the actor does not implement. ` +
+          `Implemented kinds: ${KIND_NAMES.join(', ')}. An unknown kind fails the run rather ` +
+          'than being skipped: a scenario that silently did less than it says is not a baseline.',
+      );
+    }
+    const shapeName = STEP_KINDS[step.kind];
+    if (shapeName === null && step.expect !== undefined) {
+      throw new Error(
+        `step "${step.id}" (kind "${step.kind}") emits no event and must not claim expectation ` +
+          `"${step.expect}" — nothing would ever confirm it`,
+      );
+    }
+    if (shapeName !== null) {
+      if (step.expect === undefined) {
+        throw new Error(
+          `step "${step.id}" (kind "${step.kind}") emits a "${shapeName}" event and must name the ` +
+            'expectation it satisfies in `expect`',
+        );
+      }
+      const expectation = expectations.get(step.expect);
+      if (!expectation) {
+        throw new Error(
+          `step "${step.id}" claims expectation "${step.expect}", which the scenario does not declare`,
+        );
+      }
+      const shape = catalogue.EVENT_SHAPES[shapeName];
+      if (expectation.category !== shape.category || expectation.type !== shape.type) {
+        throw new Error(
+          `step "${step.id}" (kind "${step.kind}") emits ${shape.category}/${shape.type} but ` +
+            `expectation "${expectation.id}" declares ${expectation.category}/${expectation.type}`,
+        );
+      }
+      claimed.add(step.expect);
+    }
+    const requiredKind = FROM_STEP_KIND[step.kind];
+    if (requiredKind) {
+      const target = seen.get(step.with.fromStep);
+      if (!target) {
+        throw new Error(
+          `step "${step.id}" refers to step "${step.with.fromStep}", which does not appear before it`,
+        );
+      }
+      if (target.kind !== requiredKind) {
+        throw new Error(
+          `step "${step.id}" (kind "${step.kind}") needs a "${requiredKind}" step but ` +
+            `"${step.with.fromStep}" is a "${target.kind}" step`,
+        );
+      }
+    }
+    seen.set(step.id, step);
+  }
+  for (const id of expectations.keys()) {
+    if (!claimed.has(id)) {
+      throw new Error(`expectation "${id}" is declared but no step produces it`);
+    }
+  }
+}
+
+/**
+ * Confirm the staged name really is one this agent is known by.
+ * @param {string} databasePath
+ * @param {string} agentId
+ * @param {string} agentName
+ * @throws {Error} When the id or the name is not in the database.
+ */
+function assertAgentName(databasePath, agentId, agentName) {
+  const db = JSON.parse(fs.readFileSync(databasePath, 'utf8'));
+  const agent = (db.agents ?? []).find((a) => a.id === agentId);
+  if (!agent) {
+    throw new Error(`agent id "${agentId}" is not in ${databasePath}`);
+  }
+  const names = agent.names ?? [];
+  if (!names.some((n) => n.toLowerCase() === agentName.toLowerCase())) {
+    throw new Error(
+      `"${agentName}" is not one of the names ${databasePath} gives "${agentId}" ` +
+        `(${names.join(', ')}) — the stimulus has to be drawn from the database, not resemble it`,
+    );
+  }
+}
+
+/**
+ * Resolve when the child is running, reject when it never started.
+ * @param {import('child_process').ChildProcess} child
+ * @returns {Promise<string>} The instant the OS reported it spawned.
+ */
+function awaitSpawn(child) {
+  return new Promise((resolve, reject) => {
+    child.once('spawn', () => resolve(new Date().toISOString()));
+    child.once('error', reject);
+  });
+}
+
+/**
+ * Resolve when the child exits.
+ * @param {import('child_process').ChildProcess} child
+ * @param {number} timeoutMs
+ * @returns {Promise<{exitCode: number|null, signal: string|null, timestamp: string}>}
+ */
+function awaitExit(child, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`process ${child.pid} did not exit within ${timeoutMs} ms of being killed`));
+    }, timeoutMs);
+    child.once('exit', (exitCode, signal) => {
+      clearTimeout(timer);
+      resolve({ exitCode, signal, timestamp: new Date().toISOString() });
+    });
+  });
+}
+
+/**
+ * The step kinds themselves. Each returns `{observed, result}`: `observed` is
+ * what the catalogue writes, `result` is what later steps refer back to.
+ * @type {Readonly<Object<string, function(Object, Object): Promise<Object>>>}
+ */
+const KIND_IMPL = Object.freeze({
+  'copy-binary': async (step, ctx) => {
+    const from = expandEnv(step.with.from);
+    if (!fs.existsSync(from) || !fs.statSync(from).isFile()) {
+      throw new Error(`source binary ${from} does not exist`);
+    }
+    assertAgentName(ctx.agentDatabasePath, step.with.agentId, step.with.agentName);
+    fs.mkdirSync(ctx.stageDir, { recursive: true });
+    const dest = path.join(ctx.stageDir, step.with.agentName);
+    fs.copyFileSync(from, dest, fs.constants.COPYFILE_EXCL);
+    const timestamp = new Date().toISOString();
+    return {
+      observed: {
+        timestamp,
+        pid: process.pid,
+        executable: process.execPath,
+        path: dest,
+        name: path.basename(dest),
+        directory: path.dirname(dest),
+        sizeBytes: fs.statSync(dest).size,
+        sha256: sha256File(dest),
+      },
+      result: { path: dest, name: path.basename(dest), from },
+    };
+  },
+
+  'spawn-process': async (step, ctx) => {
+    const source = ctx.results.get(step.with.fromStep);
+    const args = step.with.args ?? [];
+    const child = spawn(source.path, args, { stdio: 'ignore', windowsHide: true });
+    ctx.children.push(child);
+    const timestamp = await awaitSpawn(child);
+    return {
+      observed: {
+        timestamp,
+        pid: child.pid,
+        name: source.name,
+        executable: source.path,
+        args,
+        parentPid: process.pid,
+      },
+      result: { child, pid: child.pid, name: source.name, executable: source.path },
+    };
+  },
+
+  wait: async (step) => {
+    await new Promise((resolve) => setTimeout(resolve, step.with.ms));
+    return { result: { waitedMs: step.with.ms } };
+  },
+
+  'terminate-process': async (step, ctx) => {
+    const target = ctx.results.get(step.with.fromStep);
+    if (target.child.exitCode !== null || target.child.signalCode !== null) {
+      throw new Error(
+        `process ${target.pid} had already exited (code ${target.child.exitCode}, signal ` +
+          `${target.child.signalCode}) before this step ran — the scenario's premise that it ` +
+          'stays alive across the wait did not hold, so its end is not the one being measured',
+      );
+    }
+    // The exit listener is attached before the signal is sent, or a process
+    // that dies instantly would exit between the two and never be seen.
+    const exited = awaitExit(target.child, EXIT_TIMEOUT_MS);
+    if (!target.child.kill()) {
+      // Nothing will ever await `exited` now, and its timeout would reject into
+      // an unhandled rejection — fatal on Node 22 — several seconds after this
+      // step has already been recorded as failed.
+      exited.catch(() => {});
+      throw new Error(`could not signal process ${target.pid}`);
+    }
+    const end = await exited;
+    return {
+      observed: {
+        timestamp: end.timestamp,
+        pid: target.pid,
+        name: target.name,
+        executable: target.executable,
+        exitCode: end.exitCode,
+        signal: end.signal,
+      },
+      result: { pid: target.pid, exitCode: end.exitCode, signal: end.signal },
+    };
+  },
+
+  'delete-file': async (step, ctx) => {
+    const target = ctx.results.get(step.with.fromStep);
+    fs.unlinkSync(target.path);
+    return {
+      observed: {
+        timestamp: new Date().toISOString(),
+        pid: process.pid,
+        executable: process.execPath,
+        path: target.path,
+        name: target.name,
+        directory: path.dirname(target.path),
+      },
+      result: { path: target.path, deleted: true },
+    };
+  },
+});
+
+/**
+ * Kill anything the scenario spawned and did not terminate itself. Reported,
+ * and deliberately not written to the catalogue: a cleanup kill is the harness
+ * tidying up after a failure, not an event the scenario claimed would happen.
+ * @param {Array<import('child_process').ChildProcess>} children
+ * @param {function(string): void} log
+ */
+function cleanup(children, log) {
+  for (const child of children) {
+    if (child.exitCode !== null || child.signalCode !== null) continue;
+    child.kill();
+    log(`cleanup pid ${child.pid} was still alive and was killed — no catalogue line was written`);
+  }
+}
+
+/**
+ * Execute a scenario.
+ * @param {Object} scenario - Through {@link validateScenario} and {@link validateSteps}.
+ * @param {Object} opts
+ * @param {string} opts.runDir - Absolute path of the run directory.
+ * @param {string} [opts.agentDatabasePath] - Override, for tests.
+ * @param {function(string): void} [opts.log] - Progress sink.
+ * @returns {Promise<{ok: boolean, events: Object[], steps: Object[]}>}
+ */
+async function execute(scenario, opts) {
+  const log = opts.log ?? (() => {});
+  const ctx = {
+    stageDir: path.join(opts.runDir, STAGE_DIRNAME),
+    agentDatabasePath: opts.agentDatabasePath ?? AGENT_DATABASE_PATH,
+    results: new Map(),
+    children: [],
+  };
+  const events = [];
+  const steps = [];
+  let ok = true;
+
+  try {
+    for (const step of scenario.steps) {
+      if (!ok) {
+        steps.push({ id: step.id, kind: step.kind, status: 'skipped' });
+        continue;
+      }
+      const startedAt = new Date().toISOString();
+      try {
+        const outcome = await KIND_IMPL[step.kind](step, ctx);
+        ctx.results.set(step.id, outcome.result);
+        const shapeName = STEP_KINDS[step.kind];
+        if (shapeName !== null) {
+          events.push(
+            catalogue.buildEvent({
+              scenario: scenario.id,
+              step: step.id,
+              expect: step.expect,
+              shape: shapeName,
+              observed: outcome.observed,
+            }),
+          );
+        }
+        steps.push({ id: step.id, kind: step.kind, status: 'ok', startedAt, emitted: shapeName });
+        log(`step    ${step.id} (${step.kind}) ok${shapeName ? ` → ${shapeName}` : ''}`);
+      } catch (err) {
+        ok = false;
+        steps.push({
+          id: step.id,
+          kind: step.kind,
+          status: 'failed',
+          startedAt,
+          error: err.message,
+        });
+        log(`step    ${step.id} (${step.kind}) FAILED — ${err.message}`);
+      }
+    }
+  } finally {
+    cleanup(ctx.children, log);
+  }
+  return { ok, events, steps };
+}
+
+module.exports = {
+  AGENT_DATABASE_PATH,
+  EXIT_TIMEOUT_MS,
+  FROM_STEP_KIND,
+  KIND_NAMES,
+  SCENARIOS_DIR,
+  SCHEMA_PATH,
+  STAGE_DIRNAME,
+  STEP_KINDS,
+  assertAgentName,
+  execute,
+  expandEnv,
+  loadScenario,
+  sha256File,
+  validateScenario,
+  validateSteps,
+};

--- a/bench/lib/catalogue.js
+++ b/bench/lib/catalogue.js
@@ -1,0 +1,254 @@
+/**
+ * @file bench/lib/catalogue.js
+ * @module bench/lib/catalogue
+ * @description The expected-event catalogue for one bench run.
+ *
+ *   The catalogue is the fixed point of the whole method: the oracle and the
+ *   sensor are each scored against it, never against each other. That only
+ *   works if every row of it is a record of something that actually happened,
+ *   so this module is built around one refusal — **it will not write a line
+ *   whose identity fields were not observed.** A missing pid, a timestamp that
+ *   is not a real UTC instant, an executable path nobody resolved: each throws
+ *   here rather than becoming a plausible-looking row that a later metric would
+ *   count. A hand-written catalogue is a guess; a guess that reaches
+ *   `expected.ndjson` is indistinguishable from truth by the time anyone reads
+ *   the numbers.
+ *
+ *   Field names are the minimal ECS subset the plan calls for: `@timestamp`,
+ *   `event.*`, `process.*`, `file.*`, plus a `bench.*` block naming the
+ *   scenario, the step that produced the line and the expectation the step was
+ *   declared to satisfy.
+ *
+ *   A field the actor did not observe is **omitted**, not set to `null`. This
+ *   is the opposite convention from `manifest.js` on purpose: a manifest entry
+ *   is a slot that exists whether or not the probe won, so absence has to be
+ *   spelled out, while an ECS document is a bag of observed fields and a `null`
+ *   in one reads as a measured null.
+ *
+ *   Nothing here imports from `src/`.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.11.0
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/** @type {string} ECS version the field names below follow. */
+const ECS_VERSION = '8.11.0';
+
+/** @type {string} Name of the catalogue inside a run directory. */
+const CATALOGUE_FILENAME = 'expected.ndjson';
+
+/**
+ * A UTC instant with milliseconds, exactly as `Date#toISOString` produces it.
+ * A timestamp that does not match this was not read off a clock at the moment
+ * the step ran, and the catalogue refuses it.
+ * @type {RegExp}
+ */
+const ISO_UTC_MS = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+/**
+ * The closed set of event shapes the catalogue knows how to write.
+ *
+ * `observed` lists the fields the actor must supply. Every shape includes
+ * `timestamp` and `pid`: a file event carries the pid of the process that
+ * created or removed the file — the actor itself — so that no line in the
+ * catalogue is without a real process behind it.
+ * @type {Readonly<Object<string, Object>>}
+ */
+const EVENT_SHAPES = Object.freeze({
+  'process.start': Object.freeze({
+    category: 'process',
+    type: 'start',
+    action: 'process-started',
+    observed: Object.freeze(['timestamp', 'pid', 'name', 'executable', 'args', 'parentPid']),
+    build: (o) => ({
+      process: {
+        pid: o.pid,
+        name: o.name,
+        executable: o.executable,
+        // The argv the actor handed CreateProcess, verbatim. `process.command_line`
+        // is deliberately absent: the actor never saw the command line the OS
+        // assembled, and a re-quoted reconstruction of it would be a guess that
+        // a later join could mistake for an observation.
+        args: o.args,
+        start: o.timestamp,
+        parent: { pid: o.parentPid },
+      },
+    }),
+  }),
+  'process.end': Object.freeze({
+    category: 'process',
+    type: 'end',
+    action: 'process-ended',
+    observed: Object.freeze(['timestamp', 'pid', 'name', 'executable']),
+    build: (o) => {
+      const out = {
+        process: {
+          pid: o.pid,
+          name: o.name,
+          executable: o.executable,
+        },
+      };
+      // Node reports either an exit code or the signal it used, never both:
+      // `child_process` nulls the code whenever a signal is set, which is what
+      // a `kill()` on Windows produces. Whichever of the two the OS actually
+      // gave is written; the other is left out rather than inferred. ECS 8.11
+      // has `process.exit_code` and no field for a terminating signal, so that
+      // observation goes in the bench namespace instead of being dropped or
+      // squeezed into a field that means something else.
+      if (typeof o.exitCode === 'number') out.process.exit_code = o.exitCode;
+      if (typeof o.signal === 'string') out.bench = { terminationSignal: o.signal };
+      return out;
+    },
+  }),
+  'file.creation': Object.freeze({
+    category: 'file',
+    type: 'creation',
+    action: 'file-created',
+    observed: Object.freeze([
+      'timestamp',
+      'pid',
+      'executable',
+      'path',
+      'name',
+      'directory',
+      'sizeBytes',
+      'sha256',
+    ]),
+    build: (o) => ({
+      file: {
+        path: o.path,
+        name: o.name,
+        directory: o.directory,
+        size: o.sizeBytes,
+        hash: { sha256: o.sha256 },
+      },
+      process: { pid: o.pid, executable: o.executable },
+    }),
+  }),
+  'file.deletion': Object.freeze({
+    category: 'file',
+    type: 'deletion',
+    action: 'file-deleted',
+    observed: Object.freeze(['timestamp', 'pid', 'executable', 'path', 'name', 'directory']),
+    build: (o) => ({
+      file: {
+        path: o.path,
+        name: o.name,
+        directory: o.directory,
+      },
+      process: { pid: o.pid, executable: o.executable },
+    }),
+  }),
+});
+
+/** @type {ReadonlyArray<string>} Shape names, in declaration order. */
+const SHAPE_NAMES = Object.freeze(Object.keys(EVENT_SHAPES));
+
+/**
+ * Reject an observation that cannot have come from a real execution.
+ * @param {string} shape - Shape name, for the message.
+ * @param {string} step - Step id, for the message.
+ * @param {Object} observed - What the actor captured.
+ * @param {ReadonlyArray<string>} required - Field names that must be present.
+ * @throws {Error} Naming the first field that is missing or not credible.
+ */
+function assertObserved(shape, step, observed, required) {
+  const refuse = (field, why) => {
+    throw new Error(
+      `catalogue: refusing a "${shape}" line for step "${step}" — observed field "${field}" ${why}. ` +
+        'The catalogue records what the actor saw happen; it never fills a gap with a placeholder.',
+    );
+  };
+  for (const field of required) {
+    const value = observed[field];
+    if (value === undefined || value === null) refuse(field, 'was not captured');
+    if (typeof value === 'string' && value.trim() === '') refuse(field, 'is empty');
+  }
+  if (!ISO_UTC_MS.test(String(observed.timestamp))) {
+    refuse('timestamp', `is "${observed.timestamp}", which is not a UTC instant read off a clock`);
+  }
+  if (!Number.isSafeInteger(observed.pid) || observed.pid <= 0) {
+    refuse('pid', `is ${JSON.stringify(observed.pid)}, which is not a pid the OS handed out`);
+  }
+}
+
+/**
+ * Build one catalogue line.
+ * @param {Object} opts
+ * @param {string} opts.scenario - Scenario id.
+ * @param {string} opts.step - Id of the step that produced this event.
+ * @param {string} opts.expect - Id of the expectation the step was declared to
+ *   satisfy, from the scenario's `expect` block.
+ * @param {string} opts.shape - One of {@link SHAPE_NAMES}.
+ * @param {Object} opts.observed - What the actor captured while executing.
+ * @returns {Object} An ECS document, ready to serialize.
+ * @throws {Error} On an unknown shape or an observation with a hole in it.
+ */
+function buildEvent(opts) {
+  const shape = EVENT_SHAPES[opts.shape];
+  if (!shape) {
+    throw new Error(
+      `catalogue: unknown event shape "${opts.shape}" — known shapes are ${SHAPE_NAMES.join(', ')}`,
+    );
+  }
+  assertObserved(opts.shape, opts.step, opts.observed, shape.observed);
+  // A shape may hand back a `bench` fragment for an observation ECS has no
+  // field for. It is merged into the bench block, never allowed to overwrite
+  // the three keys that identify where the line came from.
+  const { bench: benchExtra, ...fields } = shape.build(opts.observed);
+  return {
+    '@timestamp': opts.observed.timestamp,
+    ecs: { version: ECS_VERSION },
+    event: {
+      kind: 'event',
+      category: [shape.category],
+      type: [shape.type],
+      action: shape.action,
+    },
+    ...fields,
+    bench: {
+      ...benchExtra,
+      scenario: opts.scenario,
+      step: opts.step,
+      expect: opts.expect,
+    },
+  };
+}
+
+/**
+ * Render events as NDJSON: one document per line, newline-terminated.
+ * @param {Object[]} events
+ * @returns {string} Empty string for no events — an empty catalogue is a real
+ *   outcome (a run that failed on its first step) and is written as such.
+ */
+function serialize(events) {
+  if (events.length === 0) return '';
+  return `${events.map((e) => JSON.stringify(e)).join('\n')}\n`;
+}
+
+/**
+ * Write the catalogue into a run directory.
+ * @param {string} runDir - Absolute path of the run directory.
+ * @param {Object[]} events
+ * @returns {string} Absolute path of the file written.
+ */
+function write(runDir, events) {
+  const file = path.join(runDir, CATALOGUE_FILENAME);
+  fs.writeFileSync(file, serialize(events), 'utf8');
+  return file;
+}
+
+module.exports = {
+  CATALOGUE_FILENAME,
+  ECS_VERSION,
+  EVENT_SHAPES,
+  ISO_UTC_MS,
+  SHAPE_NAMES,
+  buildEvent,
+  serialize,
+  write,
+};

--- a/bench/run.js
+++ b/bench/run.js
@@ -1,13 +1,20 @@
 /**
  * @file bench/run.js
- * @description Bench V1 run entrypoint. Creates one run directory and writes
- *   its environment manifest.
+ * @description Bench V1 run entrypoint. Creates one run directory, writes its
+ *   environment manifest, and — when a scenario was named — executes that
+ *   scenario's steps and writes the expected-event catalogue they produced.
  *
- *   Sub-block B2.1 stops here on purpose: the scenario format (B2.2), the
- *   oracle adapters (B2.3, B2.6) and the SUT capture (B2.4) are separate
- *   blocks. What this file establishes is the run directory — the thing every
- *   later artefact is written into, and the reason a bench number can be traced
- *   back to a machine.
+ *   The oracle adapters (B2.3, B2.6) and the SUT capture (B2.4) are separate
+ *   blocks: a run currently produces the record everything else will be scored
+ *   against, and scores nothing itself.
+ *
+ *   Order matters here. A scenario is loaded and validated **before** the run
+ *   directory exists, so a scenario that is wrong fails without leaving an
+ *   empty run behind; a step that fails to execute happens after, and leaves
+ *   the directory with the catalogue of everything that did happen first.
+ *
+ *   Exit codes: 0 the run completed · 1 a step failed to execute · 2 the
+ *   invocation or the scenario was wrong, and nothing ran.
  *
  *   Usage:
  *     npm run bench:run
@@ -23,6 +30,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const actor = require('./lib/actor');
+const catalogue = require('./lib/catalogue');
 const manifest = require('./lib/manifest');
 
 /** @type {string} Where run directories are created. Gitignored. */
@@ -43,11 +52,17 @@ const USAGE = `bench/run.js — create a Bench V1 run directory and write its ma
 
 Usage:  node bench/run.js [--scenario <id>] [--arm A|B|C]
 
-  --scenario <id>  Scenario label for the run directory. Default: ${NO_SCENARIO}
-                   (no scenario machinery exists before sub-block B2.2).
+  --scenario <id>  A directory under bench/scenarios/. Its scenario.json is
+                   validated and executed, and its expected-event catalogue is
+                   written to expected.ndjson. Default: ${NO_SCENARIO} —
+                   a run directory and a manifest, and nothing is executed.
   --arm <A|B|C>    A = sensor + Sysmon · B = Sysmon + Procmon, no sensor
-                   · C = sensor alone. Default: A.
-  --help           Show this message.`;
+                   · C = sensor alone. Default: A. The scenario decides which
+                   arms it is meaningful in.
+  --help           Show this message.
+
+Exit codes: 0 completed · 1 a step failed to execute · 2 bad invocation or bad
+scenario, nothing ran.`;
 
 /**
  * Parse `--key value` pairs. Unknown flags are an error rather than a silent
@@ -123,10 +138,30 @@ function createRunDir(runId) {
 }
 
 /**
- * @param {string[]} argv - `process.argv.slice(2)`
- * @returns {number} Process exit code.
+ * Load, validate and arm-check a scenario. Everything that can be known to be
+ * wrong about a scenario is known here — before a run directory exists.
+ * @param {string} id - Scenario directory name.
+ * @param {string} arm - The arm asked for on the command line.
+ * @returns {Object} The validated scenario.
+ * @throws {Error} With a message naming the field, the kind or the arm.
  */
-function main(argv) {
+function prepareScenario(id, arm) {
+  const { scenario } = actor.loadScenario(id);
+  actor.validateScenario(scenario);
+  actor.validateSteps(scenario);
+  if (!scenario.arms.includes(arm)) {
+    throw new Error(
+      `scenario "${id}" declares itself meaningful in arm(s) ${scenario.arms.join(', ')}, not ${arm}`,
+    );
+  }
+  return scenario;
+}
+
+/**
+ * @param {string[]} argv - `process.argv.slice(2)`
+ * @returns {Promise<number>} Process exit code.
+ */
+async function main(argv) {
   let args;
   try {
     args = parseArgs(argv);
@@ -138,6 +173,17 @@ function main(argv) {
   if (args.help) {
     console.log(USAGE);
     return 0;
+  }
+
+  /** @type {Object|null} */
+  let scenario = null;
+  if (args.scenario !== NO_SCENARIO) {
+    try {
+      scenario = prepareScenario(args.scenario, args.arm);
+    } catch (err) {
+      console.error(`bench: ${err.message}`);
+      return 2;
+    }
   }
 
   const now = new Date();
@@ -180,15 +226,44 @@ function main(argv) {
   console.log(`arm     ${args.arm} — ${manifest.ARM_DESCRIPTIONS[args.arm]}`);
   console.log(`dir     ${dir}`);
   console.log(`written ${manifestPath}`);
+
+  let exitCode = 0;
+  if (scenario) {
+    console.log(`scenario ${scenario.id} — ${scenario.title}`);
+    const outcome = await actor.execute(scenario, { runDir: dir, log: (m) => console.log(m) });
+    const cataloguePath = catalogue.write(dir, outcome.events);
+    console.log(`written ${cataloguePath} (${outcome.events.length} expected event(s))`);
+    if (!outcome.ok) {
+      const failed = outcome.steps.find((s) => s.status === 'failed');
+      const skipped = outcome.steps.filter((s) => s.status === 'skipped').length;
+      console.error(
+        `\nbench: step "${failed.id}" (${failed.kind}) did not execute — ${failed.error}` +
+          `\nbench: ${skipped} later step(s) were skipped; the catalogue holds only the ` +
+          'events that actually happened',
+      );
+      exitCode = 1;
+    }
+  }
+
   if (absent.length > 0) {
     console.log(`\n${absent.length} fact(s) recorded as ABSENT, not guessed:`);
     for (const line of absent) console.log(`  - ${line}`);
   }
-  return 0;
+  return exitCode;
 }
 
 if (require.main === module) {
-  process.exitCode = main(process.argv.slice(2));
+  main(process.argv.slice(2)).then((code) => {
+    process.exitCode = code;
+  });
 }
 
-module.exports = { NO_SCENARIO, RUNS_DIR, buildRunId, createRunDir, main, parseArgs };
+module.exports = {
+  NO_SCENARIO,
+  RUNS_DIR,
+  buildRunId,
+  createRunDir,
+  main,
+  parseArgs,
+  prepareScenario,
+};

--- a/bench/scenario.schema.json
+++ b/bench/scenario.schema.json
@@ -1,0 +1,251 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aegis.dev/schemas/bench-scenario.json",
+  "title": "AEGIS Bench V1 scenario",
+  "description": "Shape of bench/scenarios/<id>/scenario.json. Draft-07 because the repository pins ajv ^6, which understands no later draft. This schema owns the SHAPE of a scenario: which fields exist, which values are in a closed set, and which parameters each known step kind takes. It deliberately does not own the set of step kinds — only bench/lib/actor.js can execute a kind, so only the actor can say which kinds exist, and it rejects an unimplemented one by name before any step runs.",
+  "type": "object",
+  "required": ["schemaVersion", "id", "title", "arms", "oracles", "proves", "expect", "steps"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Scenario shape version. Bump when a field changes meaning."
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^S[0-9]+-[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "description": "Scenario id, e.g. S1-agent-lifecycle. Must equal the name of the directory holding this file — a scenario that calls itself something other than where it lives would make a run directory name a lie."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One line a reader can hold in their head."
+    },
+    "arms": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "enum": ["A", "B", "C"] },
+      "description": "Run separations this scenario is meaningful in. A = sensor + Sysmon, B = Sysmon + Procmon without the sensor, C = sensor alone."
+    },
+    "oracles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "enum": ["sysmon", "procmon"] },
+      "description": "Independent sources that must confirm this scenario's catalogue. The adapters arrive in sub-blocks B2.3 and B2.6; naming them here is a declaration of what a run will need, not a claim that it exists."
+    },
+    "proves": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What a passing run of this scenario establishes, in the author's own words. Written down so a number produced by the scenario cannot later be read as answering a question the scenario never asked."
+    },
+    "expect": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/expectation" },
+      "description": "The observable events this scenario intends to produce. Every expectation must be claimed by a step and every emitting step must claim one, so the intent and the execution can be compared instead of taken on trust."
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/step" },
+      "description": "Declarative steps, executed in order. Not a script: the catalogue is derived from what each step did, which is only possible while a step is a named kind with named parameters."
+    }
+  },
+  "definitions": {
+    "expectation": {
+      "type": "object",
+      "required": ["id", "description", "category", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^E[0-9]{1,3}$",
+          "description": "Expectation id, e.g. E1. Referenced by a step's `expect` and written into every catalogue line as bench.expect."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "What is expected to become observable, in words."
+        },
+        "category": {
+          "type": "string",
+          "enum": ["process", "file"],
+          "description": "ECS event.category of the expected event."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["start", "end", "creation", "deletion"],
+          "description": "ECS event.type of the expected event. The actor refuses to run a step whose kind emits a different category or type from the expectation it claims."
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "required": ["id", "kind"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+          "description": "Step id, unique within the scenario. Written into every catalogue line as bench.step, and used by later steps to refer back to what this one produced."
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Which step kind executes this step. The closed set lives in bench/lib/actor.js."
+        },
+        "expect": {
+          "type": "string",
+          "pattern": "^E[0-9]{1,3}$",
+          "description": "Expectation this step claims to satisfy. Required for a kind that emits an event, forbidden for a kind that does not — the actor enforces both."
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why this step is shaped the way it is. Prose for the reader; the actor ignores it."
+        },
+        "with": {
+          "type": "object",
+          "description": "Parameters for the step kind. Each known kind's parameters are validated by the allOf branch below; a kind this schema has no branch for is rejected by the actor before it runs."
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "const": "copy-binary" } }
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": {
+                "type": "object",
+                "required": ["from", "agentId", "agentName"],
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Absolute path of the binary to copy. %VAR% is expanded from the environment; an unset variable fails the run rather than resolving to an empty segment."
+                  },
+                  "agentId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "id of an agent in src/shared/agent-database.json."
+                  },
+                  "agentName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Name the copy is given. The actor verifies it is one of that agent's `names` in the database and fails the run if it is not, so the stimulus is drawn from the database rather than resembling it."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "const": "spawn-process" } }
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": {
+                "type": "object",
+                "required": ["fromStep", "args"],
+                "additionalProperties": false,
+                "properties": {
+                  "fromStep": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "id of an earlier copy-binary step. Its copy is what gets spawned."
+                  },
+                  "args": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Arguments, verbatim. Written into the catalogue as process.args because they are exactly what the actor handed CreateProcess."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "const": "wait" } }
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": {
+                "type": "object",
+                "required": ["ms"],
+                "additionalProperties": false,
+                "properties": {
+                  "ms": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 600000,
+                    "description": "How long to let the scenario run on. A wait emits no event: no oracle can confirm the passage of time, and a catalogue line nothing can confirm is decoration."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "const": "terminate-process" } }
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": {
+                "type": "object",
+                "required": ["fromStep"],
+                "additionalProperties": false,
+                "properties": {
+                  "fromStep": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "id of an earlier spawn-process step. Its process is the one terminated."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["kind"],
+            "properties": { "kind": { "const": "delete-file" } }
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": {
+                "type": "object",
+                "required": ["fromStep"],
+                "additionalProperties": false,
+                "properties": {
+                  "fromStep": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "id of an earlier copy-binary step. Its copy is the file removed."
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/bench/scenarios/S1-agent-lifecycle/scenario.json
+++ b/bench/scenarios/S1-agent-lifecycle/scenario.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": 1,
+  "id": "S1-agent-lifecycle",
+  "title": "Agent lifecycle — a process named like a known agent appears, lives across several scan ticks, and is terminated",
+  "arms": ["A", "B", "C"],
+  "oracles": ["sysmon"],
+  "proves": "That a process whose image name is one src/shared/agent-database.json claims to recognise can be created, observed for longer than one scan interval, and ended — with the pid, the absolute path and the instants recorded by the actor that created it. What a sensor or an oracle then reports is scored against that record; this scenario establishes the record, not the score.",
+  "expect": [
+    {
+      "id": "E1",
+      "description": "A binary appears on disk under the agent's name, in the run's own stage directory",
+      "category": "file",
+      "type": "creation"
+    },
+    {
+      "id": "E2",
+      "description": "A process starts from that binary and is assigned a pid by the OS",
+      "category": "process",
+      "type": "start"
+    },
+    {
+      "id": "E3",
+      "description": "That process ends, and ends because the actor terminated it rather than because it ran out on its own",
+      "category": "process",
+      "type": "end"
+    },
+    {
+      "id": "E4",
+      "description": "The staged binary is removed again, so a run leaves nothing named after an agent behind",
+      "category": "file",
+      "type": "deletion"
+    }
+  ],
+  "steps": [
+    {
+      "id": "stage-binary",
+      "kind": "copy-binary",
+      "expect": "E1",
+      "note": "ping.exe is the harmless binary: 45 KB, it touches nothing but the loopback interface, and the -n count below bounds its own lifetime, so an actor that dies before the terminate step cannot leave a process running forever. The name is verified against the database rather than typed in: claude.exe is one of the names agent-database.json gives claude-code, and the actor fails the run if it stops being one.",
+      "with": {
+        "from": "%SystemRoot%\\System32\\ping.exe",
+        "agentId": "claude-code",
+        "agentName": "claude.exe"
+      }
+    },
+    {
+      "id": "spawn-agent",
+      "kind": "spawn-process",
+      "expect": "E2",
+      "with": {
+        "fromStep": "stage-binary",
+        "args": ["-n", "600", "127.0.0.1"]
+      }
+    },
+    {
+      "id": "live-across-ticks",
+      "kind": "wait",
+      "note": "The sensor's default scan interval is 10 s (scanIntervalSec in src/main/config-manager.js), so 35 s covers at least three ticks. A process that starts and ends between two ticks would only prove that a start and an end can be seen; this scenario needs the process to be present at a scan, not merely to have existed.",
+      "with": {
+        "ms": 35000
+      }
+    },
+    {
+      "id": "terminate-agent",
+      "kind": "terminate-process",
+      "expect": "E3",
+      "with": {
+        "fromStep": "spawn-agent"
+      }
+    },
+    {
+      "id": "remove-binary",
+      "kind": "delete-file",
+      "expect": "E4",
+      "with": {
+        "fromStep": "stage-binary"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build:sidecar": "node scripts/build-sidecar.js",
     "bench:generation": "node scripts/bench-generation.js",
     "bench:run": "node bench/run.js",
+    "bench:s1": "node bench/run.js --scenario S1-agent-lifecycle --arm A",
     "prepare": "husky"
   },
   "engines": {

--- a/tests/main/bench/actor.test.js
+++ b/tests/main/bench/actor.test.js
@@ -1,0 +1,257 @@
+/**
+ * @file tests/main/bench/actor.test.js
+ * @description The actor's pure half: what it refuses to run. Executing a
+ *   scenario spawns real processes and is not what these tests do — they cover
+ *   the checks that decide whether a scenario is allowed to run at all, plus
+ *   the one consistency rule between the schema and the actor that nothing else
+ *   would catch.
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+import actor from '../../../bench/lib/actor.js';
+
+const ROOT = path.resolve(__dirname, '../../..');
+const S1_PATH = path.join(ROOT, 'bench', 'scenarios', 'S1-agent-lifecycle', 'scenario.json');
+const SCHEMA_PATH = path.join(ROOT, 'bench', 'scenario.schema.json');
+const AGENT_DB_PATH = path.join(ROOT, 'src', 'shared', 'agent-database.json');
+
+/**
+ * A fresh, valid scenario every test can spoil in its own way.
+ * @returns {Object}
+ */
+function scenario() {
+  return {
+    schemaVersion: 1,
+    id: 'S9-fixture',
+    title: 'Fixture',
+    arms: ['A'],
+    oracles: ['sysmon'],
+    proves: 'Nothing — it exists to be broken by a test.',
+    expect: [
+      { id: 'E1', description: 'a file appears', category: 'file', type: 'creation' },
+      { id: 'E2', description: 'a process starts', category: 'process', type: 'start' },
+    ],
+    steps: [
+      {
+        id: 'stage',
+        kind: 'copy-binary',
+        expect: 'E1',
+        with: {
+          from: '%SystemRoot%\\System32\\ping.exe',
+          agentId: 'claude-code',
+          agentName: 'claude.exe',
+        },
+      },
+      {
+        id: 'spawn',
+        kind: 'spawn-process',
+        expect: 'E2',
+        with: { fromStep: 'stage', args: [] },
+      },
+    ],
+  };
+}
+
+describe('bench actor — the shipped S1 scenario', () => {
+  it('validates against the schema and the actor', () => {
+    const s1 = JSON.parse(fs.readFileSync(S1_PATH, 'utf8'));
+    expect(() => actor.validateScenario(s1)).not.toThrow();
+    expect(() => actor.validateSteps(s1)).not.toThrow();
+  });
+
+  it('only uses step kinds the actor implements', () => {
+    const s1 = JSON.parse(fs.readFileSync(S1_PATH, 'utf8'));
+    for (const step of s1.steps) {
+      expect(actor.KIND_NAMES).toContain(step.kind);
+    }
+  });
+});
+
+describe('bench actor — schema rejection', () => {
+  it('accepts the fixture unspoiled', () => {
+    expect(() => actor.validateScenario(scenario())).not.toThrow();
+  });
+
+  it('names a missing top-level field', () => {
+    const s = scenario();
+    delete s.proves;
+    expect(() => actor.validateScenario(s)).toThrow(/should have required property 'proves'/);
+  });
+
+  it('names an arm outside the closed set', () => {
+    const s = scenario();
+    s.arms = ['D'];
+    expect(() => actor.validateScenario(s)).toThrow(/\.arms\[0\].*allowed: A, B, C/s);
+  });
+
+  it('names a field the scenario format does not have', () => {
+    const s = scenario();
+    s.expectedEvents = 4;
+    expect(() => actor.validateScenario(s)).toThrow(/additional properties — "expectedEvents"/);
+  });
+
+  it('names a missing parameter of a known step kind', () => {
+    const s = scenario();
+    delete s.steps[0].with.agentName;
+    expect(() => actor.validateScenario(s)).toThrow(
+      /\.steps\[0\]\.with should have required property 'agentName'/,
+    );
+  });
+
+  it('names a parameter a step kind does not take', () => {
+    const s = scenario();
+    s.steps[1].with.ms = 1000;
+    expect(() => actor.validateScenario(s)).toThrow(/\.steps\[1\]\.with.*"ms"/s);
+  });
+
+  it('rejects an expectation type outside the closed set', () => {
+    const s = scenario();
+    s.expect[0].type = 'modification';
+    expect(() => actor.validateScenario(s)).toThrow(/\.expect\[0\]\.type/);
+  });
+
+  it('rejects a wait longer than the ten-minute ceiling', () => {
+    const s = scenario();
+    s.steps = [{ id: 'settle', kind: 'wait', with: { ms: 600001 } }];
+    s.expect = [{ id: 'E1', description: 'x', category: 'file', type: 'creation' }];
+    expect(() => actor.validateScenario(s)).toThrow(/\.steps\[0\]\.with\.ms/);
+  });
+});
+
+describe('bench actor — step-kind rejection', () => {
+  it('rejects a kind it does not implement, naming it and the ones it has', () => {
+    const s = scenario();
+    s.steps[1].kind = 'boil-ocean';
+    expect(() => actor.validateSteps(s)).toThrow(
+      /step kind "boil-ocean", which the actor does not implement/,
+    );
+    expect(() => actor.validateSteps(s)).toThrow(new RegExp(actor.KIND_NAMES.join(', ')));
+  });
+
+  it('lets an unimplemented kind through the schema, so the actor is the one that names it', () => {
+    const s = scenario();
+    s.steps[1].kind = 'boil-ocean';
+    delete s.steps[1].with;
+    expect(() => actor.validateScenario(s)).not.toThrow();
+  });
+
+  it('rejects a step that emits nothing but claims an expectation', () => {
+    const s = scenario();
+    s.steps[1] = { id: 'settle', kind: 'wait', expect: 'E2', with: { ms: 10 } };
+    expect(() => actor.validateSteps(s)).toThrow(
+      /emits no event and must not claim expectation "E2"/,
+    );
+  });
+
+  it('rejects an emitting step that claims nothing', () => {
+    const s = scenario();
+    delete s.steps[1].expect;
+    expect(() => actor.validateSteps(s)).toThrow(/must name the expectation it satisfies/);
+  });
+
+  it('rejects a claim on an expectation the scenario never declared', () => {
+    const s = scenario();
+    s.steps[1].expect = 'E9';
+    expect(() => actor.validateSteps(s)).toThrow(
+      /claims expectation "E9", which the scenario does not declare/,
+    );
+  });
+
+  it('rejects a claim whose category or type contradicts what the kind emits', () => {
+    const s = scenario();
+    s.expect[1].type = 'end';
+    expect(() => actor.validateSteps(s)).toThrow(
+      /emits process\/start but expectation "E2" declares process\/end/,
+    );
+  });
+
+  it('rejects an expectation no step produces', () => {
+    const s = scenario();
+    s.expect.push({ id: 'E3', description: 'never happens', category: 'file', type: 'deletion' });
+    expect(() => actor.validateSteps(s)).toThrow(
+      /expectation "E3" is declared but no step produces it/,
+    );
+  });
+
+  it('rejects a back-reference to a step that does not come earlier', () => {
+    const s = scenario();
+    s.steps[1].with.fromStep = 'nowhere';
+    expect(() => actor.validateSteps(s)).toThrow(
+      /refers to step "nowhere", which does not appear before it/,
+    );
+  });
+
+  it('rejects a back-reference to a step of the wrong kind', () => {
+    const s = scenario();
+    s.expect.push({ id: 'E3', description: 'a process ends', category: 'process', type: 'end' });
+    s.steps.push({
+      id: 'kill',
+      kind: 'terminate-process',
+      expect: 'E3',
+      with: { fromStep: 'stage' },
+    });
+    expect(() => actor.validateSteps(s)).toThrow(
+      /needs a "spawn-process" step but "stage" is a "copy-binary" step/,
+    );
+  });
+
+  it('rejects a duplicate step id', () => {
+    const s = scenario();
+    s.steps[1].id = 'stage';
+    expect(() => actor.validateSteps(s)).toThrow(/step id "stage" is used twice/);
+  });
+
+  it('rejects a duplicate expectation id', () => {
+    const s = scenario();
+    s.expect[1].id = 'E1';
+    expect(() => actor.validateSteps(s)).toThrow(/expectation "E1" is declared twice/);
+  });
+});
+
+describe('bench actor — schema and actor agree on the set of kinds', () => {
+  it('has a parameter branch in the schema for every kind the actor implements', () => {
+    const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+    const branches = schema.definitions.step.allOf.map((b) => b.if.properties.kind.const);
+    expect([...branches].sort()).toEqual([...actor.KIND_NAMES].sort());
+  });
+});
+
+describe('bench actor — stimulus is drawn from the agent database', () => {
+  it('accepts a name the database gives that agent', () => {
+    expect(() => actor.assertAgentName(AGENT_DB_PATH, 'claude-code', 'claude.exe')).not.toThrow();
+  });
+
+  it('rejects a name that merely looks like one', () => {
+    expect(() => actor.assertAgentName(AGENT_DB_PATH, 'claude-code', 'claude-code.exe')).toThrow(
+      /is not one of the names/,
+    );
+  });
+
+  it('rejects an agent id the database does not have', () => {
+    expect(() => actor.assertAgentName(AGENT_DB_PATH, 'not-an-agent', 'claude.exe')).toThrow(
+      /agent id "not-an-agent" is not in/,
+    );
+  });
+});
+
+describe('bench actor — environment expansion and loading', () => {
+  it('expands a variable that is set', () => {
+    process.env.AEGIS_BENCH_FIXTURE = 'C:\\fixture';
+    expect(actor.expandEnv('%AEGIS_BENCH_FIXTURE%\\ping.exe')).toBe('C:\\fixture\\ping.exe');
+    delete process.env.AEGIS_BENCH_FIXTURE;
+  });
+
+  it('refuses to resolve a variable that is not set', () => {
+    expect(() => actor.expandEnv('%AEGIS_BENCH_NOT_SET%\\ping.exe')).toThrow(
+      /%AEGIS_BENCH_NOT_SET% is not set/,
+    );
+  });
+
+  it('names the file it looked for when a scenario does not exist', () => {
+    expect(() => actor.loadScenario('S99-not-a-scenario')).toThrow(
+      /no scenario "S99-not-a-scenario" — expected .*scenario\.json/,
+    );
+  });
+});

--- a/tests/main/bench/catalogue.test.js
+++ b/tests/main/bench/catalogue.test.js
@@ -1,0 +1,212 @@
+/**
+ * @file tests/main/bench/catalogue.test.js
+ * @description The catalogue's refusals are the reason a bench number can be
+ *   believed, so they are what these tests are about: an event line either
+ *   carries what the actor observed or it is not written at all.
+ */
+import { describe, it, expect } from 'vitest';
+
+import catalogue from '../../../bench/lib/catalogue.js';
+
+const OBSERVED_START = Object.freeze({
+  timestamp: '2026-08-13T10:20:30.123Z',
+  pid: 4242,
+  name: 'claude.exe',
+  executable: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\r\\stage\\claude.exe',
+  args: ['-n', '600', '127.0.0.1'],
+  parentPid: 99,
+});
+
+const OBSERVED_CREATION = Object.freeze({
+  timestamp: '2026-08-13T10:20:29.001Z',
+  pid: 99,
+  executable: 'C:\\Program Files\\nodejs\\node.exe',
+  path: 'X:\\runs\\r\\stage\\claude.exe',
+  name: 'claude.exe',
+  directory: 'X:\\runs\\r\\stage',
+  sizeBytes: 45056,
+  sha256: 'a'.repeat(64),
+});
+
+/**
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function startEvent(overrides = {}) {
+  return catalogue.buildEvent({
+    scenario: 'S1-agent-lifecycle',
+    step: 'spawn-agent',
+    expect: 'E2',
+    shape: 'process.start',
+    observed: { ...OBSERVED_START, ...overrides },
+  });
+}
+
+describe('bench catalogue — line shape', () => {
+  it('writes the minimal ECS subset for a process start', () => {
+    const line = startEvent();
+    expect(line['@timestamp']).toBe('2026-08-13T10:20:30.123Z');
+    expect(line.ecs.version).toBe(catalogue.ECS_VERSION);
+    expect(line.event).toEqual({
+      kind: 'event',
+      category: ['process'],
+      type: ['start'],
+      action: 'process-started',
+    });
+    expect(line.process).toEqual({
+      pid: 4242,
+      name: 'claude.exe',
+      executable: OBSERVED_START.executable,
+      args: ['-n', '600', '127.0.0.1'],
+      start: '2026-08-13T10:20:30.123Z',
+      parent: { pid: 99 },
+    });
+  });
+
+  it('carries bench.scenario, bench.step and bench.expect on every line', () => {
+    expect(startEvent().bench).toEqual({
+      scenario: 'S1-agent-lifecycle',
+      step: 'spawn-agent',
+      expect: 'E2',
+    });
+  });
+
+  it('never writes process.command_line — the actor never saw one', () => {
+    expect(startEvent().process).not.toHaveProperty('command_line');
+  });
+
+  it('records a file event with its hash and the pid of the process that wrote it', () => {
+    const line = catalogue.buildEvent({
+      scenario: 'S1-agent-lifecycle',
+      step: 'stage-binary',
+      expect: 'E1',
+      shape: 'file.creation',
+      observed: OBSERVED_CREATION,
+    });
+    expect(line.event.category).toEqual(['file']);
+    expect(line.event.type).toEqual(['creation']);
+    expect(line.file).toEqual({
+      path: OBSERVED_CREATION.path,
+      name: 'claude.exe',
+      directory: OBSERVED_CREATION.directory,
+      size: 45056,
+      hash: { sha256: OBSERVED_CREATION.sha256 },
+    });
+    expect(line.process).toEqual({ pid: 99, executable: OBSERVED_CREATION.executable });
+  });
+
+  it('writes process.exit_code when the OS gave one', () => {
+    const line = catalogue.buildEvent({
+      scenario: 'S1-agent-lifecycle',
+      step: 'terminate-agent',
+      expect: 'E3',
+      shape: 'process.end',
+      observed: {
+        timestamp: '2026-08-13T10:21:05.500Z',
+        pid: 4242,
+        name: 'claude.exe',
+        executable: OBSERVED_START.executable,
+        exitCode: 1,
+      },
+    });
+    expect(line.process.exit_code).toBe(1);
+  });
+
+  it('records the signal instead when the OS gave no exit code', () => {
+    const line = catalogue.buildEvent({
+      scenario: 'S1-agent-lifecycle',
+      step: 'terminate-agent',
+      expect: 'E3',
+      shape: 'process.end',
+      observed: {
+        timestamp: '2026-08-13T10:21:05.500Z',
+        pid: 4242,
+        name: 'claude.exe',
+        executable: OBSERVED_START.executable,
+        exitCode: null,
+        signal: 'SIGTERM',
+      },
+    });
+    expect(line.process).not.toHaveProperty('exit_code');
+    expect(line.bench).toEqual({
+      terminationSignal: 'SIGTERM',
+      scenario: 'S1-agent-lifecycle',
+      step: 'terminate-agent',
+      expect: 'E3',
+    });
+  });
+
+  it('never lets a shape overwrite the three keys that say where a line came from', () => {
+    const line = catalogue.buildEvent({
+      scenario: 'S1-agent-lifecycle',
+      step: 'terminate-agent',
+      expect: 'E3',
+      shape: 'process.end',
+      observed: {
+        timestamp: '2026-08-13T10:21:05.500Z',
+        pid: 4242,
+        name: 'claude.exe',
+        executable: OBSERVED_START.executable,
+        exitCode: 1,
+      },
+    });
+    expect(line.bench.scenario).toBe('S1-agent-lifecycle');
+    expect(line.bench.step).toBe('terminate-agent');
+    expect(line.bench.expect).toBe('E3');
+  });
+});
+
+describe('bench catalogue — refusals', () => {
+  it('refuses a line whose pid was never observed, naming the field', () => {
+    expect(() => startEvent({ pid: undefined })).toThrow(/observed field "pid" was not captured/);
+  });
+
+  it('refuses a pid the OS could not have handed out', () => {
+    for (const pid of [0, -1, 1.5, '4242']) {
+      expect(() => startEvent({ pid })).toThrow(/not a pid the OS handed out/);
+    }
+  });
+
+  it('refuses a timestamp that was not read off a clock', () => {
+    for (const timestamp of ['2026-08-13', 'PLACEHOLDER', '2026-08-13T10:20:30Z']) {
+      expect(() => startEvent({ timestamp })).toThrow(/not a UTC instant read off a clock/);
+    }
+  });
+
+  it('refuses an empty executable path', () => {
+    expect(() => startEvent({ executable: '   ' })).toThrow(/observed field "executable" is empty/);
+  });
+
+  it('names the step it refused a line for', () => {
+    expect(() => startEvent({ name: null })).toThrow(/for step "spawn-agent"/);
+  });
+
+  it('refuses an unknown event shape and lists the ones it knows', () => {
+    expect(() =>
+      catalogue.buildEvent({
+        scenario: 'S1',
+        step: 's',
+        expect: 'E1',
+        shape: 'network.connection',
+        observed: OBSERVED_START,
+      }),
+    ).toThrow(/unknown event shape "network.connection".*process\.start/s);
+  });
+});
+
+describe('bench catalogue — serialize', () => {
+  it('writes one JSON document per line, newline-terminated', () => {
+    const text = catalogue.serialize([startEvent(), startEvent()]);
+    expect(text.endsWith('\n')).toBe(true);
+    const lines = text.trimEnd().split('\n');
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+      expect(line).not.toContain('\n');
+    }
+  });
+
+  it('renders an empty catalogue as an empty file, not as a blank line', () => {
+    expect(catalogue.serialize([])).toBe('');
+  });
+});


### PR DESCRIPTION
Sub-block B2.2. A scenario is a declarative list of named step kinds with named parameters, validated against a draft-07 schema before a run starts, and the expected-event catalogue is emitted by the actor **as a by-product of executing those steps** — never written ahead of the run. A hand-written catalogue is a guess about a machine, and a guess is not a basis for scoring anything.

## What is here

- **`bench/scenario.schema.json`** owns the shape of a scenario and the parameters of each known step kind. It deliberately does *not* own the set of kinds: only the actor can execute one, so only the actor can say which exist, and it rejects an unimplemented kind by name before any step runs rather than skipping it. A unit test asserts the two lists stay identical, so a kind added to one and forgotten in the other cannot go unvalidated.
- **`bench/lib/catalogue.js`** writes `expected.ndjson` in a minimal ECS subset (`@timestamp`, `event.*`, `process.*`/`file.*`, plus a `bench` block naming the scenario, the step and the expectation it claimed) and refuses a line it did not observe. A missing pid, a pid that is not a positive integer, a timestamp that is not a real UTC instant — each throws, naming the field and the step, instead of becoming a plausible-looking row a later metric would count. A field that was not observed is **omitted, not set to `null`**; `process.command_line` is absent because the actor never saw the string the OS assembled.
- **`bench/lib/actor.js`** executes `copy-binary`, `spawn-process`, `wait`, `terminate-process` and `delete-file`, capturing the real pid, the absolute path and the instant at each step. A step that fails to execute is recorded as failed, the remaining steps are skipped and the run exits 1 — and it emits nothing, so the catalogue never holds a row that reads as if a step had succeeded.
- **`bench/scenarios/S1-agent-lifecycle`** copies `ping.exe` to a name `src/shared/agent-database.json` gives `claude-code`, spawns it against the loopback interface, holds it alive across several scan ticks, then terminates and deletes it. The staged name is verified against the database, so the stimulus is *drawn from* it rather than resembling it.

## Failure modes kept apart

A scenario that is wrong (bad shape, an unknown kind, a reference to a step that does not exist) is caught **before the run directory is created**, so it leaves no empty run behind. A step that did not execute happens after, and leaves the directory holding the catalogue of everything that did happen first.

Exit codes: **0** completed · **1** a step failed to execute · **2** the invocation or the scenario was wrong and nothing ran.

## Boundaries

Nothing under `bench/` imports from `src/`. `agent-database.json` is read as a file because the scenario draws its stimulus from it, and it is a stimulus, never evidence: no claim about what happened comes from anything AEGIS ships. The catalogue still asserts only intent plus the fact of execution — it never confirms itself, and every row is confirmed against an independent oracle before any metric counts it.

## Verification

`npm run build:renderer`, `npm run lint`, `npm run typecheck`, `npm run typecheck:svelte`, `npm run test:coverage` and `npm audit --audit-level=high --omit=dev` all pass locally. The bench never runs in CI (Sysmon, Procmon and the Restart Manager path are Windows facilities and the required contexts run on `ubuntu-latest`); what CI covers is this tree's source quality, which `lint` and `format:check` both walk.