### PR TITLE
feat(bench): join the catalogue against the observation set and write run-report.json

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -58,8 +58,9 @@ The `--` is required; without it npm keeps the flags.
 In arm A a run takes roughly three minutes: about ninety seconds of it is waiting for the sensor's
 scan cadence to settle, then the scenario, then three more scan ticks and a flush drain.
 
-Exit codes: **0** the run completed · **1** a step failed to execute, or the sensor could not be run
-or read · **2** the invocation or the scenario was wrong and nothing ran. A scenario is loaded and
+Exit codes: **0** the run completed · **1** a step failed to execute, the sensor could not be run
+or read, or the run report could not be derived · **2** the invocation or the scenario was wrong and
+nothing ran. A scenario is loaded and
 validated *before* the run directory exists, so a wrong scenario leaves no empty run behind; a step
 that fails happens after, and leaves the directory holding the catalogue of everything that did
 happen first.
@@ -77,7 +78,7 @@ for a given deterministic scenario, and only then does A score the sensor agains
 
 ## Layout
 
-Present today (sub-blocks B2.1, B2.2 and the arm-A capture):
+Present today (sub-blocks B2.1, B2.2, the arm-A capture and the first join):
 
 ```
 bench/
@@ -88,6 +89,7 @@ bench/
   lib/catalogue.js                          # writes expected.ndjson; refuses a line it did not observe
   lib/sensor.js                             # runs AEGIS across a run; readiness, ticks, stop
   lib/observed.js                           # writes observed.ndjson out of the product's audit log
+  lib/join.js                               # joins the two, shapes run-report.json; no I/O at all
   scenarios/S1-agent-lifecycle/scenario.json
   runs/                                     # run artefacts — gitignored, created on first run
   README.md
@@ -99,7 +101,7 @@ built — nothing below exists yet:
 | path | sub-block |
 |---|---|
 | `bench/lib/oracles/sysmon.js`, `bench/oracles/sysmon-bench.xml` | B2.3 |
-| `bench/score.js`, `bench/lib/join.js`, `bench/lib/metrics.js` | B2.5 |
+| `bench/score.js`, `bench/lib/metrics.js` | B2.5 |
 | `bench/lib/oracles/procmon.js`, `bench/oracles/procmon-bench.pmc` | B2.6 |
 | `bench/report.js` | B2.9 |
 
@@ -319,6 +321,95 @@ number is read as a property of the sensor:
 - **The readiness signal exists because the app runs from source.** `logger.js` mirrors to stderr only
   while `isDev` — that is, `!app.isPackaged`. Benching a packaged build would need a different signal.
 
+## The join — `run-report.json`
+
+At the end of an arm-A run the catalogue and the observation set are joined, and the result is
+written to `run-report.json`: per category, how many events were expected, how many the sensor
+accounted for, and how long it took. This is the first row of the measurement matrix and it scores
+the sensor against the catalogue only — an unconfirmed catalogue, until B2.3's oracle confirms it.
+
+`bench/lib/join.js` **reads and writes nothing**. It takes two arrays and the window parameters and
+returns an object; `run.js` owns every byte that touches the disk. A unit test asserts the module
+requires no filesystem API at all, because a join that could reach for a fact it was not handed
+could also disagree with the files the report claims to be about.
+
+### What joins to what
+
+| category | key | why that key and no other |
+|---|---|---|
+| `process/start`, `process/end` | `process.pid` | pid is the only join key the audit gives a process event |
+| `file/creation`, `file/deletion` | `file.path`, case- and separator-normalised | path is the only one it gives a file event; the product does not persist the owner of a file event |
+
+**Nothing joins on a name.** AEGIS persists the display name it resolved — `"Claude Code"` — and
+never the image name, `claude.exe` (B2.3). They are different strings about different things, and a
+join that treated one as the other would manufacture matches out of a naming coincidence. The
+display name rides `bench.agent`, where no join reads it.
+
+Path normalisation folds separators to `\` and the whole string to lower case, because
+`X:/Future\AEGIS` and `x:\future\aegis` name one file on the platform the bench runs on. That is a
+Windows fact rather than a general one: a bench on another platform would need a different rule, not
+this one relaxed.
+
+The window is `[expected.@timestamp, expected.@timestamp + maxLatency]`. **One observed event cancels
+at most one expectation**, and one expectation is cancelled by at most one observation: every
+eligible pair is scored by its latency and taken in ascending order, so the nearest pairing wins and
+a later expectation may take an observation an earlier one could also have used. Ties break on file
+order, so the report is reproducible from the two files it was derived from.
+
+### Where `maxLatency` comes from
+
+`maxLatency` is **three scan intervals**, and the interval is read off the run rather than written
+into the code. Two sources, in order, each one a thing that happened:
+
+1. `scanIntervalSec` in the run-scoped profile's `settings.json` — the configuration the sensor
+   loaded. AEGIS writes that file as soon as it persists anything, and seeing an agent is enough.
+2. The median gap between the scan ticks the sensor itself reported **after its cadence settled**.
+   Only after: before that it is on the startup schedule at three times the configured interval, and
+   those gaps describe the wrong regime. No run has needed this source yet — every arm-A run so far
+   found the settings file — so it is pinned by a unit test rather than by a run.
+
+Neither answered → the interval is **absent and stays absent**. There is no third source, because
+the third source would be a literal. The report is still written, every recall in it reads
+`unavailable`, and the run exits 1: a recall figure is a statement about a window, and a window
+nobody derived is not one.
+
+It is not in `manifest.json`, and cannot be: `manifest.collect()` runs before the sensor starts, so
+the profile it would have to read does not exist yet, and a value copied out of the product's
+defaults would be `src/` contributing to its own measurement record. It is recorded in
+`observed.meta.json` as `sensor.scanInterval` — `{value, source}`, the manifest's own convention —
+and again in the report as `join.maxLatencySource`.
+
+Three intervals is **not** generous for `process/end`. AEGIS reports an end only after
+`session-tracker.js`'s grace of two consecutive scans that missed the process, so that category's
+floor is already two intervals plus the scan that concludes it. A `process/end` that lands past the
+bound is a miss produced by the window, which is why every miss in the report names the nearest
+observation there was and the signed distance to it — including a **negative** one. The actor stamps
+around the step and the audit stamps inside its own `log()` call, so an observation stamped a few
+milliseconds before its expectation is a stamping artefact, and the report says that instead of
+counting it as a sensor failure.
+
+### What the report says
+
+- **Per category** — `expected`, `matched`, `missed`, and `recall` both as the string `matched/expected`
+  and as a number. Where a number would be a lie the number is `null` and a `recallUnavailable`
+  line says why: a category the catalogue never expected is `0/0`, not a recall of 0.
+- **Latency** — every pair's `observedTs − expectedTs` in milliseconds, and per category a `p50` and
+  a `max` over the matched pairs. With one or two pairs — which is what one S1 run produces — the
+  `basis` field says those figures **are the points themselves, not statistics over a sample**.
+- **`unmatchedObserved`** — observations inside the run window that cancelled nothing, each with the
+  reason it could not. They are not debris: an unmatched observation is either sensor noise or
+  activity on the machine the scenario did not cause, and both are findings.
+- **`processObservable`** — `false` when no completed scan tick fell inside the scenario's own
+  process lifetime. Then the process categories read `0/N (structurally unobservable)` with a null
+  recall number: the process was never in front of the sensor, so this is not a coverage result and
+  it is named rather than dissolved into the general `missed`. **The run is still valid and still
+  exits 0** — what failed is the phase alignment, not the sensor, and not the run. If such a run
+  matched something anyway, the category carries a `note` saying the tick accounting and the
+  observation disagree.
+
+**There is no confidence figure in this report and there will not be one.** Every number it carries
+is a count of rows or a difference of two timestamps.
+
 ## Run artefacts
 
 One run is one directory under `bench/runs/`, named `<UTC instant>-<scenario>-<arm>`. The
@@ -327,10 +418,11 @@ machines' artefacts into one record.
 
 `manifest.json` is written today, and `expected.ndjson` plus a `stage/` directory whenever a
 scenario was named. `stage/` holds the binaries the scenario copied; S1 deletes its own, so the
-directory is normally left empty. In arm A there are two more: `observed.ndjson`, what the sensor
-recorded, and `observed.meta.json`, how it was run and what did not become a line of it. The
-remaining files arrive with the sub-blocks that produce them: `oracle-sysmon.ndjson`,
-`oracle-procmon.ndjson`, `oracle-loss.json`, `matched.ndjson`, `metrics.json`.
+directory is normally left empty. In arm A there are three more: `observed.ndjson`, what the sensor
+recorded; `observed.meta.json`, how it was run and what did not become a line of it; and
+`run-report.json`, the two joined. The remaining files arrive with the sub-blocks that produce them:
+`oracle-sysmon.ndjson`, `oracle-procmon.ndjson`, `oracle-loss.json`, `matched.ndjson`,
+`metrics.json`.
 
 The Electron profile a run created is **left behind** in the OS temp directory, and its path is in
 `observed.meta.json`. It holds the audit file `observed.ndjson` was derived from, which is the

--- a/bench/lib/join.js
+++ b/bench/lib/join.js
@@ -1,0 +1,558 @@
+/**
+ * @file bench/lib/join.js
+ * @module bench/lib/join
+ * @description Joins one run's expected-event catalogue to what the sensor
+ *   recorded, and shapes the result into `run-report.json` — the first row of the
+ *   measurement matrix.
+ *
+ *   **Nothing here reads or writes a file.** The input is two arrays of ECS
+ *   documents plus the window parameters; the output is a plain object. A unit
+ *   test pins that: a join that could reach the filesystem could also reach for a
+ *   fact it was not given.
+ *
+ *   The join is deliberately narrow, because the audit persists less than the
+ *   actor observed (B2.3):
+ *
+ *   - **A process expectation joins on `process.pid` alone.** pid is the only key
+ *     the audit gives a process event.
+ *   - **A file expectation joins on the normalised absolute path alone.** Path is
+ *     the only key the audit gives a file event; the product does not persist the
+ *     owner of a file event at all.
+ *   - **Nothing joins on a name.** AEGIS persists the display name it resolved —
+ *     `"Claude Code"` — and never the image name (`claude.exe`). The two are
+ *     different strings about different things, and a join that treated one as
+ *     the other would manufacture matches out of a naming coincidence.
+ *
+ *   The window is `[expected.@timestamp, expected.@timestamp + maxLatencyMs]`,
+ *   half-open at neither end and never widened here: `maxLatencyMs` arrives as a
+ *   parameter with the source that produced it, and is written into the report so
+ *   every recall figure carries the bound it was measured against.
+ *
+ *   One observed event cancels at most one expectation, and one expectation is
+ *   cancelled by at most one observed event. Where several pairings are eligible
+ *   the nearest in time wins — every candidate pair is scored by its latency and
+ *   assigned in ascending order, so a later expectation may take an observation an
+ *   earlier one could also have used, if it is nearer to it.
+ *
+ *   Two refusals to dissolve a cause into a count:
+ *
+ *   - **A miss names its nearest candidate.** An observation stamped BEFORE its
+ *     expectation, or one that arrived past the bound, is a different finding from
+ *     "the sensor never saw it", and the reason says which.
+ *   - **A structurally unobservable process category is labelled, not scored.**
+ *     When no scan tick fell inside the scenario's process lifetime the process
+ *     was never in front of the sensor, and `0/N` there is not a coverage result.
+ *     The recall string says so and the numeric recall is `null` rather than 0 —
+ *     the same convention `manifest.js` uses for a fact it could not read.
+ *
+ *   There is no confidence figure in the report and there will not be one. Every
+ *   number it carries is a count of rows or a difference of two timestamps.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.11.0
+ */
+'use strict';
+
+/** @type {number} Report shape version. Bump when a field changes meaning. */
+const SCHEMA_VERSION = 1;
+
+/** @type {string} Name of the run report inside a run directory. */
+const REPORT_FILENAME = 'run-report.json';
+
+/**
+ * The categories S1 produces, as `event.category/event.type`. A closed set: a
+ * category that is not here is not scored, and a run that produced one would be
+ * reporting on a shape the catalogue cannot write.
+ * @type {ReadonlyArray<string>}
+ */
+const CATEGORIES = Object.freeze([
+  'process/start',
+  'process/end',
+  'file/creation',
+  'file/deletion',
+]);
+
+/** @type {ReadonlyArray<string>} The subset `processObservable` speaks about. */
+const PROCESS_CATEGORIES = Object.freeze(['process/start', 'process/end']);
+
+/**
+ * What the join keys on, per category. Written into the report so a reader never
+ * has to guess which field produced a match.
+ * @type {Readonly<Object<string, string>>}
+ */
+const JOIN_KEYS = Object.freeze({
+  'process/start': 'process.pid',
+  'process/end': 'process.pid',
+  'file/creation': 'file.path, case- and separator-normalised',
+  'file/deletion': 'file.path, case- and separator-normalised',
+});
+
+/** An error in the join's own inputs — never a finding about the sensor. */
+class JoinError extends Error {
+  /**
+   * @param {string} stage - One of `bad-window`, `bad-events`.
+   * @param {string} message - What a reader needs in order to act.
+   */
+  constructor(stage, message) {
+    super(message);
+    this.name = 'JoinError';
+    this.stage = stage;
+  }
+}
+
+/**
+ * One comparable form of a Windows path.
+ *
+ * Separators collapse to `\` and the whole string folds to lower case, because
+ * `X:/Future\\AEGIS` and `x:\future\aegis` name one file on the platform the
+ * bench runs on. Case folding is a Windows fact, not a general one — this module
+ * is only ever handed paths the bench captured on Windows, and a POSIX bench
+ * would need a different rule rather than this one relaxed.
+ * @param {*} value - A path exactly as the catalogue or the audit recorded it.
+ * @returns {string|null} Null when there was no path to normalise.
+ */
+function normalizePath(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const unified = trimmed.replace(/[\\/]+/g, '\\').replace(/\\+$/, '');
+  // A bare drive letter is a directory, not a name: `X:` and `X:\` are the same
+  // place, and stripping the separator off the root would make them differ.
+  return (/^[A-Za-z]:$/.test(unified) ? `${unified}\\` : unified).toLowerCase();
+}
+
+/**
+ * The `category/type` of an ECS document, when it is one this report scores.
+ * @param {Object} event
+ * @returns {string|null}
+ */
+function categoryOf(event) {
+  const block = event && event.event;
+  if (!block || !Array.isArray(block.category) || !Array.isArray(block.type)) return null;
+  const name = `${block.category[0]}/${block.type[0]}`;
+  return CATEGORIES.includes(name) ? name : null;
+}
+
+/**
+ * The one field this category joins on, rendered as a comparable string.
+ *
+ * A file event carries a pid in the catalogue (the actor's own) and carries none
+ * in the audit, so a file NEVER keys on pid — the category decides the key, not
+ * whichever fields happen to be present.
+ * @param {Object} event
+ * @param {string} category - From {@link categoryOf}.
+ * @returns {string|null} Null when the event carries no usable key.
+ */
+function joinKeyOf(event, category) {
+  if (PROCESS_CATEGORIES.includes(category)) {
+    const pid = event && event.process ? event.process.pid : undefined;
+    return Number.isSafeInteger(pid) && pid > 0 ? `pid:${pid}` : null;
+  }
+  const normalised = normalizePath(event && event.file ? event.file.path : undefined);
+  return normalised === null ? null : `path:${normalised}`;
+}
+
+/**
+ * Reduce one side of the join to rows carrying everything the matcher needs.
+ * @param {Object[]} events - ECS documents.
+ * @param {string} side - `expected` or `observed`, for a refusal message.
+ * @returns {Object[]} One row per event, in input order.
+ * @throws {JoinError} When an event carries no timestamp that is an instant.
+ */
+function index(events, side) {
+  if (!Array.isArray(events)) {
+    throw new JoinError('bad-events', `the ${side} side of the join is not an array of events`);
+  }
+  return events.map((event, i) => {
+    const at = Date.parse(event && event['@timestamp']);
+    if (!Number.isFinite(at)) {
+      throw new JoinError(
+        'bad-events',
+        `${side} event ${i} carries @timestamp ${JSON.stringify(event && event['@timestamp'])}, ` +
+          'which is not a UTC instant — a row with no instant can be neither inside a window nor ' +
+          'outside one',
+      );
+    }
+    const category = categoryOf(event);
+    return {
+      i,
+      event,
+      at,
+      category,
+      key: category ? joinKeyOf(event, category) : null,
+      used: false,
+    };
+  });
+}
+
+/**
+ * Assign observed events to expectations, nearest pair first.
+ *
+ * Every eligible pair — same category, same key, `0 ≤ observed − expected ≤
+ * maxLatencyMs` — is scored by its latency and taken in ascending order, so the
+ * nearest pairing always wins and neither side is ever used twice. Ties break on
+ * input order, which makes the result of a run reproducible from its two files.
+ * @param {Object[]} expected - From {@link index}.
+ * @param {Object[]} observed - From {@link index}.
+ * @param {number} maxLatencyMs
+ * @returns {Array<{expected: Object, observed: Object, latencyMs: number}>}
+ */
+function assign(expected, observed, maxLatencyMs) {
+  const candidates = [];
+  for (const e of expected) {
+    if (!e.category || e.key === null) continue;
+    for (const o of observed) {
+      if (o.category !== e.category || o.key !== e.key) continue;
+      const latencyMs = o.at - e.at;
+      if (latencyMs < 0 || latencyMs > maxLatencyMs) continue;
+      candidates.push({ e, o, latencyMs });
+    }
+  }
+  candidates.sort((a, b) => a.latencyMs - b.latencyMs || a.e.i - b.e.i || a.o.i - b.o.i);
+
+  const pairs = [];
+  for (const candidate of candidates) {
+    if (candidate.e.used || candidate.o.used) continue;
+    candidate.e.used = true;
+    candidate.o.used = true;
+    pairs.push({ expected: candidate.e, observed: candidate.o, latencyMs: candidate.latencyMs });
+  }
+  return pairs;
+}
+
+/**
+ * The counterpart on the other side that came closest to this row, whether or not
+ * it was eligible. This is what keeps a window artefact from reading as a miss.
+ * @param {Object} row - From {@link index}.
+ * @param {Object[]} others - The other side, from {@link index}.
+ * @param {number} sign - `1` when `others` is the observed side, `-1` when it is
+ *   the expected side, so the reported latency always reads observed − expected.
+ * @returns {{row: Object, latencyMs: number}|null}
+ */
+function nearest(row, others, sign) {
+  let best = null;
+  for (const other of others) {
+    if (other.category !== row.category || other.key !== row.key) continue;
+    const latencyMs = sign * (other.at - row.at);
+    if (best === null || Math.abs(latencyMs) < Math.abs(best.latencyMs)) {
+      best = { row: other, latencyMs };
+    }
+  }
+  return best;
+}
+
+/**
+ * Why an expectation was not cancelled, naming the nearest observation there was.
+ * @param {Object} row - The unmatched expectation.
+ * @param {Object[]} observed - From {@link index}.
+ * @param {number} maxLatencyMs
+ * @returns {string}
+ */
+function missReason(row, observed, maxLatencyMs) {
+  if (!row.category) return 'the expectation carries no category this report scores';
+  if (row.key === null) {
+    return `the expectation carries no ${JOIN_KEYS[row.category]} to join on`;
+  }
+  const near = nearest(row, observed, 1);
+  if (!near) {
+    return `no observed ${row.category} carries ${row.key} at all`;
+  }
+  if (near.latencyMs < 0) {
+    return (
+      `the nearest observed ${row.category} for ${row.key} is stamped ${-near.latencyMs} ms ` +
+      'BEFORE the expectation, so it is outside the window. A negative latency is a stamping ' +
+      'artefact — the actor stamps around the step and the audit stamps inside its own log call ' +
+      '— and is not a coverage result'
+    );
+  }
+  if (near.latencyMs > maxLatencyMs) {
+    return (
+      `the nearest observed ${row.category} for ${row.key} arrived ${near.latencyMs} ms later, ` +
+      `past the ${maxLatencyMs} ms bound this run joined on`
+    );
+  }
+  return (
+    `the only in-window observed ${row.category} for ${row.key} (${near.latencyMs} ms) was taken ` +
+    'by a nearer expectation — one observed event cancels at most one expectation'
+  );
+}
+
+/**
+ * Why an observation cancelled nothing. Unmatched observations are signal, not
+ * debris: sensor noise, or activity on the machine the scenario did not cause.
+ * @param {Object} row - The unmatched observation.
+ * @param {Object[]} expected - From {@link index}.
+ * @param {number} maxLatencyMs
+ * @returns {string}
+ */
+function unmatchedReason(row, expected, maxLatencyMs) {
+  if (!row.category) return 'the observation carries no category this report scores';
+  if (row.key === null) return `the observation carries no ${JOIN_KEYS[row.category]} to join on`;
+  const near = nearest(row, expected, -1);
+  if (!near) {
+    return `the catalogue expects no ${row.category} for ${row.key} — this run did not cause it`;
+  }
+  if (near.latencyMs < 0) {
+    return (
+      `it is stamped ${-near.latencyMs} ms BEFORE the nearest ${row.category} expectation for ` +
+      `${row.key}, so it cannot be that expectation's observation`
+    );
+  }
+  if (near.latencyMs > maxLatencyMs) {
+    return (
+      `the nearest ${row.category} expectation for ${row.key} is ${near.latencyMs} ms earlier, ` +
+      `past the ${maxLatencyMs} ms bound this run joined on`
+    );
+  }
+  return `the nearest ${row.category} expectation for ${row.key} was cancelled by another observation`;
+}
+
+/**
+ * Nearest-rank percentile: the value at rank `ceil(p · n)` of the sorted sample.
+ * @param {number[]} sorted - Ascending, non-empty.
+ * @param {number} p - In (0, 1].
+ * @returns {number}
+ */
+function nearestRank(sorted, p) {
+  return sorted[Math.max(1, Math.ceil(p * sorted.length)) - 1];
+}
+
+/**
+ * The latency block of one category.
+ *
+ * A sample of one or two is reported as the points it is. Calling two numbers a
+ * p50 and a max invites the reader to treat them as a distribution, and this
+ * bench produces exactly one pair per category per S1 run.
+ * @param {number[]} points - Latencies of that category's matched pairs.
+ * @returns {{points: number[], p50: number|null, max: number|null, basis: string}}
+ */
+function latencyBlock(points) {
+  const sorted = [...points].sort((a, b) => a - b);
+  if (sorted.length === 0) {
+    return { points: [], p50: null, max: null, basis: 'no matched pair — no latency was measured' };
+  }
+  return {
+    points: sorted,
+    p50: nearestRank(sorted, 0.5),
+    max: sorted[sorted.length - 1],
+    basis:
+      sorted.length <= 2
+        ? `${sorted.length} matched ${sorted.length === 1 ? 'pair' : 'pairs'} — p50 and max ARE ` +
+          'those points, not statistics over a sample'
+        : `${sorted.length} matched pairs, nearest-rank percentile (rank ceil(p·n))`,
+  };
+}
+
+/**
+ * One category's counts, recall and latency.
+ * @param {Object} opts
+ * @param {string} opts.category
+ * @param {number} opts.expected
+ * @param {number} opts.matched
+ * @param {number[]} opts.latencies
+ * @param {boolean|null} opts.processObservable
+ * @param {string|null} opts.unavailable - Set when no join happened at all.
+ * @returns {Object}
+ */
+function categoryBlock(opts) {
+  const { category, expected, matched } = opts;
+  const block = {
+    expected,
+    matched: opts.unavailable ? null : matched,
+    missed: opts.unavailable ? null : expected - matched,
+    recall: '',
+    recallValue: null,
+    latencyMs: latencyBlock(opts.latencies),
+  };
+
+  if (opts.unavailable) {
+    block.recall = `unavailable — ${opts.unavailable}`;
+    block.recallUnavailable = opts.unavailable;
+    return block;
+  }
+  if (expected === 0) {
+    block.recall = '0/0';
+    block.recallUnavailable =
+      'the catalogue holds no expectation in this category, and a recall over nothing is not 0';
+    return block;
+  }
+
+  const unobservable =
+    opts.processObservable === false && PROCESS_CATEGORIES.includes(category) && matched === 0;
+  if (unobservable) {
+    block.recall = `0/${expected} (structurally unobservable)`;
+    block.recallUnavailable =
+      'no scan tick fell inside the process lifetime — the process was never in front of the ' +
+      'sensor, so this is not a coverage result and no number is derived from it';
+    return block;
+  }
+
+  block.recall = `${matched}/${expected}`;
+  block.recallValue = matched / expected;
+  if (opts.processObservable === false && PROCESS_CATEGORIES.includes(category)) {
+    block.note =
+      'the tick accounting says no scan fell inside the process lifetime, yet an observation ' +
+      'matched — the two disagree, and this recall should not be read until they are reconciled';
+  }
+  return block;
+}
+
+/**
+ * The catalogue-side identity of a row: which step made it, which expectation it
+ * claimed.
+ * @param {Object} row - From {@link index}.
+ * @returns {Object}
+ */
+function expectedRef(row) {
+  const bench = row.event.bench || {};
+  return {
+    index: row.i,
+    '@timestamp': row.event['@timestamp'],
+    step: bench.step ?? null,
+    expect: bench.expect ?? null,
+  };
+}
+
+/**
+ * The audit-side identity of a row: which record of which chained file it came
+ * out of, so any line of the report can be walked back to its evidence.
+ * @param {Object} row - From {@link index}.
+ * @returns {Object}
+ */
+function observedRef(row) {
+  const bench = row.event.bench || {};
+  const ref = {
+    index: row.i,
+    '@timestamp': row.event['@timestamp'],
+    auditFile: bench.auditFile ?? null,
+    auditSeq: bench.auditSeq ?? null,
+    auditType: bench.auditType ?? null,
+  };
+  if (bench.agent !== undefined) ref.agent = bench.agent;
+  if (bench.instanceId !== undefined) ref.instanceId = bench.instanceId;
+  if (bench.attribution !== undefined) ref.attribution = bench.attribution;
+  return ref;
+}
+
+/**
+ * Join one run's two event sets and shape the whole report.
+ * @param {Object} opts
+ * @param {string} opts.runId
+ * @param {string} opts.scenario
+ * @param {string} opts.arm
+ * @param {Object[]} opts.expected - The catalogue, as ECS documents.
+ * @param {Object[]} opts.observed - The observation set, as ECS documents.
+ * @param {{value: number|null, source: string, unavailable?: string}} opts.maxLatency -
+ *   The join bound and where it came from, in `manifest.js`'s convention: a null
+ *   value carries the reason it is null and no join is performed.
+ * @param {number|null} opts.ticksWhileProcessAlive - Completed scan ticks inside
+ *   the scenario's own process lifetime, or null when there was no lifetime.
+ * @returns {Object} The report, ready to serialize.
+ * @throws {JoinError} On a malformed bound or an event with no instant.
+ */
+function buildReport(opts) {
+  const bound = opts.maxLatency || {};
+  if (bound.value !== null && bound.value !== undefined) {
+    if (!Number.isFinite(bound.value) || bound.value <= 0) {
+      throw new JoinError(
+        'bad-window',
+        `maxLatency ${JSON.stringify(bound.value)} is not a positive number of milliseconds — a ` +
+          'join window is derived from the run or it is absent, never defaulted',
+      );
+    }
+  }
+  const maxLatencyMs = bound.value ?? null;
+  const unavailable =
+    maxLatencyMs === null ? (bound.unavailable ?? 'no reason was recorded') : null;
+
+  const expected = index(opts.expected, 'expected');
+  const observed = index(opts.observed, 'observed');
+  const pairs = unavailable ? [] : assign(expected, observed, maxLatencyMs);
+
+  const ticks = opts.ticksWhileProcessAlive;
+  const processObservable = ticks === null || ticks === undefined ? null : ticks > 0;
+
+  const categories = {};
+  for (const category of CATEGORIES) {
+    const inCategory = pairs.filter((p) => p.expected.category === category);
+    categories[category] = categoryBlock({
+      category,
+      expected: expected.filter((e) => e.category === category).length,
+      matched: inCategory.length,
+      latencies: inCategory.map((p) => p.latencyMs),
+      processObservable,
+      unavailable,
+    });
+  }
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    runId: opts.runId,
+    scenario: opts.scenario,
+    arm: opts.arm,
+    join: {
+      maxLatencyMs,
+      maxLatencySource: bound.source ?? null,
+      unavailable,
+      window: 'observed ∈ [expected.@timestamp, expected.@timestamp + maxLatencyMs]',
+      keys: JOIN_KEYS,
+      notJoinedOn:
+        'a name. AEGIS persists the display name it resolved ("Claude Code"), never the image ' +
+        'name ("claude.exe"), so the two sides hold different strings about different things and ' +
+        'a name join would manufacture matches (B2.3)',
+      cardinality:
+        'one observed event cancels at most one expectation; where several pairings are eligible ' +
+        'the nearest in time wins',
+      noConfidenceFigure:
+        'every number here is a count of rows or a difference of two timestamps. This report ' +
+        'carries no confidence score and none is derived from it',
+    },
+    processObservable,
+    ticksWhileProcessAlive: ticks ?? null,
+    categories,
+    matched: pairs.map((p) => ({
+      category: p.expected.category,
+      key: p.expected.key,
+      latencyMs: p.latencyMs,
+      expected: expectedRef(p.expected),
+      observed: observedRef(p.observed),
+    })),
+    missed: expected
+      .filter((e) => !e.used)
+      .map((e) => ({
+        category: e.category,
+        key: e.key,
+        expected: expectedRef(e),
+        reason: unavailable
+          ? `no join was performed — ${unavailable}`
+          : missReason(e, observed, maxLatencyMs),
+      })),
+    unmatchedObserved: observed
+      .filter((o) => !o.used)
+      .map((o) => ({
+        category: o.category,
+        key: o.key,
+        observed: observedRef(o),
+        reason: unavailable
+          ? `no join was performed — ${unavailable}`
+          : unmatchedReason(o, expected, maxLatencyMs),
+      })),
+  };
+}
+
+module.exports = {
+  CATEGORIES,
+  JOIN_KEYS,
+  JoinError,
+  PROCESS_CATEGORIES,
+  REPORT_FILENAME,
+  SCHEMA_VERSION,
+  assign,
+  buildReport,
+  categoryOf,
+  index,
+  joinKeyOf,
+  latencyBlock,
+  nearestRank,
+  normalizePath,
+};

