### PR TITLE
test(scan-loop): stop real resource spawns leaking across tests

### DIFF
--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -105,6 +105,11 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     Per #21 it also cannot credit #206/#208 either way: `process-utils.js` is never loaded by this
     file, `platform/process-snapshot.js` loads transitively but is never called, and both birth times
     are literals in the test's own factory fed to the pure `identify()`.
+    **Fixed 2026-08-13 in #219** — root cause was this file stubbing resource-monitor's exec in ONE
+    describe block while every scanning test reached it, so the rest spawned real `powershell.exe`
+    that settled on real time and resumed inside a later test, against that test's exec. 40/40 green
+    after, 0 real spawns, exactly 2 sampling calls where 13 had landed. The vacuity above is unchanged:
+    the fix removed the noise, not the missing coverage.
 
 ## Rule
 NEVER change what was not asked. Do ONLY what the prompt says.

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -5,6 +5,35 @@ describe('scan-loop', () => {
   let scanLoop;
   const require_ = createRequire(import.meta.url);
 
+  /**
+   * Inert command runner for resource-monitor, installed for the WHOLE file.
+   *
+   * `doProcessScan` fires `resourceMonitor.getResourcesForPids` for every scanned
+   * pid > 0, so EVERY test here that drives a scan reaches it — not just the
+   * `agent-resource-usage` block that asserts on the result. Left unstubbed, that
+   * is the real `execFile`: a live `powershell.exe` / `nvidia-smi` per scanning
+   * test, in CI as much as locally.
+   *
+   * Those spawns settle on REAL time while the tests run on fake timers, so a
+   * chain started in one test resumes during whichever test happens to be running
+   * when the OS answers — and calls the exec THAT test installed. That is how a
+   * backlog of earlier scans landed on `makeVaryingExec` below and drove its
+   * sample counter past the value the test had just measured (`expected 5 to be
+   * 1`). An already-resolved promise keeps every chain inside the test that
+   * started it, and `_setExecForTest` is module-level state that `_resetForTest`
+   * deliberately does NOT restore, so it is re-armed on both sides of each test.
+   * @returns {Promise<string>}
+   */
+  const inertExec = () => Promise.resolve('');
+
+  /** Reset resource-monitor's module state and re-arm the inert exec. */
+  function isolateResourceMonitor() {
+    const rm = require_('../../src/main/resource-monitor.js');
+    rm._resetForTest();
+    rm._setLoggerForTest({ warn: vi.fn() });
+    rm._setExecForTest(inertExec);
+  }
+
   beforeEach(() => {
     vi.useFakeTimers();
     // Clear CJS cache so each test gets fresh module-level state
@@ -13,12 +42,20 @@ describe('scan-loop', () => {
     // Also clear llm-runtime-detector (required inside enrichWithLocalModels)
     const llmPath = require_.resolve('../../src/main/llm-runtime-detector.js');
     delete require_.cache[llmPath];
+    // resource-monitor survives that cache clear — it is required at scan-loop's
+    // module scope and holds the exec, so it is isolated explicitly instead.
+    isolateResourceMonitor();
     scanLoop = require_('../../src/main/scan-loop.js');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     scanLoop.stopScanIntervals();
+    // Settle the fire-and-forget resource push INSIDE the test that started it,
+    // while its own exec is still the installed one. Pending timers are not run;
+    // this only drains microtasks, which is all an inert exec needs.
+    await vi.advanceTimersByTimeAsync(0);
     vi.useRealTimers();
+    isolateResourceMonitor();
   });
 
   /**
@@ -1196,14 +1233,6 @@ describe('scan-loop', () => {
       rm._setExecForTest(exec);
       return rm;
     }
-
-    afterEach(() => {
-      const rm = require_('../../src/main/resource-monitor.js');
-      rm._resetForTest();
-      // Leave an inert exec behind: the module survives this file's CJS cache clearing,
-      // and a real spawn from a later test would be a live process query in CI.
-      rm._setExecForTest(() => Promise.resolve(''));
-    });
 
     /**
      * Deps whose enrich stamps identity through the real `identify()`, over a fresh


### PR DESCRIPTION
Follow-up to #218, which recorded the verdict on this flake without fixing it.

## Root cause

`doProcessScan` fires `resourceMonitor.getResourcesForPids` for every scanned `pid > 0`, so **every** test in this file that drives a scan reaches it — but the exec was stubbed only inside the `agent-resource-usage push` block. Every other scanning test ran against the real `execFile` and spawned a live `powershell.exe` / `nvidia-smi`.

Those spawns settle on **real** time while the tests run on **fake** timers. A chain started in one test therefore resumes during whichever test happens to be running when the OS answers — and calls the exec *that* test installed.

Instrumented run (diagnostic harness kept out of the repo), failing case:

```
[INSTALL] exec #3 during="a recycled pid does not inherit the previous instance’s cached sample"
[EXEC] cmd=powershell.exe exec=#3 during="a recycled pid …"   ← ×13, not ×2
```

The backlog of earlier scans drains onto `makeVaryingExec`'s sample counter, so the figure the test reads back is not the one its own tick produced — `expected 5 to be 1`, `expected 14 to be 2`. In passing runs the same backlog happened to drain a few tests earlier, against an exec nobody was counting.

## Fix

Isolate `resource-monitor` for the **whole file**, which is what `tests/main/resource-monitor.test.js` already does for its own (a `beforeEach` covering every test in the file):

- top-level `beforeEach` installs an inert, already-resolved exec + resets module state — no real process is spawned by this file at all now;
- top-level `afterEach` drains microtasks before the next test installs anything, so a fire-and-forget push settles while its own exec is still the installed one;
- the block-level `afterEach` existed only to leave an inert exec behind and is now covered by the file-level hooks.

No product code and no assertion changed.

## Verification

| | before | after |
|---|---|---|
| idle ×20 | 19 / 1 | **20 / 0** |
| concurrent full-suite load ×20 | 18 / 2 | **20 / 0** |
| real spawns from this file | dozens | **0** |
| sampling calls reaching the recycled-pid test's exec | 5, 13, … | **exactly 2** |

The last two rows are deterministic, not probabilistic — they are read off the instrumented run, so the result does not rest on 40 green runs alone.

Not vacuous (ai-mistakes #21): mutating `resource-monitor`'s cache key from `instanceId` to `pid` still turns the test red — `expected '100:1717000000000' to be '100:1717000999000'` — mutation reverted.

Also updates the #26 entry in `memory-bank/ai-mistakes.md`, which #218 left reading "still live". It still cannot credit #206/#208: the test never reaches the birth-time gate, and that has not changed.

## Gates

All seven local pre-merge commands green: `build:renderer`, `format:check`, `lint` (0 errors), `typecheck`, `typecheck:svelte` (385 files, 0 errors), `test:coverage` (95 files / 1588 passed / 4 skipped), `npm audit` (0 vulnerabilities).
