### PR TITLE
chore(format): set prettier endOfLine to auto

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,6 +7,7 @@
     "useTabs": false,
     "bracketSpacing": true,
     "arrowParens": "always",
+    "endOfLine": "auto",
     "plugins": [
         "prettier-plugin-svelte"
     ],

--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -77,6 +77,7 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     to undo it and only an external editor snapshot brought the log back. Untracked files have no
     safety net: git cannot restore what it never saw. Touch ONLY the bytes the prompt named. If a
     file looks wrong in a way the task did not mention, report it and leave it alone.
+    Corollary: a local `format:check` red on a Windows checkout (150 files, CRLF-only diffs, CI green) is a config gap, not a formatting one — `"endOfLine": "auto"` in .prettierrc clears it without touching a single source byte; never "fix" it with a repo-wide `prettier --write`.
 
 ## Verification
 25. **Confirmed good approach — a measurement gate that refuses or blocks beats one that annotates.**


### PR DESCRIPTION
## Problem

`npm run format:check` fails on any Windows checkout with `core.autocrlf=true`: the working tree is CRLF, Prettier's default `endOfLine: "lf"` expects LF, so **150 files** are reported as style violations that differ only by line ending. Linux CI (LF checkout) stays green — the red is local-only and false.

## Fix

One key in `.prettierrc`:

```json
"endOfLine": "auto"
```

Prettier then accepts whatever endings the checkout already has, so the same tree passes on Windows and on CI. Git normalization is unchanged — `.gitattributes` (`* text=auto`) still keeps the repository LF; `.gitattributes` was not touched.

## Verification

| | `format:check` |
|---|---|
| before | exit 1 — "Code style issues found in 150 files" |
| after | exit 0 — "All matched files use Prettier code style!" |

Run in Git Bash (PowerShell mangles CRLF in pipes). No `prettier --write` was run, no file was renormalized — the diff is 2 insertions, 0 deletions.

## Also

`memory-bank/ai-mistakes.md` entry #22 gets one line recording that this false-red is a config gap, so the next reader does not "fix" it with a repo-wide `prettier --write` — which is exactly the unrequested side edit #22 is about.
