### PR TITLE
fix(bench): prove the live write path's byte parity and correct two overclaims

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -506,8 +506,15 @@ itself — `manifest.reportRenderer`, written by `bench/run.js` out of a fingerp
 
 Content hashes and not a commit, so a dirty tree is captured honestly rather than pointed at. Taken
 **once, at load**, and frozen: a bench run acts for minutes against a tree its author may still be
-editing, and a hash taken when the report is finally written would describe the file on disk
-instead of the code that rendered it.
+editing, and a hash taken when the report is finally written would describe a file the run had that
+long to change.
+
+What that read is, exactly: a read of the **disk**, not of the loader. `join.js` is already in the
+module cache by the time `report.js` hashes it, and `report.js` reads its own file while executing.
+So under a concurrent modification of the working tree the digests describe the file bytes at that
+moment, which can differ from the bytes Node compiled. Closing that gap would take loader
+introspection; short of it, a disk read taken at load is the closest observation available, and the
+block's own `source` field states it in those terms rather than claiming the loaded bytes.
 
 **What it covers:** `bench/lib/join.js` and `bench/lib/report.js` — the report object, the join
 window, and `serializeReport`, the single definition of a report's bytes that the live run and a
@@ -525,9 +532,10 @@ rebuild reproduced the recorded bytes, and which renderer produced them:
 | `renderer-skew` | the fingerprint names other source bytes | the byte comparison stands on its own. Identical bytes are still identical bytes; a difference is stated with skew named as a candidate explanation and not as its cause |
 | `legacy-unversioned` | no `reportRenderer` block at all | the same, minus even the candidate: the recorded report is still preserved evidence and equality with it is still directly observable, but which renderer wrote those bytes was never recorded, and nothing is invented retroactively to close the gap |
 
-The cell worth having is `renderer-match` with a **difference**: the renderer is ruled out, so what
-failed is the deterministic contract between those files and this renderer — and replay says that
-without inventing a second cause for it.
+The cell worth having is `renderer-match` with a **difference**: skew in the two fingerprinted files
+is ruled out — and that is the whole of what the fingerprint can rule out. What is left is the
+recording itself, or the surface the fingerprint does not cover: the Node version, the platform, and
+any code outside those two files. Replay says exactly that and picks none of them.
 
 `--out` writes exactly the report the current renderer built, and nothing else: no envelope, no
 provenance smuggled into the report shape, no `join.SCHEMA_VERSION` moved. What such a file is, is

--- a/bench/lib/report.js
+++ b/bench/lib/report.js
@@ -21,9 +21,16 @@
  *   two files whose bytes decide a report's bytes — `./join.js` and this file — and
  *   freezes the result as {@link RENDERER_FINGERPRINT}. Once, at load, and never
  *   again: a bench run may execute for minutes against a dirty working tree, and a
- *   hash taken later would describe the file on disk rather than the code this
- *   process is running. Nothing else here touches the filesystem, the clock, the
- *   environment or `src/`.
+ *   hash taken later would describe a file the run had that long to change.
+ *
+ *   It is a read of the DISK, not of the loader, and the difference is worth stating
+ *   rather than glossing: `./join.js` is already in the module cache by the time this
+ *   read happens, and this file is being executed while it reads itself. So under a
+ *   concurrent edit of the working tree these digests describe the file bytes at that
+ *   moment, which can differ from the bytes Node compiled. Closing that gap would take
+ *   loader introspection; short of it, a disk read taken at load is the closest
+ *   observation available, and {@link RENDERER_SOURCE} says so in the record itself.
+ *   Nothing else here touches the filesystem, the clock, the environment or `src/`.
  *
  *   **What the fingerprint covers, and what it does not.** Those two files own the
  *   whole path from two event arrays to the bytes on disk: `join.js` builds the
