### PR TITLE
feat(bench): B2.3 Sysmon oracle adapter — offline contract closure

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -51,9 +51,15 @@ prose around the numbers survives a re-run — the precedent is
 npm run bench:run                                        # defaults: no-scenario, arm A
 npm run bench:run -- --scenario S1-agent-lifecycle --arm A
 npm run bench:s1                                         # the line above, without the -- trap
+npm run bench:run -- --scenario S1-agent-lifecycle --arm B   # oracle only: no sensor, no renderer
 node bench/replay.js bench/runs/<run id>                 # rebuild that run's report from its files
 node bench/replay.js bench/runs/<run id> --out <file>    # write the rebuild elsewhere
 ```
+
+Arm B needs no built renderer and starts no sensor: it executes the scenario and collects the
+Sysmon oracle. On a machine with no Sysmon installed it runs to completion, records the absence,
+and exits **1** — which is the honest outcome, not a harness failure. See
+[The Sysmon oracle](#the-sysmon-oracle--b23).
 
 The `--` is required; without it npm keeps the flags.
 
@@ -65,7 +71,8 @@ scan cadence to settle, then the scenario, then three more scan ticks and a flus
 [Replaying a recorded run](#replaying-a-recorded-run).
 
 Exit codes: **0** the run completed · **1** a step failed to execute, the sensor could not be run
-or read, or the run report could not be derived · **2** the invocation or the scenario was wrong and
+or read, the run report could not be derived, or an arm-B run collected no oracle record · **2** the
+invocation or the scenario was wrong and
 nothing ran. A scenario is loaded and
 validated *before* the run directory exists, so a wrong scenario leaves no empty run behind; a step
 that fails happens after, and leaves the directory holding the catalogue of everything that did
@@ -84,7 +91,8 @@ for a given deterministic scenario, and only then does A score the sensor agains
 
 ## Layout
 
-Present today (sub-blocks B2.1, B2.2, the arm-A capture and the first join):
+Present today (sub-blocks B2.1, B2.2, the arm-A capture, the first join and B2.3's Sysmon
+adapter):
 
 ```
 bench/
@@ -98,6 +106,8 @@ bench/
   lib/observed.js                           # writes observed.ndjson out of the product's audit log
   lib/join.js                               # joins the two, shapes run-report.json; no I/O at all
   lib/report.js                             # the join bound, the report's exact bytes, the printed summary and the renderer fingerprint — shared by both entrypoints
+  lib/oracles/sysmon.js                     # normalizes Sysmon EventRecord XML; writes oracle-sysmon.ndjson and oracle-loss.json
+  oracles/sysmon-bench.xml                  # the Sysmon config a run is measured under — never yet offered to a binary
   scenarios/S1-agent-lifecycle/scenario.json
   runs/                                     # run artefacts — gitignored, created on first run
   README.md
@@ -108,7 +118,6 @@ built — nothing below exists yet:
 
 | path | sub-block |
 |---|---|
-| `bench/lib/oracles/sysmon.js`, `bench/oracles/sysmon-bench.xml` | B2.3 |
 | `bench/score.js`, `bench/lib/metrics.js` | B2.5 |
 | `bench/lib/oracles/procmon.js`, `bench/oracles/procmon-bench.pmc` | B2.6 |
 | `bench/report.js` | B2.9 |
@@ -329,12 +338,146 @@ number is read as a property of the sensor:
 - **The readiness signal exists because the app runs from source.** `logger.js` mirrors to stderr only
   while `isDev` — that is, `!app.isPackaged`. Benching a packaged build would need a different signal.
 
+## The Sysmon oracle — B2.3
+
+The oracle column runs in the two arms whose definition includes Sysmon, **A and B**, and writes
+two files: `oracle-loss.json` always, and `oracle-sysmon.ndjson` when there is at least one record
+to put in it. It does not reach `run-report.json`: confirming the catalogue against the oracle is
+B2.5, and until then the report still scores the sensor against an unconfirmed catalogue.
+
+`bench/lib/oracles/sysmon.js` imports nothing from `src/` and nothing from `bench/lib/observed.js`
+either — that module is the sensor side, and an oracle sharing code with the thing it confirms
+stops being independent. The two path helpers are duplicated on purpose.
+
+### Three layers, and only two of them are proven
+
+| layer | what it is | status |
+|---|---|---|
+| RAW | a real `Microsoft-Windows-Sysmon/Operational` channel → `Get-WinEvent` → EventRecord XML | **LIVE-UNVALIDATED** |
+| NORMALIZED | EventRecord XML → canonical oracle record → `oracle-sysmon.ndjson` | proven offline |
+| DERIVED | matching the oracle against the catalogue, and any metric over it | B2.5 |
+
+`readChannelXml` is the ONE function that crosses the raw boundary, it is injectable, and **no
+test in this repository has ever executed it**: the machine this was built on runs Windows 11 Home
+with no Sysmon installed. A green suite is not a claim about EVTX ingestion. **No binary `.evtx`
+file is fabricated anywhere** — a synthetic EVTX container would test our imitation of the Windows
+Event Log rather than Windows. The normalizer is tested against clearly-labelled synthetic XML in
+the documented shape, and `tests/main/bench/oracle-sysmon.test.js` says so in its own docblock.
+
+Two design choices in the reader exist to keep .NET's clock out of the pipeline. It emits
+`$_.ToXml()` and never the `TimeCreated` property, which `Get-WinEvent` hands back as a `DateTime`
+with `Kind=Local`; and it does **not** filter by time, because a `-FilterHashtable`
+`StartTime`/`EndTime` would mean building .NET `DateTime`s out of our instants. The window is
+applied in JavaScript over the XML's own `System/TimeCreated@SystemTime`, where it is testable.
+
+### The event set
+
+RESEARCH-BASELINE §10's oracle column — 1/2/3/5/11/22 — plus **26 FileDeleteDetected**, ratified
+2026-08-14. Four have a shape in the catalogue's ECS subset; the rest are real observations the
+subset has no room for and are **tallied, not dropped**, exactly as `observed.js` tallies what the
+audit records that the subset cannot hold.
+
+| event | treatment |
+|---|---|
+| 1 ProcessCreate | `process/start` |
+| 5 ProcessTerminate | `process/end` |
+| 11 FileCreate | `file/creation` |
+| 26 FileDeleteDetected | `file/deletion` |
+| 2, 3, 22 | counted under `records.shapelessByEventId` |
+| 23 FileDelete | **never a deletion** — see below |
+| 255 Error | its own loss signal |
+| anything else | `refused.unsupportedEventId` |
+
+**23 is not 26.** Microsoft documents 23 as additionally saving the deleted file into
+`ArchiveDirectory`, and 26 as "similar behavior but without saving the deleted files". The bench
+config enables 26 and never 23, so a 23 arriving at the parser means the running configuration is
+not the one the manifest names — it is recorded as exactly that finding and never accepted as a
+deletion observation. Whether an installed binary requires or touches `ArchiveDirectory` when 26 is
+configured is **LIVE-UNVALIDATED**: neither primary page settles it, and nothing is invented here.
+
+### What a normalized record keeps
+
+Only what that event carried. A field the event did not expose is **omitted**, never nulled — the
+B2.2 convention. **Nothing is copied between events**: an EID 5 record gets no command line, no
+parent and no exit code, because Sysmon's terminate event has none, and the EID 1 that shares its
+`ProcessGuid` is not merged into it. `process.name` is `basename(Image)`, a string derivation of an
+observed field and the image name the product's own audit never persists.
+
+`ProcessGuid` is **opaque**. It is retained verbatim and compared only for EQUALITY between Sysmon
+events. It is never parsed, never decoded into a timestamp, and never turned into an AEGIS
+`instanceId`. Guid equality pairs an EID 5 to its EID 1; **pid is not a fallback key**, because two
+generations sharing one pid are two generations and pairing them by pid would manufacture a
+lifecycle the OS never had. A terminate whose guid matches no creation in the window is UNPAIRED,
+and two creations sharing one guid are AMBIGUOUS. That accounting lives beside the records, in
+`oracle-loss.json`, and is never written back into them. EID 1 ordinality remains the truth about
+process identity; guid equality is an additional fact beside it.
+
+### The two timestamps
+
+`System/TimeCreated@SystemTime` and EventData `UtcTime` are two representations written by two
+layers, and **no delta between them is computed here**. `@timestamp` is `SystemTime` truncated —
+never rounded — to the catalogue's millisecond format; the untruncated original stays in
+`bench.timeCreatedSystemTime` and Sysmon's own `UtcTime` stays verbatim in `bench.utcTime`, in
+Sysmon's own format, unparsed.
+
+A `SystemTime` that does not end in `Z` is **REFUSED, not converted**. The offset arithmetic that
+turns `…T08:00:00-04:00` into `…T12:00:00Z` is exactly the arithmetic that turns a reader's local
+time zone into four hours of apparent latency, so it does not exist in this module.
+
+**This module declares no epsilon.** The ~2 s figure in RESEARCH-BASELINE §10 is a tolerance for
+comparing Sysmon's own two representations; guest-clock uncertainty is a different quantity and is
+unmeasured. The two are never merged. The oracle window is `[the run's startedAt, the moment
+collection began]`, both read off the harness's own clock, so nothing the scenario caused can fall
+outside it and no tolerance has to be invented to pull it in.
+
+### `oracle-loss.json`
+
+Written on every path, including — especially including — the one where nothing was collected.
+**It never reports a loss of zero.** What can be counted is counted; what cannot be established
+offline is an explicit `{value: null, unavailable}`, the manifest's own convention.
+
+- **`records`** — read, normalized, out of window, and the shapeless tally. With no read at all it
+  is the absence itself, not a row of zeroes that would read as a clean collection.
+- **`refused`** — malformed documents, foreign providers, missing required fields, non-UTC
+  timestamps, and unsupported event ids. Each names an index and a reason.
+- **`config.filterAccounting`** — an event this config excludes is never emitted, so it is not
+  lost; but Sysmon publishes no filter-hit counter, so a run cannot count what it declined to see
+  either. Records intentionally filtered out and records that never occurred are indistinguishable
+  from here, and neither is reported as loss.
+- **`eventRecordIds`** — the collected ids, and the gaps. **A gap is not a loss count**: the id is
+  assigned per channel, and every Sysmon event this run did not collect legitimately consumes one.
+- **`sysmonErrors`** — EID 255, reported as itself and never folded into another count.
+- **`channelRetention`** — `null` with a reason. Whether the channel wrapped during a run would
+  come from the log configuration, and no such probe runs here. Absent, not zero.
+
+### Arm B is a PARTIAL calibration, and says so
+
+Arm B is defined as **Sysmon + Procmon**, and B2.6 does not exist. There is no new report field for
+that: the manifest's `oracles.procmon` entry is `unavailable` with the reason, `armDescription`
+names both oracles, and `run.js` sweeps `oracles` alongside `host` and `sensor` for absent facts
+and prints them at the end of the run. A B run therefore states which of the two columns it
+produced at the moment of measurement rather than looking complete.
+
+Arm B exits **1** when it collected no oracle record — it produces nothing else, so an empty
+oracle column is an empty run, exactly as an empty observation set is in arm A. Arm A keeps its own
+exit code: it still has a sensor column, and its missing oracle is recorded as an absent fact.
+
+`manifest.oracles.sysmon` is the reserved `{version, configPath, configSha256}` contract and
+nothing is added to it. `configSha256` is taken over the config file's **exact bytes** at
+`configPath` — never over the path, never as a committed constant, because `.gitattributes` puts
+this file under `text=auto` and a hard-coded digest would go red on a checkout with other line
+endings while naming the same configuration. `version` comes from a read-only probe for an
+installed Sysmon service and **is never invented**: no string off a web page, no default. Where the
+probe does not answer, the entry is absent with the reason, and the path and digest name the
+configuration the run *would* have used rather than evidence that it was applied.
+
 ## The join — `run-report.json`
 
 At the end of an arm-A run the catalogue and the observation set are joined, and the result is
 written to `run-report.json`: per category, how many events were expected, how many the sensor
 accounted for, and how long it took. This is the first row of the measurement matrix and it scores
-the sensor against the catalogue only — an unconfirmed catalogue, until B2.3's oracle confirms it.
+the sensor against the catalogue only. The catalogue is still **unconfirmed** here: B2.3 collects
+the oracle column into its own files, and reading that column against the catalogue is B2.5.
 
 `bench/lib/join.js` **reads and writes nothing**. It takes two arrays and the window parameters and
 returns an object; `run.js` owns every byte that touches the disk. A unit test asserts the module
@@ -566,9 +709,10 @@ machines' artefacts into one record.
 scenario was named. `stage/` holds the binaries the scenario copied; S1 deletes its own, so the
 directory is normally left empty. In arm A there are three more: `observed.ndjson`, what the sensor
 recorded; `observed.meta.json`, how it was run and what did not become a line of it; and
-`run-report.json`, the two joined. The remaining files arrive with the sub-blocks that produce them:
-`oracle-sysmon.ndjson`, `oracle-procmon.ndjson`, `oracle-loss.json`, `matched.ndjson`,
-`metrics.json`.
+`run-report.json`, the two joined. In arms A and B there is `oracle-loss.json`, and
+`oracle-sysmon.ndjson` whenever the oracle collected anything. The remaining files arrive with the
+sub-blocks that produce them: `oracle-procmon.ndjson` (B2.6), `matched.ndjson` and `metrics.json`
+(B2.5).
 
 The Electron profile a run created is **left behind** in the OS temp directory, and its path is in
 `observed.meta.json`. It holds the audit file `observed.ndjson` was derived from, which is the

--- a/bench/lib/manifest.js
+++ b/bench/lib/manifest.js
@@ -161,21 +161,30 @@ function processCount() {
 }
 
 /**
- * Placeholder oracle block. B2.3 fills `sysmon`, B2.6 fills `procmon` — each
- * with a version, the config path and that config's SHA-256, so a run can be
- * re-created. Until then the fields are present and explicitly null, because a
- * key that is simply missing reads as "we forgot" rather than "not yet wired".
+ * The oracle block, with a placeholder for every oracle a caller did not supply.
+ *
+ * Each entry is a version, the config path and that config's SHA-256, so a run
+ * can be re-created. `sysmon` is filled by B2.3's adapter and handed in;
+ * `procmon` has no adapter yet and keeps its placeholder, which is not a
+ * formality — it is where an arm-B run states that its calibration is PARTIAL.
+ * Arm B is defined as Sysmon **and** Procmon (see {@link ARM_DESCRIPTIONS}), so a
+ * B run whose `procmon` entry is unavailable is a run that produced one of the
+ * two oracle columns, and the manifest says which one is missing and why.
+ *
+ * A key that is simply absent would read as "we forgot" rather than "not yet
+ * wired", so every oracle is present whether or not it answered.
+ * @param {Object} [supplied] - Blocks handed in by the caller, keyed by oracle id.
  * @returns {Object}
  */
