### PR TITLE
feat(bench): capture what the sensor recorded in arm A

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -55,10 +55,14 @@ npm run bench:s1                                         # the line above, witho
 
 The `--` is required; without it npm keeps the flags.
 
-Exit codes: **0** the run completed · **1** a step failed to execute · **2** the invocation or the
-scenario was wrong and nothing ran. A scenario is loaded and validated *before* the run directory
-exists, so a wrong scenario leaves no empty run behind; a step that fails happens after, and leaves
-the directory holding the catalogue of everything that did happen first.
+In arm A a run takes roughly three minutes: about ninety seconds of it is waiting for the sensor's
+scan cadence to settle, then the scenario, then three more scan ticks and a flush drain.
+
+Exit codes: **0** the run completed · **1** a step failed to execute, or the sensor could not be run
+or read · **2** the invocation or the scenario was wrong and nothing ran. A scenario is loaded and
+validated *before* the run directory exists, so a wrong scenario leaves no empty run behind; a step
+that fails happens after, and leaves the directory holding the catalogue of everything that did
+happen first.
 
 Arms, from §10 — a run is one scenario in one arm:
 
@@ -73,15 +77,17 @@ for a given deterministic scenario, and only then does A score the sensor agains
 
 ## Layout
 
-Present today (sub-blocks B2.1 and B2.2):
+Present today (sub-blocks B2.1, B2.2 and the arm-A capture):
 
 ```
 bench/
-  run.js                                    # create a run directory, execute a scenario
+  run.js                                    # create a run directory, execute a scenario, run the sensor
   scenario.schema.json                      # draft-07; the shape of a scenario
   lib/manifest.js                           # environment snapshot; absent facts stay absent
   lib/actor.js                              # executes steps, captures what happened
   lib/catalogue.js                          # writes expected.ndjson; refuses a line it did not observe
+  lib/sensor.js                             # runs AEGIS across a run; readiness, ticks, stop
+  lib/observed.js                           # writes observed.ndjson out of the product's audit log
   scenarios/S1-agent-lifecycle/scenario.json
   runs/                                     # run artefacts — gitignored, created on first run
   README.md
@@ -93,7 +99,6 @@ built — nothing below exists yet:
 | path | sub-block |
 |---|---|
 | `bench/lib/oracles/sysmon.js`, `bench/oracles/sysmon-bench.xml` | B2.3 |
-| `bench/lib/sut-capture.js` | B2.4 |
 | `bench/score.js`, `bench/lib/join.js`, `bench/lib/metrics.js` | B2.5 |
 | `bench/lib/oracles/procmon.js`, `bench/oracles/procmon-bench.pmc` | B2.6 |
 | `bench/report.js` | B2.9 |
@@ -153,6 +158,10 @@ see it present rather than only its start and its end — then terminated and de
 by construction: 45 KB, loopback only, and its `-n` count bounds its own lifetime if the actor dies
 before the terminate step.
 
+That 35 s is measured against the *configured* interval, which is why arm A waits for the sensor's
+cadence to settle before the first step rather than starting at its first completed scan — see
+[Arm A](#when-the-run-may-start-and-when-it-may-stop).
+
 ## The catalogue
 
 `expected.ndjson` is written by the actor **as a by-product of executing the steps**, one line per
@@ -187,6 +196,129 @@ succeeded. The catalogue that survives a failed run holds exactly the events tha
 Everything above is still only intent plus the fact of execution. The catalogue never confirms
 itself — every row is confirmed against an independent oracle before any metric counts it.
 
+## Arm A — what the sensor recorded
+
+In arm A with a scenario, `run.js` runs AEGIS itself across the steps and writes what it recorded to
+`observed.ndjson`, in the same ECS subset as the catalogue.
+
+The source is the product's own hash-chained audit log — `userData/audit-logs/aegis-audit-<day>.json`
+— and **not** a bench-only channel inside the main process. A capture path that exists only while
+the bench is running measures the bench. Nothing was added to `src/` for this: the run reads what
+AEGIS already writes when nobody is benching it.
+
+### Running the product
+
+AEGIS is started as `electron .` on a **run-scoped Electron profile** under the OS temp directory,
+via the stock `--user-data-dir` switch. That changes where the product writes, never how it observes,
+and it buys three things a bench needs: the audit file is written by this run alone, so its hash
+chain starts at GENESIS and a verdict on it is a verdict on our own records; the run does not inherit
+whatever `scanIntervalSec` the developer last saved, nor append to their real audit trail; and the
+single-instance lock lives in the profile, so a bench run does not collide with an AEGIS the user
+already has open. The profile is deliberately **not** inside the repository — `src/main/file-watcher.js`
+watches the project directory, so an audit write there would raise a file event, which is logged to
+the audit, which is a write.
+
+The run needs a built renderer (`npm run build:renderer`). Without `dist/renderer/index.html` the
+main window never reaches `ready-to-show`, the deferred subsystems that own the sensors never start,
+and the sensor refuses rather than letting the run act into a dead app.
+
+### When the run may start, and when it may stop
+
+Readiness is the sensor's own report, never a sleep. AEGIS logs `DEBUG [scan] process {ms, agents}`
+after a completed process-scan tick, and mirrors it to stderr while unpackaged. One such line means
+the sensor is alive. **Two of them under 20 s apart** mean something more, and it is what the run
+actually waits for: AEGIS spends its first minute on a startup schedule that scans at three times the
+configured interval, so a run that begins at the first tick acts into a ~37 s gap — and S1's subject,
+alive for 35 s, is then never in front of a scan at all. That is a harness artefact, and it produced
+an arm-A run that could not observe a process start or end no matter how well the sensor worked.
+
+Afterwards the sensor is given three more completed ticks. Not one: AEGIS reports a process end only
+after `session-tracker.js`'s grace of two consecutive scans that missed it, so 2 + 1 is the smallest
+number that lets the product reach its own conclusion.
+
+Stopping is a kill, and that is a limitation rather than a preference — AEGIS has no external
+graceful-shutdown path, since its window `close` handler calls `preventDefault()` and hides to tray,
+so only `taskkill /F` ends it and `/F` skips `before-quit → audit.shutdown()`. The kill is therefore
+preceded by a drain longer than the audit logger's 5 s flush interval, which is what makes the last
+records durable.
+
+`expected.ndjson` is written **after** the sensor is stopped. The run directory sits inside the
+watched project directory, so writing the catalogue while the sensor is live puts a file creation the
+harness made for itself into the sensor's own answer.
+
+### The mapping
+
+| audit record | ECS shape | what the audit does NOT carry |
+|---|---|---|
+| `agent-enter` | `process.start` | image name, executable path, OS birth time |
+| `agent-exit` | `process.end` | exit code, terminating signal |
+| `file-access` / `config-access` + `created` | `file.creation` | owner pid, size, hash |
+| `file-access` / `config-access` + `deleted` | `file.deletion` | owner pid |
+
+pid is the only join key the audit gives a process event; path is the only one it gives a file event.
+The display name AEGIS resolved (`"Claude Code"`) is **not** written into `process.name`: it is not
+the image name, and a join would read it as one. It rides `bench.agent`, next to `bench.instanceId`
+and the sensor's own `bench.attribution` verdict. `instanceId` encodes the OS birth time as
+`"<pid>:<ms>"` and is carried verbatim, never parsed — reconstructing an instant out of an identity
+string would be a derivation dressed as an observation.
+
+Everything the sensor observed with no home in that subset — network connections, anomaly alerts,
+`modified` and `accessed` file events — is not written, because a fifth shape would stop being the
+same subset as the catalogue. It is **tallied by type and action** in `observed.meta.json` and
+printed at the end of the run, so what was left out is visible rather than absent.
+
+The window is `[the first step, the sensor's stop] ± 250 ms`. It opens at the first step and not at
+the run's `startedAt`, because between the two the sensor is started and waited for, and its start-up
+burst is a fact about the machine rather than about this scenario. The epsilon is small on purpose:
+both processes read one clock and every audit timestamp is taken after the thing it describes, so
+both ends are inert by construction and a generous value would only pull that burst in.
+
+### What fails a run
+
+`bench/lib/observed.js` re-implements the chain check rather than importing
+`src/main/audit-hashchain.js`: a sensor is never its own oracle, and a disagreement between the two
+cannot be a finding if both sides run the same code. A unit test pins the re-implementation against
+records AEGIS actually wrote, hashes included.
+
+- **A broken chain** — an interior line that does not parse, a seq that is not its line number, a
+  hash that does not recompute. The run exits 1 and takes no record out of the file. Not "skip the
+  record and carry on": a quietly shortened observation set reads exactly like a sensor that saw less.
+- **A `buffer-overflow-drop` marker inside the window.** That is the product stating on disk that it
+  threw records away, from the interval the run is about to call observed.
+- **Zero observations.** An empty `observed.ndjson` is indistinguishable from "the sensor ran and saw
+  nothing", so none is written; the reason goes to `observed.meta.json` instead.
+- **A sensor that will not start.** Refused before any step runs — an arm-A run whose sensor never ran
+  is an arm-C run under the wrong name.
+
+The one thing that is not a refusal is an unparseable **last** line: the kill can land mid-append, and
+a torn trailing line leaves a valid prefix. It is dropped and the drop is recorded, so a run that may
+be missing one observation says so.
+
+### Reading a capture
+
+`observed.meta.json` is written in arm A whether the capture succeeded or refused, and holds the
+profile path, the audit files read, the window, every completed scan tick, the tally of what did not
+become an observed line, and the failure reason if there was one. Two of its fields answer questions
+a coverage number cannot answer by itself:
+
+- **`sensor.ticksWhileProcessAlive`** — scans that fell inside the scenario's own process lifetime.
+  Zero means the process was never in front of the sensor, and anything missing about it is not a
+  coverage result.
+- **`sensor.steadyCadence`** — false means the steps ran against the startup schedule, and every
+  figure from that run describes that regime rather than the configured one.
+
+### What the sensor cannot see, and why
+
+Two observations in arm A exist only because of where things sit, and both are worth knowing before a
+number is read as a property of the sensor:
+
+- **File creation and deletion are seen because the run directory is inside the repository.**
+  `src/main/file-watcher.js` watches the project directory to a depth of 5, and
+  `bench/runs/<id>/stage/claude.exe` is four levels down. A stage directory outside the repository
+  produces no file events at all.
+- **The readiness signal exists because the app runs from source.** `logger.js` mirrors to stderr only
+  while `isDev` — that is, `!app.isPackaged`. Benching a packaged build would need a different signal.
+
 ## Run artefacts
 
 One run is one directory under `bench/runs/`, named `<UTC instant>-<scenario>-<arm>`. The
@@ -195,9 +327,14 @@ machines' artefacts into one record.
 
 `manifest.json` is written today, and `expected.ndjson` plus a `stage/` directory whenever a
 scenario was named. `stage/` holds the binaries the scenario copied; S1 deletes its own, so the
-directory is normally left empty. The remaining files arrive with the sub-blocks that produce them:
-`oracle-sysmon.ndjson`, `oracle-procmon.ndjson`, `oracle-loss.json`, `sut.ndjson`,
-`matched.ndjson`, `metrics.json`.
+directory is normally left empty. In arm A there are two more: `observed.ndjson`, what the sensor
+recorded, and `observed.meta.json`, how it was run and what did not become a line of it. The
+remaining files arrive with the sub-blocks that produce them: `oracle-sysmon.ndjson`,
+`oracle-procmon.ndjson`, `oracle-loss.json`, `matched.ndjson`, `metrics.json`.
+
+The Electron profile a run created is **left behind** in the OS temp directory, and its path is in
+`observed.meta.json`. It holds the audit file `observed.ndjson` was derived from, which is the
+evidence for every line of it.
 
 ### Absent, never guessed
 

--- a/bench/lib/observed.js
+++ b/bench/lib/observed.js
@@ -1,0 +1,545 @@
+/**
+ * @file bench/lib/observed.js
+ * @module bench/lib/observed
+ * @description What the AEGIS sensor actually recorded during one bench run,
+ *   read back out of the product's own audit log.
+ *
+ *   The source is deliberately the hash-chained audit JSONL the product writes
+ *   in its ordinary mode of operation — `userData/audit-logs/aegis-audit-<day>.json`
+ *   — and not a bench-only channel inside the main process. A capture path that
+ *   exists only when the bench is running measures the bench, not the product.
+ *
+ *   Nothing here imports from `src/`. The chain check below is an INDEPENDENT
+ *   re-implementation of the record format, for the same reason the catalogue is
+ *   never diffed against a live stream: a sensor is never its own oracle. If
+ *   `src/main/audit-hashchain.js` and this file ever disagree, that disagreement
+ *   is a finding, and it cannot be one if both sides run the same code.
+ *
+ *   Three refusals, because a measurement that explains a doubt away is
+ *   decoration (memory-bank/ai-mistakes.md #25):
+ *
+ *   - **A broken chain fails the run.** Not "skip the record and carry on" — the
+ *     records around a break are not trustworthy, and a quietly shortened
+ *     observation set reads exactly like a sensor that saw less.
+ *   - **A loss marker inside the window fails the run.** `buffer-overflow-drop`
+ *     is the product stating on disk that it threw records away. Whatever it
+ *     threw away was inside the window we are about to call complete.
+ *   - **Zero observations is a failure, not an empty file.** An empty
+ *     `observed.ndjson` is indistinguishable from "the sensor was running and saw
+ *     nothing", which is a claim no run that produced no records may make.
+ *
+ *   The one thing that is NOT a refusal is an unparseable LAST line. The bench
+ *   stops the sensor by killing it (AEGIS has no external graceful-shutdown
+ *   path), which can land mid-append; a truncated trailing line leaves a valid
+ *   prefix, exactly as `audit-hashchain.js` documents. It is dropped and the
+ *   drop is RECORDED — the run may be missing one observation and says so.
+ *
+ *   Field names are the same minimal ECS subset the catalogue writes
+ *   (`bench/lib/catalogue.js`), so `expected.ndjson` and `observed.ndjson` are
+ *   comparable line for line. A field the audit record does not carry is
+ *   **omitted**, never nulled — the B2.2 convention. The audit persists less
+ *   than the actor observes, and the gaps are the point:
+ *
+ *   | audit record | ECS shape | what it does NOT carry |
+ *   |---|---|---|
+ *   | `agent-enter` | `process.start` | image name, executable path, OS birth time |
+ *   | `agent-exit` | `process.end` | exit code, terminating signal |
+ *   | `file-access`/`config-access` + `created` | `file.creation` | owner pid, size, hash |
+ *   | `file-access`/`config-access` + `deleted` | `file.deletion` | owner pid |
+ *
+ *   pid is the only join key the audit gives a process event; path is the only
+ *   one it gives a file event. Everything the sensor observed that has no home
+ *   in that subset — network connections, anomaly alerts, `modified`/`accessed`
+ *   file events — is NOT written (a fifth shape would stop being the same
+ *   subset) and is tallied instead, so what was left out is visible.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.11.0
+ */
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const catalogue = require('./catalogue');
+
+/** @type {string} Name of the observation set inside a run directory. */
+const OBSERVED_FILENAME = 'observed.ndjson';
+
+/** @type {string} Name of the capture record inside a run directory. */
+const META_FILENAME = 'observed.meta.json';
+
+/** @type {string} Subdirectory of an Electron profile holding the audit files. */
+const AUDIT_DIRNAME = 'audit-logs';
+
+/** @type {RegExp} A daily audit file. One file, one independent chain. */
+const AUDIT_FILENAME = /^aegis-audit-\d{4}-\d{2}-\d{2}\.json$/;
+
+/**
+ * Seed of every daily chain, from the record format this module reads.
+ * Re-declared rather than imported: see the file docblock.
+ * @type {string}
+ */
+const GENESIS = 'AEGIS-AUDIT-GENESIS-v1';
+
+/** @type {string} Record type the product writes when it evicted entries. */
+const DROP_MARKER_TYPE = 'buffer-overflow-drop';
+
+/**
+ * Slack added to both ends of the run window, in milliseconds.
+ *
+ * Deliberately small. The bench and the sensor run on one machine off one
+ * clock, and every audit timestamp is taken inside the product's `log()` call —
+ * i.e. AFTER the thing it describes — so a record caused by a step cannot
+ * precede that step and nothing can be stamped after the sensor was killed.
+ * Both ends are therefore inert by construction, which makes this a tolerance
+ * for clock granularity and for the sub-millisecond ordering of two writes, not
+ * a way to widen the window until the wanted records fall inside it. A generous
+ * value would only pull the sensor's own start-up burst into the observation
+ * set, where it would score as a run of file creations the scenario never made.
+ * @type {number}
+ */
+const EPSILON_MS = 250;
+
+/**
+ * The closed set of audit types that map into the catalogue's ECS subset.
+ *
+ * `agent-enter`/`agent-exit` are session events: AEGIS reports a process start
+ * when a scan first sees the process and a process end after the session
+ * tracker's grace of missed scans, not from a process-creation notification. The
+ * distance between the two instants is what arm A measures, so both map onto the
+ * process shapes and neither is renamed to hide the difference.
+ * @type {Readonly<Object<string, string>>}
+ */
+const PROCESS_TYPES = Object.freeze({
+  'agent-enter': 'process.start',
+  'agent-exit': 'process.end',
+});
+
+/**
+ * Audit types whose records describe a file, keyed by the `action` the product
+ * wrote. `modified` and `accessed` are absent on purpose: the catalogue has no
+ * shape for them, and inventing one here would mean `expected.ndjson` and
+ * `observed.ndjson` no longer speak the same subset.
+ * @type {ReadonlySet<string>}
+ */
+const FILE_TYPES = Object.freeze(new Set(['file-access', 'config-access']));
+
+/** @type {Readonly<Object<string, string>>} File actions that have a shape. */
+const FILE_ACTIONS = Object.freeze({
+  created: 'file.creation',
+  deleted: 'file.deletion',
+});
+
+/**
+ * An error the run must fail on. Carries a machine-readable `stage` so the
+ * capture record can name what refused without parsing English.
+ */
+class ObservedError extends Error {
+  /**
+   * @param {string} stage - One of `audit-missing`, `chain-broken`,
+   *   `records-lost`, `no-observations`.
+   * @param {string} message - What a reader needs in order to act.
+   */
+  constructor(stage, message) {
+    super(message);
+    this.name = 'ObservedError';
+    this.stage = stage;
+  }
+}
+
+/**
+ * Deterministic, key-order-independent serialization — the preimage half of the
+ * record hash. Object keys sort recursively, so the result depends only on
+ * content.
+ * @param {*} value - Any JSON-serializable value.
+ * @returns {string}
+ */
+function canonical(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`).join(',')}}`;
+}
+
+/**
+ * A record's chain hash: `sha256(prevHash + canonical(record without seq/hash))`.
+ *
+ * The JSON round-trip matches what was hashed at write time: `JSON.stringify`
+ * drops undefined-valued keys, so a record carrying one would otherwise hash
+ * differently here than it did on disk and produce a false break.
+ * @param {string} prevHash - Previous record's hash, or {@link GENESIS}.
+ * @param {Object} record - The record WITHOUT its `seq` and `hash` fields.
+ * @returns {string} Hex-encoded SHA-256.
+ */
+function computeHash(prevHash, record) {
+  return crypto
+    .createHash('sha256')
+    .update(prevHash + canonical(JSON.parse(JSON.stringify(record))))
+    .digest('hex');
+}
+
+/**
+ * The daily audit files an Electron profile holds, oldest first.
+ * @param {string} profileDir - Electron `userData` directory.
+ * @returns {string[]} Absolute paths. Empty when the directory is absent.
+ */
+function listAuditFiles(profileDir) {
+  const dir = path.join(profileDir, AUDIT_DIRNAME);
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch (_) {
+    return [];
+  }
+  return names
+    .filter((n) => AUDIT_FILENAME.test(n))
+    .sort()
+    .map((n) => path.join(dir, n));
+}
+
+/**
+ * Read one daily file and prove its chain.
+ *
+ * Every line is re-derived from the previous record's hash, from GENESIS. There
+ * is no stored back-pointer to trust: linkage exists only if it recomputes.
+ * @param {string} filePath - One `aegis-audit-<day>.json`.
+ * @returns {{records: Object[], truncatedTail: string|null}} `truncatedTail` is
+ *   the reason a trailing line was dropped, or `null` when none was.
+ * @throws {ObservedError} On an interior line that does not parse, a seq that is
+ *   not its line number, or a hash that does not recompute.
+ */
+function readChain(filePath) {
+  const lines = fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0);
+
+  // A kill can land mid-append, and a half-written trailing line leaves a valid
+  // prefix — the same asymmetry audit-hashchain.js documents for truncation. It
+  // is dropped, and the fact that it existed is returned so the run records that
+  // one observation may be missing. Only the LAST line gets this: a hole
+  // anywhere else is a file nobody may read records out of.
+  let truncatedTail = null;
+  if (lines.length > 0) {
+    try {
+      JSON.parse(lines[lines.length - 1]);
+    } catch (err) {
+      truncatedTail =
+        `the last line of ${path.basename(filePath)} does not parse (${err.message}) — it was ` +
+        'dropped as a torn write, so this run may be missing the observation it held';
+      lines.pop();
+    }
+  }
+
+  const records = [];
+  let prevHash = GENESIS;
+  for (let i = 0; i < lines.length; i++) {
+    let record;
+    try {
+      record = JSON.parse(lines[i]);
+    } catch (err) {
+      throw new ObservedError(
+        'chain-broken',
+        `${filePath} line ${i} does not parse (${err.message}) — an interior malformed line ` +
+          'breaks the chain, and the records after it cannot be read as observations',
+      );
+    }
+    if (record.seq !== i) {
+      throw new ObservedError(
+        'chain-broken',
+        `${filePath} line ${i} carries seq ${JSON.stringify(record.seq)} — a chain whose ` +
+          'sequence skips or repeats is missing records or holds them twice',
+      );
+    }
+    const preimage = { ...record };
+    delete preimage.seq;
+    delete preimage.hash;
+    const expected = computeHash(prevHash, preimage);
+    if (expected !== record.hash) {
+      throw new ObservedError(
+        'chain-broken',
+        `${filePath} seq ${i} does not recompute (stored ${record.hash}, derived ${expected}) — ` +
+          'the file is not trustworthy, so no record is taken out of it',
+      );
+    }
+    prevHash = record.hash;
+    records.push({ ...record, auditFile: path.basename(filePath) });
+  }
+  return { records, truncatedTail };
+}
+
+/**
+ * Split an observed path into its file name and directory WITHOUT touching the
+ * filesystem — the file it names is usually gone by the time this runs.
+ *
+ * The separator is read off the string rather than taken from the running
+ * platform: the bench only runs on Windows, but its tests do not, and
+ * `path.basename` on POSIX would hand back a whole `X:\...\claude.exe` as the
+ * name.
+ * @param {string} value - The path exactly as the audit recorded it.
+ * @returns {{name: string, directory: string}}
+ */
+function splitPath(value) {
+  const flavour = /\\/.test(value) || /^[A-Za-z]:/.test(value) ? path.win32 : path.posix;
+  return { name: flavour.basename(value), directory: flavour.dirname(value) };
+}
+
+/**
+ * The `bench` block of an observed line: where the row came from, plus the three
+ * sensor-specific observations ECS has no field for.
+ *
+ * `agent` is the display name from `src/shared/agent-database.json`, NOT the
+ * image name — the audit does not persist the image name, so it must not be
+ * written into `process.name` where a join would read it as one. `instanceId` is
+ * carried verbatim and never parsed: it encodes the OS birth time as
+ * `"<pid>:<ms>"`, and reconstructing an instant out of an identity string would
+ * be a derivation dressed up as an observation.
+ * @param {Object} record - The audit record.
+ * @param {string} scenario - Scenario id.
+ * @returns {Object}
+ */
+function benchBlock(record, scenario) {
+  const block = {
+    scenario,
+    source: 'aegis-audit',
+    auditFile: record.auditFile,
+    auditSeq: record.seq,
+    auditType: record.type,
+  };
+  if (typeof record.agent === 'string' && record.agent !== '') block.agent = record.agent;
+  if (typeof record.instanceId === 'string' && record.instanceId !== '') {
+    block.instanceId = record.instanceId;
+  }
+  if (record.attribution) block.attribution = record.attribution;
+  return block;
+}
+
+/**
+ * `process.pid`, but only when the audit gave one the OS could have handed out.
+ *
+ * `null` is what a file event carries (chokidar knows no owner) and `0` is what
+ * a synthetic, process-less agent carries. Neither is a pid, and per the B2.2
+ * convention neither is written as one — the field is left out, and its absence
+ * is the observation.
+ * @param {Object} record
+ * @returns {Object|null} `{pid}` or null when there is nothing to write.
+ */
+function processIdentity(record) {
+  return Number.isSafeInteger(record.pid) && record.pid > 0 ? { pid: record.pid } : null;
+}
+
+/**
+ * Map one audit record onto the catalogue's ECS subset.
+ * @param {Object} record - A chain-verified audit record.
+ * @param {string} scenario - Scenario id, for the bench block.
+ * @returns {Object|null} An ECS document, or `null` when the record has no shape
+ *   in the subset (the caller tallies those; it never drops them silently).
+ */
+function toEcs(record, scenario) {
+  const shapeName = PROCESS_TYPES[record.type]
+    ? PROCESS_TYPES[record.type]
+    : FILE_TYPES.has(record.type)
+      ? FILE_ACTIONS[record.action]
+      : undefined;
+  if (!shapeName) return null;
+  const shape = catalogue.EVENT_SHAPES[shapeName];
+
+  const fields = {};
+  if (shape.category === 'file') {
+    if (typeof record.path !== 'string' || record.path.trim() === '') return null;
+    const { name, directory } = splitPath(record.path);
+    fields.file = { path: record.path, name, directory };
+    const identity = processIdentity(record);
+    if (identity) fields.process = identity;
+  } else {
+    const identity = processIdentity(record);
+    if (identity) fields.process = identity;
+  }
+
+  return {
+    '@timestamp': record.timestamp,
+    ecs: { version: catalogue.ECS_VERSION },
+    event: {
+      kind: 'event',
+      category: [shape.category],
+      type: [shape.type],
+      action: shape.action,
+    },
+    ...fields,
+    bench: benchBlock(record, scenario),
+  };
+}
+
+/**
+ * Reduce every record the sensor wrote to the ones that belong to this run, in
+ * the shape the catalogue speaks.
+ * @param {Object} opts
+ * @param {Object[]} opts.records - Chain-verified records, all files, in order.
+ * @param {string} opts.scenario - Scenario id.
+ * @param {string} opts.windowStart - ISO instant of the run's first step.
+ * @param {string} opts.windowEnd - ISO instant the sensor was stopped.
+ * @param {number} [opts.epsilonMs] - Override, for tests.
+ * @returns {{events: Object[], skipped: {outOfWindow: number, unparsableTimestamp: number,
+ *   dropMarkersOutsideWindow: number, byShapelessType: Object<string, number>}}}
+ * @throws {ObservedError} When a loss marker sits inside the window.
+ */
+function select(opts) {
+  const epsilon = opts.epsilonMs != null ? opts.epsilonMs : EPSILON_MS;
+  const from = Date.parse(opts.windowStart) - epsilon;
+  const to = Date.parse(opts.windowEnd) + epsilon;
+  if (!Number.isFinite(from) || !Number.isFinite(to)) {
+    throw new ObservedError(
+      'no-observations',
+      `the run window [${opts.windowStart}, ${opts.windowEnd}] is not two UTC instants, so no ` +
+        'record can be said to fall inside it',
+    );
+  }
+
+  const events = [];
+  const skipped = {
+    outOfWindow: 0,
+    unparsableTimestamp: 0,
+    dropMarkersOutsideWindow: 0,
+    byShapelessType: {},
+  };
+
+  for (const record of opts.records) {
+    const at = Date.parse(record.timestamp);
+    if (!Number.isFinite(at)) {
+      skipped.unparsableTimestamp += 1;
+      continue;
+    }
+    const inWindow = at >= from && at <= to;
+    if (record.type === DROP_MARKER_TYPE) {
+      if (!inWindow) {
+        skipped.dropMarkersOutsideWindow += 1;
+        continue;
+      }
+      const dropped = (record.details && record.details.droppedCount) || 'an unstated number of';
+      throw new ObservedError(
+        'records-lost',
+        `the sensor recorded a ${DROP_MARKER_TYPE} marker at ${record.timestamp}, inside this ` +
+          `run's window: ${dropped} entries were evicted before they reached disk. What was ` +
+          'lost was lost from the interval this run is about to call observed',
+      );
+    }
+    if (!inWindow) {
+      skipped.outOfWindow += 1;
+      continue;
+    }
+    const event = toEcs(record, opts.scenario);
+    if (!event) {
+      const key = record.action ? `${record.type}/${record.action}` : record.type;
+      skipped.byShapelessType[key] = (skipped.byShapelessType[key] || 0) + 1;
+      continue;
+    }
+    events.push(event);
+  }
+  return { events, skipped };
+}
+
+/**
+ * Read a profile's audit trail and reduce it to this run's observations.
+ * @param {Object} opts
+ * @param {string} opts.profileDir - The Electron profile the sensor ran on.
+ * @param {string} opts.scenario - Scenario id.
+ * @param {string} opts.windowStart - ISO instant of the run's first step.
+ * @param {string} opts.windowEnd - ISO instant the sensor was stopped.
+ * @param {number} [opts.epsilonMs] - Override, for tests.
+ * @returns {{events: Object[], files: string[], lines: number, truncatedTails: string[],
+ *   skipped: Object}}
+ * @throws {ObservedError} No audit file, a broken chain, a loss marker inside the
+ *   window, or nothing observed at all.
+ */
+function capture(opts) {
+  const files = listAuditFiles(opts.profileDir);
+  if (files.length === 0) {
+    throw new ObservedError(
+      'audit-missing',
+      `no audit file under ${path.join(opts.profileDir, AUDIT_DIRNAME)} — the sensor ran but ` +
+        'persisted nothing, so there is no record of what it observed',
+    );
+  }
+
+  const records = [];
+  const truncatedTails = [];
+  for (const file of files) {
+    const chain = readChain(file);
+    records.push(...chain.records);
+    if (chain.truncatedTail) truncatedTails.push(chain.truncatedTail);
+  }
+
+  const { events, skipped } = select({
+    records,
+    scenario: opts.scenario,
+    windowStart: opts.windowStart,
+    windowEnd: opts.windowEnd,
+    epsilonMs: opts.epsilonMs,
+  });
+
+  if (events.length === 0) {
+    throw new ObservedError(
+      'no-observations',
+      `the audit holds ${records.length} verified record(s) but none of them falls in ` +
+        `[${opts.windowStart}, ${opts.windowEnd}] with a shape this subset knows. An empty ` +
+        'observed.ndjson would read as "the sensor saw nothing", which is a different claim',
+    );
+  }
+
+  return { events, files, lines: records.length, truncatedTails, skipped };
+}
+
+/**
+ * Write the observation set into a run directory.
+ * @param {string} runDir - Absolute path of the run directory.
+ * @param {Object[]} events - Never empty: {@link capture} refuses first.
+ * @returns {string} Absolute path of the file written.
+ */
+function write(runDir, events) {
+  const file = path.join(runDir, OBSERVED_FILENAME);
+  fs.writeFileSync(file, catalogue.serialize(events), 'utf8');
+  return file;
+}
+
+/**
+ * Write the capture record: how the sensor was run, what window was read, and
+ * everything that did NOT become a line of `observed.ndjson`.
+ *
+ * Always written in arm A, including — especially including — when the capture
+ * refused. A run directory that holds no observations has to say why in a file,
+ * or the next reader will assume the sensor was silent.
+ * @param {string} runDir - Absolute path of the run directory.
+ * @param {Object} record - Serializable capture record.
+ * @returns {string} Absolute path of the file written.
+ */
+function writeMeta(runDir, record) {
+  const file = path.join(runDir, META_FILENAME);
+  fs.writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+  return file;
+}
+
+module.exports = {
+  AUDIT_DIRNAME,
+  AUDIT_FILENAME,
+  DROP_MARKER_TYPE,
+  EPSILON_MS,
+  FILE_ACTIONS,
+  FILE_TYPES,
+  GENESIS,
+  META_FILENAME,
+  OBSERVED_FILENAME,
+  ObservedError,
+  PROCESS_TYPES,
+  canonical,
+  capture,
+  computeHash,
+  listAuditFiles,
+  readChain,
+  select,
+  splitPath,
+  toEcs,
+  write,
+  writeMeta,
+};