--- a/bench/run.js
+++ b/bench/run.js
@@ -6,13 +6,15 @@
  *
  *   In **arm A** it also runs the AEGIS sensor across the scenario and writes
  *   what the sensor recorded to `observed.ndjson`, read back out of the
- *   product's own hash-chained audit log (`bench/lib/observed.js`). Arms B and C
- *   start nothing and write no observation set — arm C is defined as the sensor
+ *   product's own hash-chained audit log (`bench/lib/observed.js`), then joins
+ *   the two files and writes `run-report.json` (`bench/lib/join.js`) — recall and
+ *   latency per category, and the observations that cancelled nothing. Arms B and
+ *   C start nothing and write no observation set — arm C is defined as the sensor
  *   alone with no oracle, and measuring its overhead is a later block.
  *
- *   The oracle adapters (B2.6) are still a separate block: a run produces the
- *   record everything else will be scored against, and the sensor's answer next
- *   to it, and scores neither.
+ *   The oracle adapters (B2.6) are still a separate block: the report scores the
+ *   sensor against the catalogue and against nothing else, and the catalogue is
+ *   still unconfirmed until an oracle confirms it.
  *
  *   Order matters here, in three places.
  *
@@ -31,9 +33,9 @@
  *   would show up as a file creation in the sensor's own answer, a false
  *   positive the harness manufactured for itself.
  *