-function oraclePlaceholders() {
+function oraclePlaceholders(supplied) {
   return {
-    sysmon: {
+    sysmon: (supplied && supplied.sysmon) || {
       version: null,
       configPath: null,
       configSha256: null,
-      unavailable: 'oracle adapter not implemented — arrives in sub-block B2.3',
+      unavailable: 'oracle adapter not run for this arm — see armDescription',
     },
-    procmon: {
+    procmon: (supplied && supplied.procmon) || {
       version: null,
       configPath: null,
       configSha256: null,
@@ -200,6 +209,12 @@ function oraclePlaceholders() {
  *   that supplies none leaves the field null, and a null reads as
  *   `legacy-unversioned` downstream: no fingerprint is ever reconstructed for a
  *   run that recorded none.
+ * @param {Object} [opts.oracles] - Oracle blocks, keyed by oracle id, for the
+ *   oracles this arm actually runs. Handed in for the same reason
+ *   `reportRenderer` is: the adapter owns its own facts (which config, which
+ *   binary), and a manifest that re-derived them could disagree with the run.
+ *   Anything not supplied keeps its placeholder — see
+ *   {@link oraclePlaceholders}.
  * @returns {Object} The manifest, ready to serialize.
  */
 function collect(opts) {
@@ -244,7 +259,7 @@ function collect(opts) {
     // it — a dirty tree names a commit the renderer is not.
     reportRenderer: opts.reportRenderer ?? null,
     processCountAtStart: processCount(),
-    oracles: oraclePlaceholders(),
+    oracles: oraclePlaceholders(opts.oracles),
   };
 }
 
@@ -254,6 +269,9 @@ module.exports = {
   MANIFEST_SCHEMA_VERSION,
   ROOT,
   collect,
+  // Exported so the oracle placeholders can be pinned without spawning the three
+  // `git` calls, the `reg query` and the `tasklist` that `collect` runs.
+  oraclePlaceholders,
   probe,
   readRegistryValues,
 };

--- a/bench/lib/oracles/sysmon.js
+++ b/bench/lib/oracles/sysmon.js
@@ -950,7 +950,17 @@ function probeVersion(opts = {}) {
         { encoding: 'utf8', windowsHide: true },
       ));
   return manifest.probe(source, () => {
-    if (process.platform !== 'win32') return null;
+    // Named rather than returned as a bare `null`. `manifest.probe` turns a null
+    // into "probe produced no value", which is true and says nothing — and the
+    // bench's own rule is that a Windows fact on another platform is recorded as
+    // ABSENT WITH A REASON (bench/README.md, "Windows-only"). This is the reason.
+    if (process.platform !== 'win32') {
+      throw new Error(
+        `this is not a Windows host (process.platform is "${process.platform}"). Sysmon is a ` +
+          'Windows facility, so no version exists to probe for here — absent because the ' +
+          'platform cannot have one, not because a probe failed',
+      );
+    }
     const parsed = JSON.parse(exec(script));
     if (!parsed || typeof parsed.fileVersion !== 'string' || parsed.fileVersion.trim() === '') {
       return null;

--- a/bench/lib/oracles/sysmon.js
+++ b/bench/lib/oracles/sysmon.js
@@ -1,0 +1,1263 @@
+/**
+ * @file bench/lib/oracles/sysmon.js
+ * @module bench/lib/oracles/sysmon
+ * @description The Sysmon oracle adapter for one bench run (sub-block B2.3).
+ *
+ *   Sysmon is the independent source the catalogue is confirmed against. It is
+ *   kernel-backed and shares no failure mode with Electron, chokidar or
+ *   `tasklist`, which is the whole reason a disagreement between it and the
+ *   sensor is a finding rather than two user-mode pollers agreeing.
+ *
+ *   Nothing here imports from `src/`, and nothing here imports
+ *   `bench/lib/observed.js` either: that module is the SENSOR side, and an oracle
+ *   that shared code with the thing it confirms would stop being independent. The
+ *   two path helpers below are therefore a deliberate duplication.
+ *
+ *   ## Three layers, and only two of them are proven
+ *
+ *   **RAW — LIVE-UNVALIDATED.** A real `Microsoft-Windows-Sysmon/Operational`
+ *   channel, read by Windows into EventRecord XML. {@link readChannelXml} is the
+ *   ONE function that crosses it, it is injectable, and no test in this
+ *   repository has ever executed it: the machine this was written on runs
+ *   Windows 11 Home with no Sysmon installed. Nothing here may be read as a claim
+ *   that EVTX ingestion works. It is proven when it runs in a guest against an
+ *   installed binary, and not before.
+ *
+ *   **NORMALIZER — proven offline.** EventRecord XML → a canonical oracle record.
+ *   {@link parseEventXml} and {@link select} are pure, take strings, and are
+ *   tested against clearly-labelled SYNTHETIC XML. No binary `.evtx` file is
+ *   fabricated anywhere in this repository: a synthetic EVTX container would test
+ *   our imitation of the Windows Event Log rather than Windows.
+ *
+ *   **DERIVED — a later block.** Matching the oracle against the catalogue, and
+ *   any metric over the result, is B2.5. This file scores nothing and compares
+ *   nothing.
+ *
+ *   ## What is retained, and what is refused
+ *
+ *   A normalized record keeps only fields the Sysmon event actually carried. The
+ *   `bench` block holds the observational facts ECS has no home for, and follows
+ *   the B2.2 convention: a field the event did not expose is **omitted**, never
+ *   nulled. Above all, three refusals:
+ *
+ *   - **`ProcessGuid` is opaque.** It is retained verbatim and compared only for
+ *     EQUALITY between Sysmon events. It is never parsed, never decoded, never
+ *     turned into a timestamp, and never transformed into an AEGIS `instanceId`.
+ *     Community reverse-engineering of its bit layout is not an API.
+ *   - **The two timestamps are never mixed.** `System/TimeCreated@SystemTime` and
+ *     EventData `UtcTime` are two different representations written by two
+ *     different layers. Both are retained, separately labelled; NO delta between
+ *     them is computed here and no tolerance for one is declared. `@timestamp` is
+ *     `SystemTime` and nothing else, and a `SystemTime` that is not UTC is
+ *     REFUSED rather than converted — an offset silently applied is how a
+ *     four-hour local-time skew becomes a latency figure.
+ *   - **Nothing is copied between events.** EID 5 carries no command line, no
+ *     parent and no exit code; the EID 1 that shares its `ProcessGuid` does. They
+ *     are not merged. Lifecycle correlation is stated as correlation, in the
+ *     `oracle-loss.json` accounting, and never by writing EID 1's fields into an
+ *     EID 5 record where they would read as raw observations of it.
+ *
+ *   ## The event set
+ *
+ *   RESEARCH-BASELINE section 10's oracle column, 1/2/3/5/11/22, plus **26
+ *   FileDeleteDetected**, added by ratification on 2026-08-14. Four of them have
+ *   a shape in the catalogue's ECS subset (1, 5, 11, 26); the rest are real
+ *   observations with no shape in it and are tallied rather than dropped, exactly
+ *   as `observed.js` tallies what the audit records that the subset cannot hold.
+ *
+ *   **EID 23 FileDelete is not EID 26.** 23 archives the deleted file into
+ *   `ArchiveDirectory`; 26 logs the deletion and saves nothing. The bench config
+ *   enables 26 and never 23, so a 23 arriving at this parser means the running
+ *   configuration is not the one the manifest names — it is recorded as that
+ *   finding and is never accepted as a deletion observation.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.11.0
+ */
+'use strict';
+
+const { execFileSync } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const catalogue = require('../catalogue');
+const manifest = require('../manifest');
+
+/** @type {string} Oracle id, as scenarios name it in their `oracles` array. */
+const ORACLE_ID = 'sysmon';
+
+/** @type {string} Normalized oracle records inside a run directory. */
+const ORACLE_FILENAME = 'oracle-sysmon.ndjson';
+
+/** @type {string} Collection and loss accounting inside a run directory. */
+const LOSS_FILENAME = 'oracle-loss.json';
+
+/** @type {number} Shape version of `oracle-loss.json`. */
+const LOSS_SCHEMA_VERSION = 1;
+
+/**
+ * `bench.source` on every line this module writes, in the `<source>-<form>`
+ * kebab-case the harness already uses (`aegis-audit` in `bench/lib/observed.js`,
+ * `derived-model` in the replay fixtures).
+ *
+ * It names the acquisition boundary that is actually implemented: the
+ * `Microsoft-Windows-Sysmon/Operational` **Event Log channel**, read through
+ * `Get-WinEvent` and rendered by `EventRecord.ToXml()`. It deliberately does
+ * **not** say `evtx`. This module never opens, exports or ingests an `.evtx`
+ * file, and a label saying otherwise would put a claim about a file format into
+ * every record — where a later reader would take it for provenance rather than
+ * for the aspiration it was. `.evtx` ingestion remains LIVE-UNVALIDATED and
+ * unimplemented; see {@link readChannelXml}.
+ * @type {string}
+ */
+const SOURCE = 'sysmon-eventlog-xml';
+
+/** @type {string} The channel Sysmon writes to on Vista and higher. */
+const CHANNEL = 'Microsoft-Windows-Sysmon/Operational';
+
+/** @type {string} The only provider whose records are oracle evidence. */
+const PROVIDER = 'Microsoft-Windows-Sysmon';
+
+/**
+ * The bench config, absolute. There is deliberately no second constant holding
+ * the repository-relative form: {@link manifestBlock} derives it with
+ * `path.relative`, and two hand-maintained spellings of one path are exactly the
+ * pair that drifts (memory-bank/ai-mistakes.md #24).
+ * @type {string}
+ */
+const CONFIG_PATH = path.join(manifest.ROOT, 'bench', 'oracles', 'sysmon-bench.xml');
+
+/**
+ * Event ids by name, so no number below is a bare literal.
+ * @type {Readonly<Object<string, number>>}
+ */
+const EVENT_IDS = Object.freeze({
+  PROCESS_CREATE: 1,
+  FILE_CREATE_TIME: 2,
+  NETWORK_CONNECT: 3,
+  PROCESS_TERMINATE: 5,
+  FILE_CREATE: 11,
+  DNS_QUERY: 22,
+  FILE_DELETE_ARCHIVED: 23,
+  FILE_DELETE_DETECTED: 26,
+  SYSMON_ERROR: 255,
+});
+
+/**
+ * The event ids `bench/oracles/sysmon-bench.xml` asks Sysmon to emit: the
+ * RESEARCH-BASELINE section 10 oracle column plus the ratified 26. **23 is not
+ * in it and must never be added to it** — see the file docblock.
+ * @type {ReadonlyArray<number>}
+ */
+const CANONICAL_EVENT_IDS = Object.freeze([
+  EVENT_IDS.PROCESS_CREATE,
+  EVENT_IDS.FILE_CREATE_TIME,
+  EVENT_IDS.NETWORK_CONNECT,
+  EVENT_IDS.PROCESS_TERMINATE,
+  EVENT_IDS.FILE_CREATE,
+  EVENT_IDS.DNS_QUERY,
+  EVENT_IDS.FILE_DELETE_DETECTED,
+]);
+
+/**
+ * Which event ids have a shape in the catalogue's ECS subset. An id that is not
+ * here is not unknown and not lost — it is a real observation the subset has no
+ * room for, and it is counted.
+ * @type {Readonly<Object<number, string>>}
+ */
+const SHAPED_EVENT_IDS = Object.freeze({
+  [EVENT_IDS.PROCESS_CREATE]: 'process.start',
+  [EVENT_IDS.PROCESS_TERMINATE]: 'process.end',
+  [EVENT_IDS.FILE_CREATE]: 'file.creation',
+  [EVENT_IDS.FILE_DELETE_DETECTED]: 'file.deletion',
+});
+
+/**
+ * EventData fields a shaped record cannot be written without.
+ *
+ * Deliberately short. Microsoft's prose for EID 5 names exactly `UtcTime`,
+ * `ProcessGuid` and `ProcessId`, and that is the leanest Sysmon event there is —
+ * so those three are the floor, plus the target path for a file event, which has
+ * no shape without one. Everything richer (`Image`, `CommandLine`, the parent
+ * block) is retained WHERE THE EVENT EXPOSES IT and omitted where it does not.
+ * Requiring a field the published schema does not guarantee would refuse real
+ * records; inventing one would be worse.
+ * @type {Readonly<Object<number, ReadonlyArray<string>>>}
+ */
+const REQUIRED_DATA = Object.freeze({
+  [EVENT_IDS.PROCESS_CREATE]: Object.freeze(['UtcTime', 'ProcessGuid', 'ProcessId']),
+  [EVENT_IDS.PROCESS_TERMINATE]: Object.freeze(['UtcTime', 'ProcessGuid', 'ProcessId']),
+  [EVENT_IDS.FILE_CREATE]: Object.freeze(['UtcTime', 'ProcessGuid', 'ProcessId', 'TargetFilename']),
+  [EVENT_IDS.FILE_DELETE_DETECTED]: Object.freeze([
+    'UtcTime',
+    'ProcessGuid',
+    'ProcessId',
+    'TargetFilename',
+  ]),
+});
+
+/**
+ * `System/TimeCreated@SystemTime` as Windows renders it: an ISO-8601 instant with
+ * up to seven fractional digits and a literal `Z`. The `Z` is not optional here
+ * — see {@link normalizeSystemTime}.
+ * @type {RegExp}
+ */
+const SYSTEM_TIME = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,7}))?Z$/;
+
+/**
+ * How many records one read may take off the channel.
+ *
+ * A bound rather than "everything", because the channel is machine-wide and a
+ * long-lived host's can be enormous. Reaching it is itself a finding and is
+ * recorded: the read may have stopped short of the window's start.
+ * @type {number}
+ */
+const MAX_EVENTS_READ = 20000;
+
+/**
+ * Frames one event XML document from the next in the reader's stdout.
+ *
+ * `EventRecord.ToXml()` may contain newlines inside a `Data` value, so a
+ * line-per-record assumption is not safe. The sentinel is part of the
+ * LIVE-UNVALIDATED boundary, not of the record format.
+ * @type {string}
+ */
+const RECORD_DELIMITER = '<<<AEGIS-SYSMON-RECORD-BOUNDARY>>>';
+
+/**
+ * An oracle failure the caller must not paper over. Carries a machine-readable
+ * `stage`, the same convention `bench/lib/observed.js` uses.
+ */
+class SysmonError extends Error {
+  /**
+   * @param {string} stage - One of `config-unreadable`, `reader-failed`,
+   *   `window-invalid`.
+   * @param {string} message - What a reader needs in order to act.
+   */
+  constructor(stage, message) {
+    super(message);
+    this.name = 'SysmonError';
+    this.stage = stage;
+  }
+}
+
+/**
+ * SHA-256 over a file's exact bytes — never over its decoded text and never over
+ * its path. The digest names what a run was measured under, so it has to be a
+ * digest of the thing itself.
+ * @param {string} file - Absolute path.
+ * @returns {string} Hex-encoded SHA-256.
+ */
+function sha256OfFile(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+/**
+ * Split a path into name and directory WITHOUT touching the filesystem: the file
+ * a deletion event names is gone by definition.
+ *
+ * The separator is read off the string rather than off the running platform, so
+ * the tests can run on a POSIX CI machine over Windows paths. Duplicated from
+ * `bench/lib/observed.js` on purpose — see the file docblock.
+ * @param {string} value - The path exactly as Sysmon recorded it.
+ * @returns {{name: string, directory: string}}
+ */
+function splitPath(value) {
+  const flavour = /\\/.test(value) || /^[A-Za-z]:/.test(value) ? path.win32 : path.posix;
+  return { name: flavour.basename(value), directory: flavour.dirname(value) };
+}
+
+/**
+ * Decode the five XML predefined entities and numeric character references.
+ *
+ * `&amp;` is resolved LAST so that `&amp;lt;` decodes to the literal text
+ * `&lt;` rather than to `<`.
+ * @param {string} value - Raw text between two XML tags.
+ * @returns {string}
+ */
+function decodeXmlText(value) {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#x([0-9A-Fa-f]+);/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Parse one rendered EventRecord XML document into the two blocks Windows gives
+ * it: the `System` header and the provider's `EventData`.
+ *
+ * A scanner rather than a general XML parser, and strict on purpose. It knows one
+ * document shape — the one the Windows Event Log renders — and refuses anything
+ * else by name instead of returning a half-read record that a later count would
+ * treat as an observation. No XML dependency is added for it: the shape is
+ * closed, and the refusals are required by the loss accounting anyway.
+ * @param {string} xml - One `<Event>…</Event>` document.
+ * @returns {{system: {eventId: number, eventRecordId: number|null, version: number|null,
+ *   timeCreated: string, channel: string|null, computer: string|null, provider: string|null},
+ *   data: Object<string, string>}}
+ * @throws {Error} Naming what was missing or ambiguous.
+ */
+function parseEventXml(xml) {
+  const refuse = (why) => {
+    throw new Error(`sysmon: refusing an event record — ${why}`);
+  };
+  if (typeof xml !== 'string' || xml.trim() === '') refuse('it is empty');
+  if (!/<Event[\s>]/.test(xml)) refuse('it has no <Event> element');
+
+  const systemBlock = xml.match(/<System[^>]*>([\s\S]*?)<\/System>/);
+  if (!systemBlock) refuse('it has no <System> block, so it carries no event identity');
+  const system = systemBlock[1];
+
+  /**
+   * @param {string} tag
+   * @returns {string|null}
+   */
+  const text = (tag) => {
+    const m = system.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`));
+    return m ? decodeXmlText(m[1]).trim() : null;
+  };
+
+  const rawEventId = text('EventID');
+  if (rawEventId === null) refuse('its <System> block carries no <EventID>');
+  const eventId = Number.parseInt(rawEventId, 10);
+  if (!Number.isSafeInteger(eventId) || String(eventId) !== rawEventId) {
+    refuse(`its <EventID> is "${rawEventId}", which is not an event id`);
+  }
+
+  const timeMatch = system.match(/<TimeCreated[^>]*\bSystemTime="([^"]*)"/);
+  if (!timeMatch) refuse(`EventID ${eventId} carries no <TimeCreated SystemTime="…">`);
+  const timeCreated = decodeXmlText(timeMatch[1]).trim();
+
+  const providerMatch = system.match(/<Provider[^>]*\bName="([^"]*)"/);
+  const rawRecordId = text('EventRecordID');
+  const recordId = rawRecordId === null ? null : Number.parseInt(rawRecordId, 10);
+  if (rawRecordId !== null && (!Number.isSafeInteger(recordId) || recordId < 0)) {
+    refuse(`EventID ${eventId} carries <EventRecordID>${rawRecordId}</EventRecordID>`);
+  }
+  const rawVersion = text('Version');
+  const version = rawVersion === null ? null : Number.parseInt(rawVersion, 10);
+
+  /** @type {Object<string, string>} */
+  const data = {};
+  const dataBlock = xml.match(/<EventData[^>]*>([\s\S]*?)<\/EventData>/);
+  if (dataBlock) {
+    const entry = /<Data\b[^>]*\bName="([^"]*)"\s*(?:\/>|>([\s\S]*?)<\/Data>)/g;
+    let m;
+    while ((m = entry.exec(dataBlock[1])) !== null) {
+      const name = decodeXmlText(m[1]);
+      if (Object.prototype.hasOwnProperty.call(data, name)) {
+        refuse(
+          `EventID ${eventId} carries two <Data Name="${name}"> entries — which of the two is ` +
+            'the observation cannot be decided here',
+        );
+      }
+      data[name] = m[2] === undefined ? '' : decodeXmlText(m[2]);
+    }
+  }
+
+  return {
+    system: {
+      eventId,
+      eventRecordId: rawRecordId === null ? null : recordId,
+      version: Number.isSafeInteger(version) ? version : null,
+      timeCreated,
+      channel: text('Channel'),
+      computer: text('Computer'),
+      provider: providerMatch ? decodeXmlText(providerMatch[1]) : null,
+    },
+    data,
+  };
+}
+
+/**
+ * `System/TimeCreated@SystemTime` reduced to the catalogue's instant format, and
+ * refused outright when it is not UTC.
+ *
+ * Two decisions, both about the same trap. **Truncation, never rounding:**
+ * Windows writes seven fractional digits and the catalogue speaks three, and
+ * rounding could move an instant across a millisecond boundary that a later join
+ * reads as ordering. **A non-`Z` value is refused, never converted:** the offset
+ * arithmetic that would turn `…T08:00:00-04:00` into `…T12:00:00Z` is exactly the
+ * arithmetic that turns a reader's local-time slip into four hours of apparent
+ * latency, so it does not exist in this module. If a future live reader ever
+ * hands local instants over, this fails loudly at the first record instead of
+ * producing a plausible number.
+ *
+ * The original string is retained unmodified as `bench.timeCreatedSystemTime`;
+ * nothing here overwrites it.
+ * @param {string} raw - The attribute value, verbatim.
+ * @returns {string} `YYYY-MM-DDTHH:MM:SS.mmmZ`.
+ * @throws {Error} On anything that is not a UTC instant.
+ */
+function normalizeSystemTime(raw) {
+  const m = SYSTEM_TIME.exec(raw);
+  if (!m) {
+    throw new Error(
+      `sysmon: refusing SystemTime "${raw}" — it is not a UTC instant ending in Z. A local or ` +
+        'offset-bearing timestamp is not converted here: applying an offset is how a reader ' +
+        "running in another zone turns its own clock into the oracle's latency",
+    );
+  }
+  return `${m[1]}.${`${m[2] || ''}000`.slice(0, 3)}Z`;
+}
+
+/**
+ * A non-empty EventData value, or `undefined` when the event did not expose one.
+ * @param {Object<string, string>} data
+ * @param {string} key
+ * @returns {string|undefined}
+ */
+function exposed(data, key) {
+  const value = data[key];
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * A pid Windows could have handed out, or `undefined`.
+ * @param {Object<string, string>} data
+ * @param {string} key
+ * @returns {number|undefined}
+ */
+function pidField(data, key) {
+  const raw = exposed(data, key);
+  if (raw === undefined) return undefined;
+  const pid = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+/**
+ * The `bench` block: where the row came from, plus every observational fact ECS
+ * has no field for. Absent fields are omitted, never nulled (the B2.2 convention).
+ *
+ * `processGuid` rides here and NOT in an identity field, because it is opaque:
+ * two records carrying the same string describe the same process generation, and
+ * that is the whole of what may be read out of it.
+ * @param {Object} parsed - From {@link parseEventXml}.
+ * @param {string} scenario - Scenario id.
+ * @returns {Object}
+ */
+function benchBlock(parsed, scenario) {
+  const { system, data } = parsed;
+  /** @type {Object} */
+  const block = {
+    scenario,
+    source: SOURCE,
+    oracle: ORACLE_ID,
+    eventId: system.eventId,
+    // The raw attribute, unrounded and unconverted. `@timestamp` is derived from
+    // it; this is the observation that derivation was made from.
+    timeCreatedSystemTime: system.timeCreated,
+    // Sysmon's OWN representation, in Sysmon's own format. Kept verbatim and
+    // never parsed: it is not the same clock reading as SystemTime, and no delta
+    // between the two is computed anywhere in this module.
+    utcTime: data.UtcTime,
+    processGuid: data.ProcessGuid,
+  };
+  if (system.eventRecordId !== null) block.eventRecordId = system.eventRecordId;
+  if (system.version !== null) block.eventVersion = system.version;
+  if (system.channel) block.channel = system.channel;
+  if (system.computer) block.computer = system.computer;
+  if (system.provider) block.provider = system.provider;
+
+  // Which rule of bench/oracles/sysmon-bench.xml let this event through. The
+  // config names every rule, so a record with no RuleName — or with someone
+  // else's — came from a configuration this run does not describe.
+  const ruleName = exposed(data, 'RuleName');
+  if (ruleName !== undefined && ruleName !== '-') block.ruleName = ruleName;
+
+  const parentGuid = exposed(data, 'ParentProcessGuid');
+  if (parentGuid !== undefined) block.parentProcessGuid = parentGuid;
+  const creation = exposed(data, 'CreationUtcTime');
+  if (creation !== undefined) block.creationUtcTime = creation;
+  const hashes = exposed(data, 'Hashes');
+  if (hashes !== undefined) block.hashes = hashes;
+  // EID 26 states whether the file was archived. Retained because it is the
+  // observation that separates 26's behaviour from 23's, and never inferred.
+  const archived = exposed(data, 'Archived');
+  if (archived !== undefined) block.archived = archived;
+  const user = exposed(data, 'User');
+  if (user !== undefined) block.user = user;
+  return block;
+}
+
+/**
+ * The ECS fields for one shaped event, built from THAT event's own data.
+ *
+ * Nothing is carried across events. An EID 5 record gets no command line, no
+ * parent and no exit code, because Sysmon's process-terminate event has none —
+ * Microsoft's prose gives it `UtcTime`, `ProcessGuid` and `ProcessId`. Whether a
+ * given binary's schema also exposes `Image` there is not settled by the
+ * documentation, so it is written when present and left out when not.
+ *
+ * `process.name` is `basename(Image)` — a string derivation of an observed field,
+ * and the image name the product's own audit never persists. `process.start` is
+ * deliberately NOT written: the instant Sysmon has for it is `UtcTime`, in
+ * Sysmon's own format, and putting that in an ECS date field would invite a
+ * later subtraction across two representations.
+ * @param {number} eventId
+ * @param {Object<string, string>} data - The event's EventData.
+ * @returns {Object} ECS field groups.
+ */
+function ecsFields(eventId, data) {
+  const image = exposed(data, 'Image');
+  /** @type {Object} */
+  const process = {};
+  const pid = pidField(data, 'ProcessId');
+  if (pid !== undefined) process.pid = pid;
+  if (image !== undefined) {
+    process.executable = image;
+    process.name = splitPath(image).name;
+  }
+
+  if (eventId === EVENT_IDS.PROCESS_CREATE) {
+    const commandLine = exposed(data, 'CommandLine');
+    if (commandLine !== undefined) process.command_line = commandLine;
+    /** @type {Object} */
+    const parent = {};
+    const parentPid = pidField(data, 'ParentProcessId');
+    if (parentPid !== undefined) parent.pid = parentPid;
+    const parentImage = exposed(data, 'ParentImage');
+    if (parentImage !== undefined) {
+      parent.executable = parentImage;
+      parent.name = splitPath(parentImage).name;
+    }
+    const parentCommandLine = exposed(data, 'ParentCommandLine');
+    if (parentCommandLine !== undefined) parent.command_line = parentCommandLine;
+    if (Object.keys(parent).length > 0) process.parent = parent;
+    return { process };
+  }
+
+  if (eventId === EVENT_IDS.PROCESS_TERMINATE) return { process };
+
+  // 11 and 26: a file event. TargetFilename is required for both, so the path is
+  // present by the time this runs.
+  const target = data.TargetFilename;
+  const { name, directory } = splitPath(target);
+  return { file: { path: target, name, directory }, process };
+}
+
+/**
+ * Turn one parsed record into a canonical oracle record.
+ * @param {Object} parsed - From {@link parseEventXml}.
+ * @param {string} scenario - Scenario id.
+ * @returns {Object} An ECS document in the catalogue's subset.
+ * @throws {Error} When a required EventData field is missing, or the timestamp is
+ *   not a UTC instant.
+ */
+function toOracleRecord(parsed, scenario) {
+  const { system, data } = parsed;
+  const shapeName = SHAPED_EVENT_IDS[system.eventId];
+  const shape = catalogue.EVENT_SHAPES[shapeName];
+  for (const field of REQUIRED_DATA[system.eventId]) {
+    if (exposed(data, field) === undefined) {
+      throw new Error(
+        `sysmon: EventID ${system.eventId} carries no "${field}" — a record without it is not an ` +
+          'observation this oracle can write, and no value is substituted for it',
+      );
+    }
+  }
+  return {
+    '@timestamp': normalizeSystemTime(system.timeCreated),
+    ecs: { version: catalogue.ECS_VERSION },
+    event: {
+      kind: 'event',
+      category: [shape.category],
+      type: [shape.type],
+      action: shape.action,
+      code: String(system.eventId),
+      provider: system.provider || PROVIDER,
+      ...(system.eventRecordId === null ? {} : { sequence: system.eventRecordId }),
+    },
+    ...ecsFields(system.eventId, data),
+    bench: benchBlock(parsed, scenario),
+  };
+}
+
+/**
+ * Empty loss accounting. Every counter starts at zero and every "we could not
+ * establish this" starts as an explicit absence, so a field that is never filled
+ * reads as unmeasured rather than as measured-zero.
+ * @returns {Object}
+ */
+function emptyTally() {
+  return {
+    read: 0,
+    normalized: 0,
+    outOfWindow: 0,
+    shapelessByEventId: {},
+    refused: {
+      malformed: [],
+      foreignProvider: [],
+      missingRequiredField: [],
+      nonUtcTimestamp: [],
+      unsupportedEventId: {},
+    },
+    archivalDeletes: [],
+    sysmonErrors: [],
+    eventRecordIds: [],
+  };
+}
+
+/**
+ * Reduce a set of raw XML documents to this run's oracle records.
+ *
+ * Pure: strings in, objects out, no filesystem and no clock. The window is
+ * `[windowStart, windowEnd]` inclusive and carries **no epsilon**. Both ends are
+ * instants the bench read off its own clock — the run's `startedAt`, before
+ * anything the scenario causes, and the moment collection begins, after all of it
+ * — so nothing the scenario produced can fall outside, and no tolerance has to be
+ * invented to pull it in. A tolerance here would be a guess about clock agreement
+ * between Sysmon and the harness, and that is not a quantity this repository has
+ * measured.
+ * @param {Object} opts
+ * @param {string[]} opts.documents - Raw EventRecord XML, one per element.
+ * @param {string} opts.scenario - Scenario id.
+ * @param {string} opts.windowStart - ISO instant.
+ * @param {string} opts.windowEnd - ISO instant.
+ * @returns {{events: Object[], tally: Object}}
+ * @throws {SysmonError} When the window is not two instants.
+ */
+function select(opts) {
+  const from = Date.parse(opts.windowStart);
+  const to = Date.parse(opts.windowEnd);
+  if (!Number.isFinite(from) || !Number.isFinite(to)) {
+    throw new SysmonError(
+      'window-invalid',
+      `the oracle window [${opts.windowStart}, ${opts.windowEnd}] is not two UTC instants, so no ` +
+        'record can be said to fall inside it',
+    );
+  }
+
+  const events = [];
+  const tally = emptyTally();
+
+  for (let i = 0; i < opts.documents.length; i++) {
+    tally.read += 1;
+    let parsed;
+    try {
+      parsed = parseEventXml(opts.documents[i]);
+    } catch (err) {
+      tally.refused.malformed.push({ index: i, reason: err.message });
+      continue;
+    }
+    const { system } = parsed;
+
+    if (system.provider !== null && system.provider !== PROVIDER) {
+      tally.refused.foreignProvider.push({
+        index: i,
+        eventId: system.eventId,
+        provider: system.provider,
+      });
+      continue;
+    }
+
+    let at;
+    try {
+      at = Date.parse(normalizeSystemTime(system.timeCreated));
+    } catch (err) {
+      tally.refused.nonUtcTimestamp.push({
+        index: i,
+        eventId: system.eventId,
+        reason: err.message,
+      });
+      continue;
+    }
+    if (at < from || at > to) {
+      tally.outOfWindow += 1;
+      continue;
+    }
+    if (system.eventRecordId !== null) tally.eventRecordIds.push(system.eventRecordId);
+
+    // EID 23 archives the file it reports deleted. The bench config never enables
+    // it, so one arriving here says the running configuration is not the one this
+    // run names — it is recorded as exactly that and NEVER read as a deletion.
+    if (system.eventId === EVENT_IDS.FILE_DELETE_ARCHIVED) {
+      tally.archivalDeletes.push({
+        index: i,
+        eventRecordId: system.eventRecordId,
+        targetFilename: exposed(parsed.data, 'TargetFilename') || null,
+        reason:
+          'EventID 23 FileDelete archives the deleted file into ArchiveDirectory; the bench ' +
+          'config enables 26 FileDeleteDetected and never 23. This record is NOT accepted as a ' +
+          'deletion observation — its presence means the running configuration is not the one ' +
+          'this run names',
+      });
+      continue;
+    }
+
+    if (system.eventId === EVENT_IDS.SYSMON_ERROR) {
+      tally.sysmonErrors.push({
+        index: i,
+        eventRecordId: system.eventRecordId,
+        description: exposed(parsed.data, 'Description') || null,
+      });
+      continue;
+    }
+
+    if (!SHAPED_EVENT_IDS[system.eventId]) {
+      const key = String(system.eventId);
+      if (CANONICAL_EVENT_IDS.includes(system.eventId)) {
+        tally.shapelessByEventId[key] = (tally.shapelessByEventId[key] || 0) + 1;
+      } else {
+        tally.refused.unsupportedEventId[key] = (tally.refused.unsupportedEventId[key] || 0) + 1;
+      }
+      continue;
+    }
+
+    try {
+      events.push(toOracleRecord(parsed, opts.scenario));
+      tally.normalized += 1;
+    } catch (err) {
+      tally.refused.missingRequiredField.push({
+        index: i,
+        eventId: system.eventId,
+        reason: err.message,
+      });
+    }
+  }
+
+  return { events, tally };
+}
+
+/**
+ * Lifecycle correlation between ProcessCreate and ProcessTerminate, by OPAQUE
+ * `ProcessGuid` equality and nothing else.
+ *
+ * This is an accounting fact recorded next to the records, not an enrichment of
+ * them: no field produced here is ever written back into a normalized record,
+ * because a terminate event that borrowed its creation's fields would read as
+ * having observed them itself.
+ *
+ * The guid is compared with `===`. It is not parsed, not decoded and not ordered.
+ * pid is deliberately NOT a fallback key: two generations sharing one pid are two
+ * generations, and pairing them by pid would manufacture a lifecycle the OS never
+ * had. A terminate whose guid matches no creation in this window is UNPAIRED and
+ * is counted as such — the creation may simply predate the window.
+ *
+ * `ordinality` keeps RESEARCH-BASELINE section 10's rule intact: truth about
+ * process identity comes from EID 1 ordinality, and guid equality is an
+ * additional lifecycle fact beside it, never a replacement for it.
+ * @param {Object[]} events - Normalized records, in the order they were read.
+ * @returns {Object} The correlation accounting.
+ */
+function correlateLifecycle(events) {
+  /** @type {Map<string, Object[]>} */
+  const creationsByGuid = new Map();
+  const creations = [];
+  const terminations = [];
+  for (const event of events) {
+    if (event.event.code === String(EVENT_IDS.PROCESS_CREATE)) creations.push(event);
+    if (event.event.code === String(EVENT_IDS.PROCESS_TERMINATE)) terminations.push(event);
+  }
+  creations.forEach((event, ordinality) => {
+    const guid = event.bench.processGuid;
+    if (!creationsByGuid.has(guid)) creationsByGuid.set(guid, []);
+    creationsByGuid.get(guid).push({ event, ordinality });
+  });
+
+  const paired = [];
+  const unpaired = [];
+  const ambiguous = [];
+  for (const [index, event] of terminations.entries()) {
+    const matches = creationsByGuid.get(event.bench.processGuid);
+    if (!matches || matches.length === 0) {
+      unpaired.push({
+        terminateOrdinality: index,
+        processGuid: event.bench.processGuid,
+        processId: event.process ? (event.process.pid ?? null) : null,
+        reason:
+          'no ProcessCreate in this window carries that ProcessGuid. The creation may predate ' +
+          'the window; it is never paired by pid instead',
+      });
+      continue;
+    }
+    if (matches.length > 1) {
+      ambiguous.push({
+        terminateOrdinality: index,
+        processGuid: event.bench.processGuid,
+        creationOrdinalities: matches.map((m) => m.ordinality),
+        reason:
+          'more than one ProcessCreate in this window carries that ProcessGuid, which the guid ' +
+          'is supposed to make impossible. Nothing is guessed: the pairing is AMBIGUOUS',
+      });
+      continue;
+    }
+    paired.push({
+      createOrdinality: matches[0].ordinality,
+      terminateOrdinality: index,
+      processGuid: event.bench.processGuid,
+      processId: event.process ? (event.process.pid ?? null) : null,
+    });
+  }
+
+  const pidsSeen = creations.map((e) => (e.process ? (e.process.pid ?? null) : null));
+  const reusedPids = pidsSeen.filter((pid, i) => pid !== null && pidsSeen.indexOf(pid) !== i);
+  return {
+    key:
+      'ProcessGuid, compared for equality only — never parsed, never decoded, and never ' +
+      'transformed into an AEGIS instanceId',
+    creations: creations.length,
+    terminations: terminations.length,
+    paired,
+    unpaired,
+    ambiguous,
+    // Two EID 1 records sharing a pid are two generations by ordinality, whatever
+    // the pid says. Recorded so a pid-keyed reader downstream cannot assume the
+    // question never came up.
+    distinctPidsAcrossCreations: new Set(pidsSeen.filter((p) => p !== null)).size,
+    pidsReusedAcrossCreations: [...new Set(reusedPids)],
+  };
+}
+
+/**
+ * Ascending EventRecordID gaps in what was collected.
+ *
+ * A gap is NOT loss, and this block says so in the file rather than leaving the
+ * inference to a reader. EventRecordID is per channel, and this run reads a
+ * window out of a channel whose other records — other Sysmon events, from other
+ * filters, about other processes — legitimately sit between the ones it kept. A
+ * gap is consistent with loss and equally consistent with a working filter, and
+ * nothing available offline separates the two.
+ * @param {number[]} ids - Collected EventRecordIDs, in read order.
+ * @returns {Object}
+ */
+function recordIdGaps(ids) {
+  const sorted = [...ids].sort((a, b) => a - b);
+  const gaps = [];
+  for (let i = 1; i < sorted.length; i++) {
+    const delta = sorted[i] - sorted[i - 1];
+    if (delta > 1) gaps.push({ after: sorted[i - 1], before: sorted[i], missing: delta - 1 });
+  }
+  return {
+    collected: sorted.length,
+    first: sorted.length > 0 ? sorted[0] : null,
+    last: sorted.length > 0 ? sorted[sorted.length - 1] : null,
+    gaps,
+    meaning:
+      'a gap is NOT a loss count. EventRecordID is assigned per channel, and every Sysmon event ' +
+      'this run did not collect — a different event id, a record outside the window, a record ' +
+      'this config filtered out — legitimately consumes an id. Nothing available offline ' +
+      'separates a gap caused by loss from a gap caused by a working filter',
+  };
+}
+
+/**
+ * Read the Sysmon channel into raw EventRecord XML documents.
+ *
+ * **THIS IS THE LIVE-UNVALIDATED BOUNDARY, AND NOTHING HAS EVER EXERCISED IT.**
+ * No test in this repository calls it, because the machine it was written on has
+ * no Sysmon installed. Do not read a green suite as evidence that this works.
+ *
+ * Two deliberate choices, both about keeping .NET's clock out of the pipeline:
+ *
+ * - It emits `$_.ToXml()` and never the `TimeCreated` property. `Get-WinEvent`
+ *   hands that back as a `DateTime` with `Kind=Local`, and every downstream
+ *   conversion of it is an opportunity to turn the reader's own time zone into
+ *   the oracle's latency. The XML carries `System/TimeCreated@SystemTime`
+ *   instead, which {@link normalizeSystemTime} refuses unless it ends in `Z`.
+ * - It does **not** filter by time. A `-FilterHashtable` `StartTime`/`EndTime`
+ *   would mean constructing .NET `DateTime`s from our instants — the same trap
+ *   one step earlier. The window is applied by {@link select}, in JavaScript,
+ *   over the XML's own timestamps, where it is unit-testable.
+ *
+ * The read is bounded by `-MaxEvents`. Hitting that bound is recorded: it means
+ * the read may have stopped before reaching the start of the window.
+ *
+ * The `command` it returns — which becomes `collection.reader` in
+ * `oracle-loss.json` — is built from the same argv array that is executed, so a
+ * provenance field cannot come to describe something narrower than what ran.
+ * @param {Object} [opts]
+ * @param {number} [opts.maxEvents] - Bound on records read. Default
+ *   {@link MAX_EVENTS_READ}.
+ * @param {string} [opts.channel] - Channel name. Default {@link CHANNEL}.
+ * @returns {{documents: string[], capReached: boolean, command: string}}
+ * @throws {SysmonError} When PowerShell or the channel refused.
+ */
+function readChannelXml(opts = {}) {
+  const maxEvents = opts.maxEvents || MAX_EVENTS_READ;
+  const channel = opts.channel || CHANNEL;
+  const script =
+    `$ErrorActionPreference='Stop'; ` +
+    `Get-WinEvent -LogName '${channel}' -MaxEvents ${maxEvents} | ` +
+    `ForEach-Object { $_.ToXml(); '${RECORD_DELIMITER}' }`;
+  const argv = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script];
+  // Derived from the SAME array that is executed, so the record of what ran
+  // cannot drift from what ran. It is the argv joined for reading, not a shell
+  // command line: no shell is involved, and nothing here is quoted for one.
+  const command = ['powershell', ...argv].join(' ');
+  let out;
+  try {
+    out = execFileSync('powershell', argv, {
+      encoding: 'utf8',
+      windowsHide: true,
+      maxBuffer: 256 * 1024 * 1024,
+    });
+  } catch (err) {
+    throw new SysmonError(
+      'reader-failed',
+      `${command} did not produce a channel read: ${String((err && err.message) || err).trim()}`,
+    );
+  }
+  const documents = out
+    .split(RECORD_DELIMITER)
+    .map((d) => d.trim())
+    .filter((d) => d.length > 0);
+  return { documents, capReached: documents.length >= maxEvents, command };
+}
+
+/**
+ * What Sysmon binary, if any, this host is running.
+ *
+ * A read-only probe: it asks for a service and a file version and changes
+ * nothing. **A version is never invented** — no string from a web page, no
+ * default, no "latest". When the probe does not answer, the manifest records the
+ * absence and the reason the probe gave.
+ * @param {Object} [opts]
+ * @param {function(string): string} [opts.exec] - Runs a PowerShell script and
+ *   returns its stdout. Injectable so the absent branch can be exercised without
+ *   a shell.
+ * @returns {{value: Object|null, source: string, unavailable?: string}}
+ */
+function probeVersion(opts = {}) {
+  const script =
+    `$ErrorActionPreference='Stop'; ` +
+    `$svc = Get-Service -Name 'Sysmon64','Sysmon' -ErrorAction SilentlyContinue | ` +
+    `Select-Object -First 1; ` +
+    `if (-not $svc) { throw 'no Sysmon or Sysmon64 service is installed on this host' }; ` +
+    `$img = (Get-CimInstance Win32_Service -Filter ("Name='" + $svc.Name + "'")).PathName; ` +
+    `$img = $img.Trim('"'); ` +
+    `$info = (Get-Item $img).VersionInfo; ` +
+    `ConvertTo-Json -Compress @{ service = $svc.Name; image = $img; ` +
+    `fileVersion = $info.FileVersion; productVersion = $info.ProductVersion }`;
+  // A SUMMARY of the probe, not the literal argv — the script itself is long and
+  // `manifest.probe` puts its whole failure output in `unavailable` anyway, so
+  // the exact text that ran is on the record either way. Said here so the field
+  // is not read as a copy of the command line.
+  const source =
+    'summary of the probe: PowerShell Get-Service Sysmon64,Sysmon → Win32_Service PathName → ' +
+    'that file\'s VersionInfo. The literal invocation appears in "unavailable" when it fails';
+  const exec =
+    opts.exec ||
+    ((s) =>
+      execFileSync(
+        'powershell',
+        ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', s],
+        { encoding: 'utf8', windowsHide: true },
+      ));
+  return manifest.probe(source, () => {
+    if (process.platform !== 'win32') return null;
+    const parsed = JSON.parse(exec(script));
+    if (!parsed || typeof parsed.fileVersion !== 'string' || parsed.fileVersion.trim() === '') {
+      return null;
+    }
+    return {
+      service: parsed.service,
+      image: parsed.image,
+      fileVersion: parsed.fileVersion,
+      productVersion: parsed.productVersion ?? null,
+    };
+  });
+}
+
+/**
+ * The `oracles.sysmon` block of a run manifest: the reserved
+ * `{version, configPath, configSha256}` contract, and nothing added to it.
+ *
+ * `configSha256` is taken over the config file's EXACT BYTES at
+ * `configPath` — not over the path string, not over decoded text, and never as a
+ * committed constant. `.gitattributes` puts this repository's non-fixture files
+ * under `text=auto`, so a constant would go red on a checkout with different line
+ * endings while naming the same configuration.
+ *
+ * `configPath` is repository-relative on purpose: the sha256 plus that path make
+ * a run re-creatable from the repository, which an absolute path on one
+ * developer's disk does not.
+ * @param {Object} [opts]
+ * @param {{value: Object|null, unavailable?: string}} [opts.version] - From
+ *   {@link probeVersion}. Omitted means the probe was never run.
+ * @param {string} [opts.configPath] - Absolute path to the config. For tests.
+ * @returns {{version: string|null, configPath: string|null, configSha256: string|null,
+ *   unavailable?: string}}
+ */
+function manifestBlock(opts = {}) {
+  const file = opts.configPath || CONFIG_PATH;
+  const relative = path.relative(manifest.ROOT, file).split(path.sep).join('/');
+  /** @type {{version: string|null, configPath: string|null, configSha256: string|null,
+   *   unavailable?: string}} */
+  const block = { version: null, configPath: relative, configSha256: null };
+  try {
+    block.configSha256 = sha256OfFile(file);
+  } catch (err) {
+    block.configPath = null;
+    block.unavailable = `${relative} could not be read: ${String((err && err.message) || err)}`;
+    return block;
+  }
+
+  const version = opts.version;
+  if (!version) {
+    block.unavailable =
+      'no Sysmon version was probed for this run, so none is recorded. The path and digest name ' +
+      'the configuration this run WOULD be measured under; they are not evidence it was applied';
+    return block;
+  }
+  if (!version.value) {
+    block.unavailable =
+      `${version.unavailable || 'the Sysmon version probe produced no value'} — so this run was ` +
+      'not measured under a Sysmon binary. The path and digest name the configuration it WOULD ' +
+      'have used; they are not evidence it was applied';
+    return block;
+  }
+  block.version = version.value.fileVersion;
+  return block;
+}
+
+/**
+ * Collection and loss accounting for one run — the whole of `oracle-loss.json`.
+ *
+ * Written whether or not anything was collected, and especially when nothing
+ * was: a run directory with no oracle records has to say why, or the next reader
+ * assumes the oracle saw nothing, which is a different claim.
+ *
+ * **It never reports a loss of zero.** What can be counted is counted; what
+ * cannot be established offline is an explicit absence with the reason, in the
+ * `{value: null, unavailable}` shape the manifest uses.
+ * @param {Object} opts
+ * @param {string} opts.runId
+ * @param {string} opts.scenario
+ * @param {string} opts.arm
+ * @param {{start: string|null, end: string|null}} opts.window
+ * @param {Object} opts.config - From {@link manifestBlock}.
+ * @param {Object|null} [opts.tally] - From {@link select}; null when no read ran.
+ * @param {Object[]} [opts.events] - Normalized records, for the correlation block.
+ * @param {Object} opts.collection - `{ran, reader, unavailable?, capReached?}`.
+ * @returns {Object}
+ */
+function buildLoss(opts) {
+  const tally = opts.tally;
+  return {
+    schemaVersion: LOSS_SCHEMA_VERSION,
+    oracle: ORACLE_ID,
+    runId: opts.runId,
+    scenario: opts.scenario,
+    arm: opts.arm,
+    collection: {
+      ran: opts.collection.ran,
+      channel: CHANNEL,
+      reader: opts.collection.reader,
+      window: opts.window,
+      windowEpsilonMs: 0,
+      windowBasis:
+        "both ends are instants the harness read off its own clock — the run's startedAt, which " +
+        'precedes everything the scenario causes, and the moment collection began, which follows ' +
+        'all of it. No epsilon is applied and none is declared: a tolerance here would be a guess ' +
+        'about clock agreement between Sysmon and the harness, which nothing in this repository ' +
+        'has measured',
+      ...(opts.collection.unavailable ? { unavailable: opts.collection.unavailable } : {}),
+      ...(opts.collection.capReached === undefined
+        ? {}
+        : {
+            readCapReached: opts.collection.capReached,
+            readCap: MAX_EVENTS_READ,
+            readCapMeaning:
+              'the reader takes at most this many records off the channel, newest first. Reaching ' +
+              'the cap means the read may have stopped before the window opened, and records ' +
+              'from inside the window may therefore be missing from this file',
+          }),
+    },
+    config: {
+      path: opts.config.configPath,
+      sha256: opts.config.configSha256,
+      enabledEventIds: [...CANONICAL_EVENT_IDS],
+      archivalEventId: EVENT_IDS.FILE_DELETE_ARCHIVED,
+      filterAccounting:
+        'an event this configuration excludes is never emitted, so it is not lost — but Sysmon ' +
+        'publishes no filter-hit counter, so a run cannot count what it declined to see either. ' +
+        'Records intentionally filtered out and records that never occurred are indistinguishable ' +
+        'from here, and neither is reported as loss',
+    },
+    records:
+      tally === null
+        ? {
+            value: null,
+            unavailable: 'no read ran, so there is nothing to account for',
+          }
+        : {
+            read: tally.read,
+            normalized: tally.normalized,
+            outOfWindow: tally.outOfWindow,
+            shapelessByEventId: tally.shapelessByEventId,
+            shapelessMeaning:
+              'canonical oracle events with no shape in the catalogue ECS subset (2, 3, 22). ' +
+              'Real observations, counted rather than dropped, and not written as records: a ' +
+              'fifth shape would stop expected/observed/oracle speaking one subset',
+          },
+    refused: tally === null ? null : tally.refused,
+    archivalDeletes:
+      tally === null
+        ? null
+        : {
+            count: tally.archivalDeletes.length,
+            records: tally.archivalDeletes,
+            meaning:
+              'EventID 23 FileDelete, which archives the deleted file. Never folded into ' +
+              'EventID 26 FileDeleteDetected and never accepted as a deletion observation',
+          },
+    sysmonErrors:
+      tally === null
+        ? null
+        : {
+            count: tally.sysmonErrors.length,
+            records: tally.sysmonErrors,
+            meaning:
+              'EventID 255, which Sysmon writes when it could not do something. This is a real ' +
+              'loss signal and is reported as itself, not merged into any other count',
+          },
+    eventRecordIds: tally === null ? null : recordIdGaps(tally.eventRecordIds),
+    lifecycle: tally === null ? null : correlateLifecycle(opts.events || []),
+    channelRetention: {
+      value: null,
+      unavailable:
+        'not measured. Whether the channel wrapped or overwrote records during this run would ' +
+        'come from the log configuration itself (retention policy, maximum size, `wevtutil gl`), ' +
+        'and no such probe runs here. Absent, not zero',
+    },
+  };
+}
+
+/**
+ * Run the oracle for one bench run: read the channel, normalize what it holds,
+ * and account for everything that did not become a record.
+ *
+ * Never throws for a reason the run should survive. A reader that refused comes
+ * back as `collection.ran: false` with the reason on the loss record, so the
+ * caller still writes the accounting and still writes the catalogue.
+ * @param {Object} opts
+ * @param {string} opts.runId
+ * @param {string} opts.scenario
+ * @param {string} opts.arm
+ * @param {string} opts.windowStart - ISO instant; the run's `startedAt`.
+ * @param {string} opts.windowEnd - ISO instant; when collection began.
+ * @param {Object} opts.config - From {@link manifestBlock}.
+ * @param {function(Object): {documents: string[], capReached: boolean, command: string}} [opts.read]
+ *   - The raw boundary. Defaults to {@link readChannelXml}; injected in tests so
+ *   the normalizer is exercised without a channel.
+ * @returns {{events: Object[], loss: Object, ok: boolean}}
+ */
+function collect(opts) {
+  const window = { start: opts.windowStart, end: opts.windowEnd };
+  const read = opts.read || readChannelXml;
+  let raw;
+  try {
+    raw = read({ channel: CHANNEL, maxEvents: MAX_EVENTS_READ });
+  } catch (err) {
+    return {
+      events: [],
+      ok: false,
+      loss: buildLoss({
+        runId: opts.runId,
+        scenario: opts.scenario,
+        arm: opts.arm,
+        window,
+        config: opts.config,
+        tally: null,
+        collection: {
+          ran: false,
+          reader: 'bench/lib/oracles/sysmon.js readChannelXml',
+          unavailable: String((err && err.message) || err),
+        },
+      }),
+    };
+  }
+
+  const { events, tally } = select({
+    documents: raw.documents,
+    scenario: opts.scenario,
+    windowStart: opts.windowStart,
+    windowEnd: opts.windowEnd,
+  });
+  return {
+    events,
+    ok: true,
+    loss: buildLoss({
+      runId: opts.runId,
+      scenario: opts.scenario,
+      arm: opts.arm,
+      window,
+      config: opts.config,
+      tally,
+      events,
+      collection: {
+        ran: true,
+        reader: raw.command || 'injected reader',
+        capReached: Boolean(raw.capReached),
+      },
+    }),
+  };
+}
+
+/**
+ * Write the normalized oracle records into a run directory.
+ *
+ * Serialized by `catalogue.serialize`, the one definition of an NDJSON line's
+ * bytes in this harness, so `expected.ndjson`, `observed.ndjson` and
+ * `oracle-sysmon.ndjson` are comparable line for line.
+ * @param {string} runDir - Absolute path of the run directory.
+ * @param {Object[]} events - Never empty: the caller writes no file for none.
+ * @returns {string} Absolute path of the file written.
+ */
+function write(runDir, events) {
+  const file = path.join(runDir, ORACLE_FILENAME);
+  fs.writeFileSync(file, catalogue.serialize(events), 'utf8');
+  return file;
+}
+
+/**
+ * Write the collection and loss accounting into a run directory.
+ * @param {string} runDir - Absolute path of the run directory.
+ * @param {Object} loss - From {@link buildLoss}.
+ * @returns {string} Absolute path of the file written.
+ */
+function writeLoss(runDir, loss) {
+  const file = path.join(runDir, LOSS_FILENAME);
+  fs.writeFileSync(file, `${JSON.stringify(loss, null, 2)}\n`, 'utf8');
+  return file;
+}
+
+module.exports = {
+  CANONICAL_EVENT_IDS,
+  CHANNEL,
+  CONFIG_PATH,
+  EVENT_IDS,
+  LOSS_FILENAME,
+  LOSS_SCHEMA_VERSION,
+  MAX_EVENTS_READ,
+  ORACLE_FILENAME,
+  ORACLE_ID,
+  PROVIDER,
+  RECORD_DELIMITER,
+  REQUIRED_DATA,
+  SHAPED_EVENT_IDS,
+  SOURCE,
+  SysmonError,
+  buildLoss,
+  collect,
+  correlateLifecycle,
+  decodeXmlText,
+  manifestBlock,
+  normalizeSystemTime,
+  parseEventXml,
+  probeVersion,
+  readChannelXml,
+  recordIdGaps,
+  select,
+  sha256OfFile,
+  splitPath,
+  toOracleRecord,
+  write,
+  writeLoss,
+};

--- a/bench/oracles/sysmon-bench.xml
+++ b/bench/oracles/sysmon-bench.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  bench/oracles/sysmon-bench.xml — the Sysmon configuration one Bench V1 run is
+  measured under (sub-block B2.3).
+
+  NOT YET ACCEPTED BY A SYSMON BINARY. This file has never been handed to
+  `sysmon -c` or `sysmon -i`, because no Sysmon binary is installed on the machine
+  it was written on. Everything below is derived from Microsoft's published
+  documentation; the installed binary is authoritative for the schema it actually
+  supports, and proving that it accepts this file is the live half of B2.3.
+
+  schemaversion="4.82" is the value Microsoft publishes in the example
+  configuration on BOTH current primary pages — learn.microsoft.com
+  /sysinternals/downloads/sysmon (2026-06-17) and
+  /windows/security/operating-system-security/sysmon/sysmon-configuration-files
+  (2026-02-03). Both state that this version "is independent from the Sysmon
+  binary version and allows the parsing of older configuration files", and that
+  the current one is obtained from the binary with `-? config` (`-s` prints the
+  full schema). So the number is documented rather than guessed — and whether the
+  binary a run installs accepts it is LIVE-UNVALIDATED until measured against
+  that binary, whose version, SHA-256 and `-s` output the live step records.
+
+  WHY EACH EVENT IS HERE. The set is RESEARCH-BASELINE section 10's oracle column
+  — 1/2/3/5/11/22 — plus 26, added by ratification on 2026-08-14. Nothing else is
+  enabled: no ImageLoad, no ProcessAccess, no registry, no pipes, no WMI. Those
+  are the high-volume events, none of them is in the oracle column, and an event
+  nobody scores is noise a bench pays for twice (collection cost, then the reader
+  who has to decide it is irrelevant).
+
+  EID 23 FileDelete is DELIBERATELY ABSENT. It is the archiving delete: Microsoft
+  states that "the deleted file is also saved in the ArchiveDirectory (which is
+  C:\Sysmon by default)" and that "under normal operating conditions this
+  directory might grow to an unreasonable size". EID 26 FileDeleteDetected is the
+  same observation "without saving the deleted files". A bench needs to see that a
+  deletion happened; it has no business copying the deleted file somewhere. The
+  two are never treated as interchangeable — `bench/lib/oracles/sysmon.js` refuses
+  to read a 23 as a 26.
+
+  Whether the installed binary requires, creates or otherwise touches
+  ArchiveDirectory when 26 is configured is NOT settled by the documentation —
+  both pages describe ArchiveDirectory only in terms of copy-on-delete — and no
+  answer is invented here. That is LIVE-UNVALIDATED.
+
+  WHY THE FILTERS LOOK LIKE THIS. `\bench\runs\` is the one path fragment every
+  artefact of every run shares: `bench/run.js` creates each run directory under
+  `bench/runs/<run id>/` and a scenario stages its binaries in `stage/` beneath
+  it. It is a property of the harness rather than of a machine or a scenario, so
+  it narrows collection to the run without a literal that only holds on one
+  checkout. A run directory's name is chosen at run time and cannot appear in a
+  committed file.
+
+  ProcessTerminate is the exception: it logs EVERYTHING. Narrowing it would mean
+  filtering on a field, and the only field list Microsoft publishes for EID 5 is
+  the prose "It provides the UtcTime, ProcessGuid and ProcessId of the process" —
+  none of which can be known before the run. A filter naming a field the
+  installed schema may not expose is a configuration that fails to load; logging
+  every termination and correlating it back by ProcessGuid is the shape that does
+  not depend on an unverified field. The cost is real and is stated rather than
+  hidden: on a busy host this is the noisiest thing here.
+
+  WHAT A FILTER COSTS. An event this configuration excludes is never emitted, so
+  it is not "lost" — but Sysmon publishes no filter-hit counter, so a run cannot
+  count what it declined to see either. `oracle-loss.json` records that
+  distinction as an explicit limit rather than reporting zero.
+-->
+
+<Sysmon schemaversion="4.82">
+  <!--
+    SHA256 only. The catalogue records file.hash.sha256 for every file it
+    creates (bench/lib/catalogue.js), so this is the one algorithm that lets the
+    oracle's ProcessCreate hash be compared with what the actor observed. The
+    other algorithms would be a second answer to a question already answered.
+  -->
+  <HashAlgorithms>SHA256</HashAlgorithms>
+
+  <EventFiltering>
+    <!-- EID 1 — the process-identity truth this whole bench rests on. -->
+    <ProcessCreate onmatch="include">
+      <Image name="bench-run-dir" condition="contains">\bench\runs\</Image>
+    </ProcessCreate>
+
+    <!-- EID 2 — in the oracle column; near-zero volume once path-scoped. -->
+    <FileCreateTime onmatch="include">
+      <TargetFilename name="bench-run-dir" condition="contains">\bench\runs\</TargetFilename>
+    </FileCreateTime>
+
+    <!--
+      EID 3 — the oracle column's network reference. Enabled and path-scoped, but
+      no offline test may read anything into it: NetworkConnect is emitted only
+      because this element is here, and S1's subject speaks ICMP, which is not a
+      TCP/UDP connection.
+    -->
+    <NetworkConnect onmatch="include">
+      <Image name="bench-run-dir" condition="contains">\bench\runs\</Image>
+    </NetworkConnect>
+
+    <!-- EID 5 — everything. See the note above on why it is not narrowed. -->
+    <ProcessTerminate onmatch="exclude" />
+
+    <!-- EID 11 — create/overwrite. Sysmon has no file-read event at all. -->
+    <FileCreate onmatch="include">
+      <TargetFilename name="bench-run-dir" condition="contains">\bench\runs\</TargetFilename>
+    </FileCreate>
+
+    <!-- EID 22 — DNS queries only, per the network canon. -->
+    <DnsQuery onmatch="include">
+      <Image name="bench-run-dir" condition="contains">\bench\runs\</Image>
+    </DnsQuery>
+
+    <!--
+      EID 26 — the deletion observation this bench uses. Ratified 2026-08-14 as
+      an addition to the oracle column precisely because it does not archive.
+    -->
+    <FileDeleteDetected onmatch="include">
+      <TargetFilename name="bench-run-dir" condition="contains">\bench\runs\</TargetFilename>
+    </FileDeleteDetected>
+  </EventFiltering>
+</Sysmon>

--- a/bench/run.js
+++ b/bench/run.js
@@ -12,9 +12,15 @@
  *   C start nothing and write no observation set — arm C is defined as the sensor
  *   alone with no oracle, and measuring its overhead is a later block.
  *
- *   The oracle adapters (B2.6) are still a separate block: the report scores the
- *   sensor against the catalogue and against nothing else, and the catalogue is
- *   still unconfirmed until an oracle confirms it.
+ *   In the two arms whose definition includes Sysmon — A and B — it also runs the
+ *   **Sysmon oracle** (B2.3, `bench/lib/oracles/sysmon.js`) and writes
+ *   `oracle-loss.json` always and `oracle-sysmon.ndjson` when there was anything
+ *   to write. That does NOT yet reach `run-report.json`: the report still scores
+ *   the sensor against the catalogue and against nothing else, and confirming the
+ *   catalogue against the oracle column is B2.5. Procmon (B2.6) does not exist,
+ *   so an arm-B run is a PARTIAL calibration and its manifest says so — the
+ *   `oracles.procmon` entry is unavailable and is printed in the absent-facts
+ *   list at the end of the run.
  *
  *   The manifest also records **which report renderer this process is running** —
  *   `reportRenderer`, the sha256 of `bench/lib/join.js` and `bench/lib/report.js`
@@ -42,8 +48,9 @@
  *   positive the harness manufactured for itself.
  *
  *   Exit codes: 0 the run completed · 1 a step failed to execute, the sensor
- *   could not be run or read, or the run report could not be derived · 2 the
- *   invocation or the scenario was wrong, and nothing ran.
+ *   could not be run or read, the run report could not be derived, or an arm-B
+ *   run collected no oracle record · 2 the invocation or the scenario was wrong,
+ *   and nothing ran.
  *
  *   Usage:
  *     npm run bench:run
@@ -78,6 +85,7 @@ const {
   serializeReport,
 } = require('./lib/report');
 const sensor = require('./lib/sensor');
+const sysmon = require('./lib/oracles/sysmon');
 
 /** @type {string} Where run directories are created. Gitignored. */
 const RUNS_DIR = path.join(manifest.ROOT, 'bench', 'runs');
@@ -92,6 +100,21 @@ const SETTINGS_FILENAME = 'settings.json';
  * @type {string}
  */
 const SENSOR_ARM = 'A';
+
+/**
+ * The arms whose definition includes Sysmon: A is sensor + Sysmon, B is Sysmon +
+ * Procmon without the sensor. C is the sensor alone with no oracle at all, so it
+ * runs none and its manifest keeps the oracle placeholders.
+ *
+ * The two arms differ in what a missing oracle MEANS, and therefore in the exit
+ * code. Arm B produces nothing else: no oracle column is an empty run, and it
+ * exits 1 for the same reason arm A exits 1 on an empty observation set. Arm A
+ * still produces its sensor column and its report, so a missing oracle there is
+ * recorded as an absent fact — in the manifest, in `oracle-loss.json` and in the
+ * absent-facts list printed at the end — and does not change its exit code.
+ * @type {ReadonlyArray<string>}
+ */
+const ORACLE_ARMS = Object.freeze(['A', 'B']);
 
 /**
  * Scenario label used when none was named. Deliberately not `smoke` or
@@ -122,8 +145,14 @@ run-scoped Electron profile, and what it recorded is written to observed.ndjson
 next to the catalogue. It needs a built renderer: run \`npm run build:renderer\`
 first, or the sensor refuses to start and the run stops before acting.
 
-Exit codes: 0 completed · 1 a step failed to execute, or the sensor could not be
-run or read · 2 bad invocation or bad scenario, nothing ran.`;
+In arms A and B the Sysmon oracle (B2.3) is collected and oracle-loss.json is
+written; oracle-sysmon.ndjson is written only if it holds a record. Procmon
+(B2.6) does not exist, so arm B is a PARTIAL calibration — its manifest records
+oracles.procmon as unavailable and the run prints it as an absent fact.
+
+Exit codes: 0 completed · 1 a step failed to execute, the sensor could not be
+run or read, or an arm-B run collected no oracle record · 2 bad invocation or
+bad scenario, nothing ran.`;
 
 /**
  * Parse `--key value` pairs. Unknown flags are an error rather than a silent
@@ -539,6 +568,66 @@ function writeReport(opts) {
 }
 
 /**
+ * Run the Sysmon oracle across this run and write both of its artefacts.
+ *
+ * Called AFTER the sensor has been stopped and after the catalogue is written,
+ * for the reason those two are ordered that way: the run directory sits inside
+ * the watched project directory, so a file the harness creates while the sensor
+ * is live becomes a file creation in the sensor's own answer.
+ *
+ * The window is `[the run's startedAt, now]`. The start is the manifest instant,
+ * which precedes the sensor, the steps and everything the scenario causes; the
+ * end is taken here, after all of it. Both are read off the harness's own clock,
+ * which is why the oracle window carries no epsilon — see
+ * `bench/lib/oracles/sysmon.js`.
+ *
+ * `oracle-loss.json` is written on every path, including — especially including —
+ * the one where nothing was collected. `oracle-sysmon.ndjson` is written only
+ * when there is at least one record: an empty one would be indistinguishable
+ * from "the oracle ran and saw nothing", which is a different claim.
+ * @param {Object} opts
+ * @param {string} opts.dir - Run directory.
+ * @param {string} opts.runId
+ * @param {string} opts.scenario
+ * @param {string} opts.arm
+ * @param {string} opts.startedAt - The run's start instant.
+ * @param {Object} opts.config - The manifest's `oracles.sysmon` block.
+ * @param {function(Object): Object} [opts.read] - The raw channel boundary. A
+ *   live run passes none and the adapter uses its own; a test injects one, which
+ *   is the only way the bytes this function writes can be exercised without an
+ *   installed Sysmon.
+ * @returns {{events: Object[], loss: Object, ok: boolean}}
+ */
+function runOracle(opts) {
+  const result = sysmon.collect({
+    runId: opts.runId,
+    scenario: opts.scenario,
+    arm: opts.arm,
+    windowStart: opts.startedAt,
+    windowEnd: new Date().toISOString(),
+    config: opts.config,
+    read: opts.read,
+  });
+
+  const lossPath = sysmon.writeLoss(opts.dir, result.loss);
+  console.log(`written ${lossPath}`);
+
+  if (result.events.length > 0) {
+    const file = sysmon.write(opts.dir, result.events);
+    console.log(`written ${file} (${result.events.length} oracle record(s))`);
+  } else {
+    console.log(
+      `oracle  no ${sysmon.ORACLE_FILENAME} was written — an empty one would read as "the ` +
+        `oracle ran and saw nothing". Why it holds none is in ${sysmon.LOSS_FILENAME}`,
+    );
+  }
+  if (!result.ok) {
+    console.error(`\nbench: ${result.loss.collection.unavailable}`);
+  }
+  return result;
+}
+
+/**
  * @param {string[]} argv - `process.argv.slice(2)`
  * @returns {Promise<number>} Process exit code.
  */
@@ -584,11 +673,21 @@ async function main(argv) {
     );
     return 2;
   }
+  // Built before the manifest and only for the arms that run an oracle. The
+  // adapter owns these facts — which config file, and which binary if any is
+  // installed — and hands them over, exactly as `reportRenderer` is handed over
+  // rather than re-derived inside the manifest. Arm C runs no oracle and keeps
+  // the placeholders.
+  const oracles = ORACLE_ARMS.includes(args.arm)
+    ? { sysmon: sysmon.manifestBlock({ version: sysmon.probeVersion() }) }
+    : undefined;
+
   const record = manifest.collect({
     runId,
     scenario: args.scenario,
     arm: args.arm,
     startedAt: now.toISOString(),
+    oracles,
     // Frozen while `lib/report.js` was loading, a few milliseconds before this
     // line — the renderer source bytes as they stood on disk at that instant,
     // not the file as it will stand when the report is written some minutes
@@ -602,7 +701,15 @@ async function main(argv) {
   fs.writeFileSync(manifestPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
 
   const absent = [];
-  for (const [group, fields] of Object.entries({ host: record.host, sensor: record.sensor })) {
+  // `oracles` is swept with the rest: an oracle that did not answer is an absent
+  // fact about this run, and an arm-B run reads its own PARTIAL calibration out
+  // of this list — `oracles.procmon` is unavailable until B2.6 exists, so a B run
+  // says so at the moment of measurement instead of looking complete.
+  for (const [group, fields] of Object.entries({
+    host: record.host,
+    sensor: record.sensor,
+    oracles: record.oracles,
+  })) {
     for (const [name, entry] of Object.entries(fields)) {
       if (entry && entry.unavailable) absent.push(`${group}.${name}: ${entry.unavailable}`);
     }
@@ -680,6 +787,30 @@ async function main(argv) {
       // harness made for itself into the sensor's own answer.
       const cataloguePath = catalogue.write(dir, outcome.events);
       console.log(`written ${cataloguePath} (${outcome.events.length} expected event(s))`);
+
+      // Same ordering rule, same reason: after the sensor is stopped, so the two
+      // oracle artefacts cannot appear as file creations in the sensor's answer.
+      if (oracles) {
+        const oracle = runOracle({
+          dir,
+          runId,
+          scenario: scenario.id,
+          arm: args.arm,
+          startedAt: now.toISOString(),
+          config: oracles.sysmon,
+        });
+        // Arm B is the oracle and nothing else. A B run that collected no record
+        // produced no calibration column at all, which is the same kind of empty
+        // answer an arm-A run with no observation set gives — and it exits the
+        // same way. Arm A keeps its own exit code: it still has a sensor column.
+        if (args.arm !== SENSOR_ARM && (!oracle.ok || oracle.events.length === 0)) {
+          console.error(
+            `bench: arm ${args.arm} is defined as an oracle calibration and this run produced no ` +
+              `oracle record, so there is nothing to calibrate against — see ${sysmon.LOSS_FILENAME}`,
+          );
+          exitCode = 1;
+        }
+      }
 
       if (capture) {
         const metaPath = observed.writeMeta(dir, capture.record);
@@ -759,6 +890,7 @@ if (require.main === module) {
 module.exports = {
   MAX_LATENCY_INTERVALS,
   NO_SCENARIO,
+  ORACLE_ARMS,
   RUNS_DIR,
   SENSOR_ARM,
   SETTINGS_FILENAME,
@@ -771,6 +903,10 @@ module.exports = {
   prepareScenario,
   processAliveWindow,
   resolveScanInterval,
+  // Exported for the same reason `writeReport` is: `main` reaches it only through
+  // a completed scenario run, so without this export the bytes it writes rest on
+  // a call site nothing exercises.
+  runOracle,
   // Exported for one reason: so a test can hold the bytes this function actually
   // writes against `serializeReport`'s output. `main` reaches it only through a
   // live arm-A capture — a started sensor, a stopped sensor and a read audit

--- a/memory-bank/RESEARCH-BASELINE.md
+++ b/memory-bank/RESEARCH-BASELINE.md
@@ -159,11 +159,23 @@ NDJSON). Decide naming BEFORE freezing Bench Replay schema. OCSF = possible late
 - Bench before ANY numeric accuracy/confidence claim.
 - Method: generate an expected-event catalogue per scenario, confirm with independent oracles.
   Never diff two live streams. Never self-oracle.
-- Oracle columns are separate: Sysmon (EID 1/2/3/5/11/22) = security-event reference; Procmon =
-  file-IRP reference; Kernel-File ETW appears only as SUT when it is the sensor.
+- Oracle columns are separate: Sysmon (EID 1/2/3/5/11/22/**26**) = security-event reference;
+  Procmon = file-IRP reference; Kernel-File ETW appears only as SUT when it is the sensor.
+- **Ratified 2026-08-14 (B2.3).** (a) **EID 26 FileDeleteDetected** joins the oracle column: it is
+  the deletion observation that does NOT archive the file. **EID 23 FileDelete is never enabled
+  merely to observe a deletion** — Microsoft documents 23 as additionally saving the deleted file
+  into `ArchiveDirectory`, and the two are never collapsed into one semantic event. Whether an
+  installed binary requires or otherwise touches `ArchiveDirectory` when 26 is configured is
+  **LIVE-UNVALIDATED**: the docs settle neither, and no answer is invented offline. (b) ProcessGuid
+  may be retained and compared as an OPAQUE **equality** key between Sysmon events (EID 1 ↔ EID 5)
+  — an additional lifecycle-correlation fact BESIDE EID 1 ordinality, never a replacement for it,
+  and never a source of an `instanceId`.
 - Sysmon writes two timestamps (EventData UtcTime ms vs System TimeCreated FILETIME) diverging
   1-2 s — join on TimeCreated, record both. ProcessGuid is Sysmon-generated — never parse it.
-  Match by pid + start-time FILETIME, epsilon ~2 s.
+  Match by pid + start-time FILETIME, epsilon ~2 s. **That epsilon is a tolerance for comparing
+  Sysmon's own two representations. It is NOT guest-clock uncertainty**, which is unmeasured, and
+  the two must never be merged into one error bound. B2.3 declares no epsilon at all: it retains
+  both representations, computes no delta, and leaves matching to B2.5.
 - Environment: Hyper-V Gen2 gold image first; Windows Sandbox second (driver load and unattended
   teardown unverified; nested virt unsupported on GitHub runners). Pin the Windows build.
 - Run separation: A = sensor+Sysmon (coverage/latency) · B = Sysmon+Procmon without sensor

--- a/tests/main/bench/oracle-sysmon.test.js
+++ b/tests/main/bench/oracle-sysmon.test.js
@@ -812,7 +812,19 @@ describe('sysmon oracle — the manifest block', () => {
       },
     });
     expect(probed.value).toBeNull();
-    expect(probed.unavailable).toMatch(/no Sysmon or Sysmon64 service is installed/);
+    // The reason depends on the platform, and BOTH branches are pinned rather
+    // than the assertion being loosened to whichever one this runner takes. The
+    // bench is Windows-only and CI runs on ubuntu-latest, so the non-Windows
+    // branch is the one the required `test` context actually executes — and a
+    // Windows fact on another platform must be absent WITH A REASON, never a
+    // bare "probe produced no value".
+    if (process.platform === 'win32') {
+      expect(probed.unavailable).toMatch(/no Sysmon or Sysmon64 service is installed/);
+    } else {
+      expect(probed.unavailable).toMatch(/this is not a Windows host/);
+      expect(probed.unavailable).toMatch(/Sysmon is a Windows facility/);
+    }
+    expect(probed.unavailable).not.toMatch(/^probe produced no value$/);
 
     const block = sysmon.manifestBlock({ version: probed });
     expect(block.version).toBeNull();

--- a/tests/main/bench/oracle-sysmon.test.js
+++ b/tests/main/bench/oracle-sysmon.test.js
@@ -1,0 +1,1176 @@
+/**
+ * @file tests/main/bench/oracle-sysmon.test.js
+ * @description The gate on B2.3's Sysmon oracle adapter.
+ *
+ *   **Every fixture in this file is SYNTHETIC.** The XML below was written by
+ *   hand in the shape the Windows Event Log renders an EventRecord in, from
+ *   Microsoft's published Sysmon documentation. No Sysmon binary produced it, no
+ *   `.evtx` file was fabricated to hold it, and nothing here is evidence about
+ *   Windows.
+ *
+ *   That boundary is the point of the file, so it is worth stating twice in the
+ *   two directions it cuts:
+ *
+ *   - **What these tests DO prove.** Given an EventRecord in the documented
+ *     shape, the normalizer produces the record it claims to, refuses what it
+ *     claims to refuse, keeps the two timestamp representations apart, treats
+ *     `ProcessGuid` as opaque, and accounts for everything that did not become a
+ *     record.
+ *   - **What they do NOT prove, and cannot.** That a real
+ *     `Microsoft-Windows-Sysmon/Operational` channel exists, that `Get-WinEvent`
+ *     hands back this shape, that an installed binary accepts
+ *     `bench/oracles/sysmon-bench.xml`, or that any field named here is on that
+ *     binary's schema. `readChannelXml` is called by nothing in this file. A
+ *     green run of this suite is not a claim about EVTX ingestion.
+ */
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import catalogue from '../../../bench/lib/catalogue.js';
+import manifest from '../../../bench/lib/manifest.js';
+import sysmon from '../../../bench/lib/oracles/sysmon.js';
+import run from '../../../bench/run.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..', '..');
+
+/** @type {string} Window the synthetic records below are stamped inside. */
+const WINDOW_START = '2026-08-14T12:00:00.000Z';
+
+/** @type {string} */
+const WINDOW_END = '2026-08-14T12:10:00.000Z';
+
+/**
+ * Two opaque ProcessGuid strings. They are OPAQUE here as well: nothing in this
+ * file decodes them, and the only operation performed on them is `===`.
+ * @type {string}
+ */
+const GUID_A = '{9f1c3a52-0001-68ad-0100-000000000c00}';
+
+/** @type {string} */
+const GUID_B = '{9f1c3a52-0002-68ad-0200-000000000c00}';
+
+/**
+ * Escape the five XML predefined characters, so a fixture can carry a command
+ * line with quotes and ampersands in it the way a real record does.
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * One SYNTHETIC EventRecord XML document, in the shape Windows renders.
+ * @param {Object} opts
+ * @param {number} opts.eventId
+ * @param {string} opts.systemTime - `System/TimeCreated@SystemTime`, verbatim.
+ * @param {number} [opts.recordId]
+ * @param {Object<string, string>} [opts.data] - EventData entries, in order.
+ * @param {string|null} [opts.provider] - `null` omits the Provider element.
+ * @param {boolean} [opts.omitEventData]
+ * @returns {string}
+ */
+function syntheticEventXml(opts) {
+  const entries = Object.entries(opts.data || {})
+    .map(([name, value]) => `      <Data Name="${name}">${escapeXml(value)}</Data>`)
+    .join('\n');
+  const provider =
+    opts.provider === null
+      ? ''
+      : `    <Provider Name="${opts.provider || 'Microsoft-Windows-Sysmon'}" ` +
+        `Guid="{5770385f-c22a-43e0-bf4c-06f5698ffbd9}"/>\n`;
+  const recordId =
+    opts.recordId === undefined ? '' : `    <EventRecordID>${opts.recordId}</EventRecordID>\n`;
+  const eventData = opts.omitEventData ? '' : `  <EventData>\n${entries}\n  </EventData>\n`;
+  return (
+    `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">\n` +
+    `  <System>\n` +
+    provider +
+    `    <EventID>${opts.eventId}</EventID>\n` +
+    `    <Version>5</Version>\n` +
+    `    <Level>4</Level>\n` +
+    `    <Task>${opts.eventId}</Task>\n` +
+    `    <Opcode>0</Opcode>\n` +
+    `    <Keywords>0x8000000000000000</Keywords>\n` +
+    `    <TimeCreated SystemTime="${opts.systemTime}"/>\n` +
+    recordId +
+    `    <Correlation/>\n` +
+    `    <Execution ProcessID="4242" ThreadID="8888"/>\n` +
+    `    <Channel>Microsoft-Windows-Sysmon/Operational</Channel>\n` +
+    `    <Computer>SYNTHETIC-HOST</Computer>\n` +
+    `    <Security UserID="S-1-5-18"/>\n` +
+    `  </System>\n` +
+    eventData +
+    `</Event>`
+  );
+}
+
+/**
+ * A SYNTHETIC EID 1 ProcessCreate, with the field names Microsoft's schema
+ * example and documentation use.
+ * @param {Object} over
+ * @returns {string}
+ */
+function processCreateXml(over = {}) {
+  return syntheticEventXml({
+    eventId: 1,
+    systemTime: over.systemTime || '2026-08-14T12:01:00.1234567Z',
+    recordId: over.recordId === undefined ? 1001 : over.recordId,
+    data: {
+      RuleName: 'bench-run-dir',
+      UtcTime: '2026-08-14 12:01:00.121',
+      ProcessGuid: over.processGuid || GUID_A,
+      ProcessId: String(over.processId === undefined ? 7788 : over.processId),
+      Image: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\R1\\stage\\claude.exe',
+      CommandLine: '"X:\\...\\stage\\claude.exe" -n 600 127.0.0.1',
+      CurrentDirectory: 'X:\\Future\\ESCAPE\\AEGIS\\',
+      Hashes: 'SHA256=3F786850E387550FDAB836ED7E6DC881DE23001B',
+      ParentProcessGuid: '{9f1c3a52-9999-68ad-0900-000000000c00}',
+      ParentProcessId: '4242',
+      ParentImage: 'C:\\Program Files\\nodejs\\node.exe',
+      ParentCommandLine: 'node bench/run.js --scenario S1-agent-lifecycle --arm B',
+      ...(over.data || {}),
+    },
+  });
+}
+
+/**
+ * A SYNTHETIC EID 5 ProcessTerminate. Microsoft's prose gives this event
+ * `UtcTime`, `ProcessGuid` and `ProcessId`; `Image` is included here only where a
+ * test is about a record that exposes it.
+ * @param {Object} over
+ * @returns {string}
+ */
+function processTerminateXml(over = {}) {
+  return syntheticEventXml({
+    eventId: 5,
+    systemTime: over.systemTime || '2026-08-14T12:02:00.7654321Z',
+    recordId: over.recordId === undefined ? 1002 : over.recordId,
+    data: {
+      RuleName: '-',
+      UtcTime: '2026-08-14 12:02:00.764',
+      ProcessGuid: over.processGuid || GUID_A,
+      ProcessId: String(over.processId === undefined ? 7788 : over.processId),
+      ...(over.data || {}),
+    },
+  });
+}
+
+/**
+ * Normalize a set of SYNTHETIC documents inside the standard window.
+ * @param {string[]} documents
+ * @returns {{events: Object[], tally: Object}}
+ */
+function normalize(documents) {
+  return sysmon.select({
+    documents,
+    scenario: 'S1-agent-lifecycle',
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+  });
+}
+
+/**
+ * A reader that returns SYNTHETIC documents, standing in for the live boundary.
+ * @param {string[]} documents
+ * @returns {function(): Object}
+ */
+function injectedReader(documents) {
+  return () => ({
+    documents,
+    capReached: false,
+    command: 'INJECTED SYNTHETIC READER — no channel was read',
+  });
+}
+
+/* ------------------------------------------------------------------ 1, 15 --- */
+
+describe('sysmon oracle — ProcessCreate normalization', () => {
+  it('produces one process.start record carrying only what EID 1 exposed', () => {
+    const { events, tally } = normalize([processCreateXml()]);
+
+    expect(tally.read).toBe(1);
+    expect(tally.normalized).toBe(1);
+    expect(events).toHaveLength(1);
+
+    const event = events[0];
+    expect(event.event.category).toEqual(['process']);
+    expect(event.event.type).toEqual(['start']);
+    expect(event.event.action).toBe(catalogue.EVENT_SHAPES['process.start'].action);
+    expect(event.event.code).toBe('1');
+    expect(event.event.provider).toBe('Microsoft-Windows-Sysmon');
+    expect(event.event.sequence).toBe(1001);
+    expect(event.ecs.version).toBe(catalogue.ECS_VERSION);
+
+    expect(event.process.pid).toBe(7788);
+    expect(event.process.executable).toBe(
+      'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\R1\\stage\\claude.exe',
+    );
+    expect(event.process.name).toBe('claude.exe');
+    expect(event.process.command_line).toBe('"X:\\...\\stage\\claude.exe" -n 600 127.0.0.1');
+    expect(event.process.parent).toEqual({
+      pid: 4242,
+      executable: 'C:\\Program Files\\nodejs\\node.exe',
+      name: 'node.exe',
+      command_line: 'node bench/run.js --scenario S1-agent-lifecycle --arm B',
+    });
+
+    expect(event.bench.source).toBe('sysmon-eventlog-xml');
+    expect(event.bench.oracle).toBe('sysmon');
+    expect(event.bench.eventId).toBe(1);
+    expect(event.bench.ruleName).toBe('bench-run-dir');
+    expect(event.bench.scenario).toBe('S1-agent-lifecycle');
+  });
+
+  // The catalogue's convention, and the reason it exists: an omitted field says
+  // "nobody observed this", a null says "it was observed to be nothing".
+  it('omits a field the record did not expose rather than nulling it', () => {
+    const bare = syntheticEventXml({
+      eventId: 1,
+      systemTime: '2026-08-14T12:01:00.0000000Z',
+      recordId: 1,
+      data: {
+        UtcTime: '2026-08-14 12:01:00.000',
+        ProcessGuid: GUID_A,
+        ProcessId: '7788',
+      },
+    });
+    const { events } = normalize([bare]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].process).toEqual({ pid: 7788 });
+    expect('executable' in events[0].process).toBe(false);
+    expect('name' in events[0].process).toBe(false);
+    expect('command_line' in events[0].process).toBe(false);
+    expect('parent' in events[0].process).toBe(false);
+    expect('ruleName' in events[0].bench).toBe(false);
+    expect(JSON.stringify(events[0])).not.toContain('null');
+  });
+});
+
+/* ---------------------------------------------------------------------- 2 --- */
+
+describe('sysmon oracle — ProcessTerminate normalization', () => {
+  it('produces a process.end record with no exit code and no invented image', () => {
+    const { events } = normalize([processTerminateXml()]);
+
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.event.category).toEqual(['process']);
+    expect(event.event.type).toEqual(['end']);
+    expect(event.event.code).toBe('5');
+    expect(event.process).toEqual({ pid: 7788 });
+    // Sysmon's process-terminate event has no exit code and no signal. Neither is
+    // invented, and neither is borrowed from anywhere else.
+    expect('exit_code' in event.process).toBe(false);
+    expect('executable' in event.process).toBe(false);
+    expect('name' in event.process).toBe(false);
+  });
+
+  it('keeps Image when the record exposed one, because that is an observation', () => {
+    const withImage = processTerminateXml({
+      data: { Image: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\R1\\stage\\claude.exe' },
+    });
+    const { events } = normalize([withImage]);
+
+    expect(events[0].process.executable).toBe(
+      'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\R1\\stage\\claude.exe',
+    );
+    expect(events[0].process.name).toBe('claude.exe');
+  });
+
+  // The failure this forbids is the tempting one: EID 1 has a command line and a
+  // parent, EID 5 shares its ProcessGuid, and merging them would produce a record
+  // that reads as if Sysmon had observed a command line at termination.
+  it('never copies EID 1 fields into an EID 5 record', () => {
+    const { events } = normalize([processCreateXml(), processTerminateXml()]);
+
+    const terminate = events.find((e) => e.event.code === '5');
+    expect(terminate.process).toEqual({ pid: 7788 });
+    expect('command_line' in terminate.process).toBe(false);
+    expect('parent' in terminate.process).toBe(false);
+    expect('parentProcessGuid' in terminate.bench).toBe(false);
+    expect(JSON.stringify(terminate)).not.toContain('600');
+  });
+});
+
+/* ------------------------------------------------------------------- 3, 4 --- */
+
+describe('sysmon oracle — lifecycle correlation by opaque ProcessGuid', () => {
+  it('pairs a terminate to the create that shares its guid', () => {
+    const { events } = normalize([processCreateXml(), processTerminateXml()]);
+    const lifecycle = sysmon.correlateLifecycle(events);
+
+    expect(lifecycle.creations).toBe(1);
+    expect(lifecycle.terminations).toBe(1);
+    expect(lifecycle.paired).toEqual([
+      { createOrdinality: 0, terminateOrdinality: 0, processGuid: GUID_A, processId: 7788 },
+    ]);
+    expect(lifecycle.unpaired).toEqual([]);
+    expect(lifecycle.ambiguous).toEqual([]);
+    expect(lifecycle.key).toMatch(/never parsed/);
+    expect(lifecycle.key).toMatch(/never transformed into an AEGIS instanceId/);
+  });
+
+  // The load-bearing case. Two generations reuse one pid; only the guid separates
+  // them. A pairing that fell back to pid would cross the generations and report a
+  // lifecycle the OS never had.
+  it('keeps two generations apart when they share a pid and differ only by guid', () => {
+    const documents = [
+      processCreateXml({ processGuid: GUID_A, processId: 7788, recordId: 2001 }),
+      processCreateXml({
+        processGuid: GUID_B,
+        processId: 7788,
+        recordId: 2002,
+        systemTime: '2026-08-14T12:03:00.1000000Z',
+      }),
+      processTerminateXml({
+        processGuid: GUID_B,
+        processId: 7788,
+        recordId: 2003,
+        systemTime: '2026-08-14T12:04:00.1000000Z',
+      }),
+    ];
+    const { events } = normalize(documents);
+    const lifecycle = sysmon.correlateLifecycle(events);
+
+    expect(lifecycle.creations).toBe(2);
+    expect(lifecycle.distinctPidsAcrossCreations).toBe(1);
+    expect(lifecycle.pidsReusedAcrossCreations).toEqual([7788]);
+
+    // Exactly one pairing, and it is to the SECOND creation — the one whose guid
+    // the terminate carries — not to the first, which shares the pid.
+    expect(lifecycle.paired).toHaveLength(1);
+    expect(lifecycle.paired[0].createOrdinality).toBe(1);
+    expect(lifecycle.paired[0].processGuid).toBe(GUID_B);
+    expect(lifecycle.unpaired).toEqual([]);
+  });
+
+  it('reports a terminate with no matching create as UNPAIRED, never paired by pid', () => {
+    const { events } = normalize([
+      processCreateXml({ processGuid: GUID_A, processId: 7788 }),
+      processTerminateXml({ processGuid: GUID_B, processId: 7788, recordId: 3003 }),
+    ]);
+    const lifecycle = sysmon.correlateLifecycle(events);
+
+    expect(lifecycle.paired).toEqual([]);
+    expect(lifecycle.unpaired).toHaveLength(1);
+    expect(lifecycle.unpaired[0].processGuid).toBe(GUID_B);
+    expect(lifecycle.unpaired[0].reason).toMatch(/never paired by pid instead/);
+  });
+
+  it('reports two creates sharing one guid as AMBIGUOUS rather than guessing', () => {
+    const { events } = normalize([
+      processCreateXml({ processGuid: GUID_A, processId: 7788, recordId: 4001 }),
+      processCreateXml({
+        processGuid: GUID_A,
+        processId: 9999,
+        recordId: 4002,
+        systemTime: '2026-08-14T12:03:00.1000000Z',
+      }),
+      processTerminateXml({ processGuid: GUID_A, recordId: 4003 }),
+    ]);
+    const lifecycle = sysmon.correlateLifecycle(events);
+
+    expect(lifecycle.paired).toEqual([]);
+    expect(lifecycle.ambiguous).toHaveLength(1);
+    expect(lifecycle.ambiguous[0].creationOrdinalities).toEqual([0, 1]);
+    expect(lifecycle.ambiguous[0].reason).toMatch(/AMBIGUOUS/);
+  });
+});
+
+/* ------------------------------------------------------------------- 5, 6 --- */
+
+describe('sysmon oracle — ProcessGuid stays opaque', () => {
+  it('carries the guid verbatim and derives nothing from its contents', () => {
+    const { events } = normalize([processCreateXml()]);
+    const event = events[0];
+
+    expect(event.bench.processGuid).toBe(GUID_A);
+    // Nothing anywhere in the record is a substring or a transform of the guid's
+    // interior. The two timestamp fields come from the event's own timestamps,
+    // and the pid from ProcessId — none of them from the guid.
+    expect(event['@timestamp']).toBe('2026-08-14T12:01:00.123Z');
+    expect(event.bench.utcTime).toBe('2026-08-14 12:01:00.121');
+    expect(event.process.pid).toBe(7788);
+  });
+
+  // A guid whose interior is nonsense must normalize exactly like a well-formed
+  // one: if any code path read meaning out of those bytes, this would diverge.
+  it('normalizes a structurally meaningless guid identically to a plausible one', () => {
+    const nonsense = '{zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz}';
+    const plausible = normalize([processCreateXml({ processGuid: GUID_A })]).events[0];
+    const opaque = normalize([processCreateXml({ processGuid: nonsense })]).events[0];
+
+    expect(opaque.bench.processGuid).toBe(nonsense);
+    expect({ ...opaque.bench, processGuid: null }).toEqual({
+      ...plausible.bench,
+      processGuid: null,
+    });
+    expect(opaque['@timestamp']).toBe(plausible['@timestamp']);
+    expect(opaque.process).toEqual(plausible.process);
+  });
+
+  // `instanceId` is `"<pid>:<startTimeMs>"` (src/main/process-identity.js). No
+  // record this oracle writes may hold that key, under any name: manufacturing an
+  // AEGIS identity out of a Sysmon guid would make the oracle a second opinion on
+  // AEGIS's own identity scheme instead of an independent observation.
+  it('never manufactures an AEGIS instanceId out of a Sysmon guid', () => {
+    const { events } = normalize([processCreateXml(), processTerminateXml()]);
+
+    for (const event of events) {
+      const serialized = JSON.stringify(event);
+      expect(serialized).not.toMatch(/instanceId/i);
+      expect(serialized).not.toMatch(/"7788:\d+"/);
+      expect(Object.keys(event.bench)).not.toContain('instanceId');
+    }
+  });
+});
+
+/* ---------------------------------------------------------------- 7, 8, 9 --- */
+
+describe('sysmon oracle — file events', () => {
+  /**
+   * @param {number} eventId - 11, 23 or 26.
+   * @param {Object} over
+   * @returns {string}
+   */
+  function fileEventXml(eventId, over = {}) {
+    return syntheticEventXml({
+      eventId,
+      systemTime: over.systemTime || '2026-08-14T12:05:00.5000000Z',
+      recordId: over.recordId === undefined ? 5001 : over.recordId,
+      data: {
+        RuleName: 'bench-run-dir',
+        UtcTime: '2026-08-14 12:05:00.499',
+        ProcessGuid: GUID_A,
+        ProcessId: '4242',
+        Image: 'C:\\Program Files\\nodejs\\node.exe',
+        TargetFilename: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\R1\\stage\\claude.exe',
+        ...(over.data || {}),
+      },
+    });
+  }
+
+  it('normalizes EID 11 FileCreate as file.creation and keeps it distinct', () => {
+    const { events } = normalize([
+      fileEventXml(11, { data: { CreationUtcTime: '2026-08-14 12:05:00.498' } }),
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].event.code).toBe('11');
+    expect(events[0].event.category).toEqual(['file']);
+    expect(events[0].event.type).toEqual(['creation']);
+    expect(events[0].event.action).toBe(catalogue.EVENT_SHAPES['file.creation'].action);
+    expect(events[0].file).toEqual({
+      path: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\R1\\stage\\claude.exe',
+      name: 'claude.exe',
+      directory: 'X:\\Future\\ESCAPE\\AEGIS\\bench\\runs\\R1\\stage',
+    });
+    // Sysmon's own creation timestamp, kept verbatim in its own format and never
+    // parsed into an instant.
+    expect(events[0].bench.creationUtcTime).toBe('2026-08-14 12:05:00.498');
+  });
+
+  it('normalizes EID 26 FileDeleteDetected as the canonical deletion observation', () => {
+    const { events, tally } = normalize([fileEventXml(26, { data: { Archived: 'false' } })]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].event.code).toBe('26');
+    expect(events[0].event.category).toEqual(['file']);
+    expect(events[0].event.type).toEqual(['deletion']);
+    expect(events[0].bench.archived).toBe('false');
+    expect(tally.archivalDeletes).toEqual([]);
+    expect(sysmon.SHAPED_EVENT_IDS[26]).toBe('file.deletion');
+    expect(sysmon.CANONICAL_EVENT_IDS).toContain(26);
+  });
+
+  // The ratification this pins: 23 archives the file it reports deleted, 26 does
+  // not, and the two are never one semantic event. A 23 is not a deletion record
+  // here — it is the finding that the running configuration is not ours.
+  it('refuses EID 23 FileDelete as a deletion and records it as an archival finding', () => {
+    const { events, tally } = normalize([fileEventXml(23, { recordId: 5023 })]);
+
+    expect(events).toEqual([]);
+    expect(tally.normalized).toBe(0);
+    expect(tally.archivalDeletes).toHaveLength(1);
+    expect(tally.archivalDeletes[0].eventRecordId).toBe(5023);
+    expect(tally.archivalDeletes[0].reason).toMatch(/NOT accepted as a deletion observation/);
+    expect(tally.archivalDeletes[0].reason).toMatch(/ArchiveDirectory/);
+    expect(sysmon.SHAPED_EVENT_IDS[23]).toBeUndefined();
+    expect(sysmon.CANONICAL_EVENT_IDS).not.toContain(23);
+  });
+
+  it('keeps 23 and 26 apart when both arrive, rather than collapsing them', () => {
+    const { events, tally } = normalize([
+      fileEventXml(26, { recordId: 6026 }),
+      fileEventXml(23, { recordId: 6023, systemTime: '2026-08-14T12:06:00.0000000Z' }),
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events.map((e) => e.event.code)).toEqual(['26']);
+    expect(tally.archivalDeletes.map((a) => a.eventRecordId)).toEqual([6023]);
+  });
+});
+
+/* --------------------------------------------------------------------- 10 --- */
+
+describe('sysmon oracle — canonical events with no shape in the subset', () => {
+  it('counts EID 2, 3 and 22 rather than writing them, and claims no network coverage', () => {
+    const network = syntheticEventXml({
+      eventId: 3,
+      systemTime: '2026-08-14T12:07:00.0000000Z',
+      recordId: 7003,
+      data: {
+        RuleName: 'bench-run-dir',
+        UtcTime: '2026-08-14 12:07:00.000',
+        ProcessGuid: GUID_A,
+        ProcessId: '7788',
+        Image: 'X:\\...\\stage\\claude.exe',
+        DestinationIp: '127.0.0.1',
+        DestinationPort: '443',
+      },
+    });
+    const dns = syntheticEventXml({
+      eventId: 22,
+      systemTime: '2026-08-14T12:07:01.0000000Z',
+      recordId: 7022,
+      data: {
+        UtcTime: '2026-08-14 12:07:01.000',
+        ProcessGuid: GUID_A,
+        ProcessId: '7788',
+        QueryName: 'example.invalid',
+      },
+    });
+    const fileTime = syntheticEventXml({
+      eventId: 2,
+      systemTime: '2026-08-14T12:07:02.0000000Z',
+      recordId: 7002,
+      data: {
+        UtcTime: '2026-08-14 12:07:02.000',
+        ProcessGuid: GUID_A,
+        ProcessId: '7788',
+        TargetFilename: 'X:\\...\\stage\\claude.exe',
+      },
+    });
+
+    const { events, tally } = normalize([network, dns, fileTime]);
+
+    expect(events).toEqual([]);
+    expect(tally.read).toBe(3);
+    expect(tally.normalized).toBe(0);
+    expect(tally.shapelessByEventId).toEqual({ 2: 1, 3: 1, 22: 1 });
+    // Not refused, not lost: real observations the catalogue's four shapes have
+    // no room for. They must not land in any refusal bucket.
+    expect(tally.refused.unsupportedEventId).toEqual({});
+    expect(tally.refused.malformed).toEqual([]);
+  });
+
+  it('puts an event id outside the canonical set in unsupportedEventId', () => {
+    const imageLoad = syntheticEventXml({
+      eventId: 7,
+      systemTime: '2026-08-14T12:07:03.0000000Z',
+      recordId: 7007,
+      data: { UtcTime: '2026-08-14 12:07:03.000', ProcessGuid: GUID_A, ProcessId: '7788' },
+    });
+    const { events, tally } = normalize([imageLoad]);
+
+    expect(events).toEqual([]);
+    expect(tally.refused.unsupportedEventId).toEqual({ 7: 1 });
+    expect(tally.shapelessByEventId).toEqual({});
+  });
+});
+
+/* --------------------------------------------------------------------- 11 --- */
+
+describe('sysmon oracle — malformed and incomplete records are explicit', () => {
+  it('refuses a document that is not an event record, naming why', () => {
+    const { events, tally } = normalize(['', 'not xml at all', '<Event></Event>']);
+
+    expect(events).toEqual([]);
+    expect(tally.read).toBe(3);
+    expect(tally.refused.malformed).toHaveLength(3);
+    expect(tally.refused.malformed[0].reason).toMatch(/it is empty/);
+    expect(tally.refused.malformed[1].reason).toMatch(/no <Event> element/);
+    expect(tally.refused.malformed[2].reason).toMatch(/no <System> block/);
+    expect(tally.refused.malformed.map((r) => r.index)).toEqual([0, 1, 2]);
+  });
+
+  it('refuses a shaped record missing a required EventData field', () => {
+    const noGuid = syntheticEventXml({
+      eventId: 1,
+      systemTime: '2026-08-14T12:01:00.0000000Z',
+      recordId: 8001,
+      data: { UtcTime: '2026-08-14 12:01:00.000', ProcessId: '7788' },
+    });
+    const noTarget = syntheticEventXml({
+      eventId: 26,
+      systemTime: '2026-08-14T12:01:01.0000000Z',
+      recordId: 8026,
+      data: { UtcTime: '2026-08-14 12:01:01.000', ProcessGuid: GUID_A, ProcessId: '7788' },
+    });
+    const { events, tally } = normalize([noGuid, noTarget]);
+
+    expect(events).toEqual([]);
+    expect(tally.refused.missingRequiredField).toHaveLength(2);
+    expect(tally.refused.missingRequiredField[0].reason).toMatch(/carries no "ProcessGuid"/);
+    expect(tally.refused.missingRequiredField[0].reason).toMatch(/no value is substituted/);
+    expect(tally.refused.missingRequiredField[1].reason).toMatch(/carries no "TargetFilename"/);
+  });
+
+  it('refuses two Data entries of one name instead of picking one', () => {
+    const ambiguous = processCreateXml().replace(
+      '<Data Name="ProcessId">7788</Data>',
+      '<Data Name="ProcessId">7788</Data>\n      <Data Name="ProcessId">9999</Data>',
+    );
+    const { tally } = normalize([ambiguous]);
+
+    expect(tally.refused.malformed).toHaveLength(1);
+    expect(tally.refused.malformed[0].reason).toMatch(/two <Data Name="ProcessId"> entries/);
+  });
+
+  it('refuses a record from another provider rather than reading it as oracle evidence', () => {
+    const foreign = syntheticEventXml({
+      eventId: 1,
+      systemTime: '2026-08-14T12:01:00.0000000Z',
+      recordId: 9001,
+      provider: 'Microsoft-Windows-Security-Auditing',
+      data: { UtcTime: '2026-08-14 12:01:00.000', ProcessGuid: GUID_A, ProcessId: '7788' },
+    });
+    const { events, tally } = normalize([foreign]);
+
+    expect(events).toEqual([]);
+    expect(tally.refused.foreignProvider).toEqual([
+      { index: 0, eventId: 1, provider: 'Microsoft-Windows-Security-Auditing' },
+    ]);
+  });
+
+  it('decodes XML entities rather than storing their escaped form', () => {
+    const escaped = processCreateXml({
+      data: { CommandLine: '"c.exe" --a <b> & \'c\'' },
+    });
+    const { events } = normalize([escaped]);
+
+    expect(events[0].process.command_line).toBe('"c.exe" --a <b> & \'c\'');
+    expect(sysmon.decodeXmlText('&amp;lt;')).toBe('&lt;');
+    expect(sysmon.decodeXmlText('&#x41;&#66;')).toBe('AB');
+  });
+});
+
+/* ----------------------------------------------------------- 12, 15 -------- */
+
+describe('sysmon oracle — the two timestamps are never mixed', () => {
+  it('takes @timestamp from SystemTime and truncates, never rounds', () => {
+    expect(sysmon.normalizeSystemTime('2026-08-14T12:00:00.9999999Z')).toBe(
+      '2026-08-14T12:00:00.999Z',
+    );
+    expect(sysmon.normalizeSystemTime('2026-08-14T12:00:00.1234567Z')).toBe(
+      '2026-08-14T12:00:00.123Z',
+    );
+    expect(sysmon.normalizeSystemTime('2026-08-14T12:00:00Z')).toBe('2026-08-14T12:00:00.000Z');
+    expect(sysmon.normalizeSystemTime('2026-08-14T12:00:00.5Z')).toBe('2026-08-14T12:00:00.500Z');
+    // The catalogue's own instant format, so all three NDJSON files agree.
+    expect(
+      catalogue.ISO_UTC_MS.test(sysmon.normalizeSystemTime('2026-08-14T12:00:00.9999999Z')),
+    ).toBe(true);
+  });
+
+  // The four-hour trap, stated as a refusal. `Get-WinEvent`'s `TimeCreated`
+  // property is a .NET DateTime with Kind=Local; if a future reader ever hands
+  // local instants over instead of the XML's SystemTime, this fails at the first
+  // record instead of producing a plausible latency figure.
+  it('REFUSES a non-UTC instant instead of applying its offset', () => {
+    expect(() => sysmon.normalizeSystemTime('2026-08-14T08:00:00.0000000-04:00')).toThrow(
+      /not a UTC instant ending in Z/,
+    );
+    expect(() => sysmon.normalizeSystemTime('2026-08-14T08:00:00.0000000')).toThrow(/UTC instant/);
+    expect(() => sysmon.normalizeSystemTime('8/14/2026 8:00:00 AM')).toThrow(/UTC instant/);
+
+    const local = syntheticEventXml({
+      eventId: 1,
+      systemTime: '2026-08-14T08:01:00.1234567-04:00',
+      recordId: 1,
+      data: { UtcTime: '2026-08-14 12:01:00.121', ProcessGuid: GUID_A, ProcessId: '7788' },
+    });
+    const { events, tally } = normalize([local]);
+
+    expect(events).toEqual([]);
+    expect(tally.refused.nonUtcTimestamp).toHaveLength(1);
+    expect(tally.refused.nonUtcTimestamp[0].reason).toMatch(/turns its own clock into/);
+    // And above all: no record was produced whose instant was shifted by four
+    // hours into the window.
+    expect(tally.normalized).toBe(0);
+  });
+
+  // RAW is not overwritten by NORMALIZED. Both representations survive, labelled,
+  // and no arithmetic is ever done between them.
+  it('keeps both representations, and computes no delta between them', () => {
+    const { events } = normalize([processCreateXml()]);
+    const event = events[0];
+
+    expect(event['@timestamp']).toBe('2026-08-14T12:01:00.123Z');
+    expect(event.bench.timeCreatedSystemTime).toBe('2026-08-14T12:01:00.1234567Z');
+    expect(event.bench.utcTime).toBe('2026-08-14 12:01:00.121');
+
+    // No field anywhere holds the difference, and none is an epsilon: this module
+    // declares no timestamp tolerance at all. B2.5 owns matching, and the ~2 s
+    // figure in RESEARCH-BASELINE section 10 is about comparing two Sysmon
+    // representations — not about guest-clock uncertainty, which is unmeasured.
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toMatch(/epsilon/i);
+    expect(serialized).not.toMatch(/latency/i);
+    expect(serialized).not.toMatch(/skew/i);
+    expect(Object.keys(sysmon)).not.toContain('EPSILON_MS');
+    expect(
+      sysmon.buildLoss({
+        runId: 'r',
+        scenario: 's',
+        arm: 'B',
+        window: { start: WINDOW_START, end: WINDOW_END },
+        config: { configPath: 'p', configSha256: 'x' },
+        tally: null,
+        collection: { ran: false, reader: 'none', unavailable: 'none' },
+      }).collection.windowEpsilonMs,
+    ).toBe(0);
+  });
+
+  it('does not modify the raw documents it was handed', () => {
+    const documents = [processCreateXml(), processTerminateXml(), 'garbage'];
+    const before = JSON.parse(JSON.stringify(documents));
+    normalize(documents);
+
+    expect(documents).toEqual(before);
+  });
+
+  it('drops a record outside the window instead of widening the window to reach it', () => {
+    const early = processCreateXml({ systemTime: '2026-08-14T11:59:59.9990000Z' });
+    const late = processCreateXml({ systemTime: '2026-08-14T12:10:00.0010000Z' });
+    const { events, tally } = normalize([early, late]);
+
+    expect(events).toEqual([]);
+    expect(tally.outOfWindow).toBe(2);
+  });
+});
+
+/* ----------------------------------------------------------------- 13, 14 --- */
+
+describe('sysmon oracle — the manifest block', () => {
+  it('digests the exact bytes of the config file it names', () => {
+    const block = sysmon.manifestBlock();
+
+    expect(block.configPath).toBe('bench/oracles/sysmon-bench.xml');
+    const bytes = fs.readFileSync(path.join(REPO, block.configPath));
+    expect(block.configSha256).toBe(crypto.createHash('sha256').update(bytes).digest('hex'));
+
+    // Not the path, not the decoded text with some other newline convention, and
+    // not a committed constant: `.gitattributes` puts this file under
+    // `text=auto`, so a hard-coded digest would go red on a checkout with other
+    // line endings while naming exactly the same configuration.
+    expect(block.configSha256).not.toBe(
+      crypto.createHash('sha256').update(block.configPath).digest('hex'),
+    );
+    expect(block.configSha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('digests a different config to a different value', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-sysmon-cfg-'));
+    try {
+      const other = path.join(dir, 'other.xml');
+      fs.writeFileSync(other, '<Sysmon schemaversion="4.82"><EventFiltering/></Sysmon>', 'utf8');
+      const block = sysmon.manifestBlock({ configPath: other });
+
+      expect(block.configSha256).not.toBe(sysmon.manifestBlock().configSha256);
+      expect(block.configSha256).toBe(
+        crypto.createHash('sha256').update(fs.readFileSync(other)).digest('hex'),
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // No version reaches a manifest from this suite, from a web page, or from a
+  // default. A version is a fact about an installed binary, and no binary is
+  // installed here.
+  it('records no Sysmon version offline, and says why instead', () => {
+    expect(sysmon.manifestBlock().version).toBeNull();
+    expect(sysmon.manifestBlock().unavailable).toMatch(/no Sysmon version was probed/);
+
+    const probed = sysmon.probeVersion({
+      exec: () => {
+        throw new Error('no Sysmon or Sysmon64 service is installed on this host');
+      },
+    });
+    expect(probed.value).toBeNull();
+    expect(probed.unavailable).toMatch(/no Sysmon or Sysmon64 service is installed/);
+
+    const block = sysmon.manifestBlock({ version: probed });
+    expect(block.version).toBeNull();
+    expect(block.configSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(block.unavailable).toMatch(/not measured under a Sysmon binary/);
+    expect(block.unavailable).toMatch(/not evidence it was applied/);
+  });
+
+  it('records a version only when a probe actually produced one', () => {
+    const block = sysmon.manifestBlock({
+      version: {
+        value: {
+          service: 'Sysmon64',
+          image: 'C:\\Windows\\Sysmon64.exe',
+          // Unmistakably synthetic: no released Sysmon carries this version.
+          fileVersion: '0.0.0-SYNTHETIC-TEST-ONLY',
+          productVersion: '0.0.0-SYNTHETIC-TEST-ONLY',
+        },
+        source: 'injected',
+      },
+    });
+
+    expect(block.version).toBe('0.0.0-SYNTHETIC-TEST-ONLY');
+    expect(block.unavailable).toBeUndefined();
+    expect(Object.keys(block).sort()).toEqual(['configPath', 'configSha256', 'version']);
+  });
+
+  it('keeps the reserved three-field contract and adds nothing to it', () => {
+    expect(Object.keys(sysmon.manifestBlock()).sort()).toEqual([
+      'configPath',
+      'configSha256',
+      'unavailable',
+      'version',
+    ]);
+  });
+});
+
+/* --------------------------------------------------------------------- 16 --- */
+
+describe('sysmon oracle — loss accounting claims nothing it cannot establish', () => {
+  /**
+   * @param {string[]} documents
+   * @returns {Object}
+   */
+  function collectWith(documents) {
+    return sysmon.collect({
+      runId: 'R1',
+      scenario: 'S1-agent-lifecycle',
+      arm: 'B',
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+      config: sysmon.manifestBlock(),
+      read: injectedReader(documents),
+    });
+  }
+
+  it('never reports channel retention as zero, only as unmeasured', () => {
+    const { loss } = collectWith([processCreateXml(), processTerminateXml()]);
+
+    expect(loss.channelRetention.value).toBeNull();
+    expect(loss.channelRetention.unavailable).toMatch(/not measured/);
+    expect(loss.channelRetention.unavailable).toMatch(/Absent, not zero/);
+  });
+
+  it('says a filtered-out record is not a lost one, and that it cannot count them', () => {
+    const { loss } = collectWith([processCreateXml()]);
+
+    expect(loss.config.filterAccounting).toMatch(/no filter-hit counter/);
+    expect(loss.config.filterAccounting).toMatch(/neither is reported as loss/);
+    expect(loss.config.enabledEventIds).toEqual([1, 2, 3, 5, 11, 22, 26]);
+    expect(loss.config.enabledEventIds).not.toContain(23);
+    expect(loss.config.archivalEventId).toBe(23);
+    expect(loss.config.sha256).toBe(sysmon.manifestBlock().configSha256);
+  });
+
+  it('reports EventRecordID gaps without calling them loss', () => {
+    const { loss } = collectWith([
+      processCreateXml({ recordId: 100 }),
+      processTerminateXml({ recordId: 104 }),
+    ]);
+
+    expect(loss.eventRecordIds.collected).toBe(2);
+    expect(loss.eventRecordIds.first).toBe(100);
+    expect(loss.eventRecordIds.last).toBe(104);
+    expect(loss.eventRecordIds.gaps).toEqual([{ after: 100, before: 104, missing: 3 }]);
+    expect(loss.eventRecordIds.meaning).toMatch(/a gap is NOT a loss count/);
+    expect(loss.eventRecordIds.meaning).toMatch(/caused by a working filter/);
+  });
+
+  it('reports EID 255 as its own signal rather than folding it into another count', () => {
+    const error255 = syntheticEventXml({
+      eventId: 255,
+      systemTime: '2026-08-14T12:08:00.0000000Z',
+      recordId: 255255,
+      data: { UtcTime: '2026-08-14 12:08:00.000', ID: 'RuleEngine', Description: 'synthetic' },
+    });
+    const { loss } = collectWith([error255]);
+
+    expect(loss.sysmonErrors.count).toBe(1);
+    expect(loss.sysmonErrors.records[0].description).toBe('synthetic');
+    expect(loss.sysmonErrors.meaning).toMatch(/real loss signal/);
+    expect(loss.records.normalized).toBe(0);
+    expect(loss.refused.unsupportedEventId).toEqual({});
+  });
+
+  it('states that its window carries no epsilon, and why none was invented', () => {
+    const { loss } = collectWith([processCreateXml()]);
+
+    expect(loss.collection.windowEpsilonMs).toBe(0);
+    expect(loss.collection.window).toEqual({ start: WINDOW_START, end: WINDOW_END });
+    expect(loss.collection.windowBasis).toMatch(/No epsilon is applied and none is declared/);
+    expect(loss.collection.windowBasis).toMatch(/nothing in this repository has measured/);
+  });
+
+  it('writes the accounting when nothing was collected, and no records file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-sysmon-run-'));
+    try {
+      const failing = () => {
+        throw new sysmon.SysmonError('reader-failed', 'no channel on this host');
+      };
+      const result = sysmon.collect({
+        runId: 'R1',
+        scenario: 'S1-agent-lifecycle',
+        arm: 'B',
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+        config: sysmon.manifestBlock(),
+        read: failing,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.events).toEqual([]);
+      expect(result.loss.collection.ran).toBe(false);
+      expect(result.loss.collection.unavailable).toMatch(/no channel on this host/);
+      // Absent, not zero: with no read there is nothing to account for, and the
+      // counters are not written as zeroes that would read as a clean collection.
+      expect(result.loss.records).toEqual({
+        value: null,
+        unavailable: 'no read ran, so there is nothing to account for',
+      });
+      expect(result.loss.refused).toBeNull();
+      expect(result.loss.eventRecordIds).toBeNull();
+      expect(result.loss.lifecycle).toBeNull();
+
+      sysmon.writeLoss(dir, result.loss);
+      expect(fs.readdirSync(dir)).toEqual([sysmon.LOSS_FILENAME]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // `runOracle` closes its own window at the moment it is called, which is the
+  // live behaviour and not something to stub out — so the synthetic records here
+  // are stamped in the past rather than at this file's usual window, and the run
+  // instant is the one thing this test lets the clock decide.
+  it('writes both artefacts through run.js, in the shapes the harness reads', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-sysmon-run-'));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const result = run.runOracle({
+        dir,
+        runId: 'R1',
+        scenario: 'S1-agent-lifecycle',
+        arm: 'B',
+        startedAt: '2026-08-01T00:00:00.000Z',
+        config: sysmon.manifestBlock(),
+        read: injectedReader([
+          processCreateXml({ systemTime: '2026-08-01T12:01:00.1234567Z' }),
+          processTerminateXml({ systemTime: '2026-08-01T12:02:00.7654321Z' }),
+        ]),
+      });
+
+      expect(result.ok).toBe(true);
+      expect(fs.readdirSync(dir).sort()).toEqual(
+        [sysmon.LOSS_FILENAME, sysmon.ORACLE_FILENAME].sort(),
+      );
+      const ndjson = fs.readFileSync(path.join(dir, sysmon.ORACLE_FILENAME), 'utf8');
+      expect(ndjson).toBe(catalogue.serialize(result.events));
+      expect(ndjson.endsWith('\n')).toBe(true);
+      expect(
+        ndjson
+          .trimEnd()
+          .split('\n')
+          .map((l) => JSON.parse(l).event.code),
+      ).toEqual(['1', '5']);
+
+      const loss = JSON.parse(fs.readFileSync(path.join(dir, sysmon.LOSS_FILENAME), 'utf8'));
+      expect(loss.schemaVersion).toBe(sysmon.LOSS_SCHEMA_VERSION);
+      expect(loss.oracle).toBe('sysmon');
+      expect(loss.arm).toBe('B');
+      expect(loss.records.read).toBe(2);
+      expect(loss.records.normalized).toBe(2);
+      expect(loss.lifecycle.paired).toHaveLength(1);
+    } finally {
+      log.mockRestore();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes no records file when the read ran but normalized nothing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-sysmon-run-'));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      run.runOracle({
+        dir,
+        runId: 'R1',
+        scenario: 'S1-agent-lifecycle',
+        arm: 'B',
+        startedAt: WINDOW_START,
+        config: sysmon.manifestBlock(),
+        read: injectedReader(['garbage']),
+      });
+
+      expect(fs.readdirSync(dir)).toEqual([sysmon.LOSS_FILENAME]);
+    } finally {
+      log.mockRestore();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+/* --------------------------------------------------------------------- 17 --- */
+
+describe('sysmon oracle — arm B is a PARTIAL calibration and says so', () => {
+  it('leaves procmon unavailable in the manifest when sysmon is supplied', () => {
+    const oracles = manifest.oraclePlaceholders({ sysmon: sysmon.manifestBlock() });
+
+    expect(oracles.sysmon.configPath).toBe('bench/oracles/sysmon-bench.xml');
+    expect(oracles.procmon.version).toBeNull();
+    expect(oracles.procmon.unavailable).toMatch(/sub-block B2\.6/);
+  });
+
+  // The arm's own definition is the other half of the statement: B is Sysmon AND
+  // Procmon, so an unavailable procmon entry is the run saying which of the two
+  // columns it produced.
+  it('keeps arm B defined as Sysmon and Procmon, so the gap is legible', () => {
+    expect(manifest.ARM_DESCRIPTIONS.B).toMatch(/Sysmon \+ Procmon/);
+    expect(manifest.ARM_DESCRIPTIONS.B).toMatch(/oracle calibration/);
+  });
+
+  // `run.js` sweeps `host`, `sensor` and `oracles` for `unavailable` entries and
+  // prints them at the end of a run. This is the condition that sweep tests, so a
+  // B run states the missing Procmon column at the moment of measurement.
+  it('exposes the limitation as an absent fact the run prints', () => {
+    const record = {
+      host: {},
+      sensor: {},
+      oracles: manifest.oraclePlaceholders({ sysmon: sysmon.manifestBlock() }),
+    };
+    const absent = [];
+    for (const [group, fields] of Object.entries(record)) {
+      for (const [name, entry] of Object.entries(fields)) {
+        if (entry && entry.unavailable) absent.push(`${group}.${name}: ${entry.unavailable}`);
+      }
+    }
+
+    expect(absent.some((line) => line.startsWith('oracles.procmon:'))).toBe(true);
+    expect(absent.join('\n')).toMatch(/B2\.6/);
+  });
+
+  it('runs an oracle in arms A and B, and none in C', () => {
+    expect(run.ORACLE_ARMS).toEqual(['A', 'B']);
+    expect(run.ORACLE_ARMS).not.toContain('C');
+    expect(manifest.oraclePlaceholders().sysmon.unavailable).toMatch(/not run for this arm/);
+  });
+});
+
+/* ------------------------------------------------- the boundary, restated --- */
+
+describe('sysmon oracle — every record names the acquisition boundary that exists', () => {
+  // `bench.source` is provenance, and it rides on every single normalized record.
+  // The implemented boundary is the Event Log channel read through `Get-WinEvent`
+  // and rendered by `EventRecord.ToXml()`. Nothing here opens, exports or ingests
+  // an `.evtx` file, so no record may carry a label that says it did — that would
+  // put a claim about a file format where a later reader takes it for evidence
+  // (memory-bank/ai-mistakes.md #27: write the guarantee, not the impression).
+  it('labels the source as the Event Log XML boundary, never as EVTX', () => {
+    expect(sysmon.SOURCE).toBe('sysmon-eventlog-xml');
+    expect(sysmon.SOURCE).toMatch(/eventlog/);
+    expect(sysmon.SOURCE).toMatch(/xml/);
+    expect(sysmon.SOURCE).not.toMatch(/evtx/i);
+    // The `<source>-<form>` kebab-case the harness already speaks, next to
+    // `aegis-audit` and `derived-model`.
+    expect(sysmon.SOURCE).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)+$/);
+  });
+
+  it('carries that label on every normalized record, whatever the event', () => {
+    const documents = [
+      processCreateXml(),
+      processTerminateXml(),
+      syntheticEventXml({
+        eventId: 11,
+        systemTime: '2026-08-14T12:05:00.0000000Z',
+        recordId: 5011,
+        data: {
+          UtcTime: '2026-08-14 12:05:00.000',
+          ProcessGuid: GUID_A,
+          ProcessId: '4242',
+          TargetFilename: 'X:\\...\\stage\\claude.exe',
+        },
+      }),
+      syntheticEventXml({
+        eventId: 26,
+        systemTime: '2026-08-14T12:06:00.0000000Z',
+        recordId: 5026,
+        data: {
+          UtcTime: '2026-08-14 12:06:00.000',
+          ProcessGuid: GUID_A,
+          ProcessId: '4242',
+          TargetFilename: 'X:\\...\\stage\\claude.exe',
+        },
+      }),
+    ];
+    const { events } = normalize(documents);
+
+    expect(events).toHaveLength(4);
+    for (const event of events) {
+      expect(event.bench.source).toBe('sysmon-eventlog-xml');
+      // No record claims EVTX provenance anywhere in it — not in the source
+      // label, not in the channel, not in a leftover field.
+      expect(JSON.stringify(event)).not.toMatch(/evtx/i);
+    }
+  });
+
+  it('does not claim EVTX provenance anywhere in the loss accounting either', () => {
+    const { loss } = sysmon.collect({
+      runId: 'R1',
+      scenario: 'S1-agent-lifecycle',
+      arm: 'B',
+      windowStart: WINDOW_START,
+      windowEnd: WINDOW_END,
+      config: sysmon.manifestBlock(),
+      read: injectedReader([processCreateXml()]),
+    });
+
+    expect(JSON.stringify(loss)).not.toMatch(/evtx/i);
+    expect(loss.collection.channel).toBe('Microsoft-Windows-Sysmon/Operational');
+  });
+});
+
+describe('sysmon oracle — the live boundary is untested and says so', () => {
+  it('keeps the raw channel read behind one injectable function', () => {
+    expect(typeof sysmon.readChannelXml).toBe('function');
+    // Nothing in this suite calls it. Named here only so the contract that it is
+    // the single crossing point is pinned rather than assumed.
+    expect(sysmon.CHANNEL).toBe('Microsoft-Windows-Sysmon/Operational');
+    expect(sysmon.PROVIDER).toBe('Microsoft-Windows-Sysmon');
+  });
+
+  it('ships a config that has never been offered to a Sysmon binary, and says so', () => {
+    const xml = fs.readFileSync(path.join(REPO, 'bench/oracles/sysmon-bench.xml'), 'utf8');
+
+    expect(xml).toMatch(/NOT YET ACCEPTED BY A SYSMON BINARY/);
+    expect(xml).toMatch(/schemaversion="4\.82"/);
+    expect(xml).toMatch(/<FileDeleteDetected onmatch="include">/);
+    // EID 23 is not enabled anywhere: the only occurrences of FileDelete in this
+    // file are in the prose explaining why it is absent.
+    expect(xml).not.toMatch(/<FileDelete\b/);
+    expect(xml).toMatch(/LIVE-UNVALIDATED/);
+  });
+});


### PR DESCRIPTION
## What this is

**B2.3a: offline contract closure**, not live Sysmon validation.

Implements the B2.3 contract the repository already reserved — `bench/lib/oracles/sysmon.js`,
`bench/oracles/sysmon-bench.xml`, the `manifest.oracles.sysmon` block, and the
`oracle-sysmon.ndjson` / `oracle-loss.json` run artefacts — rather than inventing a parallel
subsystem. The oracle is collected in arms A and B, the two arms whose definition includes Sysmon.

## Three layers, and only two of them are proven

| layer | what it is | status |
|---|---|---|
| RAW | a real `Microsoft-Windows-Sysmon/Operational` channel → `Get-WinEvent` → `EventRecord.ToXml()` | **LIVE-UNVALIDATED** |
| NORMALIZED | EventRecord XML → canonical oracle record → `oracle-sysmon.ndjson` | proven offline |
| DERIVED | matching the oracle against the catalogue, and any metric over it | B2.5 |

`readChannelXml` is the one function that crosses the raw boundary, it is injectable, and **no test
executes it**: the machine this was written on runs Windows 11 Home with no Sysmon installed. A
green suite is not a claim about Event Log ingestion.

**No binary `.evtx` file is fabricated anywhere.** A synthetic EVTX container would test our
imitation of the Windows Event Log rather than Windows. The normalizer is tested against
clearly-labelled synthetic XML in the documented shape.

`bench.source` is `sysmon-eventlog-xml` — deliberately not `-evtx`. The label names the acquisition
boundary that exists; `.evtx` ingestion is neither implemented nor validated.

## Semantics this PR pins

- **`ProcessGuid` is opaque.** Retained verbatim, compared only for equality between Sysmon events.
  Never parsed, never decoded into a timestamp, never turned into an AEGIS `instanceId`. Guid
  equality pairs an EID 5 to its EID 1; **pid is not a fallback key**, so two generations sharing
  one pid stay two generations. EID 1 ordinality remains the independent creation identity fact,
  and the correlation lives beside the records rather than inside them.
- **The two timestamps are never mixed.** `@timestamp` is `System/TimeCreated@SystemTime`
  truncated — never rounded; EventData `UtcTime` is kept verbatim in its own format. No delta is
  computed and **no epsilon is declared anywhere in this module**. A `SystemTime` that does not end
  in `Z` is refused, not converted.
- **EID 23 is not EID 26.** 23 archives the file it reports deleted; it is never enabled to observe
  a deletion, never collapsed into 26, and never accepted as a deletion observation.
- **`oracle-loss.json` never reports a loss of zero.** Filtered-out records are not lost but cannot
  be counted either (Sysmon publishes no filter-hit counter); an EventRecordID gap is not a loss
  count; channel retention is absent rather than zero.
- **Arm B stays explicitly PARTIAL** until Procmon B2.6. No new report field was invented:
  `manifest.oracles.procmon` remains unavailable, and `run.js` now sweeps `oracles` alongside `host`
  and `sensor` so a run states the missing column at the moment of measurement. **Arm A keeps its
  existing exit status** and records the absent oracle as an absent fact.

## Still LIVE-UNVALIDATED after this PR

Real Event Log acquisition · config acceptance by an actual Sysmon binary · `schemaversion`
compatibility · the EID 26 × `ArchiveDirectory` interaction. Guest clock offset/jitter remains
UNKNOWN. **No coverage metric exists yet.**

## Canon

`memory-bank/RESEARCH-BASELINE.md` §10 records the 2026-08-14 ratification: EID 26 joins the oracle
column, EID 23 is never enabled merely to observe a deletion, `ProcessGuid` may be compared as an
opaque equality key beside EID 1 ordinality, and the existing ~2 s epsilon is a tolerance between
Sysmon's own two representations — **not** guest-clock uncertainty.

## Verification

Three deliberate mutations, each red on the assertions that matter, each restored green:
pairing EID 5 by pid instead of opaque `ProcessGuid` (3 red) · hashing the config path instead of
its bytes (2 red) · reverting the source label to `sysmon-evtx` (3 red).

An honest end-to-end `--arm B` run was exercised on a host with no Sysmon: it completes the
scenario, records the measured absence in the manifest and `oracle-loss.json`, writes no
`oracle-sysmon.ndjson`, and exits 1.

All seven local gates green.