--- a/bench/lib/sensor.js
+++ b/bench/lib/sensor.js
@@ -417,13 +417,14 @@ async function waitForTicks(handle, count, opts = {}) {
  * @param {Object} handle - From {@link start}.
  * @param {Object} [opts]
  * @param {function(string): void} [opts.log]
- * @param {number} [opts.drainMs] - Override, for tests.
+ * @param {number} [opts.drainMs] - Override. `0` skips the drain entirely, for
+ *   the paths where nothing is going to read the audit file afterwards.
  * @returns {Promise<Object>} The same handle, with `stoppedAt` set.
  */
 async function stop(handle, opts = {}) {
   const log = opts.log ?? (() => {});
   const drainMs = opts.drainMs ?? DRAIN_MS;
-  if (!handle.exit) {
+  if (!handle.exit && drainMs > 0) {
     log(`sensor  draining ${drainMs} ms so the audit logger's flush timer runs`);
     await new Promise((resolve) => setTimeout(resolve, drainMs));
   }

--- a/bench/lib/sensor.js
+++ b/bench/lib/sensor.js
@@ -1,0 +1,519 @@
+/**
+ * @file bench/lib/sensor.js
+ * @module bench/lib/sensor
+ * @description Runs the AEGIS sensor as a child process for the length of one
+ *   arm-A bench run, and tells the run when it is safe to start and safe to stop.
+ *
+ *   The product is started the way a developer starts it — `electron .` against
+ *   the repository — and left in its ordinary mode of operation. Two deliberate
+ *   choices shape the rest:
+ *
+ *   **A run-scoped Electron profile, outside the repository.** `--user-data-dir`
+ *   is a stock Electron switch and changes nothing about how the sensor observes
+ *   or what it writes; it changes only where. That buys three things a bench
+ *   needs: the audit file is written by this run alone, so its hash chain starts
+ *   at GENESIS and a verdict on it is a verdict on our own records; the run does
+ *   not depend on whatever `scanIntervalSec` the developer last saved, or append
+ *   to their real audit trail; and the single-instance lock lives in the profile,
+ *   so a bench run does not collide with an AEGIS the user already has open.
+ *   The profile must NOT live inside the repository: `src/main/file-watcher.js`
+ *   watches the project directory, so an audit write there would raise a file
+ *   event, which is logged to the audit, which is a write. That is a loop.
+ *
+ *   **Readiness is the sensor's own report of a completed scan, twice.** AEGIS
+ *   logs `DEBUG [scan] process {ms, agents}` after a full process-scan tick —
+ *   snapshot, identity stamp, session reconcile, batch — and `logger.js` mirrors
+ *   every line to stderr while the app is unpackaged. The first such line says
+ *   the process sensor has completed a cycle; every later one is a tick the run
+ *   can count. Nothing here sleeps for a guessed interval.
+ *
+ *   One completed scan is not enough to start acting, and the first version of
+ *   this file learned that the expensive way. AEGIS spends its first minute on a
+ *   startup schedule (`scan-loop.js` `staggeredStartup`/`startWarmup`) that
+ *   scans at THREE TIMES the configured interval before switching to the real
+ *   one. A run that begins at the first tick therefore acts into a ~37 s gap; a
+ *   scenario whose subject lives 35 s — S1 lives exactly that long, chosen
+ *   against the 10 s configured interval — is then never in front of a scan at
+ *   all, and its process start and end are unobservable for a reason that
+ *   belongs to the harness, not to the sensor. So readiness waits for the
+ *   cadence to settle: two consecutive ticks closer together than
+ *   {@link STEADY_GAP_MS}, which is the sensor saying it has left the startup
+ *   regime. Still its own output, still no sleep on a guess. If it never
+ *   settles, the run says so on the record and proceeds rather than refusing —
+ *   a slow cadence is a fact about the sensor, and the tick accounting makes it
+ *   readable.
+ *
+ *   The signal is a property of running from source: a packaged build sets
+ *   `isDev` false and prints nothing, and this module would have to be given a
+ *   different signal before it could bench one.
+ *
+ *   Stopping is a kill, and that is a limitation, not a preference. AEGIS has no
+ *   external graceful-shutdown path — its window `close` handler calls
+ *   `preventDefault()` and hides to tray, so a polite `taskkill` leaves the app
+ *   running and only `/F` ends it, which skips `before-quit → audit.shutdown()`.
+ *   The audit's own 5 s flush timer is what makes the last records durable, so
+ *   the kill is preceded by a drain longer than one flush interval.
+ *
+ *   Nothing here imports from `src/`.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.11.0
+ */
+'use strict';
+
+const { execFile, spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const manifest = require('./manifest');
+
+/** @type {string} The renderer bundle the main window loads. */
+const RENDERER_ENTRY = path.join(manifest.ROOT, 'dist', 'renderer', 'index.html');
+
+/**
+ * One completed process-scan tick, as the product logs it
+ * (`src/main/scan-loop.js`, via `logger.debug('scan', 'process', …)`).
+ * @type {RegExp}
+ */
+const TICK_LINE =
+  /^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\]\s+DEBUG\s+\[scan]\s+process\b/;
+
+/**
+ * How long to wait for the first completed scan. Generous: boot pays for a
+ * `tasklist` spawn, the snapshot sidecar handshake and a CIM query, and the
+ * first scan is deliberately staggered a few seconds behind the window.
+ * @type {number}
+ */
+const READY_TIMEOUT_MS = 120000;
+
+/**
+ * The gap between two completed scans, below which the sensor is taken to have
+ * left its startup schedule and reached its configured cadence.
+ *
+ * 20 s sits in the empty space between the two regimes rather than close to
+ * either: on the run-scoped profile the settings are the product defaults, so
+ * warmup scans land ~30–40 s apart and steady scans ~10 s apart. It is not a
+ * duration anything waits for — it is the test applied to instants the sensor
+ * itself reported.
+ *
+ * A deployment configured with a much longer scan interval would never satisfy
+ * it. That is deliberate and non-fatal: {@link start} gives up after
+ * {@link STEADY_TIMEOUT_MS}, records that the cadence never settled, and lets
+ * the run proceed with the fact on its capture record — where a reader can see
+ * it next to how many ticks actually fell inside the scenario.
+ * @type {number}
+ */
+const STEADY_GAP_MS = 20000;
+
+/**
+ * How long to wait for the cadence to settle before giving up on it and acting
+ * anyway. AEGIS switches off its startup schedule 60 s after the schedule
+ * begins, which is itself ~12 s into the app's life, so ~90 s is the honest
+ * expectation and this is twice it.
+ * @type {number}
+ */
+const STEADY_TIMEOUT_MS = 180000;
+
+/**
+ * How long to wait for the post-run ticks. The scan cadence is not constant:
+ * `staggeredStartup` runs the first minute of an app's life at three times the
+ * configured interval, so three ticks can legitimately take two minutes.
+ * @type {number}
+ */
+const TICK_TIMEOUT_MS = 240000;
+
+/**
+ * Ticks to let the sensor play out after the last step.
+ *
+ * Three, because one is not enough to see the end of a process. AEGIS reports a
+ * process end only after `session-tracker.js`'s exit grace of 2 consecutive
+ * reliable scans that missed it, so a run that stops one tick after the last
+ * step captures the start of a process and never its end. 2 + 1 is the smallest
+ * number that lets the product reach its own conclusion.
+ * @type {number}
+ */
+const POST_RUN_TICKS = 3;
+
+/**
+ * Quiet period between the last tick and the kill, in milliseconds. Longer than
+ * the audit logger's 5 s flush interval, so the records of that last tick are on
+ * disk before the process that holds them is destroyed.
+ * @type {number}
+ */
+const DRAIN_MS = 6000;
+
+/** @type {number} Diagnostic output kept from the child, in lines. */
+const LOG_TAIL_LINES = 40;
+
+/** An error that fails the run, carrying a machine-readable stage. */
+class SensorError extends Error {
+  /**
+   * @param {string} stage - One of `renderer-missing`, `spawn-failed`,
+   *   `died-before-ready`, `ready-timeout`, `died-mid-run`.
+   * @param {string} message - What a reader needs in order to act.
+   */
+  constructor(stage, message) {
+    super(message);
+    this.name = 'SensorError';
+    this.stage = stage;
+  }
+}
+
+/**
+ * Where this run's Electron profile goes: the OS temp directory, never the
+ * repository (see the file docblock — a profile under the watched project
+ * directory feeds the audit its own writes).
+ * @param {string} runId
+ * @returns {string}
+ */
+function profileDirFor(runId) {
+  return path.join(os.tmpdir(), `aegis-bench-${runId}`);
+}
+
+/**
+ * Split a stream into lines and hand each one to a sink, carrying the partial
+ * last line over to the next chunk.
+ * @param {import('stream').Readable} stream
+ * @param {function(string): void} onLine
+ * @returns {void}
+ */
+function pumpLines(stream, onLine) {
+  let carry = '';
+  stream.setEncoding('utf8');
+  stream.on('data', (chunk) => {
+    const parts = (carry + chunk).split('\n');
+    carry = parts.pop();
+    for (const line of parts) onLine(line.replace(/\r$/, ''));
+  });
+  stream.on('end', () => {
+    if (carry.trim()) onLine(carry.replace(/\r$/, ''));
+    carry = '';
+  });
+}
+
+/**
+ * Start AEGIS on a run-scoped profile and wait for its first completed scan.
+ * @param {Object} opts
+ * @param {string} opts.runId - Used to name the profile directory.
+ * @param {function(string): void} [opts.log] - Progress sink.
+ * @param {number} [opts.readyTimeoutMs] - Override, for tests.
+ * @param {number} [opts.steadyTimeoutMs] - Override, for tests.
+ * @param {number} [opts.steadyGapMs] - Override, for tests.
+ * @returns {Promise<Object>} The handle every other function here takes.
+ * @throws {SensorError} When the renderer is not built, the spawn fails, the app
+ *   exits before it reports a scan, or the wait times out.
+ */
+async function start(opts) {
+  const log = opts.log ?? (() => {});
+  if (!fs.existsSync(RENDERER_ENTRY)) {
+    throw new SensorError(
+      'renderer-missing',
+      `${RENDERER_ENTRY} does not exist, so the main window has nothing to load and the deferred ` +
+        'subsystems that own the sensors never start. Run `npm run build:renderer` first',
+    );
+  }
+
+  const profileDir = profileDirFor(opts.runId);
+  fs.mkdirSync(profileDir, { recursive: true });
+
+  // Electron's own launcher trick: an IDE terminal exports ELECTRON_RUN_AS_NODE=1,
+  // and Electron checks the variable's EXISTENCE — setting it empty still starts
+  // plain Node with no app, no window and no sensors. See scripts/launch.js.
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+
+  const handle = {
+    /** @type {import('child_process').ChildProcess|null} */
+    child: null,
+    pid: null,
+    profileDir,
+    startedAt: new Date().toISOString(),
+    readyAt: null,
+    steadyAt: null,
+    steadyCadence: false,
+    stoppedAt: null,
+    /** @type {string[]} ISO instant of every completed process-scan tick. */
+    ticks: [],
+    /** @type {string[]} Tail of the child's output, for a failure message. */
+    tail: [],
+    /** @type {{code: number|null, signal: string|null}|null} */
+    exit: null,
+    /** @type {Array<function(): void>} Woken on a new tick or on exit. */
+    _waiters: [],
+  };
+
+  const wake = () => {
+    const waiters = handle._waiters.splice(0);
+    for (const w of waiters) w();
+  };
+
+  const onLine = (line) => {
+    handle.tail.push(line);
+    if (handle.tail.length > LOG_TAIL_LINES) handle.tail.shift();
+    const tick = TICK_LINE.exec(line);
+    if (tick) {
+      handle.ticks.push(tick[1]);
+      wake();
+    }
+  };
+
+  const child = spawn(require('electron'), ['.', `--user-data-dir=${profileDir}`], {
+    cwd: manifest.ROOT,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  handle.child = child;
+  pumpLines(child.stdout, onLine);
+  pumpLines(child.stderr, onLine);
+  child.on('exit', (code, signal) => {
+    handle.exit = { code, signal };
+    wake();
+  });
+
+  await new Promise((resolve, reject) => {
+    child.once('spawn', resolve);
+    child.once('error', (err) =>
+      reject(new SensorError('spawn-failed', `could not start the sensor: ${err.message}`)),
+    );
+  });
+  handle.pid = child.pid;
+  log(`sensor  started pid ${child.pid}, profile ${profileDir}`);
+
+  const readyTimeout = opts.readyTimeoutMs ?? READY_TIMEOUT_MS;
+  await waitFor(handle, () => handle.ticks.length >= 1, readyTimeout, {
+    onExit: (exit) =>
+      new SensorError(
+        'died-before-ready',
+        `the sensor exited (code ${exit.code}, signal ${exit.signal}) before it reported a ` +
+          `completed process scan.\n${formatTail(handle)}`,
+      ),
+    onTimeout: () =>
+      new SensorError(
+        'ready-timeout',
+        `the sensor did not report a completed process scan within ${readyTimeout} ms. A bench ` +
+          'never proceeds on a guessed interval, so the run stops here rather than acting into a ' +
+          `sensor that may not be watching.\n${formatTail(handle)}`,
+      ),
+  });
+  handle.readyAt = handle.ticks[0];
+  log(`sensor  alive — first completed process scan at ${handle.readyAt}`);
+
+  const steadyTimeout = opts.steadyTimeoutMs ?? STEADY_TIMEOUT_MS;
+  const gap = opts.steadyGapMs ?? STEADY_GAP_MS;
+  log(`sensor  waiting for its scan cadence to settle (two ticks under ${gap} ms apart)`);
+  await waitFor(handle, () => settledAt(handle.ticks, gap) !== null, steadyTimeout, {
+    onExit: (exit) =>
+      new SensorError(
+        'died-before-ready',
+        `the sensor exited (code ${exit.code}, signal ${exit.signal}) while the run was waiting ` +
+          `for its scan cadence to settle.\n${formatTail(handle)}`,
+      ),
+    onTimeout: null,
+  });
+  handle.steadyAt = settledAt(handle.ticks, gap);
+  handle.steadyCadence = handle.steadyAt !== null;
+  if (handle.steadyCadence) {
+    log(`sensor  ready — cadence settled at ${handle.steadyAt}`);
+  } else {
+    log(
+      `sensor  cadence never settled within ${steadyTimeout} ms — the run proceeds and records ` +
+        'that it acted while the sensor was still on its startup schedule',
+    );
+  }
+  return handle;
+}
+
+/**
+ * The instant a run of scan ticks first showed a settled cadence.
+ * @param {string[]} ticks - Completed-scan instants, in order.
+ * @param {number} gapMs - Below this, two consecutive ticks count as settled.
+ * @returns {string|null} The later of the first close pair, or null.
+ */
+function settledAt(ticks, gapMs) {
+  for (let i = 1; i < ticks.length; i++) {
+    const gap = Date.parse(ticks[i]) - Date.parse(ticks[i - 1]);
+    if (Number.isFinite(gap) && gap < gapMs) return ticks[i];
+  }
+  return null;
+}
+
+/**
+ * Wait until a condition holds, the child exits, or the clock runs out.
+ * @param {Object} handle
+ * @param {function(): boolean} done
+ * @param {number} timeoutMs
+ * @param {Object} on
+ * @param {function(Object): Error} on.onExit - Builds the error for a dead child.
+ * @param {(function(): Error)|null} on.onTimeout - Builds the error for a
+ *   timeout, or `null` to resolve quietly instead of throwing.
+ * @returns {Promise<void>}
+ */
+function waitFor(handle, done, timeoutMs, on) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      if (done()) return resolve();
+      if (handle.exit) return reject(on.onExit(handle.exit));
+      const left = deadline - Date.now();
+      if (left <= 0) {
+        if (on.onTimeout) return reject(on.onTimeout());
+        return resolve();
+      }
+      const timer = setTimeout(() => {
+        handle._waiters = handle._waiters.filter((w) => w !== waiter);
+        check();
+      }, left);
+      const waiter = () => {
+        clearTimeout(timer);
+        check();
+      };
+      handle._waiters.push(waiter);
+    };
+    check();
+  });
+}
+
+/**
+ * Let the sensor play out `count` more completed scan ticks.
+ *
+ * A timeout here is NOT a refusal: the run says how many ticks it actually got
+ * and lets the capture record carry the shortfall. A dead child is, because
+ * everything after it would be observed by nothing.
+ * @param {Object} handle - From {@link start}.
+ * @param {number} count
+ * @param {Object} [opts]
+ * @param {function(string): void} [opts.log]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<number>} Ticks actually seen, which may be fewer than asked.
+ * @throws {SensorError} When the sensor died while we were waiting.
+ */
+async function waitForTicks(handle, count, opts = {}) {
+  const log = opts.log ?? (() => {});
+  const target = handle.ticks.length + count;
+  const timeoutMs = opts.timeoutMs ?? TICK_TIMEOUT_MS;
+  log(`sensor  waiting for ${count} more completed scan tick(s)`);
+  await waitFor(handle, () => handle.ticks.length >= target, timeoutMs, {
+    onExit: (exit) =>
+      new SensorError(
+        'died-mid-run',
+        `the sensor exited (code ${exit.code}, signal ${exit.signal}) while the run was waiting ` +
+          `for it to finish scanning.\n${formatTail(handle)}`,
+      ),
+    onTimeout: null,
+  });
+  return count - Math.max(0, target - handle.ticks.length);
+}
+
+/**
+ * End the child process tree, after giving the audit logger time to flush.
+ *
+ * The drain is the whole point: AEGIS buffers audit records and writes them on a
+ * 5 s timer, and this kill is hard enough to skip `before-quit`, so without the
+ * wait the last seconds of observation would be lost with no trace on disk. The
+ * tree is killed rather than the process, or the snapshot sidecar and the
+ * renderer outlive their parent.
+ * @param {Object} handle - From {@link start}.
+ * @param {Object} [opts]
+ * @param {function(string): void} [opts.log]
+ * @param {number} [opts.drainMs] - Override, for tests.
+ * @returns {Promise<Object>} The same handle, with `stoppedAt` set.
+ */
+async function stop(handle, opts = {}) {
+  const log = opts.log ?? (() => {});
+  const drainMs = opts.drainMs ?? DRAIN_MS;
+  if (!handle.exit) {
+    log(`sensor  draining ${drainMs} ms so the audit logger's flush timer runs`);
+    await new Promise((resolve) => setTimeout(resolve, drainMs));
+  }
+  handle.stoppedAt = new Date().toISOString();
+  if (handle.exit) {
+    log(`sensor  already exited (code ${handle.exit.code}, signal ${handle.exit.signal})`);
+    return handle;
+  }
+  await killTree(handle.pid);
+  await waitFor(handle, () => handle.exit !== null, 15000, {
+    onExit: () => new Error('unreachable — an exited child satisfies the condition'),
+    onTimeout: null,
+  });
+  log(`sensor  stopped pid ${handle.pid} at ${handle.stoppedAt}`);
+  return handle;
+}
+
+/**
+ * Kill a process and its descendants.
+ * @param {number} pid
+ * @returns {Promise<void>} Resolves even when the kill fails — a process that is
+ *   already gone is the outcome we wanted, and {@link stop} confirms it by
+ *   waiting for `exit` rather than by trusting this.
+ */
+function killTree(pid) {
+  if (process.platform !== 'win32') {
+    // The bench is Windows-only (bench/README.md). This branch exists so the
+    // module can be exercised elsewhere, not so a run can happen elsewhere.
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch (_) {
+      /* already gone */
+    }
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    execFile('taskkill', ['/PID', String(pid), '/T', '/F'], () => resolve());
+  });
+}
+
+/**
+ * The child's last lines, for a failure message that says something.
+ * @param {Object} handle
+ * @returns {string}
+ */
+function formatTail(handle) {
+  if (handle.tail.length === 0) return 'The sensor produced no output at all.';
+  return `Last ${handle.tail.length} line(s) of its output:\n  ${handle.tail.join('\n  ')}`;
+}
+
+/**
+ * How many completed scan ticks fell inside a closed interval.
+ *
+ * This is the discriminator between "the sensor missed the process" and "the
+ * process was never in front of the sensor". A scenario whose subject lives for
+ * 35 s while the sensor is still in its startup cadence can be scanned once, or
+ * not at all, and a run that reports zero observations without reporting zero
+ * ticks invites the reader to score a phase coincidence as a sensor failure.
+ * @param {Object} handle - From {@link start}.
+ * @param {string|null} fromIso - Start of the interval, or null when unknown.
+ * @param {string|null} toIso - End of the interval, or null when unknown.
+ * @returns {number|null} Null when either bound is unknown or unparseable.
+ */
+function ticksWithin(handle, fromIso, toIso) {
+  if (!fromIso || !toIso) return null;
+  const from = Date.parse(fromIso);
+  const to = Date.parse(toIso);
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return null;
+  return handle.ticks.filter((t) => {
+    const at = Date.parse(t);
+    return Number.isFinite(at) && at >= from && at <= to;
+  }).length;
+}
+
+module.exports = {
+  DRAIN_MS,
+  LOG_TAIL_LINES,
+  POST_RUN_TICKS,
+  READY_TIMEOUT_MS,
+  RENDERER_ENTRY,
+  STEADY_GAP_MS,
+  STEADY_TIMEOUT_MS,
+  SensorError,
+  TICK_LINE,
+  TICK_TIMEOUT_MS,
+  profileDirFor,
+  pumpLines,
+  settledAt,
+  start,
+  stop,
+  ticksWithin,
+  waitForTicks,
+};

