### PR TITLE
docs(memory-bank): record the scan-loop recycled-pid flake verdict

### DIFF
--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -95,5 +95,16 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     cached state passes green. Lesson: when a plausible-but-wrong value could satisfy a check, make
     the disagreement halt the work; a check that annotates around a doubt is decoration (cf. #21).
 
+26. **The `scan-loop.test.js:1275` recycled-pid flake is still live, and its green proves nothing about
+    identity (verified 2026-08-13 on `b2d55b7`, 40 runs).** 19/20 pass idle, 18/20 under a concurrent
+    full-suite load, always `expected 5 to be 1` on the `memMb` assertion — lower than the reported
+    ~3-in-7, not gone. It was recorded in no known-flakes note anywhere in the repo before this line.
+    The defect is cross-test leakage, not the assertion: `-t`-filtered the test passes 20/20 and ten
+    whole-suite runs pass 10/10, because resource-monitor's module-level exec is shared and a prior
+    test's fire-and-forget `getResourcesForPids` can still reach `makeVaryingExec`'s sample counter.
+    Per #21 it also cannot credit #206/#208 either way: `process-utils.js` is never loaded by this
+    file, `platform/process-snapshot.js` loads transitively but is never called, and both birth times
+    are literals in the test's own factory fed to the pure `identify()`.
+
 ## Rule
 NEVER change what was not asked. Do ONLY what the prompt says.


### PR DESCRIPTION
## Verdict

**Still flaky, and vacuous with respect to the identity gate.**

`tests/main/scan-loop.test.js:1275` — *"a recycled pid does not inherit the previous instance's cached sample"* — run 40 times on `b2d55b7`:

| condition | pass / fail |
|---|---|
| idle, single file | **19 / 1** |
| concurrent full-suite load | **18 / 2** |

Every failure is the same `memMb` assertion (`expected 5 to be 1`, once `expected 14 to be 2`). Lower than the reported ~3-in-7, not gone.

## What the test proves about #206 / #208 — nothing

`procUtil` is a plain object of `vi.fn()` stubs, and the stub calls `identify()` directly on agents whose `startTime` is a literal in the test's own factory (`1717000000000` / `1717000999000`). Confirmed by loading the module graph: `src/main/process-utils.js` — the whole of #206 — is **not loaded at all** by this file; `src/main/platform/process-snapshot.js` (#208) loads transitively via `ide-extension-detector → platform → win32` but is never called on this path. `identify()` is pure by its own contract. So a green run here is silent about the birth-time gate in either direction (ai-mistakes #21).

## Where the flake lives

Not in the assertion. Filtered with `-t` the test passes **20/20**, and ten whole-suite runs pass **10/10**. `resource-monitor`'s exec is module-level state that survives this file's CJS-cache clearing, and a preceding test's fire-and-forget `getResourcesForPids` chain can still reach `makeVaryingExec`'s sample counter — so the counter is already ahead when the first push lands. The file's own `afterEach` (lines 1200–1206) documents that this module survives the cache clear.

## Change

One entry appended to `memory-bank/ai-mistakes.md` (#26, under `## Verification`). The flake was recorded in **no** known-flakes note anywhere in the repo — `git ls-files | grep -iE "flake|flaky|known"` is empty, and a repo-wide grep for `3/7`, `intermittent`, `non-determinis` has no hits — so per the task this is where the verdict goes.

Documentation only. No test or product code touched; the fix is a separate block.

## Gates

All seven local pre-merge commands green: `build:renderer`, `format:check`, `lint` (0 errors), `typecheck`, `typecheck:svelte` (385 files, 0 errors), `test:coverage` (95 files / 1588 passed / 4 skipped), `npm audit` (0 vulnerabilities).