@@ -91,10 +98,15 @@ const RENDERER_COVERS =
   'closure rather than a sample of it. NOT covered: the Node version, the platform, and every ' +
   'part of bench/run.js and bench/replay.js outside the serializer they both call';
 
-/** @type {string} When the hashes were taken — the distinction between the loaded code and a later file. */
+/** @type {string} When and from where the hashes were taken, and what that does and does not establish. */
 const RENDERER_SOURCE =
-  'sha256 over the bytes of those two files, read once while bench/lib/report.js was being loaded ' +
-  'into the process — the bytes this process then executed, not the file as it stood later';
+  'sha256 over the bytes of those two files, read from disk once while bench/lib/report.js was ' +
+  'being loaded into the process, and never again — a hash taken later would describe a file the ' +
+  'run had minutes to change. It is a disk observation and not a loader one: join.js is already ' +
+  'in the module cache when this read happens, and report.js reads its own file while executing. ' +
+  'Under a concurrent modification of the working tree these digests therefore describe the file ' +
+  'bytes at that moment, which can differ from the bytes Node compiled. Without loader ' +
+  'introspection that is the closest observation available';
 
 /** @type {RegExp} A lower-case sha256 digest, as `crypto` renders it. */
 const SHA256_HEX = /^[0-9a-f]{64}$/;

--- a/bench/replay.js
+++ b/bench/replay.js
@@ -515,8 +515,11 @@ function emit(opts) {
  *   exactly all the same. The recorded report is preserved evidence and equality
  *   with it is directly observable; what is unknown on a legacy recording is the
  *   renderer's identity, not the bytes.
- * - **match, bytes differ** — renderer skew is NOT available as the explanation,
- *   and none is invented in its place.
+ * - **match, bytes differ** — skew in the two FINGERPRINTED files is ruled out, and
+ *   that is the whole of what the fingerprint can rule out. What is left is the
+ *   recording itself, or the surface the fingerprint does not cover — the Node
+ *   version, the platform, code outside those two files — and none of them is
+ *   picked here.
  * - **skew or legacy, bytes differ** — the divergence and the limited attribution
  *   are stated as two separate things, because a candidate cause is not a cause.
  * @param {Object} verdict - From `classifyRenderer()`.
@@ -546,9 +549,11 @@ function reportProvenance(verdict, outcome) {
       'renderer match — the recording pins the report-renderer source bytes and this replay ran ' +
         'the same ones' +
         (differs
-          ? ', so renderer skew is NOT the explanation for the difference above. What failed is ' +
-            'the deterministic contract between those files and this renderer, and no other ' +
-            'cause is inferred here'
+          ? ', so skew in the FINGERPRINTED source is ruled out as the explanation for the ' +
+            'difference above — and that is the whole of what this block covers. What is left ' +
+            'is the recording itself, or the surface the fingerprint does not cover: the Node ' +
+            'version, the platform, and any code outside those two files. None of them is ' +
+            'picked here'
           : reproduced),
     );
     return;

--- a/bench/run.js
+++ b/bench/run.js
@@ -590,10 +590,12 @@ async function main(argv) {
     arm: args.arm,
     startedAt: now.toISOString(),
     // Frozen while `lib/report.js` was loading, a few milliseconds before this
-    // line — the renderer this process is running, not the file as it will
-    // stand when the report is written some minutes from now. Recorded in every
-    // arm: it names the code, and the code is the same whether or not this arm
-    // ends up rendering anything with it.
+    // line — the renderer source bytes as they stood on disk at that instant,
+    // not the file as it will stand when the report is written some minutes
+    // from now. It is a disk read rather than a loader one, and the block's own
+    // `source` field says so. Recorded in every arm: it names the code, and the
+    // code is the same whether or not this arm ends up rendering anything with
+    // it.
     reportRenderer: RENDERER_FINGERPRINT,
   });
   const manifestPath = path.join(dir, 'manifest.json');