--- a/bench/run.js
+++ b/bench/run.js
@@ -484,80 +484,95 @@ async function main(argv) {
   if (scenario) {
     console.log(`scenario ${scenario.id} — ${scenario.title}`);
 
-    // The sensor comes up BEFORE the first step, and a sensor that will not come
-    // up stops the run here: an arm-A run whose sensor never ran is an arm-C run
-    // under the wrong name, and its empty answer would read as a coverage miss.
-    /** @type {Object|null} */
+    /** @type {Object|null} The live sensor, from the moment it is started. */
     let handle = null;
-    if (args.arm === SENSOR_ARM) {
-      try {
-        handle = await sensor.start({ runId, log });
-      } catch (err) {
-        if (!(err instanceof sensor.SensorError)) throw err;
-        const metaPath = observed.writeMeta(dir, {
-          runId,
-          scenario: scenario.id,
-          arm: args.arm,
-          sensor: null,
-          window: null,
-          audit: null,
-          observed: null,
-          skipped: null,
-          failure: { stage: err.stage, reason: err.message },
-        });
-        console.error(`\nbench: ${err.message}`);
-        console.error(
-          `bench: nothing was executed — the scenario never ran, so this run holds a manifest and ` +
-            `the reason and no catalogue.\nbench: written ${metaPath}`,
-        );
-        return 1;
+    try {
+      // The sensor comes up BEFORE the first step, and a sensor that will not
+      // come up stops the run here: an arm-A run whose sensor never ran is an
+      // arm-C run under the wrong name, and its empty answer would read as a
+      // coverage miss.
+      if (args.arm === SENSOR_ARM) {
+        try {
+          handle = await sensor.start({ runId, log });
+        } catch (err) {
+          if (!(err instanceof sensor.SensorError)) throw err;
+          const metaPath = observed.writeMeta(dir, {
+            runId,
+            scenario: scenario.id,
+            arm: args.arm,
+            sensor: null,
+            window: null,
+            audit: null,
+            observed: null,
+            skipped: null,
+            failure: { stage: err.stage, reason: err.message },
+          });
+          console.error(`\nbench: ${err.message}`);
+          console.error(
+            `bench: nothing was executed — the scenario never ran, so this run holds a manifest ` +
+              `and the reason and no catalogue.\nbench: written ${metaPath}`,
+          );
+          return 1;
+        }
       }
-    }
 
-    const outcome = await actor.execute(scenario, { runDir: dir, log });
+      const outcome = await actor.execute(scenario, { runDir: dir, log });
 
-    /** @type {Object|null} */
-    let capture = null;
-    if (handle) {
-      capture = await captureSensor({
-        handle,
-        dir,
-        record: buildCaptureRecord({
+      /** @type {Object|null} */
+      let capture = null;
+      if (handle) {
+        capture = await captureSensor({
           handle,
-          runId,
-          scenario: scenario.id,
-          arm: args.arm,
-          window: { start: firstStepStartedAt(outcome.steps), end: null },
-          events: outcome.events,
-          ticksAfterRun: 0,
-        }),
-        scenarioOk: outcome.ok,
-        log,
-      });
-    }
+          dir,
+          record: buildCaptureRecord({
+            handle,
+            runId,
+            scenario: scenario.id,
+            arm: args.arm,
+            window: { start: firstStepStartedAt(outcome.steps), end: null },
+            events: outcome.events,
+            ticksAfterRun: 0,
+          }),
+          scenarioOk: outcome.ok,
+          log,
+        });
+      }
 
-    // Only now — the catalogue is a file inside the watched project directory,
-    // and writing it while the sensor is live would put a file creation the
-    // harness made for itself into the sensor's own answer.
-    const cataloguePath = catalogue.write(dir, outcome.events);
-    console.log(`written ${cataloguePath} (${outcome.events.length} expected event(s))`);
+      // Only now — the catalogue is a file inside the watched project directory,
+      // and writing it while the sensor is live would put a file creation the
+      // harness made for itself into the sensor's own answer.
+      const cataloguePath = catalogue.write(dir, outcome.events);
+      console.log(`written ${cataloguePath} (${outcome.events.length} expected event(s))`);
 
-    if (capture) {
-      const metaPath = observed.writeMeta(dir, capture.record);
-      console.log(`written ${metaPath}`);
-      reportCapture(capture.record);
-      if (!capture.ok) exitCode = 1;
-    }
+      if (capture) {
+        const metaPath = observed.writeMeta(dir, capture.record);
+        console.log(`written ${metaPath}`);
+        reportCapture(capture.record);
+        if (!capture.ok) exitCode = 1;
+      }
 
-    if (!outcome.ok) {
-      const failed = outcome.steps.find((s) => s.status === 'failed');
-      const skipped = outcome.steps.filter((s) => s.status === 'skipped').length;
-      console.error(
-        `\nbench: step "${failed.id}" (${failed.kind}) did not execute — ${failed.error}` +
-          `\nbench: ${skipped} later step(s) were skipped; the catalogue holds only the ` +
-          'events that actually happened',
-      );
-      exitCode = 1;
+      if (!outcome.ok) {
+        const failed = outcome.steps.find((s) => s.status === 'failed');
+        const skipped = outcome.steps.filter((s) => s.status === 'skipped').length;
+        console.error(
+          `\nbench: step "${failed.id}" (${failed.kind}) did not execute — ${failed.error}` +
+            `\nbench: ${skipped} later step(s) were skipped; the catalogue holds only the ` +
+            'events that actually happened',
+        );
+        exitCode = 1;
+      }
+    } finally {
+      // The net under every path above. `captureSensor` stops the sensor on each
+      // route it completes, so reaching here with a live one means something
+      // unforeseen threw — and a bench that dies must not leave the product it
+      // started running: a survivor holds the single-instance lock on its
+      // profile and keeps scanning and writing audit records for as long as the
+      // machine is up. No drain: nothing is going to read that audit file, and a
+      // failed run should end now.
+      if (handle && !handle.exit) {
+        console.error('bench: stopping the sensor after an unforeseen failure');
+        await sensor.stop(handle, { log, drainMs: 0 });
+      }
     }
   }
 
@@ -569,9 +584,18 @@ async function main(argv) {
 }
 
 if (require.main === module) {
-  main(process.argv.slice(2)).then((code) => {
-    process.exitCode = code;
-  });
+  main(process.argv.slice(2)).then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (err) => {
+      // An unhandled rejection here would print a Node stack and exit 1 with no
+      // statement of what the run was doing. By the time this runs, `main`'s own
+      // finally has already stopped any sensor it started.
+      console.error(`bench: the run failed unexpectedly — ${(err && err.stack) || err}`);
+      process.exitCode = 1;
+    },
+  );
 }
 
 module.exports = {

--- a/bench/run.js
+++ b/bench/run.js
@@ -4,17 +4,36 @@
  *   environment manifest, and — when a scenario was named — executes that
  *   scenario's steps and writes the expected-event catalogue they produced.
  *
- *   The oracle adapters (B2.3, B2.6) and the SUT capture (B2.4) are separate
- *   blocks: a run currently produces the record everything else will be scored
- *   against, and scores nothing itself.
+ *   In **arm A** it also runs the AEGIS sensor across the scenario and writes
+ *   what the sensor recorded to `observed.ndjson`, read back out of the
+ *   product's own hash-chained audit log (`bench/lib/observed.js`). Arms B and C
+ *   start nothing and write no observation set — arm C is defined as the sensor
+ *   alone with no oracle, and measuring its overhead is a later block.
  *
- *   Order matters here. A scenario is loaded and validated **before** the run
- *   directory exists, so a scenario that is wrong fails without leaving an
- *   empty run behind; a step that fails to execute happens after, and leaves
- *   the directory with the catalogue of everything that did happen first.
+ *   The oracle adapters (B2.6) are still a separate block: a run produces the
+ *   record everything else will be scored against, and the sensor's answer next
+ *   to it, and scores neither.
  *
- *   Exit codes: 0 the run completed · 1 a step failed to execute · 2 the
- *   invocation or the scenario was wrong, and nothing ran.
+ *   Order matters here, in three places.
+ *
+ *   A scenario is loaded and validated **before** the run directory exists, so a
+ *   scenario that is wrong fails without leaving an empty run behind; a step
+ *   that fails to execute happens after, and leaves the directory with the
+ *   catalogue of everything that did happen first.
+ *
+ *   The sensor is started **before the first step and after the manifest**, and
+ *   a sensor that will not start fails the run before anything is executed: an
+ *   arm-A run whose sensor never ran is an arm-C run wearing the wrong name.
+ *
+ *   `expected.ndjson` is written **after the sensor is stopped**. AEGIS watches
+ *   the project directory, so a file the harness creates inside the run
+ *   directory while the sensor is live is observed and audited — the catalogue
+ *   would show up as a file creation in the sensor's own answer, a false
+ *   positive the harness manufactured for itself.
+ *
+ *   Exit codes: 0 the run completed · 1 a step failed to execute, or the sensor
+ *   could not be run or read · 2 the invocation or the scenario was wrong, and
+ *   nothing ran.
  *
  *   Usage:
  *     npm run bench:run
@@ -33,9 +52,19 @@ const path = require('path');
 const actor = require('./lib/actor');
 const catalogue = require('./lib/catalogue');
 const manifest = require('./lib/manifest');
+const observed = require('./lib/observed');
+const sensor = require('./lib/sensor');
 
 /** @type {string} Where run directories are created. Gitignored. */
 const RUNS_DIR = path.join(manifest.ROOT, 'bench', 'runs');
+
+/**
+ * The one arm that runs the sensor. B is Sysmon and Procmon without it, and C
+ * is the sensor alone with no oracle — an overhead measurement that scores
+ * nothing and therefore captures nothing here.
+ * @type {string}
+ */
+const SENSOR_ARM = 'A';
 
 /**
  * Scenario label used when none was named. Deliberately not `smoke` or
@@ -57,12 +86,17 @@ Usage:  node bench/run.js [--scenario <id>] [--arm A|B|C]
                    written to expected.ndjson. Default: ${NO_SCENARIO} —
                    a run directory and a manifest, and nothing is executed.
   --arm <A|B|C>    A = sensor + Sysmon · B = Sysmon + Procmon, no sensor
-                   · C = sensor alone. Default: A. The scenario decides which
-                   arms it is meaningful in.
+                   · C = sensor alone. Default: ${SENSOR_ARM}. The scenario
+                   decides which arms it is meaningful in.
   --help           Show this message.
 
-Exit codes: 0 completed · 1 a step failed to execute · 2 bad invocation or bad
-scenario, nothing ran.`;
+In arm ${SENSOR_ARM} with a scenario, AEGIS itself is run across the steps on a
+run-scoped Electron profile, and what it recorded is written to observed.ndjson
+next to the catalogue. It needs a built renderer: run \`npm run build:renderer\`
+first, or the sensor refuses to start and the run stops before acting.
+
+Exit codes: 0 completed · 1 a step failed to execute, or the sensor could not be
+run or read · 2 bad invocation or bad scenario, nothing ran.`;
 
 /**
  * Parse `--key value` pairs. Unknown flags are an error rather than a silent
@@ -158,6 +192,224 @@ function prepareScenario(id, arm) {
 }
 
 /**
+ * The instant the run began ACTING, which is where the observation window opens.
+ *
+ * Not the manifest's `startedAt`: between the two the sensor is started and
+ * waited for, and everything it records in that interval — its own start-up
+ * burst, the agents already running on the machine — is a fact about the
+ * machine, not about this scenario. The window opens where the stimulus does.
+ * @param {Array<{startedAt?: string}>} steps - `actor.execute()`'s step log.
+ * @returns {string|null} Null when no step ever started.
+ */
+function firstStepStartedAt(steps) {
+  const started = steps.find((s) => typeof s.startedAt === 'string');
+  return started ? started.startedAt : null;
+}
+
+/**
+ * The interval the scenario's own processes were alive, from the catalogue.
+ *
+ * Its purpose is to keep a phase coincidence from being read as a sensor
+ * failure: a subject that lives 35 s while the sensor is still on its startup
+ * cadence may be scanned once or not at all, and "the sensor saw no process"
+ * and "no scan happened while a process existed" are different findings.
+ * @param {Object[]} events - Catalogue events from `actor.execute()`.
+ * @returns {{from: string|null, to: string|null}}
+ */
+function processAliveWindow(events) {
+  const at = (type) =>
+    events
+      .filter((e) => e.event.category.includes('process') && e.event.type.includes(type))
+      .map((e) => e['@timestamp'])
+      .sort();
+  const starts = at('start');
+  const ends = at('end');
+  if (starts.length === 0 || ends.length === 0) return { from: null, to: null };
+  return { from: starts[0], to: ends[ends.length - 1] };
+}
+
+/**
+ * Build the capture record — how the sensor was run and what did NOT become an
+ * observation. Written in arm A whether the capture succeeded or refused: a run
+ * directory holding no observations has to say why, or the next reader assumes
+ * the sensor was silent.
+ * @param {Object} opts
+ * @param {Object} opts.handle - The sensor handle.
+ * @param {string} opts.runId
+ * @param {string} opts.scenario
+ * @param {string} opts.arm
+ * @param {{start: string|null, end: string|null}} opts.window
+ * @param {Object[]} opts.events - Catalogue events, for the alive window.
+ * @param {number} opts.ticksAfterRun - Ticks the sensor played out after the
+ *   last step, which may be fewer than asked for.
+ * @returns {Object}
+ */
+function buildCaptureRecord(opts) {
+  const alive = processAliveWindow(opts.events);
+  return {
+    runId: opts.runId,
+    scenario: opts.scenario,
+    arm: opts.arm,
+    sensor: {
+      profileDir: opts.handle.profileDir,
+      pid: opts.handle.pid,
+      startedAt: opts.handle.startedAt,
+      readyAt: opts.handle.readyAt,
+      steadyAt: opts.handle.steadyAt,
+      steadyCadence: opts.handle.steadyCadence,
+      stoppedAt: opts.handle.stoppedAt,
+      readySignal:
+        'the app\'s own "DEBUG [scan] process" lines on stderr: one completed scan means the ' +
+        `sensor is alive, and two under ${sensor.STEADY_GAP_MS} ms apart mean it has left the ` +
+        'startup schedule that scans at three times the configured interval',
+      stopMethod:
+        `taskkill /T /F after a ${sensor.DRAIN_MS} ms drain. AEGIS has no external ` +
+        'graceful-shutdown path (its window close handler hides to tray), so the kill skips ' +
+        "before-quit and the drain is what makes the last records durable via the logger's " +
+        'own 5 s flush timer',
+      exit: opts.handle.exit,
+      scanTicks: opts.handle.ticks,
+      ticksRequestedAfterRun: sensor.POST_RUN_TICKS,
+      ticksAfterRun: opts.ticksAfterRun,
+      processAliveWindow: alive,
+      ticksWhileProcessAlive: sensor.ticksWithin(opts.handle, alive.from, alive.to),
+    },
+    window: { start: opts.window.start, end: opts.window.end, epsilonMs: observed.EPSILON_MS },
+    audit: null,
+    observed: null,
+    skipped: null,
+    failure: null,
+  };
+}
+
+/**
+ * Run the sensor's half of an arm-A run: let it finish scanning, stop it, read
+ * its audit trail, and write the observation set.
+ *
+ * Never throws for a reason the run should survive — a refusal comes back as
+ * `failure` on the capture record and as a non-zero exit code, so the caller
+ * still writes the catalogue of what actually happened.
+ * @param {Object} opts
+ * @param {Object} opts.handle - The sensor handle.
+ * @param {string} opts.dir - Run directory.
+ * @param {Object} opts.record - From {@link buildCaptureRecord}.
+ * @param {boolean} opts.scenarioOk - Whether every step executed.
+ * @param {function(string): void} opts.log
+ * @returns {Promise<{record: Object, ok: boolean}>}
+ */
+async function captureSensor(opts) {
+  const { handle, record, log } = opts;
+  let ticksAfterRun = 0;
+  try {
+    if (opts.scenarioOk) {
+      // A failed scenario is not given the post-run ticks: there is nothing left
+      // to play out, and making a broken run wait two minutes to say so helps
+      // nobody. The shortfall is on the record either way.
+      ticksAfterRun = await sensor.waitForTicks(handle, sensor.POST_RUN_TICKS, { log });
+    } else {
+      log('sensor  scenario did not complete — not waiting for post-run scan ticks');
+    }
+  } catch (err) {
+    if (!(err instanceof sensor.SensorError)) throw err;
+    record.failure = { stage: err.stage, reason: err.message };
+  }
+  record.sensor.ticksAfterRun = ticksAfterRun;
+
+  await sensor.stop(handle, { log });
+  record.sensor.stoppedAt = handle.stoppedAt;
+  record.sensor.exit = handle.exit;
+  record.sensor.scanTicks = handle.ticks;
+  record.window.end = handle.stoppedAt;
+  const alive = record.sensor.processAliveWindow;
+  record.sensor.ticksWhileProcessAlive = sensor.ticksWithin(handle, alive.from, alive.to);
+
+  if (record.failure) return { record, ok: false };
+
+  try {
+    const captured = observed.capture({
+      profileDir: handle.profileDir,
+      scenario: record.scenario,
+      windowStart: record.window.start,
+      windowEnd: record.window.end,
+    });
+    record.audit = {
+      files: captured.files,
+      verifiedRecords: captured.lines,
+      chain: 'verified from GENESIS, re-derived by bench/lib/observed.js',
+      truncatedTails: captured.truncatedTails,
+    };
+    record.skipped = captured.skipped;
+    const observedPath = observed.write(opts.dir, captured.events);
+    record.observed = { path: observedPath, events: captured.events.length };
+    log(`written ${observedPath} (${captured.events.length} observed event(s))`);
+    for (const tail of captured.truncatedTails) log(`sensor  ${tail}`);
+    return { record, ok: true };
+  } catch (err) {
+    if (!(err instanceof observed.ObservedError)) throw err;
+    record.failure = { stage: err.stage, reason: err.message };
+    return { record, ok: false };
+  }
+}
+
+/**
+ * Say out loud what the sensor half of the run produced — above all, what did
+ * NOT become an observation. A tally that only lives in a file is a tally
+ * nobody reads until they already distrust the number.
+ * @param {Object} record - From {@link captureSensor}.
+ * @returns {void}
+ */
+function reportCapture(record) {
+  const s = record.sensor;
+  console.log(
+    `sensor  ${s.scanTicks.length} completed scan tick(s), ` +
+      `${s.ticksAfterRun} of ${s.ticksRequestedAfterRun} asked for after the last step` +
+      (s.ticksWhileProcessAlive === null
+        ? ''
+        : `, ${s.ticksWhileProcessAlive} while the scenario's process was alive`),
+  );
+  if (!s.steadyCadence) {
+    console.log(
+      'sensor  its scan cadence never settled, so the steps ran against the startup schedule — ' +
+        'read every coverage figure from this run as a statement about that regime',
+    );
+  }
+  if (s.ticksWhileProcessAlive === 0) {
+    console.log(
+      'sensor  no scan tick fell inside the process lifetime — anything missing about that ' +
+        'process was never in front of the sensor, and is not a coverage result',
+    );
+  }
+  if (record.failure) {
+    console.error(`\nbench: ${record.failure.reason}`);
+    console.error(
+      `bench: no ${observed.OBSERVED_FILENAME} was written — an empty one would be ` +
+        'indistinguishable from a sensor that ran and saw nothing',
+    );
+    return;
+  }
+  const skipped = record.skipped;
+  const shapeless = Object.entries(skipped.byShapelessType);
+  const lines = [];
+  if (skipped.outOfWindow > 0) lines.push(`${skipped.outOfWindow} outside the run window`);
+  if (skipped.unparsableTimestamp > 0) {
+    lines.push(`${skipped.unparsableTimestamp} with a timestamp that is not an instant`);
+  }
+  if (skipped.dropMarkersOutsideWindow > 0) {
+    lines.push(`${skipped.dropMarkersOutsideWindow} loss marker(s) outside the window`);
+  }
+  for (const [key, count] of shapeless) {
+    lines.push(`${count} ${key} — real observations with no shape in this ECS subset`);
+  }
+  if (lines.length > 0) {
+    console.log(
+      `\n${record.audit.verifiedRecords} verified audit record(s); ` +
+        `${lines.length} kind(s) did not become an observed line:`,
+    );
+    for (const line of lines) console.log(`  - ${line}`);
+  }
+}
+
+/**
  * @param {string[]} argv - `process.argv.slice(2)`
  * @returns {Promise<number>} Process exit code.
  */
@@ -227,12 +479,76 @@ async function main(argv) {
   console.log(`dir     ${dir}`);
   console.log(`written ${manifestPath}`);
 
+  const log = (m) => console.log(m);
   let exitCode = 0;
   if (scenario) {
     console.log(`scenario ${scenario.id} — ${scenario.title}`);
-    const outcome = await actor.execute(scenario, { runDir: dir, log: (m) => console.log(m) });
+
+    // The sensor comes up BEFORE the first step, and a sensor that will not come
+    // up stops the run here: an arm-A run whose sensor never ran is an arm-C run
+    // under the wrong name, and its empty answer would read as a coverage miss.
+    /** @type {Object|null} */
+    let handle = null;
+    if (args.arm === SENSOR_ARM) {
+      try {
+        handle = await sensor.start({ runId, log });
+      } catch (err) {
+        if (!(err instanceof sensor.SensorError)) throw err;
+        const metaPath = observed.writeMeta(dir, {
+          runId,
+          scenario: scenario.id,
+          arm: args.arm,
+          sensor: null,
+          window: null,
+          audit: null,
+          observed: null,
+          skipped: null,
+          failure: { stage: err.stage, reason: err.message },
+        });
+        console.error(`\nbench: ${err.message}`);
+        console.error(
+          `bench: nothing was executed — the scenario never ran, so this run holds a manifest and ` +
+            `the reason and no catalogue.\nbench: written ${metaPath}`,
+        );
+        return 1;
+      }
+    }
+
+    const outcome = await actor.execute(scenario, { runDir: dir, log });
+
+    /** @type {Object|null} */
+    let capture = null;
+    if (handle) {
+      capture = await captureSensor({
+        handle,
+        dir,
+        record: buildCaptureRecord({
+          handle,
+          runId,
+          scenario: scenario.id,
+          arm: args.arm,
+          window: { start: firstStepStartedAt(outcome.steps), end: null },
+          events: outcome.events,
+          ticksAfterRun: 0,
+        }),
+        scenarioOk: outcome.ok,
+        log,
+      });
+    }
+
+    // Only now — the catalogue is a file inside the watched project directory,
+    // and writing it while the sensor is live would put a file creation the
+    // harness made for itself into the sensor's own answer.
     const cataloguePath = catalogue.write(dir, outcome.events);
     console.log(`written ${cataloguePath} (${outcome.events.length} expected event(s))`);
+
+    if (capture) {
+      const metaPath = observed.writeMeta(dir, capture.record);
+      console.log(`written ${metaPath}`);
+      reportCapture(capture.record);
+      if (!capture.ok) exitCode = 1;
+    }
+
     if (!outcome.ok) {
       const failed = outcome.steps.find((s) => s.status === 'failed');
       const skipped = outcome.steps.filter((s) => s.status === 'skipped').length;
@@ -261,9 +577,12 @@ if (require.main === module) {
 module.exports = {
   NO_SCENARIO,
   RUNS_DIR,
+  SENSOR_ARM,
   buildRunId,
   createRunDir,
+  firstStepStartedAt,
   main,
   parseArgs,
   prepareScenario,
+  processAliveWindow,
 };

--- a/tests/main/bench/observed.test.js
+++ b/tests/main/bench/observed.test.js
@@ -1,0 +1,589 @@
+/**
+ * @file tests/main/bench/observed.test.js
+ * @description `observed.js` is the bench's oracle over the product's audit log,
+ *   and an oracle that agrees only with itself proves nothing. So the first
+ *   describe block below pins the chain re-implementation against BYTES AEGIS
+ *   actually wrote — four consecutive records lifted verbatim out of a real
+ *   arm-A run, with the hashes the product computed. Everything after it may use
+ *   synthetic chains, because by then the hash function is the one under proof
+ *   rather than the thing being assumed (memory-bank/ai-mistakes.md #21).
+ *
+ *   The rest is about the refusals: a broken chain, a documented loss inside the
+ *   window and an empty observation set each fail the run instead of quietly
+ *   shortening it.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import observed from '../../../bench/lib/observed.js';
+
+/**
+ * Four consecutive records from `aegis-audit-2026-08-13.json`, written by AEGIS
+ * 0.11.0-alpha during a real S1 run, verbatim including the hashes it computed.
+ * seq 23 is only here to supply the previous hash that 24 chains from.
+ * @type {ReadonlyArray<Object>}
+ */
+const PRODUCT_RECORDS = Object.freeze([
+  {
+    schemaVersion: 1,
+    timestamp: '2026-08-13T09:31:06.794Z',
+    type: 'network-connection',
+    agent: 'Claude Code',
+    pid: 40784,
+    instanceId: '40784:1786606452193',
+    action: 'Established',
+    path: '160.79.104.10:443',
+    severity: 'normal',
+    riskScore: 0,
+    attribution: { status: 'confirmed', evidence: ['os-tcp-owner-pid'] },
+    details: { domain: '', flagged: false },
+    seq: 23,
+    hash: 'a03207224ae4fb65878f0eb4a64812ca4cf5f9371294bbd4652ae75ee741b45f',
+  },
+  {
+    schemaVersion: 1,
+    timestamp: '2026-08-13T09:31:11.599Z',
+    type: 'file-access',
+    agent: '',
+    pid: null,
+    instanceId: null,
+    action: 'created',
+    path: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\2026-08-13T09-31-10Z-S1-agent-lifecycle-A\\manifest.json',
+    severity: 'normal',
+    riskScore: 0,
+    attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+    details: null,
+    seq: 24,
+    hash: '533e1972b46688e7131d7a7cb1fde4fa32550f6ad36fb4dbc02a68d83c207cb2',
+  },
+  {
+    schemaVersion: 1,
+    timestamp: '2026-08-13T09:31:11.606Z',
+    type: 'file-access',
+    agent: '',
+    pid: null,
+    instanceId: null,
+    action: 'created',
+    path: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\2026-08-13T09-31-10Z-S1-agent-lifecycle-A\\stage\\claude.exe',
+    severity: 'normal',
+    riskScore: 0,
+    attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+    details: null,
+    seq: 25,
+    hash: 'f178604fe029c69609b75e666658072becad0763ba79b34a18ec55c3649207ad',
+  },
+  {
+    schemaVersion: 1,
+    timestamp: '2026-08-13T09:31:34.477Z',
+    type: 'agent-enter',
+    agent: 'Claude Code',
+    pid: 35280,
+    instanceId: '35280:1786613471663',
+    action: 'started',
+    path: '',
+    severity: 'normal',
+    riskScore: 0,
+    attribution: null,
+    details: { startTime: 1786613494477 },
+    seq: 26,
+    hash: '74fdf70bf09f694c7f7241bf1e95ca5bc3b4fc08cd9daf7ae6861ed256ec19c8',
+  },
+]);
+
+/** The `agent-exit` from the same run, seq 38. @type {Object} */
+const PRODUCT_EXIT = Object.freeze({
+  schemaVersion: 1,
+  timestamp: '2026-08-13T09:32:24.633Z',
+  type: 'agent-exit',
+  agent: 'Claude Code',
+  pid: 35280,
+  instanceId: '35280:1786613471663',
+  action: 'exited',
+  path: '',
+  severity: 'normal',
+  riskScore: 0,
+  attribution: null,
+  details: null,
+  seq: 38,
+  hash: '3cd17c9be9dbe56bd1649b81c4c91e645b31c687845f8f18f9197aeff564c32b',
+});
+
+/** The `file-access` deletion of the staged binary, seq 30. @type {Object} */
+const PRODUCT_DELETION = Object.freeze({
+  schemaVersion: 1,
+  timestamp: '2026-08-13T09:31:46.825Z',
+  type: 'file-access',
+  agent: '',
+  pid: null,
+  instanceId: null,
+  action: 'deleted',
+  path: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\2026-08-13T09-31-10Z-S1-agent-lifecycle-A\\stage\\claude.exe',
+  severity: 'normal',
+  riskScore: 0,
+  attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+  details: null,
+  seq: 30,
+  hash: '8448f151946b32f7e1b2a05ec71efa6d261f439b8c5d0a09f7aa87f94fee2ec2',
+});
+
+/** @type {string} A scratch directory, one per test. */
+let tmp;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bench-observed-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/**
+ * One audit record without seq/hash — the shape `audit-logger.log()` builds.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function entry(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    timestamp: '2026-08-13T09:31:11.606Z',
+    type: 'file-access',
+    agent: '',
+    pid: null,
+    instanceId: null,
+    action: 'created',
+    path: 'X:\\runs\\r\\stage\\claude.exe',
+    severity: 'normal',
+    riskScore: 0,
+    attribution: null,
+    details: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Write a daily audit file whose chain is genuinely correct, using the hash
+ * function the first describe block pins against product output.
+ * @param {string} dir - Directory to create the file in.
+ * @param {Object[]} entries - Records WITHOUT seq/hash.
+ * @param {string} [day]
+ * @returns {string} Path of the file written.
+ */
+function writeChain(dir, entries, day = '2026-08-13') {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `aegis-audit-${day}.json`);
+  let prev = observed.GENESIS;
+  const lines = entries.map((e, i) => {
+    const hash = observed.computeHash(prev, e);
+    prev = hash;
+    return JSON.stringify({ ...e, seq: i, hash });
+  });
+  fs.writeFileSync(file, `${lines.join('\n')}\n`, 'utf8');
+  return file;
+}
+
+/**
+ * A profile directory with an audit trail in it.
+ * @param {Object[]} entries
+ * @returns {string} The profile directory.
+ */
+function writeProfile(entries) {
+  const profile = path.join(tmp, 'profile');
+  writeChain(path.join(profile, observed.AUDIT_DIRNAME), entries);
+  return profile;
+}
+
+describe('bench observed — the chain re-implementation against product bytes', () => {
+  it('re-derives the hashes AEGIS itself wrote, link by link', () => {
+    for (let i = 1; i < PRODUCT_RECORDS.length; i++) {
+      const record = { ...PRODUCT_RECORDS[i] };
+      const prevHash = PRODUCT_RECORDS[i - 1].hash;
+      delete record.seq;
+      delete record.hash;
+      expect(observed.computeHash(prevHash, record)).toBe(PRODUCT_RECORDS[i].hash);
+    }
+  });
+
+  it('does not re-derive a product hash from the wrong predecessor', () => {
+    const record = { ...PRODUCT_RECORDS[2] };
+    delete record.seq;
+    delete record.hash;
+    expect(observed.computeHash(PRODUCT_RECORDS[0].hash, record)).not.toBe(PRODUCT_RECORDS[2].hash);
+  });
+
+  it('canonicalizes by content, not by key insertion order', () => {
+    const written = observed.canonical({ b: 1, a: [2, { d: 4, c: 3 }] });
+    const read = observed.canonical({ a: [2, { c: 3, d: 4 }], b: 1 });
+    expect(written).toBe(read);
+    // Array order is content, not insertion order, and must NOT be normalized away.
+    expect(observed.canonical([1, 2])).not.toBe(observed.canonical([2, 1]));
+  });
+});
+
+describe('bench observed — reading a chain', () => {
+  it('returns every record, stamped with the file it came from', () => {
+    const file = writeChain(tmp, [entry(), entry({ action: 'deleted' })]);
+    const { records, truncatedTail } = observed.readChain(file);
+    expect(records).toHaveLength(2);
+    expect(records[0].seq).toBe(0);
+    expect(records[1].auditFile).toBe('aegis-audit-2026-08-13.json');
+    expect(truncatedTail).toBeNull();
+  });
+
+  it('refuses a record whose hash does not recompute', () => {
+    const file = writeChain(tmp, [entry(), entry({ action: 'deleted' })]);
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+    const tampered = JSON.parse(lines[0]);
+    tampered.path = 'X:\\runs\\r\\stage\\something-else.exe';
+    lines[0] = JSON.stringify(tampered);
+    fs.writeFileSync(file, `${lines.join('\n')}\n`, 'utf8');
+    expect(() => observed.readChain(file)).toThrow(observed.ObservedError);
+    expect(() => observed.readChain(file)).toThrow(/does not recompute/);
+  });
+
+  it('refuses a chain whose seq is not its line number', () => {
+    const file = writeChain(tmp, [entry(), entry(), entry()]);
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+    fs.writeFileSync(file, `${lines[0]}\n${lines[2]}\n`, 'utf8');
+    expect(() => observed.readChain(file)).toThrow(/carries seq 2/);
+  });
+
+  it('refuses an interior line that does not parse', () => {
+    const file = writeChain(tmp, [entry(), entry(), entry()]);
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+    lines[1] = '{"schemaVersion":1,"timesta';
+    fs.writeFileSync(file, `${lines.join('\n')}\n`, 'utf8');
+    expect(() => observed.readChain(file)).toThrow(/line 1 does not parse/);
+  });
+
+  it('drops a torn LAST line and says it did, instead of failing the run', () => {
+    const file = writeChain(tmp, [entry(), entry({ action: 'deleted' })]);
+    fs.appendFileSync(file, '{"schemaVersion":1,"timestamp":"2026-08-13T09:3', 'utf8');
+    const { records, truncatedTail } = observed.readChain(file);
+    expect(records).toHaveLength(2);
+    expect(truncatedTail).toMatch(/torn write/);
+    expect(truncatedTail).toMatch(/may be missing/);
+  });
+});
+
+describe('bench observed — finding the audit trail', () => {
+  it('returns nothing when the profile has no audit directory', () => {
+    expect(observed.listAuditFiles(path.join(tmp, 'nowhere'))).toEqual([]);
+  });
+
+  it('takes only daily audit files, oldest first', () => {
+    const dir = path.join(tmp, 'profile', observed.AUDIT_DIRNAME);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const name of [
+      'aegis-audit-2026-08-14.json',
+      'aegis-audit-2026-08-13.json',
+      'settings.json',
+      'aegis-2026-08-13.log',
+    ]) {
+      fs.writeFileSync(path.join(dir, name), '', 'utf8');
+    }
+    expect(observed.listAuditFiles(path.join(tmp, 'profile')).map((f) => path.basename(f))).toEqual(
+      ['aegis-audit-2026-08-13.json', 'aegis-audit-2026-08-14.json'],
+    );
+  });
+
+  it('fails the run when the sensor persisted nothing at all', () => {
+    expect(() =>
+      observed.capture({
+        profileDir: path.join(tmp, 'profile'),
+        scenario: 'S1-agent-lifecycle',
+        windowStart: '2026-08-13T09:31:11.000Z',
+        windowEnd: '2026-08-13T09:33:00.000Z',
+      }),
+    ).toThrow(/no audit file under/);
+  });
+});
+
+describe('bench observed — mapping product records onto the catalogue subset', () => {
+  /**
+   * @param {Object} record
+   * @returns {Object|null}
+   */
+  const map = (record) => observed.toEcs(record, 'S1-agent-lifecycle');
+
+  it('maps a file creation, deriving name and directory from the observed path', () => {
+    const line = map(PRODUCT_RECORDS[2]);
+    expect(line['@timestamp']).toBe('2026-08-13T09:31:11.606Z');
+    expect(line.event).toEqual({
+      kind: 'event',
+      category: ['file'],
+      type: ['creation'],
+      action: 'file-created',
+    });
+    expect(line.file).toEqual({
+      path: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\2026-08-13T09-31-10Z-S1-agent-lifecycle-A\\stage\\claude.exe',
+      name: 'claude.exe',
+      directory:
+        'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\2026-08-13T09-31-10Z-S1-agent-lifecycle-A\\stage',
+    });
+    // The product knows no owner for a watcher event, so no pid is written —
+    // absent, never null (the B2.2 convention).
+    expect(line.process).toBeUndefined();
+    expect(line.bench.scenario).toBe('S1-agent-lifecycle');
+    expect(line.bench.source).toBe('aegis-audit');
+    expect(line.bench.auditSeq).toBe(25);
+    expect(line.bench.auditType).toBe('file-access');
+    expect(line.bench.attribution).toEqual({
+      status: 'unattributed',
+      evidence: ['no-owner-match'],
+    });
+    // No owner was resolved, so no display name and no instance key are claimed.
+    expect(line.bench.agent).toBeUndefined();
+    expect(line.bench.instanceId).toBeUndefined();
+  });
+
+  it('maps a file deletion', () => {
+    const line = map(PRODUCT_DELETION);
+    expect(line.event.type).toEqual(['deletion']);
+    expect(line.event.action).toBe('file-deleted');
+    expect(line.file.name).toBe('claude.exe');
+  });
+
+  it('maps agent-enter onto process.start, with pid as the only join key', () => {
+    const line = map(PRODUCT_RECORDS[3]);
+    expect(line.event).toEqual({
+      kind: 'event',
+      category: ['process'],
+      type: ['start'],
+      action: 'process-started',
+    });
+    expect(line.process).toEqual({ pid: 35280 });
+    // The audit persists the display name, not the image name, so process.name
+    // and process.executable stay out rather than being filled with something a
+    // join would read as an image name.
+    expect(line.process.name).toBeUndefined();
+    expect(line.process.executable).toBeUndefined();
+    expect(line.bench.agent).toBe('Claude Code');
+    expect(line.bench.instanceId).toBe('35280:1786613471663');
+  });
+
+  it('maps agent-exit onto process.end, and invents no exit code', () => {
+    const line = map(PRODUCT_EXIT);
+    expect(line.event.type).toEqual(['end']);
+    expect(line.event.action).toBe('process-ended');
+    expect(line.process).toEqual({ pid: 35280 });
+    expect(line.process.exit_code).toBeUndefined();
+    expect(line.bench.terminationSignal).toBeUndefined();
+  });
+
+  it('maps config-access the same way it maps file-access', () => {
+    const line = map(
+      entry({ type: 'config-access', action: 'deleted', path: '/home/a/.claude/x' }),
+    );
+    expect(line.event.category).toEqual(['file']);
+    expect(line.event.type).toEqual(['deletion']);
+    expect(line.file).toEqual({
+      path: '/home/a/.claude/x',
+      name: 'x',
+      directory: '/home/a/.claude',
+    });
+  });
+
+  it('has no shape for a network connection', () => {
+    expect(map(PRODUCT_RECORDS[0])).toBeNull();
+  });
+
+  it('has no shape for a modified or accessed file', () => {
+    expect(map(entry({ action: 'modified' }))).toBeNull();
+    expect(map(entry({ action: 'accessed' }))).toBeNull();
+  });
+
+  it('writes no pid for a synthetic, process-less agent', () => {
+    const line = map(entry({ type: 'agent-enter', action: 'started', pid: 0, path: '' }));
+    expect(line.process).toBeUndefined();
+  });
+
+  it('refuses to build a file line with no path to name it by', () => {
+    expect(map(entry({ path: '' }))).toBeNull();
+  });
+
+  it('splits a path by the separator the record used, not by the host platform', () => {
+    expect(observed.splitPath('X:\\a\\b\\c.exe')).toEqual({ name: 'c.exe', directory: 'X:\\a\\b' });
+    expect(observed.splitPath('/home/a/b.txt')).toEqual({ name: 'b.txt', directory: '/home/a' });
+  });
+});
+
+describe('bench observed — the run window', () => {
+  /** @type {Object[]} */
+  const spread = [
+    entry({ timestamp: '2026-08-13T09:30:00.000Z', path: 'X:\\before.txt' }),
+    entry({ timestamp: '2026-08-13T09:31:11.606Z', path: 'X:\\inside.txt' }),
+    entry({ timestamp: '2026-08-13T09:33:00.000Z', path: 'X:\\after.txt' }),
+  ];
+
+  it('keeps only what the sensor recorded between the first step and the stop', () => {
+    const { events, skipped } = observed.select({
+      records: spread,
+      scenario: 'S1',
+      windowStart: '2026-08-13T09:31:00.000Z',
+      windowEnd: '2026-08-13T09:32:00.000Z',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].file.path).toBe('X:\\inside.txt');
+    expect(skipped.outOfWindow).toBe(2);
+  });
+
+  it('admits a record inside epsilon of an edge and rejects one outside it', () => {
+    const edge = [
+      entry({ timestamp: '2026-08-13T09:30:59.900Z', path: 'X:\\just-before.txt' }),
+      entry({ timestamp: '2026-08-13T09:30:59.500Z', path: 'X:\\well-before.txt' }),
+    ];
+    const { events } = observed.select({
+      records: edge,
+      scenario: 'S1',
+      windowStart: '2026-08-13T09:31:00.000Z',
+      windowEnd: '2026-08-13T09:32:00.000Z',
+      epsilonMs: 250,
+    });
+    expect(events.map((e) => e.file.path)).toEqual(['X:\\just-before.txt']);
+  });
+
+  it('counts what it could not shape instead of dropping it silently', () => {
+    const { events, skipped } = observed.select({
+      records: [
+        entry({ action: 'modified' }),
+        entry({ action: 'modified' }),
+        entry({ type: 'network-connection', action: 'Established' }),
+        entry({ timestamp: '2026-08-13T09:31:11.606Z' }),
+      ],
+      scenario: 'S1',
+      windowStart: '2026-08-13T09:31:00.000Z',
+      windowEnd: '2026-08-13T09:32:00.000Z',
+    });
+    expect(events).toHaveLength(1);
+    expect(skipped.byShapelessType).toEqual({
+      'file-access/modified': 2,
+      'network-connection/Established': 1,
+    });
+  });
+
+  it('counts a record whose timestamp is not an instant', () => {
+    const { skipped } = observed.select({
+      records: [entry({ timestamp: 'not-a-time' })],
+      scenario: 'S1',
+      windowStart: '2026-08-13T09:31:00.000Z',
+      windowEnd: '2026-08-13T09:32:00.000Z',
+    });
+    expect(skipped.unparsableTimestamp).toBe(1);
+  });
+});
+
+describe('bench observed — refusals', () => {
+  it('fails the run on a loss marker inside the window', () => {
+    expect(() =>
+      observed.select({
+        records: [
+          entry({
+            timestamp: '2026-08-13T09:31:30.000Z',
+            type: observed.DROP_MARKER_TYPE,
+            action: '',
+            path: '',
+            details: { droppedCount: 12 },
+          }),
+        ],
+        scenario: 'S1',
+        windowStart: '2026-08-13T09:31:00.000Z',
+        windowEnd: '2026-08-13T09:32:00.000Z',
+      }),
+    ).toThrow(/12 entries were evicted/);
+  });
+
+  it('only counts a loss marker that falls outside the window', () => {
+    const { skipped } = observed.select({
+      records: [
+        entry({
+          timestamp: '2026-08-13T09:20:00.000Z',
+          type: observed.DROP_MARKER_TYPE,
+          action: '',
+          path: '',
+          details: { droppedCount: 3 },
+        }),
+      ],
+      scenario: 'S1',
+      windowStart: '2026-08-13T09:31:00.000Z',
+      windowEnd: '2026-08-13T09:32:00.000Z',
+    });
+    expect(skipped.dropMarkersOutsideWindow).toBe(1);
+    expect(skipped.outOfWindow).toBe(0);
+  });
+
+  it('fails the run rather than writing an empty observation set', () => {
+    const profile = writeProfile([entry({ timestamp: '2026-08-13T09:20:00.000Z' })]);
+    let thrown;
+    try {
+      observed.capture({
+        profileDir: profile,
+        scenario: 'S1',
+        windowStart: '2026-08-13T09:31:00.000Z',
+        windowEnd: '2026-08-13T09:32:00.000Z',
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(observed.ObservedError);
+    expect(thrown.stage).toBe('no-observations');
+    expect(thrown.message).toMatch(/would read as "the sensor saw nothing"/);
+  });
+
+  it('fails the run when the window is not two instants', () => {
+    expect(() =>
+      observed.select({
+        records: [entry()],
+        scenario: 'S1',
+        windowStart: null,
+        windowEnd: '2026-08-13T09:32:00.000Z',
+      }),
+    ).toThrow(/is not two UTC instants/);
+  });
+});
+
+describe('bench observed — the whole capture', () => {
+  it('verifies, filters and maps in one pass, and names the file it read', () => {
+    const profile = writeProfile([
+      entry({ timestamp: '2026-08-13T09:30:00.000Z', path: 'X:\\before.txt' }),
+      entry({ timestamp: '2026-08-13T09:31:11.606Z' }),
+      entry({ timestamp: '2026-08-13T09:31:20.000Z', type: 'agent-enter', pid: 35280, path: '' }),
+      entry({ timestamp: '2026-08-13T09:31:30.000Z', action: 'modified' }),
+    ]);
+    const captured = observed.capture({
+      profileDir: profile,
+      scenario: 'S1-agent-lifecycle',
+      windowStart: '2026-08-13T09:31:00.000Z',
+      windowEnd: '2026-08-13T09:32:00.000Z',
+    });
+    expect(captured.lines).toBe(4);
+    expect(captured.files.map((f) => path.basename(f))).toEqual(['aegis-audit-2026-08-13.json']);
+    expect(captured.truncatedTails).toEqual([]);
+    expect(captured.events.map((e) => e.event.action)).toEqual(['file-created', 'process-started']);
+    expect(captured.events[0].bench.auditFile).toBe('aegis-audit-2026-08-13.json');
+    expect(captured.skipped.outOfWindow).toBe(1);
+    expect(captured.skipped.byShapelessType).toEqual({ 'file-access/modified': 1 });
+  });
+
+  it('writes one NDJSON document per line', () => {
+    const captured = observed.capture({
+      profileDir: writeProfile([entry({ timestamp: '2026-08-13T09:31:11.606Z' })]),
+      scenario: 'S1',
+      windowStart: '2026-08-13T09:31:00.000Z',
+      windowEnd: '2026-08-13T09:32:00.000Z',
+    });
+    const file = observed.write(tmp, captured.events);
+    expect(path.basename(file)).toBe(observed.OBSERVED_FILENAME);
+    const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).event.action).toBe('file-created');
+  });
+
+  it('writes the capture record, refusal and all', () => {
+    const file = observed.writeMeta(tmp, { failure: { stage: 'chain-broken', reason: 'why' } });
+    expect(path.basename(file)).toBe(observed.META_FILENAME);
+    expect(JSON.parse(fs.readFileSync(file, 'utf8')).failure.stage).toBe('chain-broken');
+  });
+});

--- a/tests/main/bench/sensor.test.js
+++ b/tests/main/bench/sensor.test.js
@@ -1,0 +1,114 @@
+/**
+ * @file tests/main/bench/sensor.test.js
+ * @description The parts of the sensor harness that decide WHEN a run may act
+ *   and what it may conclude afterwards. Nothing here starts Electron: these are
+ *   the pure judgements sitting on top of the child process, and they are the
+ *   ones that were wrong first — a run that begins at the sensor's first
+ *   completed scan acts into the startup schedule's ~37 s gap and its subject is
+ *   never scanned at all.
+ *
+ *   The tick strings below are the instants a real arm-A run reported, offsets
+ *   from the sensor's start in the comments.
+ */
+import { describe, it, expect } from 'vitest';
+import { Readable } from 'stream';
+
+import sensor from '../../../bench/lib/sensor.js';
+
+/** Ticks from a real run: +6.1 s, +43.4 s, +85.4 s, +93.6 s. @type {string[]} */
+const REAL_TICKS = Object.freeze([
+  '2026-08-13T17:11:09.866Z',
+  '2026-08-13T17:11:47.179Z',
+  '2026-08-13T17:12:29.130Z',
+  '2026-08-13T17:12:37.370Z',
+]);
+
+describe("bench sensor — reading the product's own scan log", () => {
+  it('recognises a completed process scan and takes its instant', () => {
+    const line = '[2026-08-13T17:11:09.866Z] DEBUG [scan] process {"ms":2818,"agents":2}';
+    expect(sensor.TICK_LINE.exec(line)[1]).toBe('2026-08-13T17:11:09.866Z');
+  });
+
+  it('is not fooled by the other lines the app prints', () => {
+    for (const line of [
+      '[2026-08-13T17:11:09.866Z] DEBUG [scan] file {"ms":12}',
+      '[2026-08-13T17:11:09.866Z] DEBUG [scan] network-skip {"reason":"confirmed-zero-agents"}',
+      '[2026-08-13T17:11:09.866Z] INFO  [main] App starting {"version":"0.11.0-alpha"}',
+      '[2026-08-13T17:11:09.866Z] DEBUG [perf] spawn {"spawn":"tasklist","ms":885}',
+    ]) {
+      expect(sensor.TICK_LINE.test(line)).toBe(false);
+    }
+  });
+
+  it('splits a stream into lines and keeps a partial one for the next chunk', async () => {
+    const seen = [];
+    const stream = new Readable({ read() {} });
+    sensor.pumpLines(stream, (l) => seen.push(l));
+    stream.push('one\r\ntw');
+    stream.push('o\nthree');
+    stream.push(null);
+    await new Promise((resolve) => stream.on('end', resolve));
+    expect(seen).toEqual(['one', 'two', 'three']);
+  });
+});
+
+describe('bench sensor — when the run may start acting', () => {
+  it('does not call one completed scan a settled cadence', () => {
+    expect(sensor.settledAt([REAL_TICKS[0]], sensor.STEADY_GAP_MS)).toBeNull();
+  });
+
+  it('does not call the startup schedule settled, however many ticks it has', () => {
+    // The two ticks a run used to act between: 37.3 s apart, against a subject
+    // that lives 35 s. Acting here is what made the process unobservable.
+    expect(sensor.settledAt(REAL_TICKS.slice(0, 2), sensor.STEADY_GAP_MS)).toBeNull();
+  });
+
+  it('settles on the first pair of ticks close enough to be the real interval', () => {
+    expect(sensor.settledAt(REAL_TICKS, sensor.STEADY_GAP_MS)).toBe(REAL_TICKS[3]);
+  });
+
+  it('ignores an instant it cannot read rather than settling on it', () => {
+    expect(sensor.settledAt(['not-a-time', REAL_TICKS[0]], sensor.STEADY_GAP_MS)).toBeNull();
+  });
+});
+
+describe('bench sensor — what the run may conclude afterwards', () => {
+  /** @param {string[]} ticks @returns {Object} */
+  const handle = (ticks) => ({ ticks });
+
+  it("counts the scans that fell inside the subject's lifetime", () => {
+    expect(
+      sensor.ticksWithin(
+        handle(REAL_TICKS),
+        '2026-08-13T17:11:40.000Z',
+        '2026-08-13T17:12:30.000Z',
+      ),
+    ).toBe(2);
+  });
+
+  it('reports zero when the subject lived entirely between two scans', () => {
+    // The real failure: alive +6.3 s → +41.3 s, scans at +6.1 s and +43.4 s.
+    expect(
+      sensor.ticksWithin(
+        handle(REAL_TICKS),
+        '2026-08-13T17:11:09.998Z',
+        '2026-08-13T17:11:45.012Z',
+      ),
+    ).toBe(0);
+  });
+
+  it('says it does not know rather than saying zero when a bound is missing', () => {
+    expect(sensor.ticksWithin(handle(REAL_TICKS), null, '2026-08-13T17:12:30.000Z')).toBeNull();
+    expect(sensor.ticksWithin(handle(REAL_TICKS), 'not-a-time', 'also-not')).toBeNull();
+  });
+});
+
+describe('bench sensor — the run-scoped profile', () => {
+  it('puts it outside the repository, where the file watcher cannot see it', () => {
+    const dir = sensor.profileDirFor('2026-08-13T17-11-03Z-S1-agent-lifecycle-A');
+    expect(dir).toContain('aegis-bench-2026-08-13T17-11-03Z-S1-agent-lifecycle-A');
+    // A profile under the watched project directory would feed the audit log its
+    // own writes: write → file event → audit record → write.
+    expect(dir.startsWith(sensor.RENDERER_ENTRY.split('dist')[0])).toBe(false);
+  });
+});


### PR DESCRIPTION
Arm A now runs AEGIS itself across the scenario and writes what it recorded to `observed.ndjson`, next to `expected.ndjson` and in the same ECS subset. The source is the product's own hash-chained audit log — **not** a bench channel added to the main process. **No line under `src/` changed**, and a `git diff --stat` of this branch against master shows it.

## Running the product

AEGIS is started as `electron .` on a run-scoped Electron profile in the OS temp directory, via the stock `--user-data-dir` switch. That changes where the product writes, never how it observes, and it buys three things: the audit file is written by this run alone, so its chain starts at GENESIS and a verdict on it is a verdict on our own records; the run does not inherit whatever `scanIntervalSec` was last saved, nor append to a real audit trail; and the single-instance lock lives in the profile, so a bench run does not collide with an AEGIS already open.

The profile is deliberately **not** inside the repository. `src/main/file-watcher.js` watches the project directory, so an audit write there would raise a file event, which is logged to the audit, which is a write — a loop.

## Readiness, and the defect that shaped it

Readiness is the app's own `DEBUG [scan] process` line, twice. One says the sensor is alive; **two under 20 s apart** say it has left the startup schedule that scans at three times the configured interval.

Waiting only for the first was wrong, and measurably so. The first integrated run exited 0 while `ticksWhileProcessAlive: 0`: ticks landed at +6.1 s and +43.4 s, the scenario's process lived +6.3 s → +41.3 s, so S1's 35 s subject was never in front of a scan at all and its start and end were unobservable for a reason belonging to the harness rather than to the sensor. That is not a phase coincidence — starting at the first tick makes it deterministic.

Afterwards the sensor gets three more completed ticks. Not one: AEGIS reports a process end only after `session-tracker.js`'s grace of two consecutive scans that missed it, so 2 + 1 is the smallest number that lets the product reach its own conclusion. Then a drain longer than the audit logger's 5 s flush interval before the kill — AEGIS has no external graceful-shutdown path (its window `close` handler hides to tray), so only `taskkill /F` ends it and `/F` skips `before-quit`.

`expected.ndjson` is written **after** the sensor stops, or the catalogue's own creation lands in the sensor's answer as a false positive the harness manufactured for itself.

## The mapping

| audit record | ECS shape | what the audit does NOT carry |
|---|---|---|
| `agent-enter` | `process.start` | image name, executable path, OS birth time |
| `agent-exit` | `process.end` | exit code, terminating signal |
| `file-access`/`config-access` + `created` | `file.creation` | owner pid, size, hash |
| `file-access`/`config-access` + `deleted` | `file.deletion` | owner pid |

pid is the only join key the audit gives a process event; path is the only one it gives a file event. The display name AEGIS resolved (`"Claude Code"`) is not written into `process.name` — it is not the image name, and a join would read it as one; it rides `bench.agent` next to `bench.instanceId` and the sensor's own attribution verdict. `instanceId` encodes the OS birth time as `"<pid>:<ms>"` and is carried verbatim, never parsed.

Everything observed with no home in that subset — network connections, anomaly alerts, `modified`/`accessed` file events — is not written, because a fifth shape would stop being the same subset as the catalogue. It is tallied by type and action in `observed.meta.json` and printed at the end of the run.

## What fails a run

`bench/lib/observed.js` re-implements the chain check rather than importing `src/main/audit-hashchain.js`: a sensor is never its own oracle, and a disagreement between the two cannot be a finding if both sides run the same code. A unit test pins the re-implementation against records AEGIS actually wrote, hashes included — a fixture built with the module's own hash function would only prove it agrees with itself.

- **A broken chain** — an interior line that does not parse, a seq that is not its line number, a hash that does not recompute. Exit 1, and no record is taken out of the file.
- **A `buffer-overflow-drop` marker inside the window** — the product stating on disk that it discarded records from the interval the run is about to call observed.
- **Zero observations** — an empty `observed.ndjson` is indistinguishable from "the sensor ran and saw nothing", so none is written and the reason goes to `observed.meta.json`.
- **A sensor that will not start** — refused before any step runs; an arm-A run whose sensor never ran is an arm-C run under the wrong name.

Not a refusal: an unparseable **last** line. The kill can land mid-append and a torn trailing line leaves a valid prefix, so it is dropped and the drop is recorded.

## A run

Arms B and C start nothing and write no observation set. A verified arm-A run of S1, all four expectations observed:

| | expected | observed | latency |
|---|---|---|---|
| E1 file/creation | `17:27:22.190` | `17:27:22.206` | +16 ms |
| E2 process/start | `17:27:22.274` | `17:27:32.337` | +10 063 ms |
| E3 process/end | `17:27:57.284` | `17:28:12.196` | +14 912 ms |
| E4 file/deletion | `17:27:57.285` | `17:27:57.392` | +107 ms |

Those are numbers from a development machine and are not accuracy figures — publishing requires a pinned gold image (`bench/README.md`).

## Known, and left for a later block

`ticksWhileProcessAlive === 0` currently prints a warning and still exits 0. Observations are not zero in that case (file events still arrive), so the empty-set refusal does not fire, yet the process expectations of such a run are structurally unobservable. Whether that should become a refusal is a scoring decision, not a capture one.

## Verification

`npm run build:renderer`, `npm run lint`, `npm run typecheck`, `npm run typecheck:svelte` and `npm run test:coverage` pass locally after rebasing onto master. Both gates were checked for teeth rather than for green: breaking key sorting in `canonical` turns the two chain tests red, and injecting an `Error` immediately after `sensor.start` leaves no `electron.exe` behind — that one was a real bug, fixed in the second commit.