- *   Exit codes: 0 the run completed · 1 a step failed to execute, or the sensor
- *   could not be run or read · 2 the invocation or the scenario was wrong, and
- *   nothing ran.
+ *   Exit codes: 0 the run completed · 1 a step failed to execute, the sensor
+ *   could not be run or read, or the run report could not be derived · 2 the
+ *   invocation or the scenario was wrong, and nothing ran.
  *
  *   Usage:
  *     npm run bench:run
@@ -51,12 +53,30 @@ const path = require('path');
 
 const actor = require('./lib/actor');
 const catalogue = require('./lib/catalogue');
+const join = require('./lib/join');
 const manifest = require('./lib/manifest');
 const observed = require('./lib/observed');
 const sensor = require('./lib/sensor');
 
 /** @type {string} Where run directories are created. Gitignored. */
 const RUNS_DIR = path.join(manifest.ROOT, 'bench', 'runs');
+
+/**
+ * How many scan intervals a sensor is given to report something before the join
+ * stops calling it that expectation's observation.
+ *
+ * Three, and not fewer, because AEGIS reports a process end only after
+ * `session-tracker.js`'s grace of two consecutive scans that missed the process:
+ * the floor for `process/end` is already two intervals plus the scan that
+ * concludes it. It is not generous — a `process/end` that lands past the bound
+ * produces a miss that is a property of the window, which is why every miss in
+ * the report names its nearest candidate and the distance to it.
+ * @type {number}
+ */
+const MAX_LATENCY_INTERVALS = 3;
+
+/** @type {string} The settings file an Electron profile holds. */
+const SETTINGS_FILENAME = 'settings.json';
 
 /**
  * The one arm that runs the sensor. B is Sysmon and Procmon without it, and C
@@ -229,6 +249,93 @@ function processAliveWindow(events) {
 }
 
 /**
+ * The scan interval the sensor actually ran on, and where it was read.
+ *
+ * Not the manifest: `manifest.collect()` runs before the sensor exists, so the
+ * profile it would have to read has not been created yet — the manifest cannot
+ * carry this field honestly, and a value copied out of the product's defaults
+ * would be `src/` contributing to its own measurement record.
+ *
+ * Two sources, in order, and each one is a thing that happened rather than a
+ * constant:
+ *
+ * 1. `scanIntervalSec` in the run-scoped profile's `settings.json` — the
+ *    configuration the sensor loaded. AEGIS writes that file when it first
+ *    persists anything (seeing an agent is enough), so it normally exists by the
+ *    time a run ends, but nothing guarantees it.
+ * 2. The median gap between the scan ticks the sensor itself reported AFTER its
+ *    cadence settled. Only then: before that it is on the startup schedule at
+ *    three times the configured interval, and those gaps describe the wrong
+ *    regime.
+ *
+ * Neither one produced a number → the interval is ABSENT, and it stays absent.
+ * There is no third source, because the third source would be a literal.
+ * @param {Object} handle - The sensor handle, after it has been stopped.
+ * @returns {{value: number|null, source: string, unavailable?: string}} Seconds.
+ */
+function resolveScanInterval(handle) {
+  const settingsPath = path.join(handle.profileDir, SETTINGS_FILENAME);
+  try {
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    if (Number.isFinite(settings.scanIntervalSec) && settings.scanIntervalSec > 0) {
+      return { value: settings.scanIntervalSec, source: `scanIntervalSec in ${settingsPath}` };
+    }
+  } catch (_) {
+    // No settings file, or one that does not parse: the cadence is next.
+  }
+
+  if (handle.steadyCadence) {
+    const steady = handle.ticks.filter((t) => Date.parse(t) >= Date.parse(handle.steadyAt));
+    const gaps = [];
+    for (let i = 1; i < steady.length; i++) {
+      gaps.push(Date.parse(steady[i]) - Date.parse(steady[i - 1]));
+    }
+    gaps.sort((a, b) => a - b);
+    const median = gaps.length > 0 ? gaps[Math.ceil(gaps.length / 2) - 1] : null;
+    const seconds = median === null ? 0 : Math.round(median / 1000);
+    if (seconds > 0) {
+      return {
+        value: seconds,
+        source:
+          `the median gap (${median} ms) between the ${steady.length} scan ticks the sensor ` +
+          `reported after its cadence settled, rounded to whole seconds — ${settingsPath} ` +
+          'carried no usable scanIntervalSec',
+      };
+    }
+  }
+
+  return {
+    value: null,
+    source: `scanIntervalSec in ${settingsPath}, then the sensor's own settled scan cadence`,
+    unavailable:
+      `${settingsPath} carried no usable scanIntervalSec and the sensor never reported a settled ` +
+      'cadence to measure one from',
+  };
+}
+
+/**
+ * The join bound, from the interval — {@link MAX_LATENCY_INTERVALS} of them.
+ * @param {{value: number|null, source: string, unavailable?: string}} scanInterval
+ * @returns {{value: number|null, source: string, unavailable?: string}} Milliseconds.
+ */
+function maxLatencyFrom(scanInterval) {
+  if (scanInterval.value === null) {
+    return {
+      value: null,
+      source: scanInterval.source,
+      unavailable:
+        `the scan interval this run used could not be established — ${scanInterval.unavailable}. ` +
+        'A join window is derived from the run or it is absent; it is never defaulted, because ' +
+        'every recall figure in the report is a statement about that window',
+    };
+  }
+  return {
+    value: scanInterval.value * MAX_LATENCY_INTERVALS * 1000,
+    source: `${scanInterval.value} s × ${MAX_LATENCY_INTERVALS} scan intervals — ${scanInterval.source}`,
+  };
+}
+
+/**
  * Build the capture record — how the sensor was run and what did NOT become an
  * observation. Written in arm A whether the capture succeeded or refused: a run
  * directory holding no observations has to say why, or the next reader assumes
@@ -268,6 +375,9 @@ function buildCaptureRecord(opts) {
         "before-quit and the drain is what makes the last records durable via the logger's " +
         'own 5 s flush timer',
       exit: opts.handle.exit,
+      // Filled once the sensor has stopped: it is read off the profile the run
+      // created, which does not exist when the manifest is collected.
+      scanInterval: null,
       scanTicks: opts.handle.ticks,
       ticksRequestedAfterRun: sensor.POST_RUN_TICKS,
       ticksAfterRun: opts.ticksAfterRun,
@@ -295,7 +405,9 @@ function buildCaptureRecord(opts) {
  * @param {Object} opts.record - From {@link buildCaptureRecord}.
  * @param {boolean} opts.scenarioOk - Whether every step executed.
  * @param {function(string): void} opts.log
- * @returns {Promise<{record: Object, ok: boolean}>}
+ * @returns {Promise<{record: Object, ok: boolean, events: Object[]}>} The
+ *   observation set is handed back rather than read off disk again: the join runs
+ *   on the arrays this run produced, and `bench/lib/join.js` performs no I/O.
  */
 async function captureSensor(opts) {
   const { handle, record, log } = opts;
@@ -319,11 +431,12 @@ async function captureSensor(opts) {
   record.sensor.stoppedAt = handle.stoppedAt;
   record.sensor.exit = handle.exit;
   record.sensor.scanTicks = handle.ticks;
+  record.sensor.scanInterval = resolveScanInterval(handle);
   record.window.end = handle.stoppedAt;
   const alive = record.sensor.processAliveWindow;
   record.sensor.ticksWhileProcessAlive = sensor.ticksWithin(handle, alive.from, alive.to);
 
-  if (record.failure) return { record, ok: false };
+  if (record.failure) return { record, ok: false, events: [] };
 
   try {
     const captured = observed.capture({
@@ -343,11 +456,11 @@ async function captureSensor(opts) {
     record.observed = { path: observedPath, events: captured.events.length };
     log(`written ${observedPath} (${captured.events.length} observed event(s))`);
     for (const tail of captured.truncatedTails) log(`sensor  ${tail}`);
-    return { record, ok: true };
+    return { record, ok: true, events: captured.events };
   } catch (err) {
     if (!(err instanceof observed.ObservedError)) throw err;
     record.failure = { stage: err.stage, reason: err.message };
-    return { record, ok: false };
+    return { record, ok: false, events: [] };
   }
 }
 
@@ -407,6 +520,70 @@ function reportCapture(record) {
     );
     for (const line of lines) console.log(`  - ${line}`);
   }
+}
+
+/**
+ * Join the catalogue to the observation set and write the run report.
+ *
+ * Written after the sensor has stopped, for the same reason `expected.ndjson` is:
+ * the run directory sits inside the watched project directory, so a file created
+ * while the sensor is live becomes a file creation in the sensor's own answer.
+ * @param {Object} opts
+ * @param {string} opts.dir - Run directory.
+ * @param {string} opts.runId
+ * @param {string} opts.scenario
+ * @param {string} opts.arm
+ * @param {Object[]} opts.expected - The catalogue events, in memory.
+ * @param {Object} opts.capture - From {@link captureSensor}.
+ * @returns {Object} The report that was written.
+ */
+function writeReport(opts) {
+  const report = join.buildReport({
+    runId: opts.runId,
+    scenario: opts.scenario,
+    arm: opts.arm,
+    expected: opts.expected,
+    observed: opts.capture.events,
+    maxLatency: maxLatencyFrom(opts.capture.record.sensor.scanInterval),
+    ticksWhileProcessAlive: opts.capture.record.sensor.ticksWhileProcessAlive,
+  });
+  const file = path.join(opts.dir, join.REPORT_FILENAME);
+  fs.writeFileSync(file, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  console.log(`written ${file}`);
+  return report;
+}
+
+/**
+ * Say the report out loud: one line per category, and the two facts that decide
+ * whether its numbers may be read as coverage at all.
+ * @param {Object} report - From {@link writeReport}.
+ * @returns {void}
+ */
+function reportJoin(report) {
+  const bound = report.join.maxLatencyMs;
+  console.log(
+    `\njoin    [expected, expected + ${bound === null ? 'ABSENT' : `${bound} ms`}] — ` +
+      report.join.maxLatencySource,
+  );
+  for (const category of join.CATEGORIES) {
+    const block = report.categories[category];
+    const latency =
+      block.latencyMs.p50 === null ? 'no latency point' : `p50 ${block.latencyMs.p50} ms`;
+    console.log(`report  ${category.padEnd(14)} ${block.recall.padEnd(34)} ${latency}`);
+  }
+  if (report.processObservable === false) {
+    console.log(
+      'report  processObservable false — no scan tick fell inside the process lifetime, so the ' +
+        'process categories name a structural gap, not a coverage result',
+    );
+  }
+  console.log(
+    report.unmatchedObserved.length === 0
+      ? 'report  every observed event cancelled an expectation'
+      : `report  ${report.unmatchedObserved.length} observed event(s) cancelled no expectation — ` +
+          'listed in the report, where they are signal rather than debris',
+  );
+  if (report.join.unavailable) console.error(`\nbench: ${report.join.unavailable}`);
 }
 
 /**
@@ -551,6 +728,27 @@ async function main(argv) {
         if (!capture.ok) exitCode = 1;
       }
 
+      // Only with an observation set: a report joining the catalogue against
+      // nothing would print four zero recalls, which is exactly what a sensor
+      // that ran and saw nothing looks like. The reason is in observed.meta.json.
+      if (capture && capture.ok) {
+        const report = writeReport({
+          dir,
+          runId,
+          scenario: scenario.id,
+          arm: args.arm,
+          expected: outcome.events,
+          capture,
+        });
+        reportJoin(report);
+        if (report.join.unavailable) exitCode = 1;
+      } else if (capture) {
+        console.error(
+          `bench: no ${join.REPORT_FILENAME} was written — there is no observation set to join ` +
+            'the catalogue against, and a report over an absent one would read as four zero recalls',
+        );
+      }
+
       if (!outcome.ok) {
         const failed = outcome.steps.find((s) => s.status === 'failed');
         const skipped = outcome.steps.filter((s) => s.status === 'skipped').length;
@@ -599,14 +797,18 @@ if (require.main === module) {
 }
 
 module.exports = {
+  MAX_LATENCY_INTERVALS,
   NO_SCENARIO,
   RUNS_DIR,
   SENSOR_ARM,
+  SETTINGS_FILENAME,
   buildRunId,
   createRunDir,
   firstStepStartedAt,
   main,
+  maxLatencyFrom,
   parseArgs,
   prepareScenario,
   processAliveWindow,
+  resolveScanInterval,
 };

--- a/tests/main/bench/join.test.js
+++ b/tests/main/bench/join.test.js
@@ -1,0 +1,526 @@
+/**
+ * @file tests/main/bench/join.test.js
+ * @description `join.js` turns two files nobody disputes into the first numbers
+ *   the project will publish, so what is pinned here is not "the join works" but
+ *   the specific ways a wrong join would produce a plausible number:
+ *
+ *   - an observation counted twice, cancelling two expectations;
+ *   - a nearer pairing losing to a farther one;
+ *   - a stamping artefact (an observation stamped before its expectation) or a
+ *     window artefact (one past the bound) scoring as a coverage miss with no
+ *     trace of what it actually was;
+ *   - a structurally unobservable category reported as `0/N` next to a real
+ *     `0/N`, so the reader cannot tell "the sensor missed it" from "the sensor
+ *     was never shown it";
+ *   - a Windows path failing to match itself because one side spelled it in
+ *     lower case or with forward slashes.
+ *
+ *   The last block is a gate on the module rather than on its output:
+ *   `bench/lib/join.js` may not touch the filesystem, and a join that could reach
+ *   for a fact it was not handed is a different module from the one specified.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { describe, it, expect } from 'vitest';
+
+import join from '../../../bench/lib/join.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const JOIN_SOURCE = path.resolve(HERE, '..', '..', '..', 'bench', 'lib', 'join.js');
+
+/** @type {string} A path in the shape the bench actually records. */
+const STAGE_EXE = 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\R\\stage\\claude.exe';
+
+/** @type {{value: number, source: string}} 10 s × 3, as an arm-A run derives it. */
+const BOUND = Object.freeze({
+  value: 30000,
+  source: '10 s × 3 scan intervals — scanIntervalSec in <profile>\\settings.json',
+});
+
+/**
+ * One catalogue line, in the minimal ECS subset `catalogue.js` writes.
+ * @param {Object} o
+ * @param {string} o.ts - `@timestamp`.
+ * @param {string} o.category - `process` or `file`.
+ * @param {string} o.type - `start`, `end`, `creation` or `deletion`.
+ * @param {number} [o.pid]
+ * @param {string} [o.filePath]
+ * @param {string} [o.step]
+ * @param {string} [o.expectId]
+ * @returns {Object}
+ */
+function expectedEvent(o) {
+  const doc = {
+    '@timestamp': o.ts,
+    ecs: { version: '8.11.0' },
+    event: { kind: 'event', category: [o.category], type: [o.type], action: `${o.category}-x` },
+    bench: { scenario: 'S1', step: o.step ?? 'step', expect: o.expectId ?? 'E' },
+  };
+  if (o.filePath) doc.file = { path: o.filePath, name: 'claude.exe', directory: 'd' };
+  // A file line carries the actor's own pid, exactly as the catalogue writes it —
+  // the join must key a file on its path regardless.
+  if (o.pid) doc.process = { pid: o.pid };
+  return doc;
+}
+
+/**
+ * One observed line, in the shape `observed.js` derives from an audit record.
+ * @param {Object} o
+ * @param {string} o.ts
+ * @param {string} o.category
+ * @param {string} o.type
+ * @param {number} [o.pid]
+ * @param {string} [o.filePath]
+ * @param {number} [o.seq]
+ * @returns {Object}
+ */
+function observedEvent(o) {
+  const doc = {
+    '@timestamp': o.ts,
+    ecs: { version: '8.11.0' },
+    event: { kind: 'event', category: [o.category], type: [o.type], action: `${o.category}-x` },
+    bench: {
+      scenario: 'S1',
+      source: 'aegis-audit',
+      auditFile: 'aegis-audit-2026-08-13.json',
+      auditSeq: o.seq ?? 0,
+      auditType: o.category === 'process' ? 'agent-enter' : 'file-access',
+    },
+  };
+  if (o.filePath) doc.file = { path: o.filePath, name: 'claude.exe', directory: 'd' };
+  if (o.pid) doc.process = { pid: o.pid };
+  return doc;
+}
+
+/**
+ * Build a report over the given events with the standard bound.
+ * @param {Object[]} expectedEvents
+ * @param {Object[]} observedEvents
+ * @param {Object} [over] - Overrides for `buildReport`'s options.
+ * @returns {Object}
+ */
+function report(expectedEvents, observedEvents, over = {}) {
+  return join.buildReport({
+    runId: 'R',
+    scenario: 'S1',
+    arm: 'A',
+    expected: expectedEvents,
+    observed: observedEvents,
+    maxLatency: BOUND,
+    ticksWhileProcessAlive: 3,
+    ...over,
+  });
+}
+
+describe('join — a pair inside the window', () => {
+  it('matches a process expectation to an observation carrying the same pid', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:22.274Z',
+          category: 'process',
+          type: 'start',
+          pid: 44900,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:32.337Z',
+          category: 'process',
+          type: 'start',
+          pid: 44900,
+        }),
+      ],
+    );
+
+    expect(r.matched).toHaveLength(1);
+    expect(r.matched[0].key).toBe('pid:44900');
+    expect(r.matched[0].latencyMs).toBe(10063);
+    expect(r.categories['process/start'].recall).toBe('1/1');
+    expect(r.categories['process/start'].recallValue).toBe(1);
+    expect(r.categories['process/start'].latencyMs.p50).toBe(10063);
+    expect(r.categories['process/start'].latencyMs.max).toBe(10063);
+    expect(r.unmatchedObserved).toHaveLength(0);
+    expect(r.missed).toHaveLength(0);
+  });
+
+  it('calls a one-point and a two-point latency a point, not a statistic', () => {
+    const one = join.latencyBlock([7]);
+    expect(one.p50).toBe(7);
+    expect(one.basis).toMatch(/ARE those points, not statistics/);
+
+    const many = join.latencyBlock([9, 1, 5, 3]);
+    expect(many.points).toEqual([1, 3, 5, 9]);
+    expect(many.p50).toBe(3);
+    expect(many.max).toBe(9);
+    expect(many.basis).toMatch(/nearest-rank/);
+  });
+
+  it('reports no recall number for a category the catalogue never expected', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:22.274Z',
+          category: 'process',
+          type: 'start',
+          pid: 1,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:23.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 1,
+        }),
+      ],
+    );
+    expect(r.categories['file/deletion'].expected).toBe(0);
+    expect(r.categories['file/deletion'].recall).toBe('0/0');
+    expect(r.categories['file/deletion'].recallValue).toBeNull();
+    expect(r.categories['file/deletion'].recallUnavailable).toMatch(/is not 0/);
+  });
+});
+
+describe('join — outside the window', () => {
+  it('does not match an observation past maxLatency, and names the distance', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:00.000Z',
+          category: 'process',
+          type: 'end',
+          pid: 44900,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:30.001Z',
+          category: 'process',
+          type: 'end',
+          pid: 44900,
+        }),
+      ],
+    );
+
+    expect(r.matched).toHaveLength(0);
+    expect(r.categories['process/end'].recall).toBe('0/1');
+    expect(r.categories['process/end'].recallValue).toBe(0);
+    expect(r.missed[0].reason).toMatch(/arrived 30001 ms later, past the 30000 ms bound/);
+    expect(r.unmatchedObserved).toHaveLength(1);
+    expect(r.unmatchedObserved[0].reason).toMatch(/past the 30000 ms bound/);
+  });
+
+  it('names an observation stamped BEFORE its expectation as an artefact, not a miss', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:22.190Z',
+          category: 'file',
+          type: 'creation',
+          filePath: STAGE_EXE,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:22.150Z',
+          category: 'file',
+          type: 'creation',
+          filePath: STAGE_EXE,
+        }),
+      ],
+    );
+
+    expect(r.matched).toHaveLength(0);
+    expect(r.missed[0].reason).toMatch(/40 ms BEFORE the expectation/);
+    expect(r.missed[0].reason).toMatch(/not a coverage result/);
+    expect(r.unmatchedObserved[0].reason).toMatch(/40 ms BEFORE/);
+  });
+});
+
+describe('join — cardinality', () => {
+  it('gives an expectation the nearest of two candidates and lists the other', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:00.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:20.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+          seq: 1,
+        }),
+        observedEvent({
+          ts: '2026-08-13T17:27:05.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+          seq: 2,
+        }),
+      ],
+    );
+
+    expect(r.matched).toHaveLength(1);
+    expect(r.matched[0].latencyMs).toBe(5000);
+    expect(r.matched[0].observed.auditSeq).toBe(2);
+    expect(r.unmatchedObserved).toHaveLength(1);
+    expect(r.unmatchedObserved[0].observed.auditSeq).toBe(1);
+  });
+
+  it('lets one observation cancel one expectation and no more', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:00.000Z',
+          category: 'file',
+          type: 'creation',
+          filePath: STAGE_EXE,
+          step: 'a',
+        }),
+        expectedEvent({
+          ts: '2026-08-13T17:27:02.000Z',
+          category: 'file',
+          type: 'creation',
+          filePath: STAGE_EXE,
+          step: 'b',
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:03.000Z',
+          category: 'file',
+          type: 'creation',
+          filePath: STAGE_EXE,
+        }),
+      ],
+    );
+
+    expect(r.matched).toHaveLength(1);
+    expect(r.matched[0].expected.step).toBe('b');
+    expect(r.categories['file/creation'].recall).toBe('1/2');
+    expect(r.categories['file/creation'].recallValue).toBe(0.5);
+    expect(r.missed).toHaveLength(1);
+    expect(r.missed[0].expected.step).toBe('a');
+    expect(r.missed[0].reason).toMatch(/was taken by a nearer expectation/);
+  });
+
+  it('puts an observation the run never expected in the unmatched list', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:00.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:01.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+          seq: 1,
+        }),
+        observedEvent({
+          ts: '2026-08-13T17:27:04.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 9999,
+          seq: 2,
+        }),
+      ],
+    );
+
+    expect(r.matched).toHaveLength(1);
+    expect(r.unmatchedObserved).toHaveLength(1);
+    expect(r.unmatchedObserved[0].key).toBe('pid:9999');
+    expect(r.unmatchedObserved[0].observed.auditSeq).toBe(2);
+    expect(r.unmatchedObserved[0].reason).toMatch(/this run did not cause it/);
+  });
+});
+
+describe('join — processObservable', () => {
+  const expectedPair = [
+    expectedEvent({ ts: '2026-08-13T17:27:00.000Z', category: 'process', type: 'start', pid: 7 }),
+    expectedEvent({ ts: '2026-08-13T17:27:35.000Z', category: 'process', type: 'end', pid: 7 }),
+  ];
+
+  it('labels the process categories instead of scoring them when no tick fell inside', () => {
+    const r = report(expectedPair, [], { ticksWhileProcessAlive: 0 });
+
+    expect(r.processObservable).toBe(false);
+    expect(r.categories['process/start'].recall).toBe('0/1 (structurally unobservable)');
+    expect(r.categories['process/end'].recall).toBe('0/1 (structurally unobservable)');
+    expect(r.categories['process/start'].recallValue).toBeNull();
+    expect(r.categories['process/start'].recallUnavailable).toMatch(/never in front of the sensor/);
+    expect(r.categories['process/start'].expected).toBe(1);
+    expect(r.categories['process/start'].missed).toBe(1);
+  });
+
+  it('names the contradiction when a tickless run matched something anyway', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:00.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:01.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+        }),
+      ],
+      { ticksWhileProcessAlive: 0 },
+    );
+
+    expect(r.processObservable).toBe(false);
+    expect(r.categories['process/start'].recall).toBe('1/1');
+    expect(r.categories['process/start'].note).toMatch(/the two disagree/);
+  });
+
+  it('leaves processObservable null when the catalogue held no process lifetime', () => {
+    const r = report([], [], { ticksWhileProcessAlive: null });
+    expect(r.processObservable).toBeNull();
+    expect(r.ticksWhileProcessAlive).toBeNull();
+  });
+});
+
+describe('join — path normalisation', () => {
+  it('folds case and separators to one form', () => {
+    expect(join.normalizePath('X:/Future\\ESCAPE//AEGIS\\')).toBe('x:\\future\\escape\\aegis');
+    expect(join.normalizePath('X:\\')).toBe('x:\\');
+    expect(join.normalizePath('  ')).toBeNull();
+    expect(join.normalizePath(undefined)).toBeNull();
+  });
+
+  it('matches a file expectation to an observation spelled differently', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:22.190Z',
+          category: 'file',
+          type: 'deletion',
+          filePath: STAGE_EXE,
+          pid: 44432,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:22.290Z',
+          category: 'file',
+          type: 'deletion',
+          filePath: 'x:/future/escape/aegis/bench/runs/R/stage/CLAUDE.EXE',
+        }),
+      ],
+    );
+
+    expect(r.matched).toHaveLength(1);
+    expect(r.matched[0].latencyMs).toBe(100);
+    expect(r.matched[0].key).toBe(
+      'path:x:\\future\\escape\\aegis\\bench\\runs\\r\\stage\\claude.exe',
+    );
+  });
+
+  it('keys a file on its path even though the catalogue line carries a pid', () => {
+    const file = expectedEvent({
+      ts: '2026-08-13T17:27:22.190Z',
+      category: 'file',
+      type: 'creation',
+      filePath: STAGE_EXE,
+      pid: 44432,
+    });
+    expect(join.joinKeyOf(file, 'file/creation')).toMatch(/^path:/);
+    expect(join.joinKeyOf(file, 'process/start')).toBe('pid:44432');
+  });
+});
+
+describe('join — the bound itself', () => {
+  it('refuses a bound that is not a positive number of milliseconds', () => {
+    expect(() => report([], [], { maxLatency: { value: 0, source: 'x' } })).toThrow(join.JoinError);
+    expect(() => report([], [], { maxLatency: { value: -1, source: 'x' } })).toThrow(
+      /never defaulted/,
+    );
+  });
+
+  it('performs no join at all when the interval could not be established', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:00.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:01.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+        }),
+      ],
+      { maxLatency: { value: null, source: 'two sources tried', unavailable: 'neither answered' } },
+    );
+
+    expect(r.join.maxLatencyMs).toBeNull();
+    expect(r.categories['process/start'].matched).toBeNull();
+    expect(r.categories['process/start'].missed).toBeNull();
+    expect(r.categories['process/start'].recallValue).toBeNull();
+    expect(r.categories['process/start'].recall).toMatch(/^unavailable —/);
+    expect(r.matched).toHaveLength(0);
+    expect(r.unmatchedObserved).toHaveLength(1);
+  });
+
+  it('refuses an event whose @timestamp is not an instant', () => {
+    expect(() =>
+      report([expectedEvent({ ts: 'yesterday', category: 'process', type: 'start', pid: 7 })], []),
+    ).toThrow(/not a UTC instant/);
+  });
+});
+
+describe('join — what the report may not contain', () => {
+  it('carries no numeric confidence figure', () => {
+    const r = report(
+      [
+        expectedEvent({
+          ts: '2026-08-13T17:27:00.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+        }),
+      ],
+      [
+        observedEvent({
+          ts: '2026-08-13T17:27:01.000Z',
+          category: 'process',
+          type: 'start',
+          pid: 7,
+        }),
+      ],
+    );
+    expect(JSON.stringify(r)).not.toMatch(/"confidence"\s*:\s*-?\d/);
+    expect(r.join.noConfidenceFigure).toMatch(/no confidence score/);
+  });
+
+  it('reads and writes no files — the module requires no filesystem at all', () => {
+    const source = fs.readFileSync(JOIN_SOURCE, 'utf8');
+    expect(source).not.toMatch(/require\(\s*['"](fs|fs\/promises|path|os|child_process)['"]\s*\)/);
+    expect(source).not.toMatch(/readFileSync|writeFileSync|readdirSync|existsSync/);
+  });
+});

--- a/tests/main/bench/run.test.js
+++ b/tests/main/bench/run.test.js
@@ -1,0 +1,110 @@
+/**
+ * @file tests/main/bench/run.test.js
+ * @description The join window is the parameter every recall figure in
+ *   `run-report.json` is a statement about, so how `run.js` arrives at it is
+ *   pinned here rather than left to the one path a passing run happens to take.
+ *
+ *   Both sources are covered, and the second one deliberately: every arm-A run so
+ *   far has resolved the interval out of the profile's `settings.json`, so the
+ *   settled-cadence fallback would otherwise be a mechanism documented in the
+ *   README that nothing has ever executed (memory-bank/ai-mistakes.md #20, #21).
+ *   The warmup tick in that fixture is what makes it a real test: counted, it
+ *   would move the median off the configured interval.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import run from '../../../bench/run.js';
+
+/** @type {string} A run-scoped profile directory, made fresh per test. */
+let profileDir;
+
+beforeEach(() => {
+  profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-bench-run-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(profileDir, { recursive: true, force: true });
+});
+
+/**
+ * A sensor handle with only the fields the interval resolution reads.
+ * @param {Object} over - Overrides.
+ * @returns {Object}
+ */
+function handle(over = {}) {
+  return { profileDir, steadyCadence: false, steadyAt: null, ticks: [], ...over };
+}
+
+describe('run — the scan interval the join window is built from', () => {
+  it('reads scanIntervalSec out of the profile the run created', () => {
+    fs.writeFileSync(
+      path.join(profileDir, run.SETTINGS_FILENAME),
+      JSON.stringify({ scanIntervalSec: 10, darkMode: false }),
+      'utf8',
+    );
+
+    const interval = run.resolveScanInterval(handle());
+    expect(interval.value).toBe(10);
+    expect(interval.source).toContain(run.SETTINGS_FILENAME);
+    expect(interval.unavailable).toBeUndefined();
+  });
+
+  it('falls back to the settled cadence, ignoring the startup schedule before it', () => {
+    // No settings file at all. The first tick is a warmup scan 40 s out; counting
+    // it would put the median at 11 s and describe the wrong regime.
+    const interval = run.resolveScanInterval(
+      handle({
+        steadyCadence: true,
+        steadyAt: '2026-08-13T19:24:40.000Z',
+        ticks: [
+          '2026-08-13T19:24:00.000Z',
+          '2026-08-13T19:24:40.000Z',
+          '2026-08-13T19:24:51.000Z',
+          '2026-08-13T19:25:01.000Z',
+        ],
+      }),
+    );
+
+    expect(interval.value).toBe(10);
+    expect(interval.source).toMatch(/median gap \(10000 ms\) between the 3 scan ticks/);
+    expect(interval.source).toMatch(/after its cadence settled/);
+  });
+
+  it('records the interval as absent when neither source answered', () => {
+    const interval = run.resolveScanInterval(handle({ steadyCadence: false }));
+    expect(interval.value).toBeNull();
+    expect(interval.unavailable).toMatch(/never reported a settled cadence/);
+  });
+
+  it('ignores a settings file that carries no usable scanIntervalSec', () => {
+    fs.writeFileSync(
+      path.join(profileDir, run.SETTINGS_FILENAME),
+      JSON.stringify({ scanIntervalSec: 0 }),
+      'utf8',
+    );
+    expect(run.resolveScanInterval(handle()).value).toBeNull();
+  });
+});
+
+describe('run — the join bound', () => {
+  it('is three scan intervals, in milliseconds, naming where the interval came from', () => {
+    const bound = run.maxLatencyFrom({ value: 10, source: 'scanIntervalSec in <profile>' });
+    expect(bound.value).toBe(10 * run.MAX_LATENCY_INTERVALS * 1000);
+    expect(bound.source).toContain('scanIntervalSec in <profile>');
+    expect(bound.unavailable).toBeUndefined();
+  });
+
+  it('carries an absent interval forward as an absent window, never a default', () => {
+    const bound = run.maxLatencyFrom({
+      value: null,
+      source: 'two sources tried',
+      unavailable: 'neither answered',
+    });
+    expect(bound.value).toBeNull();
+    expect(bound.unavailable).toMatch(/never defaulted/);
+  });
+});


### PR DESCRIPTION
## What this adds

`bench/lib/join.js` joins one run's expected-event catalogue to what the AEGIS sensor recorded, and shapes `run-report.json` — the first row of the measurement matrix. `bench/run.js` calls it at the end of an arm-A run and prints a one-line-per-category summary.

The module **reads and writes nothing**. It takes two arrays and the window parameters and returns an object; `run.js` owns every byte that touches disk. A unit test asserts the module requires no filesystem API at all — a join that could reach for a fact it was not handed could also disagree with the files the report claims to be about.

## How the join is shaped

It keys on what the audit actually persists (B2.3):

| category | key |
|---|---|
| `process/start`, `process/end` | `process.pid` |
| `file/creation`, `file/deletion` | `file.path`, case- and separator-normalised |

**Nothing joins on a name.** AEGIS persists the display name it resolved (`"Claude Code"`), never the image name (`claude.exe`); a name join would manufacture matches out of a naming coincidence. The window is `[expected.@timestamp, expected.@timestamp + maxLatency]`, one observed event cancels at most one expectation, and where several pairings are eligible the nearest in time wins — every candidate pair is scored by its latency and taken in ascending order, ties breaking on file order so a report is reproducible from the two files it came from.

## Where `maxLatency` comes from

Three scan intervals, and the interval is read off the run rather than written into the code: `scanIntervalSec` from the run-scoped profile's `settings.json`, else the median gap between the sensor's own scan ticks after its cadence settled. Neither answered means the window is **absent** — the report says so and the run exits 1, rather than defaulting to a literal that every recall figure would silently depend on.

`manifest.json` cannot carry it: `manifest.collect()` runs before the sensor starts, so the profile it would have to read does not exist yet, and a value copied out of the product's defaults would be `src/` contributing to its own measurement record. It is recorded in `observed.meta.json` as `sensor.scanInterval` `{value, source}`.

Three intervals is not generous for `process/end` — that category's floor is already the session tracker's two-scan exit grace plus the scan that concludes it.

## Two causes named instead of dissolved into a count

- **A miss names its nearest candidate** and the signed distance to it. An observation stamped *before* its expectation is a stamping artefact (the actor stamps around the step, the audit stamps inside its own `log()` call) and one past the bound is a window artefact; neither is a coverage failure, and the reason says which it was.
- **A structurally unobservable category is labelled, not scored.** When no scan tick fell inside the scenario's process lifetime, the process categories read `0/N (structurally unobservable)` with a null recall number — the process was never in front of the sensor. The run stays valid and exits 0. If such a run matched something anyway, the category carries a `note` saying the tick accounting and the observation disagree.

Unmatched observations are listed with the reason each cancelled nothing: sensor noise, or activity the scenario did not cause. Both are findings.

**No confidence figure appears in the report and none is derived from it.** Every number is a count of rows or a difference of two timestamps.

## Verification

Arm-A run on this branch (`2026-08-13T19-26-29Z-S1-agent-lifecycle-A`), all four S1 categories:

| category | recall | latency |
|---|---|---|
| `process/start` | 1/1 | 9989 ms |
| `process/end` | 1/1 | 14927 ms |
| `file/creation` | 1/1 | 12 ms |
| `file/deletion` | 1/1 | 104 ms |

`processObservable: true`, `ticksWhileProcessAlive: 3`, no unmatched observations.

The `processObservable: false` branch was exercised on real data too — a recorded zero-tick run replayed through `buildReport` produced `0/1 (structurally unobservable)` for both process categories with a null recall, `1/1` for both file categories, and two genuinely foreign observations in `unmatchedObserved`.

The one-to-one guard was mutation-tested: removing `|| candidate.o.used` from `assign` turns the "one observed event cancels one expectation" test red; reverting turns it green.

Local pre-merge set: `build:renderer`, `lint`, `typecheck`, `typecheck:svelte`, `test:coverage` (95 files, 1588 passed, 4 skipped) and `npm audit --audit-level=high --omit=dev` all pass. `format:check` passes on every file in this diff; its repo-wide failures are a local CRLF artefact of `core.autocrlf=true` and are untouched here.

`src/`, `rules/`, `bench/lib/actor.js` and `bench/lib/sensor.js` are unmodified. The bench never runs in CI (Sysmon, Procmon and `reg query` are Windows facilities; the required contexts run on `ubuntu-latest`) — what CI covers here is `bench/` source quality via `lint` and `format:check`.
