### PR TITLE
docs: derive three CLAUDE.md figures, land two re-verified recon documents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
 # AEGIS — Independent AI Oversight Layer
-Electron 33 + Svelte 5 (runes) + Vite 7. Privacy-first AI agent monitor. v0.10.0-alpha
+Electron 33 + Svelte 5 (runes) + Vite 7. Privacy-first AI agent monitor.
+Version is not quoted here — it goes stale the moment it is bumped:
+`node -p "require('./package.json').version"`
 Landing: aegisprotect.vercel.app | Demo: aegis-demo-ten.vercel.app
 
 ## Commands
 npm run build:renderer    # Vite build (MUST pass before commit)
 npm run lint              # ESLint
 npm run format            # Prettier
-npm test                  # Vitest (1477 passed / 4 skipped = 1481, 89 files — measured 2026-08-12)
+npm test                  # Vitest — the suite prints its own counts; do not copy them here
 npm run verify:gate       # Injection proof: break the witness gate, require the suite to go red
 npm run dist              # Electron-builder NSIS installer
 
@@ -57,7 +59,8 @@ regenerating a lockfile.
 
 ## Key Paths
 - src/main/ — 50 CommonJS modules (38 top-level + platform/ 10 + token-adapters/ 2)
-- src/renderer/ — 46 Svelte 5 components + 11 stores + 16 utils + tokens.css/global.css
+- src/renderer/ — Svelte 5 components + stores + utils + tokens.css/global.css
+  (count: `git ls-files 'src/renderer/**/*.svelte' | wc -l`)
 - src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (8 TS files), constants.js (ignore patterns, config paths; SENSITIVE_RULES deprecated)
 - rules/ — 73 active detection rules in 8 YAML files, validated by rules/_schema.json
 - memory-bank/ — ai-mistakes.md (READ FIRST), progress.md, architecture.md

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -1,0 +1,469 @@
+# AEGIS Correctness Audit (Read-Only)
+
+**Audit date:** 2026-08-08 — branch `feat/identity-main`, version `0.10.0-alpha` at audit time.
+**Re-verified against:** `master` @ `d027f0c`, 2026-08-13. This is the state in which the file
+entered git, five days and several correctness blocks after the audit ran.
+
+**Auditor stance:** external reader of a codebase I did not write. No production source was left
+modified. One temporary break of `bindWatcherEvents` was applied, tests re-run, then the file was
+restored.
+
+## How to read this document
+
+The audit is a dated snapshot; master moved under it. Rather than publish a snapshot whose
+present-tense claims are now false, every finding below was re-checked against `d027f0c` and
+carries one of three statuses:
+
+| Status | Meaning |
+|---|---|
+| **OPEN** | Still present at `d027f0c`. The mechanism and the falsification test still apply. |
+| **CLOSED** | Fixed in code or tests since the audit. Kept as a one-line record with the evidence that closes it — the full disposition lives in `memory-bank/progress.md`. |
+| **BY DESIGN** | Behaviour unchanged, but the code now states the rationale in place. Not an unfixed defect; do not re-file it as one. |
+
+Line numbers in OPEN findings were re-anchored at `d027f0c`. Line numbers inside CLOSED entries
+were not re-anchored — they describe a tree that no longer exists and are kept only so the original
+observation stays traceable.
+
+**Gates:**
+
+| When | Command | Result |
+|---|---|---|
+| 2026-08-08 (audit) | `npm test` | exit 0 |
+| 2026-08-08 (audit) | `npm run lint` | 0 errors, 23 pre-existing `no-console` warnings |
+| 2026-08-13 (re-verify) | `npm run test:coverage` | exit 0 |
+
+Suite counts are deliberately not quoted: a hand-copied count is true only until the next merge and
+nothing goes red when it stops being true (`memory-bank/ai-mistakes.md` #24). `tsc` / typecheck is
+not evidence for `src/main/*.js` (`checkJs: false`).
+
+**Ranking key:** wrong output (user sees an untrue number or label) → evidence loss → silent failure
+→ inventory / doc drift.
+
+---
+
+## Method summary (as executed 2026-08-08)
+
+1. Counted rules, agents, signatures, modules, IPC channels, components, tests by command.
+2. Traced file events (chokidar + handle/RM scan → activityLog → dedup → IPC/audit → renderer stores
+   → pixels) and network connections (OS table → DNS → classify → baselines/audit/IPC → risk).
+3. Checked identity/attribution invariants against `process-identity.js`, `attribution.js`, maps in
+   main and renderer.
+4. Read audit logger flush, buffer cap, hash chain, and failure paths.
+5. Sampled tests for vacuity; **proved** one class by removing `bindWatcherEvents` subscriptions
+   (93 file-watcher tests stayed green), then restored the file.
+
+---
+
+## Ground truth (counts re-measured at `d027f0c`, 2026-08-13)
+
+The audit's original table compared documented figures against a 2026-08-08 tree and marked five
+rows "match". Four of those figures have since moved. The table below is a fresh measurement, not
+the audit's; each row carries the command that produced it.
+
+| Quantity | Command | Measured |
+|---|---|---|
+| Agents | `node -p` over `src/shared/agent-database.json` | **110** |
+| Name signatures | sum of `names[]` in the same file | **262** |
+| Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **50** = 38 top-level + 10 `platform/` + 2 `token-adapters/` |
+| Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
+| Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
+| Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |
+| Shared types | `.ts` under `src/shared/types` | **8** |
+| IPC surface | `ipcRenderer.invoke` / `ipcRenderer.on` in `src/main/preload.js` | **40 invoke + 9 push = 49** |
+| Attribution evidence codes | `require('./src/main/attribution.js').EVIDENCE_CODES` | **7** |
+
+At audit time these read 46 main modules, 47 components (against 46 documented), 13 stores, 16
+utils. The main-module figure moved twice — see `ai-mistakes.md` #24, which names an earlier version
+of *this file* among the eight places a dead count sat.
+
+**Dead / half-wired production surfaces, re-checked at `d027f0c`:**
+
+| Surface | Status | Evidence |
+|---|---|---|
+| `getRulesByCategory` / `categoryIndex` | **OPEN** | Defined and exported in `rule-loader.js:193,224`; zero callers under `src/` outside that file. `classifySensitive` still walks `getAllRules()`. |
+| `resource-usage` push | **CLOSED** | Channel renamed `agent-resource-usage`, consumed in `stores/ipc.ts` and read at `AgentCard.svelte:106` strictly by `instanceId`. |
+| `anomalyScoresByInstance` | **CLOSED** | `scan-loop.js:407` sends it; `stores/ipc.ts:48` types it and publishes `anomaliesByInstance`, which `risk.ts` reads instead of a name lookup. |
+| `rules:reloaded` push | **OPEN** | Sent at `file-watcher.js:844`, bridged at `preload.js:72-75`; no renderer subscriber (F-E11). |
+| `riskHistory` on agent cards | **OPEN** | Read at `AgentCard.svelte:37,200-202`; nothing in `src/` writes it — the sparkline never paints (F-S06). |
+| `attachModels` (Ollama / LM Studio) | **CLOSED** | `enrichWithLocalModels` now runs at `scan-loop.js:346`, before the `scan-batch` send at `:402`; `attachModels` stamps identity at `:526-528`. |
+
+Exported functions with no production caller: `getRulesByCategory` (rule-loader) is the one
+confirmed case. A full unused-export graph was never machine-closed, at audit time or since.
+
+---
+
+# Findings
+
+## Tier 1 — Wrong output (label or number is untrue) — **all CLOSED**
+
+Every Tier-1 finding was fixed between 2026-08-08 and `d027f0c`. The originals are not reproduced
+here: eleven present-tense "User sees:" blocks describing defects that no longer exist would be the
+exact false-confidence class this audit was written to catch. `memory-bank/progress.md` carries the
+per-finding disposition with the mutation that turns each new test red; the code carries the finding
+IDs at the sites that changed.
+
+| Finding | What was wrong | Closed by |
+|---|---|---|
+| F-W01 | "Avg Risk Score" averaged anomaly scores, not risk scores | `summary-metrics.ts:averageRiskScore` over `$enrichedAgents` — the same domain AgentCard uses |
+| F-W02 | "Total Agents" read `a.name` off raw `DetectedAgent` (always `undefined` → always 1) | `summary-metrics.ts:countUniqueAgents`; SummaryCards now imports `$enrichedAgents` |
+| F-W03 | Ollama / LM Studio never rode a `scan-batch` — attached after the send, wiped before the next | `enrichWithLocalModels` moved before the send (`scan-loop.js:346` vs `:402`) |
+| F-W04 | "Events / min" froze — `Date.now()` is not reactive state | shared 1s clock `stores/tick.ts` + pure `eventsPerMinute(events, now, window)` |
+| F-W05 | One card mixed instance risk with group file/network totals | `agent-panel-utils.ts` — representative-only metrics, no silent group sum |
+| F-W06 | "Sensitive Files" counted retained sensitive **events**, not files | relabelled `Sensitive Alerts` (`SENSITIVE_SUMMARY_LABEL`); value semantics unchanged and now stated |
+| F-W07 | "System Uptime" was monitoring-session age and stalled without stats pushes | relabelled `Monitoring Duration`, driven from `monitoringStarted` + the shared tick |
+| F-W08 | Agent-card "FILES" was a decayed weight sum, not a file count | relabelled `File Act` (`FILE_ACTIVITY_CHIP_LABEL`) |
+| F-W09 | Header (mean-complement) and RiskIndex (max) read as the same kind of number | Header states average health; RiskIndex states `Worst Risk` |
+| F-W10 | Radar coloured dots from `getTrustGrade` while badges banded on `getRiskInfo` — score 60 was amber and red at once | every renderer colour decision bands through `getRiskInfo` via `pickByRiskBand`; pinned by `tests/renderer/components/Radar.test.ts` at 0/34/35/60/65/66/100 |
+| F-W11 | RiskIndex caption said "N agents" over process instances | caption says `process` / `processes` |
+
+---
+
+## Tier 2 — Evidence loss
+
+### F-E01 — per-PID `resource-usage` push had no renderer subscriber — **CLOSED**
+
+The channel was renamed `agent-resource-usage` (the old name collided with `get-resource-usage`,
+which means the app's *own* load) and now lands in a renderer store; `AgentCard.svelte:100-106`
+consumes it strictly by `instanceId`, with no pid fallback.
+
+### F-E02 — file events dropped when no agents were known yet — **CLOSED**
+
+`handleWatcherEvent` no longer returns on an empty `latestAgents`; only `shouldIgnore`, pause and
+the path debounce remain. Zero agents now yields an honest unattributed event
+(`no-ai-agents-online`) instead of silence.
+
+### F-E03 — cross-layer file dedup keyed on display name — **CLOSED**
+
+`dedupFileEvent` (`scan-loop.js:69-75`) keys on the stamped `instanceId|file`; a null or empty
+`instanceId` bypasses the bucket entirely rather than collapsing into a shared `''|path` key. Two
+instances of one product name, and two unattributed events, now both survive.
+
+### F-E04 — four independent event windows, none disclosed — **OPEN**
+
+**User sees:** Risk, timeline and feed disagree with "how much happened", with no truncation banner.
+
+**Where:** renderer ring `stores/ipc.ts:360` (`slice(-499)` + batch); network `:365` (500);
+`ActivityFeed.svelte:155` (`slice(0, 200)`); main `activityLog` capped at 10 000 in `file-watcher.js`
+(`:377`, `:550`, `:680`); OOM trim to 1 000 at `main.js:438-450`.
+
+**Mechanism:** Multiple independent caps. Risk only ever sees the renderer's window. Sensitive
+counters follow the main ring plus its eviction hook.
+
+**Falsification:** A single durable window, or UI disclosure when a cap drops rows.
+
+### F-E05 — `attachModels` synthetics had no `instanceId` — **CLOSED**
+
+`attachModels` now calls `identify({ pid: 0, agent: name })` and stamps both `instanceId` and
+`instanceIdSource` (`scan-loop.js:526-528`), mirroring `injectDetectedExternalAgents`. The
+baselines/risk quarantine that made this visible was correct and is unchanged.
+
+### F-E06 — Linux/Darwin supply no OS birth time → real agents fall back to `"<pid>:u"` — **OPEN**
+
+**User sees:** After PID reuse on non-Windows, sessions, knownHandles and scores can continue under
+a new process as if it were the old one (degraded identity).
+
+**Where:** `platform/linux.js:247` and `platform/darwin.js:149` both document that
+`getParentProcessMap` entries carry no `startTime`; `win32.js` supplies one.
+
+**Mechanism:** Space-3 identity is honest but reuse-unsafe. The product claims instance identity
+generally; the platform gap is silent to the user.
+
+**Falsification:** `startTime` populated on linux/darwin and `instanceIdSource === 'os'` in
+production scans there.
+
+### F-E07 — audit buffer overflow can lose events with no on-disk marker if the process exits while the disk is still bad — **OPEN**
+
+**User sees:** A later "valid" hash-chain file that is incomplete; `droppedEntries` resets on
+restart.
+
+**Where:** `audit-logger.js` — `BUFFER_CAP = 500` at `:40`, drop-oldest eviction at `:246-261`,
+marker gated on the next **successful** flush at `:274-281`.
+
+**Mechanism:** Evicted entries are counted in memory; the `buffer-overflow-drop` marker only reaches
+disk on a flush that succeeds. `verifyChain` cannot detect records that were never sequenced.
+
+**Falsification:** A forced full-disk session that exits before recovery leaves a durable loss
+record.
+
+### F-E08 — `verifyChain` does not detect truncation of trailing lines — **BY DESIGN**
+
+Any prefix of a valid chain is a valid chain. This is stated outright in the code
+(`audit-hashchain.js:68`) rather than left for a reader to discover, and the JSDoc carries the
+asymmetry (valid ≠ complete). It remains a real trustworthiness limit of an append-only store — the
+fix is an external length/seq watermark — but it is a documented property, not an unfixed bug.
+
+### F-E09 — process-scan overruns drop entire ticks silently — **OPEN**
+
+**User sees:** Frozen agent list / delayed enter-exit while the machine is busy; no "scan skipped"
+signal anywhere.
+
+**Where:** `scan-loop.js:280-281` (`if (processScanRunning) return;`), cleared at `:461`.
+
+**Mechanism:** The re-entrancy guard discards overlapping interval fires without queueing or
+counting them. Note the contrast with the filesystem and network sensors, which now hold
+`sensor-health` records — the process scan has none.
+
+**Falsification:** A skipped-tick counter or health record, or a queue that always runs the latest
+scan.
+
+### F-E10 — token costs silently absent on non-Windows — **OPEN**
+
+**User sees:** Empty token footer/card despite Claude Code running (darwin/linux always; win32 when
+`startTime` is unreadable).
+
+**Where:** `token-cost-collector.js:75-76` keeps only agents where `typeof a.startTime === 'number'`;
+the file header at `:16` states darwin/linux are always null.
+
+**Mechanism:** No birth time → no procs → no feed read. One warning on win32 only, for Claude Code.
+
+**Falsification:** Token records on linux with live Claude Code, or UI that states "tokens
+unavailable on this OS".
+
+### F-E11 — `rules:reloaded` is pushed with no renderer listener — **OPEN**
+
+**User sees:** Rules change on disk, main reloads them, and any UI showing rules can stay stale.
+
+**Where:** sent at `file-watcher.js:844`, bridged at `preload.js:72-75`; `grep` for
+`onRulesReloaded` / `rules:reloaded` under `src/renderer` returns nothing.
+
+**Mechanism:** Same class as F-E01 was — a bridge endpoint with no consumer. It is now the only
+surviving instance of that class.
+
+**Falsification:** A renderer handler that updates a rules store on push, or stop sending it.
+
+### F-E12 — network rows carry the OS owner pid while attribution is unattributed — **BY DESIGN**
+
+The audit filed this as an invariant violation and flagged its own uncertainty ("may be intentional
+for network forensics"). At `d027f0c` the code answers it in place
+(`network-monitor.js:452-466`): the unmatched branch yields `agent: ''` — never a synthesized
+`PID <n>` label — and the comment states that `_getRawTcpConnections` is called *with* these agents'
+pids, so every returned pid is in `pidMap` and the unmatched branch is unreachable in practice. It
+is kept as a guard, not as a fallback that invents data, and `instanceId` comes from
+`readInstanceId(agent)` on the same tick that built the map. Nothing here needs fixing; the
+invariant wording is what should say "file path" where it says "all records".
+
+---
+
+## Tier 3 — Silent failure / invariant cracks
+
+### F-S01 — vacuous tests: chokidar subscription could be deleted and file-watcher tests stayed green — **CLOSED**
+
+The break/restore proof stands as executed: emptying `bindWatcherEvents` left 93 file-watcher tests
+passing. `tests/main/file-watcher-subscription.test.js` now mocks `chokidar.watch`, runs production
+`setupFileWatchers`, asserts every watcher registers `add` / `change` / `unlink`, and fires the
+callbacks into the real handler. Production wiring was already correct — the gap was the gate, and
+dropping a `watcher.on('change', …)` now turns that test red.
+
+### F-S02 — `getRulesByCategory` fully tested, never used on a production path — **OPEN**
+
+**User sees:** Nothing directly. The risk is false confidence that category indexing protects
+classification latency.
+
+**Where:** `rule-loader.js:193,224`; `classifySensitive` still walks `getAllRules()`.
+
+**Mechanism:** Green unit tests for code the product never calls — vacuity at feature level rather
+than assertion level, which is why no second break/restore was performed (the tests do exercise the
+function body).
+
+**Falsification:** A production caller routes through `getRulesByCategory` and a test fails when the
+index is wrong.
+
+### F-S03 — identity re-derivation fallbacks on hot paths — **CLOSED, with one documented degradation**
+
+The silent fallbacks are gone. `file-watcher.js:477` (`handleKey`) and `session-tracker.js`
+(`sessionKey`) now call `readInstanceId` only and skip an unstamped agent rather than rebuilding;
+both cite `ai-mistakes.md` #19 in place. `AgentCard.svelte:94` matches on `instanceId` when both
+sides carry one and states the pid path as the neither-side-keyed case.
+
+What remains is deliberate: `token-tracker.js:193-201` (`recordKey`) still calls `buildInstanceId`
+for bare-number callers, documented as "space-3 degradation by pid only — never invent birth-time
+identity". That is an explicit degradation with a named space, not a silent rebuild.
+
+### F-S04 — `pidMap` / `pidToAgent` are last-writer-wins for a shared pid — **OPEN**
+
+**User sees:** Wrong agent name on a network or RM-holding event if two agent records share a pid.
+All pure synthetics use **pid 0**, and there can be more than one (Ollama *and* LM Studio).
+
+**Where:** `network-monitor.js:428-429`; `file-watcher.js:626-627`.
+
+**Mechanism:** `Map.set(a.pid, a)` overwrites. Practical impact is currently limited — the TCP table
+is queried with real pids, so pid-0 rows do not come back — but the structure still cannot represent
+two agents on one pid, and F-W03's fix means those synthetics now reach the scan list.
+
+**Falsification:** A map keyed by `instanceId` with OS pid → instance resolution, or an assertion of
+at most one agent per pid in the scan list.
+
+### F-S05 — sensor errors become empty results — **PARTIALLY CLOSED (main), OPEN (UI)**
+
+**User sees:** "No file activity" / "no connections" when the sensor actually failed.
+
+**Where:** `src/main/sensor-health.js` now exists and supplies `createSensorHealth` /
+`createUnsupported` / `markHealthy` / `markDegraded`; `file-watcher.js:104-111` holds records for the
+chokidar, handle and Restart-Manager sensors, and `network-monitor.js:34,73-79` holds one for the
+network sensor. `docs/roadmap/sensor-health-degraded.md` is the design note.
+
+**Mechanism:** Main can now distinguish quiet from dead. The renderer cannot: `grep` for
+`sensorHealth` / `degraded` under `src/renderer` returns nothing, so a degraded sensor is still
+indistinguishable from a quiet machine on screen. The process scan holds no record at all (F-E09).
+
+**Falsification:** An explicit degraded state rendered in the UI when handle/RM/TCP enumeration
+fails.
+
+### F-S06 — `riskHistory` sparkline is dead UI — **OPEN**
+
+**User sees:** No risk sparkline on cards despite a `Sparkline` component and a layout slot.
+
+**Where:** `AgentCard.svelte:37` (`agent.riskHistory ?? []`), rendered at `:200-202` behind
+`length > 1`; nothing in `src/` writes the field.
+
+**Falsification:** A producer appends scores each scan and the sparkline renders.
+
+### F-S07 — evidence code list is seven items, not six — **CLOSED**
+
+`EVIDENCE_CODES` is still 7 (`rm-holder-pid`, `handle-scan-pid`, `os-tcp-owner-pid`,
+`self-config-path`, `cwd-containment`, `no-owner-match`, `no-ai-agents-online`) — the code was never
+wrong. The invariant text was: the attribution comment now describes a closed registry rather than
+naming a fixed count, so the two cannot drift apart again.
+
+---
+
+## Tier 4 — Doc / inventory drift
+
+The audit's four Tier-4 items were counts documented in one place and measured differently in
+another. All four have since been either fixed or superseded, and re-listing the audit-time figures
+would re-seed the drift. Current state at `d027f0c`:
+
+- **Component / store / util counts.** `CLAUDE.md` no longer quotes a component count; it carries
+  the command instead. Note that the command it carries,
+  `git ls-files 'src/renderer/**/*.svelte' | wc -l`, returns 47 — one short of the 48 tracked
+  `.svelte` files, because it misses `src/renderer/App.svelte`.
+- **Skill test counts.** `.claude/skills/aegis-context/SKILL.md:32` still states "1075 pass, 4 skip
+  (1079 total) across 68 files". That figure was stale when the audit found it and is staler now.
+  It is a hand-maintained counter with no gate behind it (`ai-mistakes.md` #24) — the fix is to
+  delete it, not to refresh it.
+- **IPC narrative.** 40 invoke + 9 push = 49 bridge endpoints, unchanged. Two of the audit's three
+  unconsumed push channels now have subscribers; `rules:reloaded` does not (F-E11).
+
+---
+
+## Path traces (condensed, re-checked at `d027f0c`)
+
+### File event (chokidar)
+
+1. `setupFileWatchers` → `bindWatcherEvents` → `handleWatcherEvent` (`file-watcher.js`).
+2. Early exits: paused, ignore, path debounce. **An empty agent list is no longer an early exit**
+   (F-E02) — it produces an unattributed event.
+3. Owner via `findOwningAgent` (self-config → cwd) or unattributed evidence; `readInstanceId(agent)`
+   only, never a rebuild (F-S03).
+4. Push activityLog + counters; `recordFileAccess` unless unattributed.
+5. `onFileEvent` → `dedupFileEvent` (**`instanceId|file`**, F-E03) → batcher `file-access` + audit +
+   tray.
+6. Renderer: `events` ring → `risk.ts` / `eventsByInstance` / ActivityFeed.
+
+**Filters that still diverge:** main ring (10 000, OOM-trimmed to 1 000) vs IPC dedup vs renderer
+window (≈500) vs feed (200) vs risk quarantine of unattributed — F-E04.
+
+### File event (handle / RM)
+
+1. Timer → `scanAllFileHandles` / `scanHotFileHolders`.
+2. RM path maps holder pid → agent (dropping non-agents); `knownHandles` keyed by `handleKey`, which
+   is `readInstanceId` and nothing else — an unstamped agent gets no dedup entry this tick.
+3. Events enter activityLog **before** scan-loop dedup for audit/IPC.
+
+### Network connection
+
+1. `scanNetworkConnections(agents)` builds a **pid→agent** map from this tick's agents (F-S04 notes
+   the shared-pid limit).
+2. OS TCP rows; drop private IPs; IP allowlist checked **before** any DNS work; reverse DNS then
+   forward-confirmed.
+3. Verdict `allowlisted` | `unknown` | `flagged`; `flagged` keeps its original meaning, "not
+   confirmed as an allowlisted endpoint", so `unknown` still sets it — an unidentified endpoint is
+   never displayed as safe.
+4. `recordNetworkEndpoint(instanceId, …)`; audit with `OS_TCP_OWNER_PID` or `NO_OWNER_MATCH`.
+5. Renderer `network` replace; risk splits flagged vs unknown weights.
+
+---
+
+## Invariant checklist (at `d027f0c`)
+
+| Invariant | Status |
+|---|---|
+| `instanceId` not bare pid on live identity maps | Held on the hot paths (F-S03 closed). One documented pid-space degradation in `token-tracker.recordKey`. Resource sampling is instance-keyed. |
+| No silent owner fallback to "first agent" | Held — null owner → unattributed. |
+| Three attribution statuses + closed evidence list | Held; the registry is 7 codes and is described as closed rather than counted (F-S07). |
+| Unattributed: empty name + null pid | File path: held. Network: `agent: ''` with the OS pid retained on a branch that is unreachable in practice and documented as a guard (F-E12). |
+| No numeric confidence on attribution | Held. |
+| Durable disk state not keyed on `instanceId` | Held by design — baselines name-keyed, permissions instanceKey name/cwd. |
+| Risk factor ceilings | Held (`risk-scoring.js` min ceilings; anomaly dimensions capped). |
+| Event dedup | Held at instance granularity (F-E03 closed). |
+| Audit hash-chain; no drop before confirmed write | Re-queue on flush failure held; cap eviction can still drop before a durable marker exists (F-E07). |
+| Every IPC channel has a subscriber | **One violation:** `rules:reloaded` (F-E11). |
+| Sensor failure is distinguishable from quiet | Main: held for FS + network sensors. **Renderer: no consumer** (F-S05). Process scan: no record (F-E09). |
+| Demo only in renderer / not on a production path | Held — `import.meta.env.VITE_DEMO_MODE` is a build-time literal (`vite.config.js:25`), the default build drops the engine, and a missing bridge shows a banner rather than demo data. The audit cited `production-no-demo.test.ts`, which no longer exists; the demo surface is now covered by `tests/renderer/demo-data.test.js` plus the provenance marker in `demo-provenance.js`. |
+
+---
+
+## Vacuous / weak tests
+
+| Test area | Why weak | Status at `d027f0c` |
+|---|---|---|
+| `file-watcher*.test.js` handler suite | Never required a chokidar subscription | **Closed** — `tests/main/file-watcher-subscription.test.js` asserts the bindings and fires them |
+| `rule-loader` `getRulesByCategory` | No production caller | **Open** (F-S02). The unit tests do exercise the body; the vacuity is product wiring |
+| `scan-loop` anomaly tests with Ollama | Injected Ollama via the scanner mock, not `attachModels`, so the suite could not catch F-W03 | **Superseded** — F-W03 and F-E05 are closed; a test that fixes the *ordering* rather than the symptom is still worth having |
+| `llm-runtime-detector` unit tests | Prove HTTP probe helpers only; no `scan-batch` integration | **Open** |
+| `main-watcher-startup` | Guards `setupFileWatchers` scheduling but mocks the function, so asserts no FS bindings | **Covered elsewhere** by the subscription test |
+
+---
+
+## What could not be determined (and why)
+
+1. Whether chokidar watchers actually run in a **packaged** Electron build on this machine — the
+   audit did not launch the GUI; code and unit tests only.
+2. Real disk-full audit loss rates in the field — needs a controlled full-disk soak.
+3. How often process-scan overruns occur under load — no metrics are emitted on skip (F-E09).
+4. A complete unused-export graph for every main module — partial inventory only; no whole-program
+   call graph was built.
+5. Whether any external tooling consumes `anomalyScoresByInstance` or the resource channel outside
+   this renderer — only `src/` was searched.
+6. End-to-end correctness of Restart Manager / `handle.exe` on this Windows host — platform tests are
+   unit-level with mocks. (The `bench/` harness added since the audit is the intended answer to this
+   and to item 1, but it is Windows-only and never runs in CI.)
+7. Exact user-visible Header vs SummaryCards desync duration after tab switches — logic is clear; not
+   timed in a running UI.
+
+---
+
+## Ranked shortlist of what is still open
+
+1. **F-E11** `rules:reloaded` pushed with nobody listening — the last unconsumed bridge endpoint.
+2. **F-S05** sensor health exists in main but never reaches the UI, so a dead sensor still reads as
+   a quiet machine.
+3. **F-E09** process-scan overruns dropped silently and with no health record.
+4. **F-E07** audit loss on a kill with no durable marker.
+5. **F-E04** four independent event windows, no truncation disclosure.
+6. **F-S04** pid-keyed maps cannot represent two agents on one pid, and pid-0 synthetics now reach
+   the scan list.
+7. **F-E06** linux/darwin have no OS birth time → degraded identity under PID reuse.
+8. **F-E10** token costs silently absent on non-Windows.
+9. **F-S06** `riskHistory` sparkline is dead UI.
+10. **F-S02** `getRulesByCategory` tested but never called.
+
+---
+
+## Explicit non-findings (checked, not broken as described)
+
+- **Network "PTR exists ⇒ safe / missing ⇒ hostile" inversion:** not present. Reverse DNS is
+  forward-confirmed and a missing PTR yields `unknown`, which still sets `flagged` — never
+  allowlisted.
+- **Audit flush re-queue without advancing seq on failure:** implemented as designed in the `flush()`
+  catch path.
+- **C-01 first-agent blame on the chokidar path:** not present; the unattributed path uses an empty
+  agent name and a null pid.
+- **Demo pools in the production renderer bundle:** guarded by a build-time flag.
+
+---
+
+*Audit of 2026-08-08: no fixes proposed, no PR opened, one file written. Re-verified against
+`master` @ `d027f0c` on 2026-08-13 before entering git — statuses, counts and line anchors above are
+that re-verification, not the original snapshot.*

--- a/docs/recon/EXTERNAL-TECHNIQUES.md
+++ b/docs/recon/EXTERNAL-TECHNIQUES.md
@@ -1,0 +1,359 @@
+# External techniques worth stealing
+
+**Recon date:** 2026-08-12
+**Baseline re-verified against:** `master` @ `d027f0c`, 2026-08-13 — three baseline claims had gone
+stale between the recon and this commit and are corrected below; each correction is marked
+**[since recon]** where it changes what a section recommends.
+
+Read-only recon against published specs and implementations. AEGIS baseline for comparison:
+hash-chained daily JSONL (`src/main/audit-hashchain.js` key-sorted `canonical` + SHA-256, no stored
+`prevHash`), bounded in-memory write buffer with drop-oldest + `buffer-overflow-drop` markers
+(`audit-logger.js` / `audit-drop-tracker.js`), Event Schema v1 (`schemaVersion`, `pid`, `instanceId`,
+`attribution`), `instanceId` as `<pid>:<startTimeMs>` (`process-identity.js`), polling scanners +
+chokidar, per-instance resource sample (`resource-monitor.js` TTL cache keyed by `instanceId`, pid
+carried for display only), rules as flat YAML without temporal join, a Windows-only scenario bench
+with an independent oracle (`bench/`, `npm run bench:run`) but no offline replay of recorded sensor
+fixtures, per-sensor health records in main (`sensor-health.js`) with no renderer consumer, no SQLite
+index, no second sensor, no user-facing `verify` CLI (`src/main/cli.js` has `--scan-json`,
+`--version`, `--help` only).
+
+Findings only where an external approach is **stronger** than inventing our own. Confidence tags: **impl** = read implementation source; **docs** = read specification or authoritative docs; **desc** = secondary description only.
+
+---
+
+## 1. Audit schema alignment
+
+### 1.1 RFC 8785 JSON Canonicalization Scheme (JCS)
+
+- **Technique:** Canonicalize audit records with RFC 8785 before hashing so chain digests are interoperable and free of number/UTF-16 key-order edge cases.
+- **Source:** [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) (2020, standards-track); verified JS package [erdtman/canonicalize](https://github.com/erdtman/canonicalize) (npm `canonicalize`, listed in RFC Appendix G). MIT-ish OSS; still the reference for Node.
+- **Where:** Spec §3–§3.2.3 (key sort by UTF-16 code units, ECMAScript number serialization / Ryū, no whitespace). Package entry: `canonicalize` export in `erdtman/canonicalize`.
+- **Why it beats us:** Our `canonical()` in `audit-hashchain.js:36-40` only key-sorts and `JSON.stringify`s primitives. It does **not** implement JCS number rules or the UTF-16 key order the RFC mandates. Any external verifier (or a future signed-export tool) that uses real JCS will disagree with our hashes on non-integer numbers and certain keys.
+- **Cost:** One tiny npm dep (`canonicalize`, pure JS, ~few KB) or a hand-port of the number path. No platform constraint. Migration cost is a **chain-format break** (re-hash from GENESIS with a schema version bump).
+- **Trap:** JCS forbids non-I-JSON numbers (NaN, Infinity). Our events mostly use integers and ISO strings today; introducing floats (latencies, costs) without JCS will silently change digests. Also: AAT (below) hashes the **whole previous record including signature**; we hash event-without-seq/hash. Align the *exclusion set* before swapping the serializer.
+- **Confidence:** docs (RFC) + docs (package README / Appendix G listing). Did not re-run RFC test vectors against our `canonical()`.
+
+### 1.2 Agent Audit Trail (AAT) — draft-sharif-agent-audit-trail-00
+
+- **Technique:** Session-scoped, hash-chained JSON audit records with mandatory identity/action/outcome fields, genesis + close records, optional ECDSA P-256, tombstones for erasure, JSONL as primary export.
+- **Source:** [draft-sharif-agent-audit-trail-00](https://datatracker.ietf.org/doc/draft-sharif-agent-audit-trail/) (2026-03-29, IETF individual draft, expires 2026-09-29). Explicitly binds chaining to **RFC 8785** and maps EU AI Act Art. 12, ISO/IEC 42001, SOC 2, PCI DSS.
+- **Where:** §3.1 mandatory fields (`record_id`, `agent_id`, `session_id`, `action_type`, `outcome`, `prev_hash`, …); §4.1 hash formula `prev_hash(N) = hex(SHA-256(JCS(record(N-1))))`; §6 session genesis/close; §7.3 tombstones; §8.1 JSONL primary.
+- **Why it beats us:** We already reinvented per-file chains + JSONL + “verify re-derives from GENESIS.” AAT is a published field taxonomy and chain algorithm we can **map or export into**, instead of growing a private schema forever. Session close `session_hash` and orphaned-session recovery rules cover gaps our daily-file design does not name.
+- **Cost:** Spec only (no library). Mapping layer from AEGIS v1 → AAT export shape; optional signing later. Stay **out of** AAT’s optional `risk_score` 0.0–1.0 until a ground-truth bench exists (project permanent ban on numeric confidence).
+- **Trap:** Individual draft, not WG consensus — field names can still move. AAT’s `agent_id` is a **persistent URI across restarts**; our `instanceId` is **per-boot OS instance**. Do not conflate them: keep OS instance as evidence, map a durable agent URI only if we ever have one. AAT assumes the *agent* writes the trail; AEGIS is an *external* observer — action taxonomy (`tool_call`, `decision`, …) fits agent-native logs better than OS file/network events (OCSF is better for those).
+- **Confidence:** docs (full draft text read).
+
+### 1.3 OCSF for OS-level event field names (export / index, not write-path)
+
+- **Technique:** Map process/file/network observations to OCSF classes for export and SQLite column names instead of inventing parallel vocabularies.
+- **Source:** [ocsf/ocsf-schema](https://github.com/ocsf/ocsf-schema) (Apache-2.0, active, industry standard since ~2022; AWS Security Lake native).
+- **Where:** Schema classes under `events/` (e.g. Process Activity, File System Activity, Network Activity) and attribute dictionary in the repo; consumer docs at schema.ocsf.io.
+- **Why it beats us:** SIEM/export consumers already speak OCSF. Renaming `type: file-access` / `network-connection` into OCSF class UIDs + shared attributes (`process.pid`, `file.path`, `actor`, `time`) is cheaper long-term than a private SIEM mapping table.
+- **Cost:** Mapping table only. Keep AEGIS JSONL as canonical write format; OCSF is an export/index projection. No runtime dependency required.
+- **Trap:** OCSF is huge and versioned. Full conformance is not the goal — pick the 3–4 classes we emit. Do not force OCSF into the hash-chained write path (extra fields would churn the chain).
+- **Confidence:** docs.
+
+### 1.4 User-facing integrity verify (pattern already specified, not built)
+
+- **Technique:** CLI/command that runs the same chain algorithm AAT §4.3 / our `verifyChain` and prints broken-at-seq + asymmetric semantics (valid ≠ complete; invalid ≠ tampered).
+- **Source:** Our own `verifyChain` (`audit-hashchain.js:90-121`) already implements the core; AAT §4.3 is the public procedure; no better external CLI for *local* JSONL hash chains turned up.
+- **Why it beats a greenfield:** Do not invent a new protocol — wire existing `verifyChain` to `cli.js` and document the two-way honesty already in the JSDoc.
+- **Cost:** Thin CLI surface + docs. Already in-repo.
+- **Trap:** Exposing “tampered” wording to users without the invalid≠tampered note reintroduces the honesty bug the JSDoc already fixed.
+- **Confidence:** impl (our code) + docs (AAT).
+
+---
+
+## 2. Per-instance resource usage
+
+### 2.1 Keep identity as (pid + start time); do not invent ProcessGuid
+
+- **Technique:** Sysmon’s `ProcessGuid` exists because bare PID reuses; it is a domain-scoped GUID carried on every related event. The **problem statement** is the same as our `instanceId`.
+- **Source:** Microsoft Sysmon (Sysinternals, long-lived, actively maintained). Docs: Process Create Event ID 1 field list on learn.microsoft.com / ultimatewindowssecurity encyclopedia.
+- **Where:** Documented field `ProcessGuid` on Event ID 1; correlation via `ParentProcessGuid` on child events. Sysmon source is closed; behavior is field-level, not a library.
+- **Why it beats a homemade GUID:** It does not. Our `buildInstanceId` (`process-identity.js`, spaces `pid:epochMs` / `0:name` / `pid:u`) already solves the same reuse class without a driver. **Finding is negative-space:** do not replace `instanceId` with a Sysmon-style GUID unless we *consume* Sysmon events (roadmap item 9).
+- **Cost:** N/A.
+- **Trap:** Community reverse-engineering of ProcessGuid bit layout is not a stable API. Never encode our own “looks like Sysmon GUID.”
+- **Confidence:** docs.
+
+### 2.2 Resource sample must key on instanceId, not bare pid — **[since recon: adopted]**
+
+- **Technique:** osquery / agent monitoring tables bind process metrics to a process that can disappear between samples; differential + epoch markers prevent treating a recycled PID as continuous history.
+- **Source:** osquery scheduled query **epoch** semantics (docs: logging / differential logs) — when epoch changes, treat as initial run, not a differential against the dead process.
+- **Where:** osquery docs “Logging → Differential logs” (`schedule_epoch`); process tables are snapshot, not continuous counters without epoch.
+- **Status on master:** **done — nothing left to steal here.** `resource-monitor.js` now documents `instanceId` as *the* key: the TTL `_cache` is keyed by `instanceId`, `pid` rides along for display and diagnostics only, and a target with `instanceId: null` is neither read from nor written to the cache. The pid-keyed `resource-usage` push it warned about was renamed to `agent-resource-usage` and now lands in a renderer store (`stores/ipc.ts`, consumed at `AgentCard.svelte` strictly by `instanceId`). The recon's original wording — cache and IPC payload keyed by bare pid — described the tree at recon time and is no longer true.
+- **Cost:** Paid. The same-tick rule below still governs any new sampler.
+- **Trap (still live):** GPU path via `nvidia-smi` only knows pid; join to instanceId **on the same scan tick** that produced the agent list (same-tick rule as network attribution), never by pid lookup later.
+- **Confidence:** docs (osquery) + impl (`resource-monitor.js` header and cache, re-read 2026-08-13).
+
+---
+
+## 3. Health state machine (honest subsystem signals)
+
+### 3.1 Treat sensor liveness as first-class data, not “no events means quiet”
+
+- **Technique:** osquery exposes publisher/subscriber health via the `osquery_events` table and bounds event buffers with `events_max` / `events_expiry` so “empty” is distinguishable from “expired/dropped.”
+- **Source:** [osquery](https://github.com/osquery/osquery) (Apache-2.0, 2014–, active). Docs: [Eventing / pubsub framework](https://osquery.readthedocs.io/en/stable/development/pubsub-framework/), process auditing flags.
+- **Where:** Flags `--events_max`, `--events_expiry`; table `osquery_events` for publisher status (documented; implementation under `osquery/events/` in the C++ tree).
+- **Why it beats us:** AEGIS “no file events” can mean quiet agent, dead chokidar, EPERM, or scan not scheduled. Without an explicit publisher state (running / degraded / lost-count / last-success), the UI cannot tell sleep from death. **[since recon: half-adopted]** `src/main/sensor-health.js` now exists and carries exactly this shape — `createSensorHealth` / `createUnsupported` / `markHealthy` / `markDegraded` — with records held for the chokidar, handle and Restart-Manager filesystem sensors (`file-watcher.js`) and for the network sensor (`network-monitor.js`). What is still missing is the half the finding is about: **no renderer file reads any of it**, so the UI still cannot tell a quiet machine from a dead sensor. Process-scan overruns (`scan-loop.js`) emit no health record at all.
+- **Cost:** Pattern only — a small state machine per subsystem (process scan, file watcher, network, audit flush, token feed) with last-ok timestamp + error class + drop counters we already partly have on audit. Remaining work is the scan-loop record and an IPC surface + UI consumer, not the state machine.
+- **Trap:** Copying osquery’s RocksDB event store is overkill. Steal the **signal model**, not the storage.
+- **Confidence:** docs.
+
+### 3.2 ETW session loss counters as ground truth for “sensor died silently”
+
+- **Technique:** Windows ETW reports buffers/events lost when the consumer cannot keep up or buffers are undersized — first-class loss metrics, not log absence.
+- **Source:** Microsoft ETW (OS built-in since Vista). Docs: “About Event Tracing” session statistics (buffers used/delivered, events and buffers lost).
+- **Where:** Session statistics APIs / `EventTraceProperties` (Win32); observable as “events lost” in performance data collection.
+- **Why it beats us:** If we later consume ETW (roadmap Phase C / second sensor), loss counters are the honest health input. Even without owning a session, any shadow consumer must surface lost-event counts or it lies.
+- **Cost:** Read existing ETW stats only when we attach a session. No custom driver.
+- **Trap:** Lost events are **unrecoverable** — you cannot reconstruct them. Health must go degraded; never invent filler events. Real-time sessions without a consumer also lose data.
+- **Confidence:** docs.
+
+### 3.3 Sleep / wake
+
+- **Technique:** Subscribe to OS power broadcast (Windows `WM_POWERBROADCAST` / resume) and force “sensors re-arm + baselines freeze during sleep” rather than treating a multi-hour gap as agent idle.
+- **Source:** Long-standing OS facility (not a product). Documented as Windows power management messages; used by every serious endpoint agent.
+- **Where:** Win32 power events (docs); Electron/main can listen via native hooks or `powerMonitor` in Electron (`resume` / `suspend`).
+- **Why it beats us:** Without sleep awareness, scan-gap timers and “last activity” heuristics mis-fire after lid-close. Electron already exposes `powerMonitor` — cheaper than inventing heartbeat math.
+- **Cost:** Electron `powerMonitor` in main (already a dependency). Small handler: mark health, reset TTLs, do not score sleep gaps as anomalies.
+- **Trap:** VM hosts and some “modern standby” paths deliver delayed or missing events. Treat as best-effort; still better than wall-clock only.
+- **Confidence:** docs (Electron powerMonitor is well-known; not re-read API surface this pass).
+
+---
+
+## 4. Bounded, coalescing event pipeline
+
+### 4.1 Vector disk buffer v2 — crash-safe segmented on-disk ring
+
+- **Technique:** Segmented data files (≤128MB), memory-mapped ledger of reader/writer positions, CRC32C records, record IDs encoding event counts, delete-on-ack of whole files, modes block / drop_newest / overflow-to-next-stage, recovery that reconciles partial writes.
+- **Source:** [vectordotdev/vector](https://github.com/vectordotdev/vector) `lib/vector-buffers` (MPL-2.0, actively maintained, production at scale).
+- **Where:** Design + invariants in `lib/vector-buffers/src/variants/disk_v2/mod.rs` (module docs: data file limits, ledger layout, write/read/ack lifecycle). Writer: `.../disk_v2/writer.rs`. Reader: `.../disk_v2/reader.rs`. Ledger: `.../disk_v2/ledger.rs`. Recovery: `.../disk_v2/checkpoint_recovery.rs`. Topology policies: `lib/vector-buffers/src/topology/builder.rs` (`WhenFull::{Block, DropNewest, Overflow}`).
+- **Why it beats us:** Our audit path is **memory-bounded** (`BUFFER_CAP = 500`) and loses on process kill before flush; markers only appear after a *successful* flush. Vector’s disk_v2 survives process death with ordered replay and known corruption handling. For the **pre-audit** event pipeline (file/network/process bursts → attribution → rules), this is strictly stronger than inventing another in-memory queue.
+- **Cost:** Rust dependency or reimplementation of the *ideas* in JS (segmented files + ledger + CRC + drop policy). Full Vector is a large binary — do **not** embed Vector wholesale; reimplement the ~ledger+segments pattern in a small CJS module, or shell out only if we accept an external helper. Rough size if porting concepts: low thousands of lines, not 80k of writer.rs.
+- **Trap:** Disk buffer is not a hash chain. Do not replace JSONL canonical store with Vector records. Endianness is host-local. Acknowledgement-before-delete means a bug in ack logic re-delivers (at-least-once) — rules must be idempotent. Kill mid-record is handled; dual-writer is not.
+- **Confidence:** impl (read `disk_v2/mod.rs` design docs + topology builder source).
+
+### 4.2 Differentiated drop policies per stage (Vector topology)
+
+- **Technique:** Multi-stage buffer where early stages **overflow** into later stages; only the last stage may block or drop-newest. Enforced at build time.
+- **Source:** Same Vector tree: `TopologyBuilder::build` in `lib/vector-buffers/src/topology/builder.rs` (`TopologyError::OverflowWhenLast`, `NextStageNotUsed`).
+- **Why it beats us:** We have one drop-oldest policy for audit writes only. High-volume file events and low-volume anomaly alerts need **different** ceilings and drop rules; Vector’s stage model is the published way to compose that without silent policy bugs.
+- **Cost:** Design pattern; implementable in JS with two queues (hot memory → optional disk → audit).
+- **Trap:** “Drop oldest” on alerts is wrong; “drop newest” on file chatter may be right. Policy is per class, not global.
+- **Confidence:** impl.
+
+### 4.3 osquery events_max / events_expiry
+
+- **Technique:** Hard row cap + time-to-live on buffered events; expiration is visible (removed rows / optimize path), not silent OOM.
+- **Source:** osquery flags `--events_max`, `--events_expiry` (docs under process auditing / pubsub).
+- **Why it beats unbounded Maps:** Live stores in AEGIS (`sessionData` Sets, feeds) still need explicit eviction policy; osquery’s two-knob model (count + age) is the boring correct default.
+- **Cost:** Two constants + eviction on insert. No dependency.
+- **Trap:** `events_expiry=1` after select (Palantir-style) means “query or lose.” Fine for ephemeral sensors; wrong for audit.
+- **Confidence:** docs.
+
+---
+
+## 5. Trace replay bench
+
+> **[since recon]** A bench now exists and this section must be read against it. `bench/`
+> (`npm run bench:run`, `bench/run.js` + `bench/lib/{actor,catalogue,manifest,observed,sensor}.js`,
+> scenario `S1-agent-lifecycle`, schema `bench/scenario.schema.json`) generates an expected-event
+> catalogue as a by-product of running a deterministic script, confirms every row against an
+> independent oracle, and only then compares it with what the AEGIS sensor recorded. It is
+> Windows-only and never runs in CI. What it is **not** is the offline path §5.1 asks for: it
+> drives a **live** sensor per run. Recorded-fixture replay through attribution → rules → scoring
+> without a live run is still unbuilt.
+
+### 5.1 Deterministic re-ingest of recorded events (pipeline-as-function)
+
+- **Technique:** Record raw sensor observations (not scored outputs) and push them through attribution → rules → scoring offline. AgentSight’s SQLite session + `report` CLI is one realization: load saved DB, recompute summaries without live eBPF.
+- **Source:** [eunomia-bpf/agentsight](https://github.com/eunomia-bpf/agentsight) (MIT, active 2025–2026).
+- **Where:** `collector/src/cli_db.rs` — `load_agentsight_view`, `run_audit_query`, `run_export`, `SessionSummary::from_view` rebuilds metrics from stored rows; tests prove load does not create missing DBs and token priority across sources.
+- **Why it beats us:** We still have no offline path: scoring only runs in the live scan loop, and the bench above drives that live loop rather than replacing it. A replay harness needs **immutable recorded inputs** + pure functions. AgentSight already separates sink (SQLite) from view materialization.
+- **Cost:** Define a fixture format (JSONL of pre-attribution observations). Extract pure functions from scan-loop side effects. Do not take AgentSight’s TLS/eBPF capture (out of scope / wrong platform).
+- **Trap:** Replaying *audit* JSONL only re-runs readers, not attribution — by then `instanceId` is already frozen. Replay must start from sensor-level fixtures. AgentSight confidence fields and SSL interception paths are not for us.
+- **Confidence:** impl (`cli_db.rs` read).
+
+### 5.2 Atomic Red Team / known-bad generators for expected event sets
+
+- **Technique:** Drive a scripted action catalog with known expected observations; score detector output against the catalog (recall per class).
+- **Source:** [redcanaryco/atomic-red-team](https://github.com/redcanaryco/atomic-red-team) (MIT, long-lived). Used industry-wide as a behavior generator, not as a security product to embed.
+- **Where:** Atomics under `atomics/T####/` (YAML + scripts). Not a library — a test corpus.
+- **Why it beats homemade scripts alone:** Shared, versioned actions with documented preconditions. For AI-agent scenarios we still need custom atomics (touch `.ssh`, open sockets, spawn known agent binaries), but the **runner + expected-result** pattern is free.
+- **Cost:** External test dependency (optional CI job). Not a runtime dep.
+- **Trap:** Atomic Red Team targets ATT&CK techniques, not AI agents. Map carefully; many atomics need elevation and will trip AV.
+- **Confidence:** desc (standard industry knowledge; catalog structure not re-walked file-by-file this pass).
+
+---
+
+## 6. Windows ground-truth bench
+
+### 6.1 Sysmon as independent oracle (read path only) — **[since recon: adopted]**
+
+- **Technique:** Run Sysmon with a tight config; treat its Event Log as ground truth for process create/terminate, network connect, file create — compare AEGIS attribution and event presence against Sysmon in a metrics matrix.
+- **Source:** Microsoft Sysmon (Sysinternals). Binary redistributable; config community examples exist (e.g. trustedsec SysmonCommunityGuide — documentation, not required at runtime).
+- **Where:** Event IDs 1 (process create), 5 (terminate), 3 (network), 11 (file create) — field lists on Microsoft learn.
+- **Status on master:** the comparison harness described as “ours to write” **is written**: `bench/` uses Sysmon (and Procmon) as the oracle, and `bench/README.md` states the two rules this finding implies — never diff two live streams (the catalogue is the fixed point; oracle and sensor are each scored against it), and a sensor is never its own oracle (nothing under `bench/` imports from `src/`; process-identity ground truth comes from Sysmon EID 1 ordinality). The recon's remaining value here is the rationale, not the recommendation.
+- **Why it beats a self-referential bench:** Sysmon is kernel-backed and independent of Electron/chokidar/tasklist. Discrepancies are real signal (our miss or our duplicate), not two user-mode pollers agreeing.
+- **Cost:** Dev/CI machine dependency on Sysmon install + admin. Harness reads Windows Event Log (PowerShell/`wevtutil`/node-windows). No driver written by us — **read side of the line**.
+- **Trap:** Sysmon config volume can drop events if filters are wrong; silent filter ≠ ground truth. Clock skew between ETW/Event Log and our `Date.now()` must be normalized. ProcessGuid ≠ our instanceId — join on (pid, approximate start time) with documented tolerance.
+- **Confidence:** docs.
+
+### 6.2 Metrics matrix fields already implied by mature tools
+
+- **Technique:** Report recall by event class, attribution precision, duplicate rate, latency percentiles, dropped/coalesced counts, sensor downtime — same family of stats ETW session stats + osquery drop flags + Vector discarded counters already name.
+- **Source:** Composite of ETW lost counters (docs), Vector `buffer_usage` / discarded metrics (`lib/vector-buffers/src/buffer_usage_data.rs`, `internal_events.rs`), osquery events flags.
+- **Why it beats inventing KPI names:** These quantities are what production pipelines already export; using the same vocabulary makes the bench comparable to external literature.
+- **Cost:** Instrumentation + harness. No new algorithm.
+- **Trap:** Numeric “confidence” on individual alerts remains banned; bench metrics are **aggregate** quality of the detector, not per-event scores in product UI.
+- **Confidence:** docs + impl (Vector buffer usage module existence verified via tree listing).
+
+---
+
+## 7. SQLite as rebuildable index over hash-chained JSONL
+
+### 7.1 AgentSight: SQLite session store + query CLI (index pattern)
+
+- **Technique:** Materialize events into SQLite tables (`llm_calls`, `token_usage`, `audit_events`, …) for `report` / `token` / `audit` / `export` / `list` queries; treat DB as disposable projection.
+- **Source:** agentsight (MIT). `collector/src/cli_db.rs`; sinks under `collector` (SqliteStore referenced throughout tests); CLAUDE.md documents `sinks/` SQLite row store + `report` subcommands.
+- **Where:** `load_agentsight_view` / `run_audit_query` / `run_export` / `SessionSummary::from_view` in `cli_db.rs`; `SqliteStore::open` used in tests (insert SQL shows table shapes).
+- **Why it beats us:** We plan “SQLite over JSONL” in the master plan; AgentSight already ships the CLI UX and schema separation (query path ≠ capture path). Steal **CLI verbs + rebuild-from-canonical** discipline, not their capture stack.
+- **Cost:** `better-sqlite3` or `sql.js` in main/CLI. Rebuild job: stream JSONL → INSERT. On corruption, delete DB and rebuild (JSONL remains truth).
+- **Trap:** AgentSight often treats SQLite as the live store during capture. If we write **only** to SQLite, we lose the hash chain. Dual-write without “JSONL wins” will fork truth. Their multi-source token priority (`response_usage` vs `agent_native_session`) is good engineering but orthogonal to AEGIS’s OS-only stance.
+- **Confidence:** impl (`cli_db.rs`).
+
+### 7.2 SQLite FTS5 `rebuild` for disposable text index
+
+- **Technique:** External-content FTS5 table over path/action text; `INSERT INTO ft(ft) VALUES('rebuild')` reconstructs from content tables after bulk load.
+- **Source:** SQLite FTS5 docs (sqlite.org/fts5.html) — public domain SQLite.
+- **Where:** FTS5 section “The rebuild command.”
+- **Why it beats a homemade search index:** Zero new algorithms; standard rebuild semantics match “JSONL canonical, DB disposable.”
+- **Cost:** SQLite compile with FTS5 (default in most builds). Schema only.
+- **Trap:** FTS is not integrity. Never hash FTS rows.
+- **Confidence:** docs.
+
+---
+
+## 8. Sequence rules (join keys, windows, missing events, bounded state)
+
+### 8.1 Sigma Correlation Rules Specification
+
+- **Technique:** Meta-rules over base detections: `event_count`, `value_count`, `temporal`, `temporal_ordered`, plus metric aggregates; `group-by` join keys; `timespan`; field `aliases` across heterogeneous events; chainable correlations; bounded by timespan (state eviction = window end).
+- **Source:** [SigmaHQ/sigma-specification](https://github.com/SigmaHQ/sigma-specification) — `specification/sigma-correlation-rules-specification.md` (v2.1.0, 2025-08-02). Community standard, actively maintained.
+- **Where:** § Correlation Types (`temporal`, `temporal_ordered`, `event_count`, …); § Grouping; § Time Selection; § Field Name Aliases; example “Failed logins followed by successful login” multi-doc YAML.
+- **Why it beats us:** Our `rules/*.yaml` are single-event matches. Building sequence logic from scratch will rediscover group-by, timespan, and ordered temporal — already specified with conversion caveats.
+- **Cost:** Either implement a small Sigma-correlation subset in JS, or compile a fixed subset of correlation YAML → internal state machines. pySigma is Python — not a runtime dep for Electron unless we precompile.
+- **Trap:** Spec itself warns: backends that cannot honor order produce false positives; static hour buckets produce false negatives. Missing-event is **not** first-class in Sigma correlation (that is EQL). Do not claim full Sigma compatibility if we only implement `temporal` + `group-by`.
+- **Confidence:** docs (full correlation spec read).
+
+### 8.2 Elastic EQL `sequence` with `by`, `maxspan`, and missing events
+
+- **Technique:** Ordered sequences across event categories; join with `by field`; window with `maxspan`; negative clauses `![ ... ]` for missing events (requires maxspan).
+- **Source:** Elasticsearch EQL syntax (Elastic license for the engine; language documented publicly). Docs: elastic.co EQL syntax — sequence, maxspan, missing events.
+- **Where:** Language reference sections “Sequence,” “with maxspan,” “Missing events” (`!` clauses). Open-source historical EQL Python tooling exists separately; the *language design* is the steal.
+- **Why it beats Sigma alone for our roadmap item:** Roadmap explicitly wants **missing-event support**. EQL is the widely documented syntax that has it. Sigma covers joins/windows/order; EQL covers “A then not B then C.”
+- **Cost:** Implement a minimal interpreter over in-memory event streams (not Elasticsearch). Scope: ordered stages + join keys + maxspan + optional negative stage. Hundreds of lines if ruthlessly minimal.
+- **Trap:** Running Elasticsearch is not on the table. Missing-event matching is expensive (state retention for the whole maxspan). Bound state per join key with hard eviction (max keys, maxspan) or OOM.
+- **Confidence:** docs.
+
+---
+
+## 9. Second independent sensor (shadow mode)
+
+### 9.1 Sysmon / ETW as shadow, AEGIS as primary (discrepancy report)
+
+- **Technique:** Primary remains user-mode polling + chokidar. Shadow consumer reads Sysmon Event Log or a dedicated ETW session (kernel providers already in Windows). Diff: events only in shadow, only in primary, both, attribution mismatch. Emit discrepancy report, do not auto-merge into scoring until measured.
+- **Source:** Sysmon + ETW (Microsoft). Same as §6.1; dual-use as bench oracle and runtime shadow.
+- **Where:** Event Log channel `Microsoft-Windows-Sysmon/Operational`; ETW providers e.g. kernel process/network (documented provider names on Microsoft learn).
+- **Why it beats a second user-mode poller:** Independence. Two tasklist scrapers share failure modes. Sysmon/ETW does not.
+- **Cost:** Optional Windows-only module; admin for Sysmon. Shadow off by default. Discrepancy JSONL or SQLite table.
+- **Trap:** **Writing** a minifilter or custom kernel driver is out of scope — only **read** existing providers. Sysmon may be absent; shadow must degrade to “unavailable,” not fake agreement. Volume can overwhelm without filters — start with process create/terminate only.
+- **Confidence:** docs.
+
+### 9.2 AgentSight multi-source priority (pattern only)
+
+- **Technique:** Multiple observation sources for the same logical call; pick by documented priority (e.g. network-observed usage beats session-file estimate) and record which source won.
+- **Source:** agentsight `cli_db.rs` test `token_queries_use_highest_priority_source_per_llm_call` (priority `response_usage` over `agent_native_session`).
+- **Why it beats silent overwrite:** When shadow and primary disagree, store both and mark precedence — same pattern.
+- **Cost:** Schema fields `source`, `priority` on discrepancy rows.
+- **Trap:** Do not import AgentSight’s TLS interception (out of scope). Pattern only.
+- **Confidence:** impl.
+
+---
+
+## 10. Recovery after an agent mistake
+
+### 10.1 AAT tombstone records (chain-preserving correction)
+
+- **Technique:** Replace a bad/privacy-sensitive record with a tombstone that keeps `record_id` / linkage metadata and documents deletion reason; store original hash so validators can accept the intentional chain break.
+- **Source:** draft-sharif-agent-audit-trail-00 §7.3 Tombstone Records.
+- **Where:** Spec §7.3 fields (`event: record_deleted`, `tombstone_hash`, …).
+- **Why it beats “edit the JSONL” or “delete the day file”:** Edits break or silently rewrite history; day-file delete loses everything. Tombstones are the published recovery shape for append-only chains under GDPR-style constraints — and for “we logged the wrong attribution, here is the correction.”
+- **Cost:** New event type + verifyChain exception path for tombstones. Spec is clear enough to implement without a library.
+- **Trap:** Our current chain has **no** stored prevHash and assumes `seq === line index`. Tombstones must be **appended** corrections (pointer to bad seq) if we refuse in-place replace — prefer **compensating records** (`correction` / `retraction`) append-only, which fits our model better than AAT’s in-place replace. Say so in schema docs.
+- **Confidence:** docs.
+
+### 10.2 Vector checkpoint recovery after crash mid-write
+
+- **Technique:** On open, reconcile reader/writer ledger against data files; truncate torn tails; count dropped events into buffer accounting rather than panicking or double-delivering blindly.
+- **Source:** Vector `disk_v2` — `Buffer::from_config_inner` in `mod.rs` (calls `validate_last_write`, `reconcile_checkpoint_window`, `seek_to_next_record`); detailed recovery in `checkpoint_recovery.rs`.
+- **Why it beats us:** Failed audit flush re-queues pristine memory entries (good) but a **killed process** loses the buffer. A durable pre-flush queue with torn-write recovery is how you survive “agent mistake” that takes down the host process mid-burst.
+- **Cost:** Same as §4.1 if we adopt disk segments; otherwise document that recovery only covers flush failures, not kills.
+- **Trap:** Recovery that rewrites history without a marker is indistinguishable from tampering. Always emit a loss/recovery marker into the hash chain when the durable queue detects truncation.
+- **Confidence:** impl (mod.rs recovery flow).
+
+### 10.3 AAT gap records on resume after crash
+
+- **Technique:** If a session cannot produce continuous records, insert an explicit error/lifecycle recovery record documenting the gap rather than silently continuing the chain.
+- **Source:** AAT §6.2 (no gaps; recovery record on crash), §6.3 orphaned sessions → synthetic close with `trigger: crash_recovery`.
+- **Why it beats silent resume:** Our `seedFromTail` continues seq after restart with no breadcrumb that the process died. Operators cannot tell clean restart from crash hole.
+- **Cost:** One `lifecycle`/`error` audit type on startup if unclean shutdown flag present.
+- **Trap:** Without an unclean-shutdown flag (pid file / lock), you cannot know. Prefer lockfile or “session open without close” detection on next start.
+- **Confidence:** docs.
+
+---
+
+## Roadmap items where nothing clearly beat our plan
+
+| Item | Note |
+|------|------|
+| **User-facing verify command** | Algorithm is already ours (`verifyChain`); external world only reaffirms the procedure (AAT §4.3). Ship wiring, do not redesign. |
+| **instanceId = pid + startTime** | Sysmon ProcessGuid solves the same problem differently; our OS-startTime binding is appropriate for a user-mode app that will not ship a driver. No superior portable substitute found. |
+| **JSONL as canonical store** | Confirmed by AAT (JSONL primary) and by every serious “index is disposable” design. No finding says “replace JSONL with DB as truth.” |
+| **Drop-oldest on audit buffer under full disk** | Operationally sound for a monitor; Vector offers alternatives but does not obsolete the policy choice we made. Markers for loss visibility are already better than most ship. |
+| **Attribution evidence enums** | No external schema matched our `confirmed` / `inferred` / `unattributed` + evidence codes better than keeping them; OCSF can carry them as custom extensions if needed. |
+
+---
+
+## Roadmap items where our plan is clearly weaker than what exists
+
+| Item | Gap | Steal |
+|------|-----|-------|
+| **Canonical hashing** | Homemade key-sort ≠ RFC 8785 | Adopt JCS (`canonicalize` or equivalent) on the next chain version |
+| **Audit field taxonomy / regulatory mapping** | Private v1 schema only | Map/export toward AAT for agent-level semantics; OCSF for OS events |
+| **Crash-safe event pipeline** | Memory buffer only; kill = silent loss beyond best-effort markers | Vector disk_v2 design (segmented files + ledger + CRC + policies) |
+| **Sequence / correlation rules** | Flat YAML, no join/window/missing | Sigma correlation subset + EQL-style missing events |
+| **Replay + ground-truth bench** | Live scenario bench built (`bench/`, Sysmon/Procmon oracle, Windows-only, never in CI); offline replay from recorded fixtures still unbuilt | AgentSight-style offline report path over recorded pre-attribution observations |
+| **SQLite index + query CLI** | Planned, not built | AgentSight CLI verb set + rebuild-from-JSONL discipline |
+| **Health / sleep / sensor death** | State machine built in main (`sensor-health.js`: FS chokidar/handle/RM + network); no scan-loop record, no renderer consumer, no sleep/wake handling | osquery-style publisher state for the remaining subsystems + ETW loss counters + Electron `powerMonitor` |
+| **Second sensor** | Not started | Sysmon/ETW shadow + discrepancy report (read-only) |
+| **Recovery after mistake / crash hole** | Resume chain with no gap record | AAT tombstone/compensating record + startup gap marker + durable queue recovery |
+
+---
+
+## Explicitly rejected (out of scope or not stronger)
+
+- **Writing** filesystem minifilters / custom kernel drivers — rejected; reading Sysmon/ETW is fine.
+- **TLS interception / HTTPS proxy** (AgentSight SSL path, MITM) — out of scope.
+- **Reading foreign process memory** — out of scope.
+- **Automatic containment / kill as a product feature** — out of scope (own-PID guards stay).
+- **Per-event numeric confidence / risk fractions in product** (AAT optional `risk_score`, AgentSight `confidence` columns) — banned until ground-truth bench exists; bench aggregate metrics are allowed.
+- **Community rule marketplaces** — out of scope.
+- **Embedding full Vector or Elasticsearch** — too heavy; steal designs, not products.
+
+---
+
+*Generated as a recon-only deliverable. Single write path: this file. No code changes, no PRs.
+Re-verified against `master` @ `d027f0c` on 2026-08-13 before it entered git; the corrections are
+marked **[since recon]** in place rather than appended, so no superseded claim is left standing.*


### PR DESCRIPTION
Clears the three tails that were sitting in the working tree.

## CLAUDE.md

Three figures were quoted that go stale on the next merge with nothing to turn red
(`ai-mistakes.md` #24): the version, the Vitest count, and the renderer component count.
Each is replaced by the command that derives it.

## Two recon documents, re-verified before they entered git

Both were written read-only and left untracked. Neither was filed as-is — each was
re-checked against `d027f0c` first, because a snapshot committed with stale present-tense
claims is exactly the false-confidence class these documents were written to catch.

### `docs/current-state/CORRECTNESS-AUDIT.md`

Committed because **ten** of its findings are still open at `d027f0c` — twelve if the two
marked BY DESIGN are counted as not-closed — and nothing else in the tree records them:
`memory-bank/progress.md` carries only the fixed ones.

> Correction: the commit message and the first version of this description said
> "fourteen". The document's own shortlist lists ten OPEN findings (F-E04, F-E06, F-E07,
> F-E09, F-E10, F-E11, F-S02, F-S04, F-S05, F-S06) and two BY DESIGN (F-E08, F-E12).
> Fourteen was derivable from neither. The commit message is in merged history and is left
> as written rather than rewritten; this description is the corrected record.

What changed against the untracked draft:

- **All eleven Tier-1 findings had been fixed** since the 2026-08-08 audit. Eleven
  present-tense "User sees:" blocks describing defects that no longer exist were replaced
  by a closed-findings table pointing at `progress.md` and at the code sites that carry the
  finding IDs.
- **F-E01, F-E02, F-E03, F-E05, F-S01, F-S03, F-S07** marked CLOSED with the evidence that
  closes each.
- **F-E08 and F-E12** marked BY DESIGN: the code now states the rationale in place, so
  leaving them in an open backlog would be its own stale claim. F-S05 is split — the state
  machine landed in main, the UI half did not.
- **Counts table re-measured** and each row given the command that produced it: 46 main
  modules → **50** (38 top-level + 10 `platform/` + 2 `token-adapters/`), 16 utils → **21**,
  47 components (48 tracked `.svelte` in total), evidence codes still **7**.
- **Line anchors re-checked** on every finding that is still open; anchors inside CLOSED
  entries are left alone and labelled as describing a tree that no longer exists.

### `docs/recon/EXTERNAL-TECHNIQUES.md`

Committed because it is external-technique recon with sources — RFC 8785, the AAT draft,
OCSF, Vector `disk_v2`, Sigma correlation, EQL, osquery — and none of it is recorded
anywhere else in the repo.

Three baseline claims had gone stale and are corrected in place, marked `[since recon]` so
no superseded claim is left standing:

- **"no replay/ground-truth bench"** — false on this very branch point. `bench/` exists with
  a Sysmon/Procmon oracle (`npm run bench:run`, `S1-agent-lifecycle`). What is still unbuilt
  is offline replay from recorded fixtures; §5 now says that instead.
- **"`resource-monitor.js` still keyed by pid"** — false. The TTL cache keys on `instanceId`,
  pid rides along for display only, and the push §2.2 warned about is renamed
  `agent-resource-usage` and consumed. §2.2 is marked adopted.
- **§3.1 sensor health** — `sensor-health.js` already supplies the publisher-state machine it
  recommends, for the FS and network sensors. The open half is that no renderer file reads it
  and the process scan holds no record at all.

Verified as still true and left alone: no user-facing `verify` CLI (`cli.js` has
`--scan-json`, `--version`, `--help`), no SQLite index, no second sensor, `BUFFER_CAP = 500`,
no stored `prevHash`, and the `audit-hashchain.js` line anchors.

## Gates

All seven run locally on the branch: `build:renderer`, `format:check`, `lint`, `typecheck`
(both projects), `typecheck:svelte` (385 files, 0 errors), `test:coverage` (93 files, 1563
passed / 4 skipped), `npm audit` (0 vulnerabilities).

Docs-only change: no file in this diff matches the prettier or eslint globs (`*.md` is in
`.prettierignore`).