@@ -769,4 +771,10 @@ module.exports = {
   prepareScenario,
   processAliveWindow,
   resolveScanInterval,
+  // Exported for one reason: so a test can hold the bytes this function actually
+  // writes against `serializeReport`'s output. `main` reaches it only through a
+  // live arm-A capture — a started sensor, a stopped sensor and a read audit
+  // chain — so without this export the live write path's byte parity rests on a
+  // single call site nothing exercises.
+  writeReport,
 };

--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -111,5 +111,31 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     after, 0 real spawns, exactly 2 sampling calls where 13 had landed. The vacuity above is unchanged:
     the fix removed the noise, not the missing coverage.
 
+27. **Writes a comment that claims MORE than the mechanism guarantees, and the overclaim
+    outlives every rewrite that touches the same lines.** Three live cases, all found
+    2026-08-14 in one sweep, all of the same shape: a true narrow fact stated as a total one.
+    (a) `process-identity.js` said a pid+birth-timestamp merge "is the only failure mode".
+    It is the only way that KEY FORMAT loses a distinction; the opposite failure — one live
+    instance read with two different birth milliseconds across ticks, splitting its session
+    and token ledger across two keys — comes from source disagreement and is exactly what the
+    542/542 and 419/419 sidecar-vs-CIM parity gates exist to stop (#25). "Only" was doing work
+    the file could not back. (b) The same header said "a collision needs the OS to free and
+    reissue the same pid inside 1 ms". The stored millisecond is a FLOOR, so the real condition
+    is that both creation times land in the same millisecond bucket — 0.86 ms apart inside one
+    bucket collides, 0.1 ms apart across the boundary does not, which is precisely the pair
+    `tests/fixtures/bench/derived/D1-pid-reuse-same-ms/` models. (c) `bench/lib/report.js`'s
+    fingerprint recorded itself as "the bytes this process then executed": `join.js` is already
+    in the module cache when the hash is taken and `report.js` reads its own file while
+    executing, so it is a DISK read at load — under a concurrent edit it describes on-disk
+    bytes, not loader-cached ones. Same for a diagnostic: replay said a renderer match with
+    differing bytes meant "the deterministic contract failed", when the fingerprint pins two
+    files and explicitly does not cover the Node version, the platform, or anything else.
+    Two lessons. **Write the guarantee, not the impression** — say which surface the claim
+    covers and name what is left open, the way `RENDERER_COVERS` already did next door.
+    **An overclaim is not fixed by a rewrite that walks past it:** PR #206 rewrote the very
+    bullet holding (b) and left the sentence intact, and (a) sat two lines above untouched, so
+    both survived every later reader who had seen the file "recently corrected". Grep the
+    claim, not the file (cf. #24 — assume siblings; #20 — do not document what is not there).
+
 ## Rule
 NEVER change what was not asked. Do ONLY what the prompt says.

--- a/src/main/process-identity.js
+++ b/src/main/process-identity.js
@@ -30,9 +30,9 @@
  *   wherever space 3 applies.
  *
  *   TIME RESOLUTION — the bound on space 1, per platform. Two instances sharing
- *   BOTH a pid and a birth timestamp are indistinguishable; that is the only
- *   failure mode, and it degrades to space 3's behaviour (two instances read as
- *   one). No tie-breaker is added for it — that code would never run.
+ *   BOTH a pid and a stored birth millisecond are indistinguishable, and degrade to
+ *   space 3's behaviour (two instances read as one). No tie-breaker is added for
+ *   that — the code would never run.
  *     - win32: MILLISECONDS. The snapshot sidecar reports each process's creation
  *       time in 100 ns FILETIME ticks, and `ticksToEpochMs`
  *       (platform/process-snapshot.js) floors them to the epoch-ms this key is
@@ -41,7 +41,12 @@
  *       FALLBACK, not the source. The 100 ns observation is 10 000× finer than the
  *       millisecond kept here, so this bound is a property of THIS KEY's format,
  *       not of what the OS can observe.
- *       A collision needs the OS to free and reissue the same pid inside 1 ms.
+ *       A collision needs the same pid reissued with a creation time that FLOORS
+ *       TO THE SAME stored millisecond — which is a bucket, not a sliding window:
+ *       two creations 0.86 ms apart inside one millisecond collide, two 0.1 ms
+ *       apart across the boundary do not. `tests/fixtures/bench/derived/
+ *       D1-pid-reuse-same-ms/` models that first pair, and what a pid-only join
+ *       can and cannot say about it.
  *     - linux: 10 ms would be available from `/proc/<pid>/stat` field 22 at the
  *       usual USER_HZ=100. The `/proc/stat` btime anchor carries up to ±1 s of
  *       systematic error, but it is identical for every process on the machine,
@@ -52,6 +57,15 @@
  *       would require the macOS pid counter to wrap (~99k spawns in that second).
  *       NOT WIRED: platform/darwin.js omits startTime, so darwin resolves to
  *       space 3.
+ *
+ *   That MERGE is the only way this FORMAT loses a distinction; it is not the only
+ *   way the key can be wrong. The opposite failure is a SPLIT, and it comes from
+ *   outside this file: one live instance read with two DIFFERENT birth milliseconds
+ *   across ticks resolves to two keys, and its session, dedup set and token
+ *   accounting split with it. That is a disagreement between birth-time SOURCES
+ *   rather than a property of the format, which is why the snapshot sidecar is held
+ *   to exact millisecond parity against CIM before it may be believed at all
+ *   (memory-bank/ai-mistakes.md #25) — the guard is there, not here.
  * @author AEGIS Contributors
  * @license MIT
  * @version 0.1.0

--- a/tests/main/bench/replay.test.js
+++ b/tests/main/bench/replay.test.js
@@ -379,13 +379,25 @@ describe('replay — renderer provenance, kept apart from the bytes', () => {
     expect(result.out).not.toMatch(/renderer match/);
   });
 
-  it('match + differing bytes: skew is ruled OUT, and no other cause is invented', () => {
+  // What the fingerprint rules out is skew in the two files it hashes, and nothing
+  // beyond them: the Node version, the platform and every other line of run.js and
+  // replay.js are outside the covered set and are named as still open. A diagnostic
+  // that said "the deterministic contract failed" would claim the divergence is in
+  // the renderer, which is exactly the surface the fingerprint cannot speak for.
+  it('match + differing bytes: fingerprinted skew is ruled OUT, and no cause is picked', () => {
     const result = main([pinned(report.RENDERER_FINGERPRINT, true)]);
 
     expect(result.code).toBe(1);
     expect(result.err).toMatch(/the rebuilt report differs from/);
-    expect(result.err).toMatch(/renderer skew is NOT the explanation for the difference above/);
-    expect(result.err).toMatch(/no other cause is inferred here/);
+    expect(result.err).toMatch(/skew in the FINGERPRINTED source is ruled out/);
+    expect(result.err).toMatch(/that is the whole of what this block covers/);
+    expect(result.err).toMatch(
+      /left is the recording itself, or the surface the fingerprint does not cover/,
+    );
+    expect(result.err).toMatch(/the Node version, the platform, and any code outside those two/);
+    expect(result.err).toMatch(/None of them is picked here/);
+    // The claim it must no longer make: that renderer determinism itself failed.
+    expect(result.err).not.toMatch(/deterministic contract/);
   });
 
   it('skew + differing bytes: a candidate explanation, stated as one', () => {
@@ -771,9 +783,12 @@ describe('replay — isolation', () => {
     // The renderer fingerprint is taken while `lib/report.js` loads and frozen
     // there, which is why no join.js or report.js read appears here. That is the
     // property, not an accident of when this spy was installed: a hash taken now
-    // would describe the file on disk rather than the code this process is
-    // running, and the two differ on exactly the dirty tree every arm-A run so
-    // far was measured against. The load-time pair is proven below.
+    // would describe a file the process has had its whole lifetime to see
+    // changed, on exactly the dirty tree every arm-A run so far was measured
+    // against. Both reads are of the disk — the load-time one no less than a
+    // later one would be — so what the load timing buys is the earliest and
+    // narrowest window, not identity with the bytes Node compiled. The
+    // load-time pair is proven below.
     expect(read.some((p) => p.endsWith('join.js') || p.endsWith('report.js'))).toBe(false);
   });
 

--- a/tests/main/bench/run.test.js
+++ b/tests/main/bench/run.test.js
@@ -17,14 +17,28 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+import join from '../../../bench/lib/join.js';
 import manifest from '../../../bench/lib/manifest.js';
 import report from '../../../bench/lib/report.js';
 import run from '../../../bench/run.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.resolve(HERE, '..', '..', '..');
+
+/**
+ * A complete recorded arm-A run, read but never written by this file.
+ * @type {string}
+ */
+const RECORDING = path.join(
+  REPO,
+  'tests',
+  'fixtures',
+  'bench',
+  'runs',
+  '2026-08-13T19-26-29Z-S1-agent-lifecycle-A',
+);
 
 /** @type {string} A run-scoped profile directory, made fresh per test. */
 let profileDir;
@@ -159,6 +173,24 @@ describe('run — the report renderer the run records', () => {
     );
   });
 
+  // The load-time read is a DISK read, and the record has to say that rather than
+  // the stronger thing it is tempting to say. `join.js` is in the module cache
+  // before `report.js` opens it, and `report.js` reads its own file while it is
+  // executing, so under a concurrent edit of the tree the digests are the on-disk
+  // bytes at that instant and not the bytes Node compiled. Taking the hash at load
+  // buys the narrowest window available without loader introspection — it does not
+  // buy identity with the loaded bytes, and the string must not claim it does.
+  it('says the hashes are a disk observation, and claims no identity with the loaded bytes', () => {
+    const source = report.RENDERER_FINGERPRINT.source;
+    expect(source).toMatch(/read from disk once/);
+    expect(source).toMatch(/join\.js is already in the module cache when this read happens/);
+    expect(source).toMatch(/report\.js reads its own file while executing/);
+    expect(source).toMatch(/concurrent modification of the working tree/);
+    expect(source).toMatch(/can differ from the bytes Node compiled/);
+    expect(source).toMatch(/closest observation available/);
+    expect(source).not.toMatch(/the bytes this process then executed/);
+  });
+
   // The two below call the real `manifest.collect()`, which spawns `reg query`,
   // `tasklist` and three `git` invocations — that is the module's whole job, and
   // stubbing the probes would leave the placement of this field pinned against a
@@ -198,4 +230,110 @@ describe('run — the report renderer the run records', () => {
     },
     COLLECT_TIMEOUT_MS,
   );
+});
+
+/**
+ * `serializeReport` is the ONE definition of a report's bytes, and a replay's
+ * output is pinned to it by `tests/main/bench/replay.test.js`. The live run's
+ * output was not: `run.js` calls the same function from `writeReport`, and that
+ * held by inspection of a single line rather than by anything that could go red.
+ * A live report written with `JSON.stringify(report, null, 2)` and no trailing
+ * newline, or written as latin1, would have been a silent one-byte divergence
+ * between the two ways a report comes into existence — and the whole replay
+ * contract is a byte comparison against what a live run wrote.
+ *
+ * So this exercises the real write path: `run.writeReport` builds the report,
+ * serializes it and calls `fs.writeFileSync` exactly as a live run does, into a
+ * scratch directory, and the FILE'S BYTES are held against `serializeReport`'s
+ * output for the very object it returned. Nothing re-implements the serializer;
+ * the expectation is produced by the one definition under test.
+ *
+ * Its inputs are a real recorded run's own files — the catalogue, the observation
+ * set and the capture record `observed.meta.json`, which is the capture-record
+ * shape `writeReport` reads `sensor.scanInterval` and
+ * `sensor.ticksWhileProcessAlive` out of. The recording is opened read-only and
+ * nothing is written back into it.
+ *
+ * **What this does not cover**, stated rather than implied: the call from `main`
+ * to `writeReport`. `main` reaches it only through a completed arm-A capture — a
+ * started sensor, a stopped sensor and a read audit chain — which no unit test can
+ * stand up. That link is one call site with no branch in it; everything from the
+ * report object to the bytes on disk is what is pinned here.
+ */
+describe('run — the bytes the live run actually writes', () => {
+  /** @type {string} Where the report under test is written. Never the recording. */
+  let outDir;
+
+  beforeEach(() => {
+    outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-bench-write-parity-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  /**
+   * @param {string} name - An NDJSON file in the recording.
+   * @returns {Object[]} One ECS document per non-empty line.
+   */
+  function readRecordedNdjson(name) {
+    return fs
+      .readFileSync(path.join(RECORDING, name), 'utf8')
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line));
+  }
+
+  /**
+   * Run the live write path into the scratch directory, with the console it
+   * prints its `written <file>` line on captured.
+   * @returns {{built: Object, bytes: Buffer, file: string}}
+   */
+  function writeLiveReport() {
+    const meta = JSON.parse(fs.readFileSync(path.join(RECORDING, 'observed.meta.json'), 'utf8'));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    let built;
+    try {
+      built = run.writeReport({
+        dir: outDir,
+        runId: meta.runId,
+        scenario: meta.scenario,
+        arm: meta.arm,
+        expected: readRecordedNdjson('expected.ndjson'),
+        capture: { events: readRecordedNdjson('observed.ndjson'), record: meta },
+      });
+    } finally {
+      log.mockRestore();
+    }
+    const file = path.join(outDir, join.REPORT_FILENAME);
+    return { built, bytes: fs.readFileSync(file), file };
+  }
+
+  it('writes exactly serializeReport(report) — byte for byte, not merely equal JSON', () => {
+    const { built, bytes } = writeLiveReport();
+    const expected = Buffer.from(report.serializeReport(built), 'utf8');
+
+    expect(bytes.length).toBe(expected.length);
+    expect(bytes.equals(expected)).toBe(true);
+  });
+
+  it('wrote a whole report, so the comparison above is over a real payload', () => {
+    const { built, bytes } = writeLiveReport();
+
+    expect(built.runId).toBe('2026-08-13T19-26-29Z-S1-agent-lifecycle-A');
+    expect(built.schemaVersion).toBe(join.SCHEMA_VERSION);
+    expect(Object.keys(built.categories)).toEqual([...join.CATEGORIES]);
+    // Multi-byte UTF-8 is in those bytes — the report's source strings carry `—`,
+    // `×` and `∈` — so the comparison is over a payload where the write encoding
+    // is observable, not over an ASCII file where latin1 and utf8 agree.
+    expect(bytes.includes(Buffer.from('—', 'utf8'))).toBe(true);
+    expect(bytes.length).toBeGreaterThan(Buffer.byteLength(JSON.stringify(built)));
+  });
+
+  it('writes it under the one report name, into the directory it was given', () => {
+    const { file } = writeLiveReport();
+
+    expect(fs.readdirSync(outDir)).toEqual([join.REPORT_FILENAME]);
+    expect(path.dirname(file)).toBe(outDir);
+  });
 });


### PR DESCRIPTION
Three residuals from the #221 review. No bench architecture changes.

## 1. Byte parity for the live write path

`serializeReport` is the one definition of a report's bytes. Replay's output was pinned to it by test; `run.js`'s was not — its call sat on a single line nothing exercised, so a live report written without the trailing newline, or as latin1, would have diverged silently from the only artefact replay ever compares against.

`writeReport` is now exported and driven end to end into a scratch directory, fed a real recording's own `expected.ndjson`, `observed.ndjson` and `observed.meta.json` (read-only; nothing is written back). The **file's bytes** are held against `serializeReport`'s output for the object it returned. Nothing re-implements the serializer — the expectation is produced by the definition under test.

Non-vacuity, proven by two deliberate mutations of `writeReport`:

| mutation | assertion that fired | result |
|---|---|---|
| `JSON.stringify(report, null, 2)` — no trailing newline | `bytes.length` | red, `expected 5250 to be 5251` |
| `serializeReport(report).replace('—', '–')` — equal length | `bytes.equals(expected)` | red, `expected false to be true` |

Both restored; the file is byte-identical to master apart from the export and the comment.

The link this does **not** cover — `main` → `writeReport`, which only a completed arm-A capture reaches — is stated in the test's own header rather than implied away.

## 2. The fingerprint's source string claimed loader-byte identity

It said the digests were *"the bytes this process then executed, not the file as it stood later"*. They are not. `join.js` is already in the module cache when `report.js` hashes it, and `report.js` reads its own file while executing — so under a concurrent edit of the working tree the digests describe on-disk bytes that can differ from the ones Node compiled.

`RENDERER_SOURCE`, the module header, `run.js`'s comment at the call site, `bench/README.md` and one `replay.test.js` comment now all say what is guaranteed: a disk read taken once at load, the closest observation available without loader introspection. Pinned by a new assertion that the retired phrasing is absent.

No committed manifest and no historical fixture is touched — the corrected string applies to future runs only. Both recordings stay `legacy-unversioned` and the golden is unaffected (the fingerprint lives in the manifest, not in a report).

## 3. The renderer-match + bytes-differ diagnostic

It said *"what failed is the deterministic contract between those files and this renderer"* — a claim about renderer determinism. The fingerprint pins two files and explicitly does not cover the Node version, the platform, or code outside them. It now reports that fingerprinted source skew is ruled out, names what is left open (the recording, or the uncovered surface), and picks none of it. Assertions updated, including one that `deterministic contract` no longer appears.

## Also verified (read-only) — one overclaim found live, not gone

- **`src/main/process-identity.js:33-35`** — *"that is the only failure mode"*. Present. It ignores the opposite failure: one live instance read with two different birth milliseconds across ticks splits into two keys, taking its session and token accounting with it. That is what the sidecar-vs-CIM millisecond parity gate exists to stop (ai-mistakes #25). Corrected.
- **`src/main/process-identity.js:44`** — *"A collision needs the OS to free and reissue the same pid inside 1 ms."* Present. It survived #206, which rewrote the very bullet it sits in. The stored millisecond is a floor, so the condition is a bucket rather than a sliding window: two creations 0.86 ms apart inside one millisecond collide, two 0.1 ms apart across the boundary do not — the pair `tests/fixtures/bench/derived/D1-pid-reuse-same-ms/` models. Corrected.
- **`src/main/session-tracker.js`** — no such claim, and never had one. `git log -S` over `"1 ms"`, `"millisecond"` and `"ms window"` returns nothing for that file in any revision. Its window is documented as `grace` consecutive reliable misses (`:11-14`, `:41-47`), which is scan intervals. Unchanged.

Comments only in both source files, no logic.

`memory-bank/ai-mistakes.md` #27 records the class: an overclaim outlives the rewrite that walks past it, so grep the claim rather than trusting the file.

## Verification

All seven local commands green: `build:renderer`, `format:check`, `lint` (0 errors), `typecheck`, `typecheck:svelte` (385 files, 0 errors), `test:coverage` (98 files, 1679 passed / 4 skipped), `npm audit --audit-level=high --omit=dev` (0 vulnerabilities). `fixture-immutability.test.js` 13/13; `git status tests/fixtures/` empty — recordings, derived inputs and goldens are byte-identical.
