### PR TITLE
feat(bench): record which renderer produced a run report, and replay against it

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -97,7 +97,7 @@ bench/
   lib/sensor.js                             # runs AEGIS across a run; readiness, ticks, stop
   lib/observed.js                           # writes observed.ndjson out of the product's audit log
   lib/join.js                               # joins the two, shapes run-report.json; no I/O at all
-  lib/report.js                             # the join bound and the printed summary, shared by both entrypoints
+  lib/report.js                             # the join bound, the report's exact bytes, the printed summary and the renderer fingerprint — shared by both entrypoints
   scenarios/S1-agent-lifecycle/scenario.json
   runs/                                     # run artefacts — gitignored, created on first run
   README.md
@@ -429,14 +429,14 @@ node bench/replay.js bench/runs/2026-08-13T19-26-29Z-S1-agent-lifecycle-A
 ```
 
 It reads four files out of that directory and hands the same two arrays and the same window
-parameters to the same `bench/lib/join.js` the live run used, so the report it produces **is** the
-report that run produced — byte for byte, because nothing in a report records the moment it was
-generated. No sensor is started, no scenario is loaded, no `src/` module and no `settings.json` is
-opened, and no built renderer is needed.
+parameters to the same `bench/lib/join.js` the live run used, so the report it produces is the
+report that run produced — byte for byte where the renderer is also the same one, because nothing
+in a report records the moment it was generated. No sensor is started, no scenario is loaded, no
+`src/` module and no `settings.json` is opened, and no built renderer is needed.
 
 | file | what replay takes from it |
 |---|---|
-| `manifest.json` | `runId`, `scenario`, `arm` — the run's identity |
+| `manifest.json` | `runId`, `scenario`, `arm` — the run's identity — and `reportRenderer`, which renderer produced its report |
 | `expected.ndjson` | the catalogue, one ECS document per line |
 | `observed.ndjson` | the observation set, in the same subset |
 | `observed.meta.json` | `sensor.scanInterval`, `sensor.ticksWhileProcessAlive`, and the same three identity fields, which the manifest is checked against |
@@ -480,19 +480,73 @@ is written. `--out <file>` puts the rebuild somewhere else. The recorded report 
 rebuild is being checked against, and a verification that overwrites its own target is not one.
 
 A difference is a real finding, and not always a defect: a report's bytes are a function of the
-recording **and of the `bench/lib/join.js` that renders it**. That has already happened once — the
+recording **and of the renderer that renders it**. That has already happened once — the
 `latencyMs.basis` string went from `"1 matched pair(s)"` to `"1 matched pair"` without
 `SCHEMA_VERSION` moving — so a run recorded before that change no longer rebuilds identically,
 while every number in it is unchanged. Replay states that instead of applying it.
 
+### The renderer that rendered it
+
+Which renderer produced a recorded report used to be unrecoverable. `sensor.gitSha` cannot answer
+it: every arm-A run so far was measured against a dirty tree, and `workingTreeDirty: true` says in
+so many words that the commit named is not the code that ran. So a run now records the renderer
+itself — `manifest.reportRenderer`, written by `bench/run.js` out of a fingerprint
+`bench/lib/report.js` freezes while it is being loaded:
+
+```json
+"reportRenderer": {
+  "schemaVersion": 1,
+  "algorithm": "sha256",
+  "joinSha256": "<64 hex>",
+  "reportHelperSha256": "<64 hex>",
+  "covers": "...",
+  "source": "..."
+}
+```
+
+Content hashes and not a commit, so a dirty tree is captured honestly rather than pointed at. Taken
+**once, at load**, and frozen: a bench run acts for minutes against a tree its author may still be
+editing, and a hash taken when the report is finally written would describe the file on disk
+instead of the code that rendered it.
+
+**What it covers:** `bench/lib/join.js` and `bench/lib/report.js` — the report object, the join
+window, and `serializeReport`, the single definition of a report's bytes that the live run and a
+replay both call. `join.js` requires nothing, so those two files are the whole closure rather than a
+sample of it. **What it does not cover:** the Node version, the platform, and everything in
+`bench/run.js` and `bench/replay.js` outside that shared serializer. The fingerprint is not a proof
+that two reports must be identical; it is the identity of the code that renders them.
+
+Replay reads the block back and prints **two verdicts, neither read off the other** — whether the
+rebuild reproduced the recorded bytes, and which renderer produced them:
+
+| verdict | what the recording says | what replay may claim |
+|---|---|---|
+| `renderer-match` | the fingerprint is this renderer's | byte equality here is historical byte equality: same inputs, same renderer, same bytes |
+| `renderer-skew` | the fingerprint names other source bytes | the byte comparison stands on its own. Identical bytes are still identical bytes; a difference is stated with skew named as a candidate explanation and not as its cause |
+| `legacy-unversioned` | no `reportRenderer` block at all | the same, minus even the candidate: the recorded report is still preserved evidence and equality with it is still directly observable, but which renderer wrote those bytes was never recorded, and nothing is invented retroactively to close the gap |
+
+The cell worth having is `renderer-match` with a **difference**: the renderer is ruled out, so what
+failed is the deterministic contract between those files and this renderer — and replay says that
+without inventing a second cause for it.
+
+`--out` writes exactly the report the current renderer built, and nothing else: no envelope, no
+provenance smuggled into the report shape, no `join.SCHEMA_VERSION` moved. What such a file is, is
+carried by where it is put and what it is called — see the goldens below.
+
 ### The committed recordings
 
-`bench/runs/` is gitignored, so two real arm-A runs are committed under `tests/fixtures/bench/`
+`bench/runs/` is gitignored, so two real arm-A runs are committed under `tests/fixtures/bench/runs/`
 instead: one complete run whose live-written report is the byte-for-byte target, and one recorded
 before `sensor.scanInterval` existed, which pins the refusal above against a real artefact rather
-than a synthetic one. They are inputs to `tests/main/bench/replay.test.js`, they are not accuracy
-figures, and `tests/fixtures/bench/README.md` carries their provenance and the maintenance contract
-that comes with a byte-exact golden file.
+than a synthetic one. Both predate `manifest.reportRenderer` and therefore classify as
+`legacy-unversioned`.
+
+They are **recordings**: nine files that are never regenerated, reformatted or corrected, and
+`tests/main/bench/fixture-immutability.test.js` holds each one against a committed sha256 and
+against the exact file set its run wrote. Where a golden for the current renderer is wanted, it is a
+separate derived artefact under `tests/fixtures/bench/goldens/`, named so that it cannot be mistaken
+for a recording. They are not accuracy figures, and `tests/fixtures/bench/README.md` carries their
+provenance and the maintenance contract.
 
 ## Run artefacts
 
@@ -530,3 +584,8 @@ Two fields worth knowing about:
 - **`sensor.workingTreeDirty`** means the measured sensor is not exactly the commit named in
   `sensor.gitSha`. It is recorded, not refused: running against uncommitted work is
   legitimate while building the harness, and dishonest only if left unsaid.
+- **`reportRenderer`** is the sha256 of the two files that turn this run into
+  `run-report.json`, frozen while they were loaded. It is not a `{value, source}` probe
+  because it is not a fact about this machine: it is the identity of the code that writes
+  the report, which `gitSha` above cannot supply for exactly the reason the line before this
+  one gives. See [The renderer that rendered it](#the-renderer-that-rendered-it).

--- a/bench/lib/manifest.js
+++ b/bench/lib/manifest.js
@@ -191,6 +191,15 @@ function oraclePlaceholders() {
  * @param {string} opts.scenario - Scenario id, or the no-scenario placeholder.
  * @param {string} opts.arm - One of {@link ARMS}.
  * @param {string} opts.startedAt - UTC ISO timestamp of the run start.
+ * @param {Object} [opts.reportRenderer] - `bench/lib/report.js`'s
+ *   `RENDERER_FINGERPRINT`: which report-renderer source bytes this process is
+ *   running. Handed in rather than taken here, so the manifest records the
+ *   renderer the run LOADED and not the file as it stood when this snapshot was
+ *   collected — the two differ whenever the tree is edited mid-run, which
+ *   `sensor.workingTreeDirty` says is a state this harness expects. A caller
+ *   that supplies none leaves the field null, and a null reads as
+ *   `legacy-unversioned` downstream: no fingerprint is ever reconstructed for a
+ *   run that recorded none.
  * @returns {Object} The manifest, ready to serialize.
  */
 function collect(opts) {
@@ -229,6 +238,11 @@ function collect(opts) {
         () => git(['status', '--porcelain']).length > 0,
       ),
     },
+    // Which source bytes rendered this run's report. Not a `{value, source}`
+    // probe: it is not a fact about this machine but the identity of the code
+    // that will write run-report.json, and `gitSha` above cannot stand in for
+    // it — a dirty tree names a commit the renderer is not.
+    reportRenderer: opts.reportRenderer ?? null,
     processCountAtStart: processCount(),
     oracles: oraclePlaceholders(),
   };

--- a/bench/lib/report.js
+++ b/bench/lib/report.js
@@ -1,25 +1,45 @@
 /**
  * @file bench/lib/report.js
  * @module bench/lib/report
- * @description The two report-shaping steps that are the same whether a report
- *   comes from a live run or from a recorded one: the join bound derived from the
- *   scan interval that run used, and the summary the report is said out loud with.
+ * @description The report-shaping steps that are the same whether a report comes
+ *   from a live run or from a recorded one: the join bound derived from the scan
+ *   interval that run used, the exact bytes a report is written as, the summary it
+ *   is said out loud with, and the fingerprint of the source that produced all
+ *   three.
  *
  *   It exists so that `bench/run.js` and `bench/replay.js` share one definition of
- *   the bound instead of two that can drift, and so that replay can have it
- *   **without loading the live-run graph**. Requiring `run.js` for these two
- *   functions would pull the actor, the sensor, the catalogue writer and ajv into
- *   a process that must only ever read four files out of one directory — inert at
- *   load time, but a replay whose module graph can reach the sensor is one nobody
- *   can prove did not.
+ *   each instead of two that can drift, and so that replay can have them **without
+ *   loading the live-run graph**. Requiring `run.js` for these functions would pull
+ *   the actor, the sensor, the catalogue writer and ajv into a process whose whole
+ *   contract is that it reads four files out of one directory — inert at load time,
+ *   but a replay whose module graph can reach the sensor is one nobody can prove
+ *   did not.
  *
- *   The only import here is `./join`, which reads and writes nothing. Nothing in
- *   this module touches the filesystem, the clock, the environment or `src/`.
+ *   The only import here is `./join`, which reads and writes nothing.
+ *
+ *   **The one filesystem read.** While this module is being loaded, it hashes the
+ *   two files whose bytes decide a report's bytes — `./join.js` and this file — and
+ *   freezes the result as {@link RENDERER_FINGERPRINT}. Once, at load, and never
+ *   again: a bench run may execute for minutes against a dirty working tree, and a
+ *   hash taken later would describe the file on disk rather than the code this
+ *   process is running. Nothing else here touches the filesystem, the clock, the
+ *   environment or `src/`.
+ *
+ *   **What the fingerprint covers, and what it does not.** Those two files own the
+ *   whole path from two event arrays to the bytes on disk: `join.js` builds the
+ *   report and `serializeReport` writes it, and `join.js` requires nothing at all,
+ *   so the pair is the closure rather than a sample of it. It does not cover the
+ *   Node version, the platform, or anything in `bench/replay.js` and `bench/run.js`
+ *   outside the serializer they both call.
  * @author AEGIS Contributors
  * @license MIT
  * @since v0.11.0
  */
 'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 
 const join = require('./join');
 
@@ -36,6 +56,192 @@ const join = require('./join');
  * @type {number}
  */
 const MAX_LATENCY_INTERVALS = 3;
+
+/** @type {number} Shape version of the `reportRenderer` block. Bump when a field changes meaning. */
+const RENDERER_FINGERPRINT_SCHEMA_VERSION = 1;
+
+/** @type {string} The digest the fingerprint is taken with. Recorded, never assumed by a reader. */
+const RENDERER_HASH_ALGORITHM = 'sha256';
+
+/**
+ * The renderer source set: field name in the fingerprint → absolute path.
+ *
+ * Two files and no more, because two files are the whole closure. `join.js`
+ * builds the report object and requires nothing; this module derives the window
+ * and serializes the object. A third entry would either be a file that cannot
+ * change a byte of the output, or evidence that the closure has grown and the
+ * covered set has to grow with it.
+ * @type {Readonly<Object<string, string>>}
+ */
+const RENDERER_FILES = Object.freeze({
+  joinSha256: path.join(__dirname, 'join.js'),
+  reportHelperSha256: path.join(__dirname, 'report.js'),
+});
+
+/** @type {Readonly<Object<string, string>>} Field name → repository-relative path, for messages. */
+const RENDERER_FILE_LABELS = Object.freeze({
+  joinSha256: 'bench/lib/join.js',
+  reportHelperSha256: 'bench/lib/report.js',
+});
+
+/** @type {string} What the fingerprint is a statement about — carried in every manifest that has one. */
+const RENDERER_COVERS =
+  'bench/lib/join.js and bench/lib/report.js: the report object, the join window and the exact ' +
+  'bytes the report is serialized as. join.js requires nothing, so these two files are the whole ' +
+  'closure rather than a sample of it. NOT covered: the Node version, the platform, and every ' +
+  'part of bench/run.js and bench/replay.js outside the serializer they both call';
+
+/** @type {string} When the hashes were taken — the distinction between the loaded code and a later file. */
+const RENDERER_SOURCE =
+  'sha256 over the bytes of those two files, read once while bench/lib/report.js was being loaded ' +
+  'into the process — the bytes this process then executed, not the file as it stood later';
+
+/** @type {RegExp} A lower-case sha256 digest, as `crypto` renders it. */
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+/**
+ * The three ways a recorded fingerprint can stand to the one replaying it. They
+ * are names rather than English so a caller never parses a sentence.
+ * @type {Readonly<Object<string, string>>}
+ */
+const RENDERER_PROVENANCE = Object.freeze({
+  MATCH: 'renderer-match',
+  SKEW: 'renderer-skew',
+  LEGACY: 'legacy-unversioned',
+});
+
+/**
+ * Hash one renderer source file.
+ * @param {string} file - Absolute path.
+ * @returns {{value: string|null, unavailable?: string}} Absent, never guessed:
+ *   a file this process could not read produces no digest and says so.
+ */
+function hashFile(file) {
+  try {
+    return {
+      value: crypto.createHash(RENDERER_HASH_ALGORITHM).update(fs.readFileSync(file)).digest('hex'),
+    };
+  } catch (err) {
+    return {
+      value: null,
+      unavailable: `${file} could not be read: ${(err && err.message) || err}`,
+    };
+  }
+}
+
+/**
+ * Take the fingerprint of the renderer this process is about to run.
+ *
+ * Called exactly once, below, during this module's own initialization. Not
+ * exported as a live probe: the whole point of the value is that it describes
+ * the loaded code, and a second call minutes later would describe the disk.
+ * @returns {Object} The `reportRenderer` block, ready to serialize.
+ */
+function fingerprintLoadedRenderer() {
+  /** @type {Object} */
+  const block = {
+    schemaVersion: RENDERER_FINGERPRINT_SCHEMA_VERSION,
+    algorithm: RENDERER_HASH_ALGORITHM,
+  };
+  const unreadable = [];
+  for (const [field, file] of Object.entries(RENDERER_FILES)) {
+    const hashed = hashFile(file);
+    block[field] = hashed.value;
+    if (hashed.unavailable) unreadable.push(hashed.unavailable);
+  }
+  block.covers = RENDERER_COVERS;
+  block.source = RENDERER_SOURCE;
+  if (unreadable.length > 0) block.unavailable = unreadable.join('; ');
+  return block;
+}
+
+/**
+ * The fingerprint of the renderer running in this process, frozen at load.
+ *
+ * `bench/run.js` hands it to `manifest.collect()` so the run records which source
+ * bytes produced its report; `bench/replay.js` holds a recording's copy up
+ * against it. A run that predates the block carries none, and that is read as
+ * `legacy-unversioned` rather than filled in.
+ * @type {Readonly<Object>}
+ */
+const RENDERER_FINGERPRINT = Object.freeze(fingerprintLoadedRenderer());
+
+/**
+ * How a recorded fingerprint stands to the renderer in this process.
+ *
+ * The verdict is about renderer IDENTITY and nothing else. Whether a rebuild
+ * reproduces a recorded report's bytes is a separate observation, made against
+ * the recorded file itself, and the two are reported side by side rather than
+ * one being read off the other: identical bytes under skew are still identical
+ * bytes, and a divergence under a match is still a divergence.
+ * @param {Object|null|undefined} recorded - `manifest.reportRenderer`, verbatim.
+ * @param {Readonly<Object>} [current] - Defaults to {@link RENDERER_FINGERPRINT}.
+ * @returns {{provenance: string, recorded: Object|null, current: Object,
+ *   differences: Array<{field: string, file: string, recorded: *, current: *}>,
+ *   reason: string|null}} `reason` is set only where the block exists but cannot
+ *   be read as a version-1 sha256 fingerprint.
+ */
+function classifyRenderer(recorded, current = RENDERER_FINGERPRINT) {
+  const verdict = {
+    provenance: RENDERER_PROVENANCE.LEGACY,
+    recorded: null,
+    current,
+    differences: [],
+    reason: null,
+  };
+
+  if (recorded === null || recorded === undefined || typeof recorded !== 'object') {
+    return verdict;
+  }
+  verdict.recorded = recorded;
+
+  if (recorded.schemaVersion !== RENDERER_FINGERPRINT_SCHEMA_VERSION) {
+    verdict.provenance = RENDERER_PROVENANCE.SKEW;
+    verdict.reason =
+      `the recorded fingerprint is schema version ${JSON.stringify(recorded.schemaVersion)}, and ` +
+      `this replay reads version ${RENDERER_FINGERPRINT_SCHEMA_VERSION} — a block it cannot read ` +
+      'is not a block it may call a match';
+    return verdict;
+  }
+  if (recorded.algorithm !== RENDERER_HASH_ALGORITHM) {
+    verdict.provenance = RENDERER_PROVENANCE.SKEW;
+    verdict.reason =
+      `the recorded fingerprint was taken with ${JSON.stringify(recorded.algorithm)} and this one ` +
+      `with ${RENDERER_HASH_ALGORITHM}; two digests of different algorithms cannot be compared`;
+    return verdict;
+  }
+
+  for (const field of Object.keys(RENDERER_FILES)) {
+    const was = recorded[field];
+    const is = current[field];
+    if (typeof was !== 'string' || !SHA256_HEX.test(was) || was !== is) {
+      verdict.differences.push({
+        field,
+        file: RENDERER_FILE_LABELS[field],
+        recorded: was === undefined ? null : was,
+        current: is === undefined ? null : is,
+      });
+    }
+  }
+
+  verdict.provenance =
+    verdict.differences.length === 0 ? RENDERER_PROVENANCE.MATCH : RENDERER_PROVENANCE.SKEW;
+  return verdict;
+}
+
+/**
+ * The bytes a report is written as, in the one form a run directory holds it in.
+ *
+ * One definition, called by the live run and by a replay alike. Two would be a
+ * pair that can drift by a newline, and the difference would be reported as a
+ * finding about the run rather than about the writer. This function is inside
+ * the fingerprinted set for the same reason: it decides bytes.
+ * @param {Object} report - From `join.buildReport()`.
+ * @returns {string}
+ */
+function serializeReport(report) {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
 
 /**
  * The join bound, from the interval — {@link MAX_LATENCY_INTERVALS} of them.
@@ -94,6 +300,16 @@ function reportJoin(report) {
 
 module.exports = {
   MAX_LATENCY_INTERVALS,
+  RENDERER_COVERS,
+  RENDERER_FILES,
+  RENDERER_FILE_LABELS,
+  RENDERER_FINGERPRINT,
+  RENDERER_FINGERPRINT_SCHEMA_VERSION,
+  RENDERER_HASH_ALGORITHM,
+  RENDERER_PROVENANCE,
+  RENDERER_SOURCE,
+  classifyRenderer,
   maxLatencyFrom,
   reportJoin,
+  serializeReport,
 };

--- a/bench/replay.js
+++ b/bench/replay.js
@@ -26,12 +26,24 @@
  *   | `observed.ndjson` | the observation set, same subset |
  *   | `observed.meta.json` | `sensor.scanInterval`, `sensor.ticksWhileProcessAlive`, and the identity the manifest is checked against |
  *
- *   The output of a replay is a function of those files **and of the current
- *   `bench/lib/join.js`** — not of the files alone. A report rendered by an older
- *   join can therefore differ from its own rebuild without either being wrong,
- *   which is why a directory that already holds a report is COMPARED against
- *   rather than overwritten: the recorded evidence survives its own verification,
- *   and a difference is stated instead of being applied.
+ *   The output of a replay is a function of those files **and of the renderer
+ *   rendering them** — `bench/lib/join.js` and `bench/lib/report.js` — not of the
+ *   files alone. A report rendered by an older renderer can therefore differ from
+ *   its own rebuild without either being wrong, which is why a directory that
+ *   already holds a report is COMPARED against rather than overwritten: the
+ *   recorded evidence survives its own verification, and a difference is stated
+ *   instead of being applied.
+ *
+ *   **Two facts, never folded into one.** Whether the rebuild reproduces the
+ *   recorded report's bytes is one observation, made against the recorded file
+ *   itself. Which renderer originally produced those bytes is another, read out of
+ *   `manifest.reportRenderer` — `renderer-match` when this replay is running the
+ *   same source bytes, `renderer-skew` when it is not, `legacy-unversioned` when
+ *   the run recorded no fingerprint at all. Neither is inferred from the other:
+ *   identical bytes under skew are still identical bytes, a difference under a
+ *   match is still a difference, and a legacy recording's report is still the
+ *   evidence it always was — what is unknown there is the renderer's identity, not
+ *   the bytes.
  *
  *   Exit codes: 0 the report was rebuilt, and matched if one was already there ·
  *   1 a required file is missing or malformed, the run recorded no join window, or
@@ -50,7 +62,13 @@ const fs = require('fs');
 const path = require('path');
 
 const join = require('./lib/join');
-const { maxLatencyFrom, reportJoin } = require('./lib/report');
+const {
+  RENDERER_PROVENANCE,
+  classifyRenderer,
+  maxLatencyFrom,
+  reportJoin,
+  serializeReport,
+} = require('./lib/report');
 
 /**
  * The four names a run directory is replayed from.
@@ -64,7 +82,9 @@ const { maxLatencyFrom, reportJoin } = require('./lib/report');
  * @type {Readonly<Object<string, string>>}
  */
 const REQUIRED_FILES = Object.freeze({
-  'manifest.json': 'the environment snapshot the run wrote before it acted',
+  'manifest.json':
+    'the environment snapshot the run wrote before it acted, which also names the report renderer ' +
+    'it was running',
   'expected.ndjson': 'the expected-event catalogue the actor wrote as it executed',
   'observed.ndjson': "the observation set read out of the product's own audit log",
   'observed.meta.json':
@@ -103,6 +123,11 @@ recorded none is refused rather than joined against a default.
 A run directory that already holds a ${join.REPORT_FILENAME} is COMPARED against,
 not overwritten: the rebuild is printed as identical or as differing, and nothing
 is written.
+
+Two verdicts are printed, and neither is read off the other: whether the rebuild
+reproduced the recorded bytes, and whether the renderer that produced them is the
+one running now — renderer-match, renderer-skew, or legacy-unversioned for a run
+recorded before manifest.reportRenderer existed.
 
 Exit codes: 0 rebuilt, and matched if one was already there · 1 a required file is
 missing or malformed, the run recorded no join window, or the rebuild differs · 2
@@ -369,7 +394,12 @@ function loadRun(dir) {
     );
   }
 
-  return { dir, ...identity, expected, observed, ...window };
+  // Taken verbatim, and never validated into existence: a manifest written
+  // before this block existed carries none, and that absence is the whole
+  // content of the `legacy-unversioned` verdict.
+  const reportRenderer = manifest.reportRenderer ?? null;
+
+  return { dir, ...identity, expected, observed, ...window, reportRenderer };
 }
 
 /**
@@ -399,19 +429,6 @@ function rebuild(run) {
 }
 
 /**
- * The report's bytes, in the one form a run directory holds it in.
- *
- * Identical to what `bench/run.js` writes, and pinned there rather than described:
- * a replay whose serialization drifted by a newline would report a difference that
- * is about this function and not about the run.
- * @param {Object} report - From {@link rebuild}.
- * @returns {string}
- */
-function serialize(report) {
-  return `${JSON.stringify(report, null, 2)}\n`;
-}
-
-/**
  * Index of the first position at which two indexable sequences differ.
  *
  * Called on Buffers, so "byte-identical" is a claim about bytes and not about
@@ -433,11 +450,17 @@ function firstDifference(a, b) {
  * Put the rebuilt report where it belongs, or hold it up against the one already
  * there. A recorded report is never overwritten in place: it is the evidence the
  * rebuild is being checked against.
+ *
+ * This says whether the bytes agree and nothing more. Which renderer produced the
+ * recorded ones is a separate verdict, printed next to this one by
+ * {@link reportProvenance} — an explanation offered here would be one this
+ * function has no evidence for.
  * @param {Object} opts
  * @param {string} opts.dir - The run directory.
  * @param {string|null} opts.out - `--out`, when it was given.
- * @param {string} opts.bytes - From {@link serialize}.
- * @returns {boolean} Whether the rebuild differs from a report already recorded.
+ * @param {string} opts.bytes - From `serializeReport`.
+ * @returns {{mode: string, differs: boolean}} `mode` is `compared` when a
+ *   recorded report was held up against the rebuild, `written` otherwise.
  * @throws {ReplayError} When the file could not be written.
  */
 function emit(opts) {
@@ -451,7 +474,7 @@ function emit(opts) {
         `replay  identical to the ${join.REPORT_FILENAME} already in the run directory, byte ` +
           `for byte (${recorded.length} bytes) — nothing was written`,
       );
-      return false;
+      return { mode: 'compared', differs: false };
     }
     console.error(`\nbench: the rebuilt report differs from ${recordedPath}`);
     console.error(`bench: first difference at byte ${at}`);
@@ -459,11 +482,10 @@ function emit(opts) {
     console.error(`bench:   recorded ${excerpt(recorded)}`);
     console.error(`bench:   rebuilt  ${excerpt(rebuilt)}`);
     console.error(
-      'bench: nothing was written. Either the recording changed under the report, or the report ' +
-        'was rendered by a different bench/lib/join.js than the one replaying it — a report ' +
-        'carries a schemaVersion, and a string it renders can change without that number moving',
+      'bench: nothing was written. The recorded report is the evidence, and it stands as it was ' +
+        'recorded',
     );
-    return true;
+    return { mode: 'compared', differs: true };
   }
 
   const target = opts.out === null ? recordedPath : opts.out;
@@ -472,8 +494,96 @@ function emit(opts) {
   } catch (err) {
     throw new ReplayError('write-failed', `${target} could not be written: ${err.message}`);
   }
-  console.log(`written ${target}`);
-  return false;
+  console.log(
+    opts.out === null
+      ? `written ${target}`
+      : `written ${target} — rendered now, by this replay's own report renderer`,
+  );
+  return { mode: 'written', differs: false };
+}
+
+/**
+ * Say which renderer produced the recording, and — where a comparison was made —
+ * put that next to the byte verdict without letting either stand in for the
+ * other.
+ *
+ * The four readings this keeps apart:
+ *
+ * - **match, bytes identical** — historical report bytes reproduced exactly, by a
+ *   renderer the recording pins as the one that wrote them.
+ * - **skew or legacy, bytes identical** — historical report bytes reproduced
+ *   exactly all the same. The recorded report is preserved evidence and equality
+ *   with it is directly observable; what is unknown on a legacy recording is the
+ *   renderer's identity, not the bytes.
+ * - **match, bytes differ** — renderer skew is NOT available as the explanation,
+ *   and none is invented in its place.
+ * - **skew or legacy, bytes differ** — the divergence and the limited attribution
+ *   are stated as two separate things, because a candidate cause is not a cause.
+ * @param {Object} verdict - From `classifyRenderer()`.
+ * @param {{mode: string, differs: boolean}} outcome - From {@link emit}.
+ * @returns {void}
+ */
+function reportProvenance(verdict, outcome) {
+  const differs = outcome.mode === 'compared' && outcome.differs;
+  const say = differs ? (m) => console.error(`bench: ${m}`) : (m) => console.log(`replay  ${m}`);
+  const detail = differs
+    ? (m) => console.error(`bench:   ${m}`)
+    : (m) => console.log(`replay    ${m}`);
+
+  /**
+   * What the byte comparison established, appended to the identity verdict.
+   * Empty when the bytes differed: the difference has already been printed in
+   * full, and this line's job is then to say what may and may not be read into it.
+   * @type {string}
+   */
+  const reproduced =
+    outcome.mode === 'written'
+      ? '; no recorded report was held up against this rebuild'
+      : '; the historical report bytes were reproduced exactly';
+
+  if (verdict.provenance === RENDERER_PROVENANCE.MATCH) {
+    say(
+      'renderer match — the recording pins the report-renderer source bytes and this replay ran ' +
+        'the same ones' +
+        (differs
+          ? ', so renderer skew is NOT the explanation for the difference above. What failed is ' +
+            'the deterministic contract between those files and this renderer, and no other ' +
+            'cause is inferred here'
+          : reproduced),
+    );
+    return;
+  }
+
+  if (verdict.provenance === RENDERER_PROVENANCE.SKEW) {
+    say(
+      'renderer skew — the recording pins report-renderer source bytes this replay did not run' +
+        (differs
+          ? '. That is a fact about the two renderers, stated next to the byte difference above ' +
+            'rather than as its cause: it is a candidate explanation, and nothing here ' +
+            'establishes it'
+          : outcome.mode === 'written'
+            ? reproduced
+            : `${reproduced}, skew or no skew`),
+    );
+    if (verdict.reason) detail(verdict.reason);
+    for (const d of verdict.differences) {
+      detail(
+        `${d.file.padEnd(20)} recorded ${d.recorded === null ? 'ABSENT' : d.recorded} · ` +
+          `this tree ${d.current === null ? 'ABSENT' : d.current}`,
+      );
+    }
+    return;
+  }
+
+  say(
+    'legacy-unversioned — this recording carries no manifest.reportRenderer block, so which ' +
+      'report-renderer source bytes originally produced its report was never recorded' +
+      (differs
+        ? '. The byte difference above stands on its own, and no cause is attributed to it here'
+        : `${reproduced}, and those bytes are the evidence they always were — what this ` +
+          'recording never captured is the identity of the renderer that wrote them, not the ' +
+          'bytes themselves'),
+  );
 }
 
 /**
@@ -502,7 +612,7 @@ function main(argv) {
   const dir = path.resolve(args.dir);
   let run;
   let report;
-  let differs;
+  let outcome;
   try {
     run = loadRun(dir);
     report = rebuild(run);
@@ -513,7 +623,8 @@ function main(argv) {
         `${OBSERVED_FILENAME} (${run.observed.length} observed), ` +
         `${META_FILENAME}, ${MANIFEST_FILENAME} — no sensor, no product code, no settings file`,
     );
-    differs = emit({ dir, out: args.out, bytes: serialize(report) });
+    outcome = emit({ dir, out: args.out, bytes: serializeReport(report) });
+    reportProvenance(classifyRenderer(run.reportRenderer), outcome);
   } catch (err) {
     if (!(err instanceof ReplayError)) throw err;
     console.error(`bench: ${err.message}`);
@@ -530,7 +641,7 @@ function main(argv) {
     );
   }
 
-  if (differs) return 1;
+  if (outcome.differs) return 1;
   return report.join.unavailable ? 1 : 0;
 }
 
@@ -560,5 +671,5 @@ module.exports = {
   readNdjson,
   readWindow,
   rebuild,
-  serialize,
+  reportProvenance,
 };

--- a/bench/run.js
+++ b/bench/run.js
@@ -16,6 +16,14 @@
  *   sensor against the catalogue and against nothing else, and the catalogue is
  *   still unconfirmed until an oracle confirms it.
  *
+ *   The manifest also records **which report renderer this process is running** —
+ *   `reportRenderer`, the sha256 of `bench/lib/join.js` and `bench/lib/report.js`
+ *   frozen while they were loaded. `sensor.gitSha` cannot stand in for it: a run
+ *   against a dirty tree names a commit whose bytes are not the ones rendering
+ *   the report, and every arm-A run so far has been exactly that. A replay reads
+ *   the block back and says whether the renderer it is running is the one that
+ *   produced the recorded report, separately from whether it reproduced its bytes.
+ *
  *   Order matters here, in three places.
  *
  *   A scenario is loaded and validated **before** the run directory exists, so a
@@ -58,9 +66,17 @@ const manifest = require('./lib/manifest');
 const observed = require('./lib/observed');
 // Destructured rather than taken as a namespace: `main` binds a local `report`
 // for the object it just built, and a namespace of the same name would be
-// shadowed exactly where these two are called. They live in `lib/report.js` so
-// that `bench/replay.js` can share them without loading this file's graph.
-const { MAX_LATENCY_INTERVALS, maxLatencyFrom, reportJoin } = require('./lib/report');
+// shadowed exactly where these are called. They live in `lib/report.js` so that
+// `bench/replay.js` can share them without loading this file's graph — above all
+// `serializeReport`, which is the one definition of a report's bytes, and
+// `RENDERER_FINGERPRINT`, which names the source those bytes came out of.
+const {
+  MAX_LATENCY_INTERVALS,
+  RENDERER_FINGERPRINT,
+  maxLatencyFrom,
+  reportJoin,
+  serializeReport,
+} = require('./lib/report');
 const sensor = require('./lib/sensor');
 
 /** @type {string} Where run directories are created. Gitignored. */
@@ -517,7 +533,7 @@ function writeReport(opts) {
     ticksWhileProcessAlive: opts.capture.record.sensor.ticksWhileProcessAlive,
   });
   const file = path.join(opts.dir, join.REPORT_FILENAME);
-  fs.writeFileSync(file, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(file, serializeReport(report), 'utf8');
   console.log(`written ${file}`);
   return report;
 }
@@ -573,6 +589,12 @@ async function main(argv) {
     scenario: args.scenario,
     arm: args.arm,
     startedAt: now.toISOString(),
+    // Frozen while `lib/report.js` was loading, a few milliseconds before this
+    // line — the renderer this process is running, not the file as it will
+    // stand when the report is written some minutes from now. Recorded in every
+    // arm: it names the code, and the code is the same whether or not this arm
+    // ends up rendering anything with it.
+    reportRenderer: RENDERER_FINGERPRINT,
   });
   const manifestPath = path.join(dir, 'manifest.json');
   fs.writeFileSync(manifestPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');

--- a/tests/fixtures/bench/README.md
+++ b/tests/fixtures/bench/README.md
@@ -11,8 +11,8 @@ Windows build. What these fixtures pin is the file contract and the arithmetic o
 not the sensor's accuracy.
 
 Nothing in them is edited. The machine paths (`C:\Users\...`, `X:\Future\...`) are the
-paths the run actually wrote, and rewriting them would destroy the property the golden
-test asserts: that a rebuild reproduces the recorded report byte for byte.
+paths the run actually wrote, and rewriting them would destroy the property the tests
+assert: that a rebuild reproduces the recorded report byte for byte.
 
 Two repository settings keep that property alive, and both are load-bearing rather than
 tidy:
@@ -22,37 +22,79 @@ tidy:
 - `.prettierignore` excludes it. The `lint-staged` entry `"*.{js,ts,json}"` matches on the
   base name, so **every** staged `.json` goes through `prettier --write` wherever it lives —
   and prettier rewrites `"points": [\n 9989\n]` as `"points": [9989]`. Without that line a
-  commit silently reformats the golden file, and the byte comparison then runs against a
-  file the formatter edited rather than against the one the run wrote.
+  commit silently reformats these files, and a byte comparison then runs against a file the
+  formatter edited rather than against the one the run wrote.
 
-| directory | what it is |
+## What is here
+
+| path | what it is |
 |---|---|
-| `runs/2026-08-13T19-26-29Z-S1-agent-lifecycle-A/` | A complete S1 run, all five files. Its `run-report.json` was written by the live run and is the golden target: replaying the other four files must reproduce it byte for byte. |
-| `runs/2026-08-13T17-11-03Z-S1-agent-lifecycle-A/` | An earlier S1 run, recorded before `observed.meta.json` carried `sensor.scanInterval` and before `run-report.json` existed. It holds four files and no report, and replay must refuse it by name: the join window is derived from the run or it is absent, never defaulted. |
+| `runs/2026-08-13T19-26-29Z-S1-agent-lifecycle-A/` | A complete S1 run, all five files. Its `run-report.json` is the file that live run wrote. |
+| `runs/2026-08-13T17-11-03Z-S1-agent-lifecycle-A/` | An earlier S1 run, recorded before `observed.meta.json` carried `sensor.scanInterval` and before `run-report.json` existed. Four files and no report, and replay must refuse it by name: the join window is derived from the run or it is absent, never defaulted. |
+| `goldens/2026-08-13T19-26-29Z-S1-agent-lifecycle-A.golden-report.current.json` | **Derived, not recorded.** What the renderer in this working tree makes of the recording above. Regenerable, and expected to move whenever a rendered string changes. |
 
 The empty `stage/` directory each run leaves behind is not copied — it holds nothing
 replay reads, and git does not track empty directories.
 
+## Recordings, and what they pin
+
+Those nine files under `runs/` are **recordings**. The observation is never rewritten by
+the interpretation, so none of them is ever regenerated, reformatted or corrected — not to
+make a test pass, not to adopt a renderer change, not for tidiness.
+`tests/main/bench/fixture-immutability.test.js` holds every one of them against a committed
+sha256 and against the exact file set its run wrote, so a drift is a red test rather than a
+discovery months later.
+
+What a recording pins is what that run did. What these two do **not** pin is which report
+renderer turned it into bytes, and the difference matters:
+
+- `run-report.json` in the 19-26-29 recording is the file the live run wrote. It is
+  byte-equal to the untracked original still sitting in `bench/runs/`, and its mtime is the
+  minute the sensor stopped. It is evidence, and a rebuild matching it byte for byte is a
+  directly observable fact about those bytes.
+- The manifest names `sensor.gitSha` `7a27b5d5…` together with `sensor.workingTreeDirty:
+  true`, and `bench/lib/join.js` was itself uncommitted when the run happened — it landed
+  two hours later as `76525d7`. A commit plus "the tree was dirty" does not identify the
+  source bytes that rendered a report.
+
+So both recordings classify as **`legacy-unversioned`**: they predate
+`manifest.reportRenderer`, and no fingerprint is back-filled into them. Replay says so by
+name, and it says it separately from the byte comparison — identical bytes are identical
+bytes whether or not the renderer behind them was ever identified. Runs recorded from now
+on carry the fingerprint and classify as `renderer-match` or `renderer-skew` instead; see
+[bench/README.md](../../../bench/README.md#the-renderer-that-rendered-it).
+
 ## Maintenance contract
 
-The golden `run-report.json` is a rendering, and `bench/lib/join.js` owns every string in
-it. **When a change to `join.js` alters a rendered string, this fixture's
-`run-report.json` must be regenerated and the diff reviewed** — otherwise the next person
-meets a red byte-equality test with no way to tell whether the code or the fixture is
-wrong.
+**Recordings are never regenerated.** If a change to `bench/lib/join.js` or
+`bench/lib/report.js` alters a rendered string, the recording keeps the bytes its run
+wrote and the rebuild stops matching them. That is the finding, and replay states it —
+with the first differing byte, and with what the renderer verdict does and does not
+explain about it. It does not apply it.
 
-Regenerate by replaying with `--out` and moving the result in, so the difference is read
-before it is accepted:
+**Goldens are derived, and they are what gets regenerated.** The file under `goldens/` is
+this renderer's rendering of that recording, committed separately so the two can diverge
+visibly:
 
 ```
-node bench/replay.js tests/fixtures/bench/runs/2026-08-13T19-26-29Z-S1-agent-lifecycle-A
+node bench/replay.js tests/fixtures/bench/runs/2026-08-13T19-26-29Z-S1-agent-lifecycle-A \
+  --out tests/fixtures/bench/goldens/2026-08-13T19-26-29Z-S1-agent-lifecycle-A.golden-report.current.json
 ```
+
+Read the diff before accepting it: a golden that moved because a string was reworded is a
+different event from one that moved because a number changed. `--out` writes exactly the
+report and nothing else — no provenance is smuggled into the report shape — so what the
+artefact is, is carried by where it lives, what it is called, and this file.
 
 With no `--out`, replay compares and writes nothing; it prints the first differing byte.
-That output is the diff to review. If the change is intended, rebuild the file with
-`--out` pointed at it.
 
-This has already happened once, before replay existed: `join.js` changed
+Today the golden and the recorded report are byte-identical, which is a fact with a date
+on it rather than a property: this renderer still renders that recording exactly as the
+run's own renderer did. The day that stops being true, the golden moves and the recording
+does not, and which of the two moved is then answerable instead of guessable.
+
+That day has already happened once, before replay existed: `join.js` changed
 `"1 matched pair(s)"` to `"1 matched pair"` without moving `SCHEMA_VERSION`, so a run
-recorded before that change no longer rebuilds identically. A report's bytes are a
-function of the recording **and** of the `join.js` that renders it.
+recorded before that change no longer rebuilds identically. A report's bytes are a function
+of the recording **and** of the renderer that renders it — which is exactly why a run now
+records which renderer that was.

--- a/tests/fixtures/bench/goldens/2026-08-13T19-26-29Z-S1-agent-lifecycle-A.golden-report.current.json
+++ b/tests/fixtures/bench/goldens/2026-08-13T19-26-29Z-S1-agent-lifecycle-A.golden-report.current.json
@@ -1,0 +1,177 @@
+{
+  "schemaVersion": 1,
+  "runId": "2026-08-13T19-26-29Z-S1-agent-lifecycle-A",
+  "scenario": "S1-agent-lifecycle",
+  "arm": "A",
+  "join": {
+    "maxLatencyMs": 30000,
+    "maxLatencySource": "10 s × 3 scan intervals — scanIntervalSec in C:\\Users\\murtu\\AppData\\Local\\Temp\\aegis-bench-2026-08-13T19-26-29Z-S1-agent-lifecycle-A\\settings.json",
+    "unavailable": null,
+    "window": "observed ∈ [expected.@timestamp, expected.@timestamp + maxLatencyMs]",
+    "keys": {
+      "process/start": "process.pid",
+      "process/end": "process.pid",
+      "file/creation": "file.path, case- and separator-normalised",
+      "file/deletion": "file.path, case- and separator-normalised"
+    },
+    "notJoinedOn": "a name. AEGIS persists the display name it resolved (\"Claude Code\"), never the image name (\"claude.exe\"), so the two sides hold different strings about different things and a name join would manufacture matches (B2.3)",
+    "cardinality": "one observed event cancels at most one expectation; where several pairings are eligible the nearest in time wins",
+    "noConfidenceFigure": "every number here is a count of rows or a difference of two timestamps. This report carries no confidence score and none is derived from it"
+  },
+  "processObservable": true,
+  "ticksWhileProcessAlive": 3,
+  "categories": {
+    "process/start": {
+      "expected": 1,
+      "matched": 1,
+      "missed": 0,
+      "recall": "1/1",
+      "recallValue": 1,
+      "latencyMs": {
+        "points": [
+          9989
+        ],
+        "p50": 9989,
+        "max": 9989,
+        "basis": "1 matched pair — p50 and max ARE those points, not statistics over a sample"
+      }
+    },
+    "process/end": {
+      "expected": 1,
+      "matched": 1,
+      "missed": 0,
+      "recall": "1/1",
+      "recallValue": 1,
+      "latencyMs": {
+        "points": [
+          14927
+        ],
+        "p50": 14927,
+        "max": 14927,
+        "basis": "1 matched pair — p50 and max ARE those points, not statistics over a sample"
+      }
+    },
+    "file/creation": {
+      "expected": 1,
+      "matched": 1,
+      "missed": 0,
+      "recall": "1/1",
+      "recallValue": 1,
+      "latencyMs": {
+        "points": [
+          12
+        ],
+        "p50": 12,
+        "max": 12,
+        "basis": "1 matched pair — p50 and max ARE those points, not statistics over a sample"
+      }
+    },
+    "file/deletion": {
+      "expected": 1,
+      "matched": 1,
+      "missed": 0,
+      "recall": "1/1",
+      "recallValue": 1,
+      "latencyMs": {
+        "points": [
+          104
+        ],
+        "p50": 104,
+        "max": 104,
+        "basis": "1 matched pair — p50 and max ARE those points, not statistics over a sample"
+      }
+    }
+  },
+  "matched": [
+    {
+      "category": "file/creation",
+      "key": "path:x:\\future\\escape\\aegis\\bench\\runs\\2026-08-13t19-26-29z-s1-agent-lifecycle-a\\stage\\claude.exe",
+      "latencyMs": 12,
+      "expected": {
+        "index": 0,
+        "@timestamp": "2026-08-13T19:28:03.835Z",
+        "step": "stage-binary",
+        "expect": "E1"
+      },
+      "observed": {
+        "index": 0,
+        "@timestamp": "2026-08-13T19:28:03.847Z",
+        "auditFile": "aegis-audit-2026-08-13.json",
+        "auditSeq": 22,
+        "auditType": "file-access",
+        "attribution": {
+          "status": "unattributed",
+          "evidence": [
+            "no-owner-match"
+          ]
+        }
+      }
+    },
+    {
+      "category": "file/deletion",
+      "key": "path:x:\\future\\escape\\aegis\\bench\\runs\\2026-08-13t19-26-29z-s1-agent-lifecycle-a\\stage\\claude.exe",
+      "latencyMs": 104,
+      "expected": {
+        "index": 3,
+        "@timestamp": "2026-08-13T19:28:38.944Z",
+        "step": "remove-binary",
+        "expect": "E4"
+      },
+      "observed": {
+        "index": 2,
+        "@timestamp": "2026-08-13T19:28:39.048Z",
+        "auditFile": "aegis-audit-2026-08-13.json",
+        "auditSeq": 26,
+        "auditType": "file-access",
+        "attribution": {
+          "status": "unattributed",
+          "evidence": [
+            "no-owner-match"
+          ]
+        }
+      }
+    },
+    {
+      "category": "process/start",
+      "key": "pid:6688",
+      "latencyMs": 9989,
+      "expected": {
+        "index": 1,
+        "@timestamp": "2026-08-13T19:28:03.933Z",
+        "step": "spawn-agent",
+        "expect": "E2"
+      },
+      "observed": {
+        "index": 1,
+        "@timestamp": "2026-08-13T19:28:13.922Z",
+        "auditFile": "aegis-audit-2026-08-13.json",
+        "auditSeq": 23,
+        "auditType": "agent-enter",
+        "agent": "Claude Code",
+        "instanceId": "6688:1786649283898"
+      }
+    },
+    {
+      "category": "process/end",
+      "key": "pid:6688",
+      "latencyMs": 14927,
+      "expected": {
+        "index": 2,
+        "@timestamp": "2026-08-13T19:28:38.943Z",
+        "step": "terminate-agent",
+        "expect": "E3"
+      },
+      "observed": {
+        "index": 3,
+        "@timestamp": "2026-08-13T19:28:53.870Z",
+        "auditFile": "aegis-audit-2026-08-13.json",
+        "auditSeq": 29,
+        "auditType": "agent-exit",
+        "agent": "Claude Code",
+        "instanceId": "6688:1786649283898"
+      }
+    }
+  ],
+  "missed": [],
+  "unmatchedObserved": []
+}

--- a/tests/main/bench/fixture-immutability.test.js
+++ b/tests/main/bench/fixture-immutability.test.js
@@ -1,0 +1,134 @@
+/**
+ * @file tests/main/bench/fixture-immutability.test.js
+ * @description The nine files under `tests/fixtures/bench/runs/` are two real
+ *   arm-A runs, and they are recordings: the observation is never rewritten by
+ *   the interpretation. This file is the gate on that sentence.
+ *
+ *   The hashes below are committed constants, not a snapshot taken at startup, and
+ *   that is the stronger check of the two. A before/after diff only catches a test
+ *   that edits a fixture while the suite is running; committed digests catch that
+ *   AND a regeneration committed by hand, a formatter that reached the tree, a
+ *   line-ending conversion on a Windows checkout, and a replay that wrote a new
+ *   file into a recording. The digests are checked twice — before this file's
+ *   tests and after them — which is what a same-file mutation would trip.
+ *   Cross-file ordering inside one vitest run is not guaranteed, so the guarantee
+ *   this file gives is against the committed bytes rather than against a moment.
+ *
+ *   Two recordings, four and five files: the earlier run predates
+ *   `run-report.json`. Their file SETS are pinned too, so an artefact appearing
+ *   inside a recording is a failure here rather than a discovery three months
+ *   later.
+ *
+ *   Derived artefacts are deliberately not covered. A current-renderer golden
+ *   under `tests/fixtures/bench/goldens/` is expected to move whenever the
+ *   renderer renders a string differently; that is what makes it a golden and a
+ *   recording not one.
+ */
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..', '..');
+const RUNS = path.join(REPO, 'tests', 'fixtures', 'bench', 'runs');
+
+/**
+ * Every recorded byte, by run directory and file name: `[sha256, length]`.
+ *
+ * Taken from the files as committed in PR #220, which are themselves byte-equal
+ * to the untracked originals the two runs left in `bench/runs/`.
+ * @type {Readonly<Object<string, Object<string, [string, number]>>>}
+ */
+const RECORDED = Object.freeze({
+  '2026-08-13T17-11-03Z-S1-agent-lifecycle-A': {
+    'expected.ndjson': ['218a147a1b5dda6c74e2b71719454f1c8f4de4d630416aea7f6b01b036550d98', 2121],
+    'manifest.json': ['9c52b49193129c4130da9755686f06c42ae6f669f72ee69898ca10d1f614f5b9', 2167],
+    'observed.meta.json': [
+      'ddee0b3cfe65f6c6c37b3ba219f9356b6329b8e93cc3935291bdecae83a2d04d',
+      1948,
+    ],
+    'observed.ndjson': ['54a349b0d477ee309d74559e5429a7e78b533501c58a08e98d0dff0195e2fc5f', 2506],
+  },
+  '2026-08-13T19-26-29Z-S1-agent-lifecycle-A': {
+    'expected.ndjson': ['9cf015de3c4afbb59d4f34763ba92fbed1d95a88fb290ccceda27a55b4d5e446', 2119],
+    'manifest.json': ['257206674bdecac1a786f174362e08898c5f3f866fdf76575840cb3d2f90ae5b', 2155],
+    'observed.meta.json': [
+      '436b8fc8a50b71dfe03929d279feb7eba92ac22794a59daac0d964e7668c439c',
+      2576,
+    ],
+    'observed.ndjson': ['8df799f88f2968ed90d85846be3043a11f8b9c92211670592f2d64a3ac7dc242', 2003],
+    'run-report.json': ['fa8f4fe32260b93b68a117a112f05ed589a56014488c92546fd21dac1703b11a', 5251],
+  },
+});
+
+/**
+ * Digest one recorded file as bytes, never as decoded text.
+ * @param {string} file - Absolute path.
+ * @returns {{sha256: string, length: number}}
+ */
+function digest(file) {
+  const bytes = fs.readFileSync(file);
+  return { sha256: crypto.createHash('sha256').update(bytes).digest('hex'), length: bytes.length };
+}
+
+/**
+ * Hold every recording up against the committed digests.
+ * @param {string} when - Named in the failure, so a mutation says when it happened.
+ * @returns {void}
+ */
+function assertRecordingsIntact(when) {
+  for (const [runId, files] of Object.entries(RECORDED)) {
+    const dir = path.join(RUNS, runId);
+    const actual = fs.readdirSync(dir).sort();
+    if (actual.join('|') !== Object.keys(files).sort().join('|')) {
+      throw new Error(
+        `${when}: ${runId} holds [${actual.join(', ')}] — a recording is the files that run ` +
+          `wrote and nothing else, and this one is expected to hold ` +
+          `[${Object.keys(files).sort().join(', ')}]`,
+      );
+    }
+    for (const [name, [sha256, length]] of Object.entries(files)) {
+      const got = digest(path.join(dir, name));
+      if (got.sha256 !== sha256 || got.length !== length) {
+        throw new Error(
+          `${when}: ${runId}/${name} is ${got.length} bytes sha256 ${got.sha256}, and the ` +
+            `recording is ${length} bytes sha256 ${sha256}. A recording is never regenerated: ` +
+            'if this renderer now renders a report differently, that belongs in a derived ' +
+            'golden under tests/fixtures/bench/goldens/, not in the run directory',
+        );
+      }
+    }
+  }
+}
+
+beforeAll(() => assertRecordingsIntact('before this file ran'));
+afterAll(() => assertRecordingsIntact('after this file ran'));
+
+describe('bench fixtures — the recordings are immutable', () => {
+  it('holds nine recorded files across two runs, byte for byte as recorded', () => {
+    const names = Object.values(RECORDED).flatMap((files) => Object.keys(files));
+    expect(names).toHaveLength(9);
+    expect(() => assertRecordingsIntact('at assertion time')).not.toThrow();
+  });
+
+  for (const [runId, files] of Object.entries(RECORDED)) {
+    it(`${runId} holds exactly its recorded file set`, () => {
+      expect(fs.readdirSync(path.join(RUNS, runId)).sort()).toEqual(Object.keys(files).sort());
+    });
+
+    for (const [name, [sha256, length]] of Object.entries(files)) {
+      it(`${runId}/${name} is unchanged`, () => {
+        expect(digest(path.join(RUNS, runId, name))).toEqual({ sha256, length });
+      });
+    }
+  }
+
+  it('pins the earlier run as the four-file recording it is, with no report', () => {
+    const files = RECORDED['2026-08-13T17-11-03Z-S1-agent-lifecycle-A'];
+    expect(Object.keys(files)).toHaveLength(4);
+    expect(files['run-report.json']).toBeUndefined();
+  });
+});

--- a/tests/main/bench/replay.test.js
+++ b/tests/main/bench/replay.test.js
@@ -15,14 +15,26 @@
  *     credits the sensor with less than it recorded;
  *   - a report rebuilt across two runs' files, naming one run and counting another.
  *
+ *   Two further blocks were added with the renderer fingerprint. **Provenance**
+ *   pins that a report's bytes and the identity of the renderer that produced
+ *   them are reported as two facts and never folded into one: identical bytes
+ *   under renderer skew are still identical bytes, a difference under a renderer
+ *   match is still a difference with no cause invented for it, and a recording
+ *   that pins no renderer is `legacy-unversioned` rather than retrofitted. **The
+ *   golden** pins the current renderer's own output as a separate committed
+ *   artefact, so that when a rendered string next changes the golden moves and
+ *   the recording does not.
+ *
  *   The last block is a gate on the module rather than on its output: replay must
- *   read nothing outside the run directory, and its module graph must not reach
- *   the sensor or the actor. An import-time dependency is invisible to an fs spy
- *   installed in a test body, so the graph is proven in a child process instead.
+ *   read nothing outside the run directory once it is running, and its module
+ *   graph must not reach the sensor or the actor. An import-time dependency is
+ *   invisible to an fs spy installed in a test body, so the graph — and the one
+ *   pair of reads that does happen at load — is proven in a child process instead.
  *
  *   The fixtures under `tests/fixtures/bench/` are two real arm-A runs, copied
- *   verbatim; `tests/fixtures/bench/README.md` states their provenance and the
- *   maintenance contract that comes with a byte-exact golden file.
+ *   verbatim; `tests/fixtures/bench/README.md` states their provenance, and
+ *   `tests/main/bench/fixture-immutability.test.js` is the gate that keeps them
+ *   the bytes those runs wrote.
  */
 import { execFileSync } from 'child_process';
 import fs from 'fs';
@@ -35,6 +47,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import catalogue from '../../../bench/lib/catalogue.js';
 import join from '../../../bench/lib/join.js';
 import observed from '../../../bench/lib/observed.js';
+import report from '../../../bench/lib/report.js';
 import replay from '../../../bench/replay.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -42,11 +55,28 @@ const REPO = path.resolve(HERE, '..', '..', '..');
 const REPLAY_SOURCE = path.join(REPO, 'bench', 'replay.js');
 const FIXTURES = path.join(REPO, 'tests', 'fixtures', 'bench', 'runs');
 
-/** @type {string} A complete arm-A run: four inputs and the report they produced. */
+/**
+ * A complete arm-A run: four inputs and the report they produced.
+ *
+ * The name is historical. This directory is a RECORDING — its `run-report.json`
+ * is the file that run wrote — and the current renderer's golden is the separate
+ * committed artefact at {@link CURRENT_RENDERER_GOLDEN}.
+ * @type {string}
+ */
 const GOLDEN = path.join(FIXTURES, '2026-08-13T19-26-29Z-S1-agent-lifecycle-A');
 
 /** @type {string} A real run recorded before `sensor.scanInterval` existed. */
 const PRE_INTERVAL = path.join(FIXTURES, '2026-08-13T17-11-03Z-S1-agent-lifecycle-A');
+
+/** @type {string} What THIS renderer makes of that recording — derived, and regenerable. */
+const CURRENT_RENDERER_GOLDEN = path.join(
+  REPO,
+  'tests',
+  'fixtures',
+  'bench',
+  'goldens',
+  '2026-08-13T19-26-29Z-S1-agent-lifecycle-A.golden-report.current.json',
+);
 
 /** @type {string} Scratch directory, made fresh per test. */
 let tmp;
@@ -148,6 +178,11 @@ function rebuildTo(dir, label) {
 }
 
 describe('replay — the report a live run wrote, rebuilt from its files', () => {
+  // A byte observation and only that. The recorded report is preserved evidence,
+  // so equality with it is directly observable and holds whatever the recording
+  // says about renderers — including nothing, which is this fixture's case. What
+  // that recording never captured is WHICH renderer wrote those bytes, and that
+  // is the separate verdict pinned under `renderer provenance` below.
   it('reproduces the recorded report byte for byte', () => {
     const rebuilt = rebuildTo(GOLDEN, 'rebuilt.json');
     expect(rebuilt.code).toBe(0);
@@ -220,6 +255,206 @@ describe('replay — determinism', () => {
 
     const recorded = fs.readFileSync(path.join(GOLDEN, join.REPORT_FILENAME));
     expect(fs.readFileSync(file).equals(recorded)).toBe(true);
+  });
+});
+
+describe('replay — the current-renderer golden', () => {
+  /**
+   * The golden is what THIS renderer makes of that recording, committed on its
+   * own outside the run directory. Today it is byte-identical to the recorded
+   * report, and that is a coincidence with a date on it: the moment a rendered
+   * string changes, this file is regenerated and the recording is not. Which of
+   * the two moved is then the finding, and neither has to be guessed at.
+   *
+   * `--out` is the only way to produce it, and it writes exactly the report —
+   * no envelope, no provenance smuggled into the report shape. What the artefact
+   * is, is carried by where it lives and what it is called.
+   */
+  it('is the report this renderer builds from that recording, byte for byte', () => {
+    const rebuilt = rebuildTo(GOLDEN, 'against-golden.json');
+    expect(rebuilt.code).toBe(0);
+
+    const produced = fs.readFileSync(rebuilt.file);
+    const committed = fs.readFileSync(CURRENT_RENDERER_GOLDEN);
+    expect(produced.length).toBe(committed.length);
+    expect(produced.equals(committed)).toBe(true);
+  });
+
+  it('is a report and nothing but a report — replay adds no field of its own', () => {
+    const golden = JSON.parse(fs.readFileSync(CURRENT_RENDERER_GOLDEN, 'utf8'));
+    expect(golden.schemaVersion).toBe(join.SCHEMA_VERSION);
+    expect(golden.runId).toBe('2026-08-13T19-26-29Z-S1-agent-lifecycle-A');
+    expect(Object.keys(golden)).toEqual(
+      Object.keys(JSON.parse(fs.readFileSync(path.join(GOLDEN, join.REPORT_FILENAME), 'utf8'))),
+    );
+  });
+
+  it('lives outside the recording, so a golden can move without a recording moving', () => {
+    expect(path.dirname(CURRENT_RENDERER_GOLDEN)).not.toBe(GOLDEN);
+    expect(path.basename(CURRENT_RENDERER_GOLDEN)).toMatch(/golden-report\.current\.json$/);
+    expect(fs.readdirSync(GOLDEN)).not.toContain(path.basename(CURRENT_RENDERER_GOLDEN));
+  });
+});
+
+describe('replay — renderer provenance, kept apart from the bytes', () => {
+  /** @type {Object} A fingerprint that is well-formed and is not this renderer's. */
+  const SKEWED = { ...report.RENDERER_FINGERPRINT, joinSha256: '0'.repeat(64) };
+
+  /**
+   * A copy of the recording whose manifest pins a renderer.
+   *
+   * The manifest is edited in the SCRATCH copy and never in the fixture: the two
+   * committed recordings pin no renderer, which is the honest state of both, and
+   * back-filling one would be inventing the fact this whole block exists to keep
+   * from being invented.
+   * @param {Object|null} block - What `manifest.reportRenderer` should hold.
+   * @param {boolean} [doctor] - Also alter the recorded report, so the rebuild differs from it.
+   * @returns {string} The copy's path.
+   */
+  function pinned(block, doctor = false) {
+    const dir = copyRun(GOLDEN);
+    const manifest = readJson(dir, replay.MANIFEST_FILENAME);
+    if (block === null) delete manifest.reportRenderer;
+    else manifest.reportRenderer = block;
+    writeJson(dir, replay.MANIFEST_FILENAME, manifest);
+    if (doctor) {
+      const file = path.join(dir, join.REPORT_FILENAME);
+      fs.writeFileSync(
+        file,
+        fs
+          .readFileSync(file, 'utf8')
+          .replace('"ticksWhileProcessAlive": 3', '"ticksWhileProcessAlive": 7'),
+        'utf8',
+      );
+    }
+    return dir;
+  }
+
+  it('match + identical bytes: the historical bytes, from the renderer that wrote them', () => {
+    const result = main([pinned(report.RENDERER_FINGERPRINT)]);
+
+    expect(result.code).toBe(0);
+    expect(result.out).toMatch(/identical to the run-report\.json already in the run directory/);
+    expect(result.out).toMatch(
+      /renderer match — the recording pins the report-renderer source bytes/,
+    );
+    expect(result.out).toMatch(/the historical report bytes were reproduced exactly/);
+  });
+
+  it('skew + identical bytes: the historical bytes all the same, and the skew named', () => {
+    const result = main([pinned(SKEWED)]);
+
+    expect(result.code).toBe(0);
+    expect(result.out).toMatch(/identical to the run-report\.json already in the run directory/);
+    expect(result.out).toMatch(
+      /renderer skew — the recording pins report-renderer source bytes this replay did not run/,
+    );
+    expect(result.out).toMatch(
+      /the historical report bytes were reproduced exactly, skew or no skew/,
+    );
+    expect(result.out).not.toMatch(/renderer match/);
+  });
+
+  it('names both digests under skew, so the reader sees what differed', () => {
+    const result = main([pinned(SKEWED)]);
+
+    expect(result.out).toMatch(
+      new RegExp(`bench/lib/join\\.js\\s+recorded ${'0'.repeat(64)} · this tree [0-9a-f]{64}`),
+    );
+    // report.js agreed, so it is not listed: the block names the files that differ.
+    expect(result.out).not.toMatch(/bench\/lib\/report\.js\s+recorded/);
+  });
+
+  it('legacy + identical bytes: the bytes are evidence, the renderer identity was never recorded', () => {
+    const result = main([GOLDEN]);
+
+    expect(result.code).toBe(0);
+    expect(result.out).toMatch(
+      /legacy-unversioned — this recording carries no manifest\.reportRenderer block/,
+    );
+    expect(result.out).toMatch(/the historical report bytes were reproduced exactly/);
+    expect(result.out).toMatch(
+      /what this recording never captured is the identity of the renderer/,
+    );
+    expect(result.out).not.toMatch(/renderer match/);
+  });
+
+  it('match + differing bytes: skew is ruled OUT, and no other cause is invented', () => {
+    const result = main([pinned(report.RENDERER_FINGERPRINT, true)]);
+
+    expect(result.code).toBe(1);
+    expect(result.err).toMatch(/the rebuilt report differs from/);
+    expect(result.err).toMatch(/renderer skew is NOT the explanation for the difference above/);
+    expect(result.err).toMatch(/no other cause is inferred here/);
+  });
+
+  it('skew + differing bytes: a candidate explanation, stated as one', () => {
+    const result = main([pinned(SKEWED, true)]);
+
+    expect(result.code).toBe(1);
+    expect(result.err).toMatch(/the rebuilt report differs from/);
+    expect(result.err).toMatch(/stated next to the byte difference above rather than as its cause/);
+    expect(result.err).toMatch(/candidate explanation, and nothing here establishes it/);
+  });
+
+  it('legacy + differing bytes: the divergence stands alone, with nothing attributed to it', () => {
+    const result = main([pinned(null, true)]);
+
+    expect(result.code).toBe(1);
+    expect(result.err).toMatch(/the rebuilt report differs from/);
+    expect(result.err).toMatch(
+      /The byte difference above stands on its own, and no cause is attributed to it here/,
+    );
+  });
+
+  it('reads a fingerprint of an unknown schema version as skew, never as a match', () => {
+    const result = main([pinned({ ...report.RENDERER_FINGERPRINT, schemaVersion: 99 })]);
+
+    expect(result.code).toBe(0);
+    expect(result.out).toMatch(/renderer skew/);
+    expect(result.out).toMatch(/is schema version 99, and this replay reads version 1/);
+    expect(result.out).not.toMatch(/renderer match/);
+  });
+
+  it('refuses to compare digests taken with two different algorithms', () => {
+    const result = main([pinned({ ...report.RENDERER_FINGERPRINT, algorithm: 'sha1' })]);
+
+    expect(result.out).toMatch(/renderer skew/);
+    expect(result.out).toMatch(/two digests of different algorithms cannot be compared/);
+  });
+
+  it('prints ABSENT for a digest the recording never captured', () => {
+    const result = main([pinned({ ...report.RENDERER_FINGERPRINT, joinSha256: null })]);
+
+    expect(result.out).toMatch(/renderer skew/);
+    expect(result.out).toMatch(/bench\/lib\/join\.js\s+recorded ABSENT · this tree [0-9a-f]{64}/);
+  });
+
+  it('is a verdict on the manifest alone: no report in the directory changes it', () => {
+    const dir = pinned(SKEWED);
+    fs.rmSync(path.join(dir, join.REPORT_FILENAME));
+
+    const result = main([dir]);
+    expect(result.code).toBe(0);
+    expect(result.out).toMatch(/renderer skew/);
+    expect(result.out).toMatch(/no recorded report was held up against this rebuild/);
+    expect(result.out).not.toMatch(/reproduced exactly/);
+  });
+
+  it('classifies without any of it: an absent block and a null one read the same', () => {
+    expect(report.classifyRenderer(undefined).provenance).toBe(report.RENDERER_PROVENANCE.LEGACY);
+    expect(report.classifyRenderer(null).provenance).toBe(report.RENDERER_PROVENANCE.LEGACY);
+    expect(report.classifyRenderer(report.RENDERER_FINGERPRINT).provenance).toBe(
+      report.RENDERER_PROVENANCE.MATCH,
+    );
+    expect(report.classifyRenderer(SKEWED).differences).toEqual([
+      {
+        field: 'joinSha256',
+        file: 'bench/lib/join.js',
+        recorded: '0'.repeat(64),
+        current: report.RENDERER_FINGERPRINT.joinSha256,
+      },
+    ]);
   });
 });
 
@@ -510,7 +745,7 @@ describe('replay — invocation', () => {
 });
 
 describe('replay — isolation', () => {
-  it('reads nothing outside the run directory it was given', () => {
+  it('reads nothing outside the run directory once it is running', () => {
     const dir = copyRun(GOLDEN, [join.REPORT_FILENAME]);
     const read = [];
     // Every spy calls through to the original: the point is to observe which paths
@@ -533,6 +768,39 @@ describe('replay — isolation', () => {
     const outside = read.filter((p) => !path.resolve(p).startsWith(path.resolve(dir)));
     expect(outside).toEqual([]);
     expect(read.some((p) => p.endsWith('settings.json'))).toBe(false);
+    // The renderer fingerprint is taken while `lib/report.js` loads and frozen
+    // there, which is why no join.js or report.js read appears here. That is the
+    // property, not an accident of when this spy was installed: a hash taken now
+    // would describe the file on disk rather than the code this process is
+    // running, and the two differ on exactly the dirty tree every arm-A run so
+    // far was measured against. The load-time pair is proven below.
+    expect(read.some((p) => p.endsWith('join.js') || p.endsWith('report.js'))).toBe(false);
+  });
+
+  it('reads exactly the two renderer files at load, and no run directory', () => {
+    const script =
+      'const fs=require("fs");const orig=fs.readFileSync;const seen=[];' +
+      'fs.readFileSync=(...a)=>{seen.push(String(a[0]));return orig(...a)};' +
+      'require(process.argv[1]);console.log(seen.join("\\n"));';
+    const seen = execFileSync(process.execPath, ['-e', script, REPLAY_SOURCE], {
+      encoding: 'utf8',
+    })
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    // Node's own CJS loader reads a module's source through this same call, so
+    // each of the three files may appear for that reason as well. What is pinned
+    // is the SET: the two renderer files are read while the process is loading,
+    // every path read then lives under bench/, and no run directory, settings
+    // file or src/ module is opened before a run directory has even been named.
+    const names = new Set(seen.map((file) => path.basename(file)));
+    expect(names.has('join.js')).toBe(true);
+    expect(names.has('report.js')).toBe(true);
+    expect([...names].every((n) => ['join.js', 'report.js', 'replay.js'].includes(n))).toBe(true);
+    for (const file of seen) {
+      expect(path.resolve(file).startsWith(path.join(REPO, 'bench'))).toBe(true);
+    }
   });
 
   it('loads a module graph that cannot reach the sensor or the actor', () => {

--- a/tests/main/bench/run.test.js
+++ b/tests/main/bench/run.test.js
@@ -11,13 +11,20 @@
  *   The warmup tick in that fixture is what makes it a real test: counted, it
  *   would move the median off the configured interval.
  */
+import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
+import manifest from '../../../bench/lib/manifest.js';
+import report from '../../../bench/lib/report.js';
 import run from '../../../bench/run.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..', '..');
 
 /** @type {string} A run-scoped profile directory, made fresh per test. */
 let profileDir;
@@ -107,4 +114,88 @@ describe('run — the join bound', () => {
     expect(bound.value).toBeNull();
     expect(bound.unavailable).toMatch(/never defaulted/);
   });
+});
+
+describe('run — the report renderer the run records', () => {
+  /**
+   * The digest, computed here with plain `crypto` over the file's bytes.
+   *
+   * Deliberately not `report.RENDERER_FILES` put through the same helper that
+   * produced the value under test: a fingerprint checked against its own
+   * producer agrees with itself no matter what either of them computes.
+   * @param {string} relative - Repository-relative path.
+   * @returns {string}
+   */
+  function sha256Of(relative) {
+    return crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(path.join(REPO, relative)))
+      .digest('hex');
+  }
+
+  it('is the sha256 of exactly bench/lib/join.js and bench/lib/report.js', () => {
+    expect(report.RENDERER_FINGERPRINT.joinSha256).toBe(sha256Of('bench/lib/join.js'));
+    expect(report.RENDERER_FINGERPRINT.reportHelperSha256).toBe(sha256Of('bench/lib/report.js'));
+    expect(report.RENDERER_FINGERPRINT.algorithm).toBe('sha256');
+    expect(report.RENDERER_FINGERPRINT.schemaVersion).toBe(
+      report.RENDERER_FINGERPRINT_SCHEMA_VERSION,
+    );
+    expect(report.RENDERER_FINGERPRINT.unavailable).toBeUndefined();
+    expect(Object.keys(report.RENDERER_FILES)).toEqual(['joinSha256', 'reportHelperSha256']);
+  });
+
+  it('is frozen, so nothing can edit the record of what this process is running', () => {
+    expect(Object.isFrozen(report.RENDERER_FINGERPRINT)).toBe(true);
+  });
+
+  it('states what it does not cover, in the record itself and not only in a README', () => {
+    expect(report.RENDERER_FINGERPRINT.covers).toContain('bench/lib/join.js');
+    expect(report.RENDERER_FINGERPRINT.covers).toContain('bench/lib/report.js');
+    expect(report.RENDERER_FINGERPRINT.covers).toMatch(/NOT covered/);
+    expect(report.RENDERER_FINGERPRINT.covers).toMatch(/Node version/);
+    expect(report.RENDERER_FINGERPRINT.covers).toMatch(/platform/);
+    expect(report.RENDERER_FINGERPRINT.source).toMatch(
+      /while bench\/lib\/report\.js was being loaded/,
+    );
+  });
+
+  // The two below call the real `manifest.collect()`, which spawns `reg query`,
+  // `tasklist` and three `git` invocations — that is the module's whole job, and
+  // stubbing the probes would leave the placement of this field pinned against a
+  // manifest nothing wrote. They are therefore slow, and slower still under a
+  // loaded full-suite run, so the bound is stated rather than left at the 5 s
+  // default that a parallel suite can walk into (ai-mistakes #26).
+  const COLLECT_TIMEOUT_MS = 30_000;
+
+  it(
+    'goes into the manifest as handed in, not re-read there',
+    () => {
+      const record = manifest.collect({
+        runId: '2026-08-13T19-26-29Z-S1-agent-lifecycle-A',
+        scenario: 'S1-agent-lifecycle',
+        arm: 'A',
+        startedAt: '2026-08-13T19:26:29.876Z',
+        reportRenderer: report.RENDERER_FINGERPRINT,
+      });
+      expect(record.reportRenderer).toBe(report.RENDERER_FINGERPRINT);
+    },
+    COLLECT_TIMEOUT_MS,
+  );
+
+  it(
+    'is null in a manifest whose caller supplied none, and is never reconstructed',
+    () => {
+      const record = manifest.collect({
+        runId: '2026-08-13T19-26-29Z-S1-agent-lifecycle-A',
+        scenario: 'S1-agent-lifecycle',
+        arm: 'A',
+        startedAt: '2026-08-13T19:26:29.876Z',
+      });
+      expect(record.reportRenderer).toBeNull();
+      expect(report.classifyRenderer(record.reportRenderer).provenance).toBe(
+        report.RENDERER_PROVENANCE.LEGACY,
+      );
+    },
+    COLLECT_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## The defect

`tests/fixtures/bench/README.md` claimed both that the committed run directories are
verbatim and unedited **and** that their `run-report.json` must be regenerated whenever
`join.js` changes a rendered string. Both cannot hold: one makes the file evidence, the
other makes it a golden.

Underneath it sat the real gap. A report's bytes are a function of the recording **and of
the code that renders it**, and nothing in a run directory identified that code.
`sensor.gitSha` cannot: the manifest of the committed S1 run names `7a27b5d5…` together
with `workingTreeDirty: true`, and `bench/lib/join.js` was itself uncommitted when that run
happened — it landed two hours later as `76525d7`.

**Provenance check first.** The premise that the fixture's `run-report.json` had already
been re-rendered does not hold, and the fix does not rest on it. All nine committed files
are byte-equal to the untracked originals still in `bench/runs/`; the report's mtime is the
minute the sensor stopped; the fixture entered git in one commit and `replay.js` did not
exist until hours later. Those bytes are what the live run wrote. What was never recorded
is *which renderer wrote them*.

## What changed

**A run records its renderer.** `manifest.reportRenderer` — sha256 of `bench/lib/join.js`
and `bench/lib/report.js`, frozen while `report.js` is being loaded rather than hashed off
disk when the manifest is written. A bench run acts for minutes against a tree its author
may still be editing; a later hash would describe the file, not the code that ran. Content
hashes, so a dirty tree is captured honestly instead of pointed at.

**The covered set is the real closure.** `serializeReport` moves into `report.js` and both
entrypoints call it, so those two files own the whole path from two event arrays to the
bytes on disk, and `join.js` requires nothing. The block carries what it does **not** cover
— the Node version, the platform, and everything in `run.js`/`replay.js` outside that
shared serializer — in the record itself and in both READMEs.

**Replay prints two verdicts and reads neither off the other:**

| | bytes identical | bytes differ |
|---|---|---|
| `renderer-match` | historical bytes reproduced, by the renderer the recording pins | the renderer is ruled **out** as the explanation, and no other cause is invented |
| `renderer-skew` | historical bytes reproduced all the same, skew or no skew | divergence and attribution stated separately: skew is a candidate, not a cause |
| `legacy-unversioned` | historical bytes reproduced; the renderer's identity was never recorded | the divergence stands on its own |

**Recordings are immutable, goldens are derived.** Both committed runs are
`legacy-unversioned` and none of their nine files is touched.
`tests/main/bench/fixture-immutability.test.js` holds each against a committed sha256 and
against the exact file set its run wrote. A current-renderer golden now lives on its own at
`tests/fixtures/bench/goldens/…golden-report.current.json` — today byte-identical to the
recording, which is a fact with a date on it: the next time a rendered string changes, the
golden moves and the recording does not, and which of the two moved becomes answerable.
`--out` writes exactly the report, with no envelope and no provenance smuggled into the
report shape; `join.SCHEMA_VERSION` is unmoved.

The fixture README's regenerate-in-place instruction is gone; its "nothing is edited" claim
is verified and stays.

## Verification

Seven local commands green: `build:renderer`, `format:check`, `lint` (0 errors),
`typecheck`, `typecheck:svelte` (385 files, 0 errors), `test:coverage` (97 files, 1656
passed, 4 skipped), `npm audit --audit-level=high --omit=dev` (0 vulnerabilities).

Both new gates were shown to go red before being trusted (ai-mistakes #21): one byte
appended to the recording fails the immutability test by name and digest; one byte appended
to the golden fails the golden comparison. Both files restored and re-verified.
