### PR TITLE
fix(main): own process/network leaf health at the provider boundary

### DIFF
--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -158,8 +158,11 @@ async function scanProcesses() {
       // Still run the empty path below for pid-set / peakAgents bookkeeping so
       // callers keep a stable return shape. Do not markHealthy on this path.
     } else {
-      // Hard provider failure: leave health update to noteProcessScanHardFailure
-      // (scan-loop catch) so we do not double-increment consecutiveFailures.
+      // Hard provider failure: leave the health write to noteProcessScanHardFailure,
+      // called from the catch that in scan-loop's doProcessScan encloses ONLY this call,
+      // so we do not double-increment consecutiveFailures. That catch is the boundary —
+      // a throw from anything downstream of this return value reaches a different handler
+      // and writes no process health at all.
       throw err;
     }
   }

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -168,58 +168,73 @@ function doNetworkScan() {
   const t0 = performance.now();
   network
     .scanNetworkConnections(agents)
-    .then((connections) => {
-      deps.setLatestNetConnections(connections);
-      for (const conn of connections) {
-        if (conn.httpUnencrypted) {
-          logger.warn(
-            'network',
-            'Unencrypted HTTP connection detected: ' + (conn.domain || conn.remoteIp),
+    .then(
+      (connections) => {
+        deps.setLatestNetConnections(connections);
+        for (const conn of connections) {
+          if (conn.httpUnencrypted) {
+            logger.warn(
+              'network',
+              'Unencrypted HTTP connection detected: ' + (conn.domain || conn.remoteIp),
+            );
+          }
+          // Key first, name second — both from the connection this scan matched. A socket
+          // that matched no agent carries no key and enters no baseline, which also retires
+          // the phantom `sessionData['']` bucket the empty name used to create.
+          baselines.recordNetworkEndpoint(
+            conn.instanceId,
+            conn.agent,
+            conn.remoteIp,
+            conn.remotePort,
           );
+          audit.log('network-connection', {
+            agent: conn.agent,
+            pid: conn.pid ?? null,
+            // Carried from the connection, never re-resolved from its pid: null means the
+            // socket matched no agent in that scan.
+            instanceId: conn.instanceId ?? null,
+            action: conn.state,
+            path: `${conn.remoteIp}:${conn.remotePort}`,
+            severity: conn.flagged ? 'high' : 'normal',
+            // The owner came from the OS connection table and was matched inside this same
+            // call, so it is `confirmed` — the same strength as a handle-scan pid. An
+            // unmatched connection keeps no agent and says so.
+            attribution: makeAttribution([
+              conn.agent ? EVIDENCE.OS_TCP_OWNER_PID : EVIDENCE.NO_OWNER_MATCH,
+            ]),
+            extra: { domain: conn.domain, flagged: conn.flagged },
+          });
         }
-        // Key first, name second — both from the connection this scan matched. A socket
-        // that matched no agent carries no key and enters no baseline, which also retires
-        // the phantom `sessionData['']` bucket the empty name used to create.
-        baselines.recordNetworkEndpoint(
-          conn.instanceId,
-          conn.agent,
-          conn.remoteIp,
-          conn.remotePort,
-        );
-        audit.log('network-connection', {
-          agent: conn.agent,
-          pid: conn.pid ?? null,
-          // Carried from the connection, never re-resolved from its pid: null means the
-          // socket matched no agent in that scan.
-          instanceId: conn.instanceId ?? null,
-          action: conn.state,
-          path: `${conn.remoteIp}:${conn.remotePort}`,
-          severity: conn.flagged ? 'high' : 'normal',
-          // The owner came from the OS connection table and was matched inside this same
-          // call, so it is `confirmed` — the same strength as a handle-scan pid. An
-          // unmatched connection keeps no agent and says so.
-          attribution: makeAttribution([
-            conn.agent ? EVIDENCE.OS_TCP_OWNER_PID : EVIDENCE.NO_OWNER_MATCH,
-          ]),
-          extra: { domain: conn.domain, flagged: conn.flagged },
+        sendToRenderer('network-update', connections);
+        logger.debug('scan', 'network', {
+          ms: Math.round(performance.now() - t0),
+          connections: connections.length,
         });
-      }
-      sendToRenderer('network-update', connections);
-      logger.debug('scan', 'network', {
-        ms: Math.round(performance.now() - t0),
-        connections: connections.length,
-      });
-    })
+      },
+      (err) => {
+        // Provider-observation ownership boundary (Stage-1 step A). This rejection handler
+        // is attached to `scanNetworkConnections` ITSELF, so it sees provider rejections
+        // only — a throw raised in the fulfilment continuation above (baselines, audit
+        // write, renderer send) cannot reach it and therefore cannot rewrite a successful
+        // TCP observation into FAILED.
+        //
+        // B-S05: provider failure health is owned by network-monitor.scanNetworkConnections
+        // (markFailed before rethrow). Fallback note only if the inject path omitted it.
+        if (
+          typeof network.noteNetworkScanHardFailure === 'function' &&
+          typeof network.getNetworkSensorHealth === 'function' &&
+          network.getNetworkSensorHealth().state !== 'FAILED'
+        ) {
+          network.noteNetworkScanHardFailure(err);
+        }
+        throw err;
+      },
+    )
     .catch((err) => {
-      // B-S05: provider failure health is owned by network-monitor.scanNetworkConnections
-      // (markFailed before rethrow). Fallback note only if the inject path omitted it.
-      if (
-        typeof network.noteNetworkScanHardFailure === 'function' &&
-        typeof network.getNetworkSensorHealth === 'function' &&
-        network.getNetworkSensorHealth().state !== 'FAILED'
-      ) {
-        network.noteNetworkScanHardFailure(err);
-      }
+      // Reached by BOTH a provider rejection (rethrown above, health already owned) and a
+      // downstream continuation throw (health deliberately untouched). Log only: the
+      // `network` leaf names the TCP observation, and delivery/persistence failures belong
+      // to the pipeline axis, which no leaf here represents.
       logger.error('main', 'Network scan failed', { error: err.message });
     })
     .finally(() => {
@@ -282,7 +297,24 @@ async function doProcessScan() {
   updateScanStatus(true);
   const t0 = performance.now();
   try {
-    const result = await scanner.scanProcesses();
+    // Provider-observation ownership boundary (Stage-1 step A). This inner try encloses
+    // ONLY the enumeration call: the `process` leaf names population enumeration, so a
+    // throw raised at or after `setAgents` below — enrichment, session reconcile, an audit
+    // write, anomaly processing, a renderer send — must not be able to write it. Without
+    // this split, `process = FAILED` proved nothing about whether the machine was
+    // enumerated. The provider throw is rethrown so the outer catch keeps the single log.
+    let result;
+    try {
+      result = await scanner.scanProcesses();
+    } catch (err) {
+      // B-S02: hard failure — a non-EPERM rethrow from scanProcesses (the EPERM path
+      // marks FAILED inside the scanner and returns normally, so it never lands here).
+      // Compatibility still leaves latestAgents unchanged: setAgents has not run.
+      if (scanner && typeof scanner.noteProcessScanHardFailure === 'function') {
+        scanner.noteProcessScanHardFailure(err);
+      }
+      throw err;
+    }
     setAgents(result.agents);
     const agents = result.agents;
     // Process IDENTITY first. This attaches the OS birth time and the derived
@@ -449,12 +481,10 @@ async function doProcessScan() {
       agents: agents.length,
     });
   } catch (err) {
-    // B-S02: hard failure (non-EPERM rethrow from scanProcesses, or later enrich throw).
-    // Compatibility still leaves latestAgents unchanged (setAgents only on success path);
-    // process health must record FAILED so empty fleet is not implied.
-    if (scanner && typeof scanner.noteProcessScanHardFailure === 'function') {
-      scanner.noteProcessScanHardFailure(err);
-    }
+    // Reached by BOTH a provider throw (rethrown above, health already owned by the inner
+    // catch) and a downstream pipeline throw (health deliberately untouched — the
+    // observation succeeded). Log only: no leaf here names delivery or persistence, and
+    // inventing one would answer a question this record was never asked.
     logger.error('main', 'Process scan failed', { error: err.message });
   } finally {
     updateScanStatus(false);

--- a/tests/main/scan-loop-provider-health.test.js
+++ b/tests/main/scan-loop-provider-health.test.js
@@ -1,0 +1,471 @@
+/**
+ * Stage-1 step A — provider-observation ownership boundaries for the `process`
+ * and `network` leaves.
+ *
+ * The rule under test: a leaf health record is written only by the code that
+ * performed or refused the provider observation that leaf names. A failure
+ * downstream of the provider's return value — enrichment, session reconcile, an
+ * audit write, a renderer send — must leave the record exactly as the provider
+ * left it.
+ *
+ * Both leaves are driven through their REAL modules, so every assertion reads the
+ * health record itself rather than a spy on the note function. The spy assertions
+ * are kept as a second, weaker witness: they pin the call site, the record pins
+ * the outcome, and a refactor that moved the write elsewhere would still be caught.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'module';
+import { SENSOR_HEALTH_STATE } from '../../src/main/sensor-health.js';
+
+const require_ = createRequire(import.meta.url);
+
+describe('scan-loop provider-health ownership (Stage-1 step A)', () => {
+  let scanLoop;
+  let scanner;
+  let network;
+  let listProcesses;
+  let getRawTcpConnections;
+  /** @type {{detectOllamaModels: Function, detectLMStudioModels: Function}} */
+  let llmOriginals;
+
+  /** Inert command runner for resource-monitor — see scan-loop.test.js for why. */
+  const inertExec = () => Promise.resolve('');
+
+  /** Reset resource-monitor's module state and re-arm the inert exec. */
+  function isolateResourceMonitor() {
+    const rm = require_('../../src/main/resource-monitor.js');
+    rm._resetForTest();
+    rm._setLoggerForTest({ warn: vi.fn() });
+    rm._setExecForTest(inertExec);
+  }
+
+  /**
+   * Neutralise the two synthetic-agent detectors `doProcessScan` reads through
+   * `injectDetectedExternalAgents`. Both return a cache synchronously and kick off
+   * a background refresh that spawns — under fake timers those spawns settle on
+   * real time inside whichever test is running then (ai-mistakes #26).
+   */
+  function isolateExternalDetectors() {
+    const ide = require_('../../src/main/ide-extension-detector.js');
+    ide._resetForTest();
+    ide._setDepsForTest({
+      listProcesses: async () => [],
+      readdir: async () => [],
+      homedir: () => '/nonexistent-home',
+    });
+    const wsl = require_('../../src/main/wsl-detector.js');
+    wsl._resetForTest();
+    wsl._setDepsForTest({ execFile: (cmd, args, opts, cb) => cb(new Error('stubbed'), '') });
+  }
+
+  /**
+   * Point llm-runtime-detector at fixed "not running" answers. `enrichWithLocalModels`
+   * re-requires the module per call, so patching its exports is enough — and it keeps
+   * the localhost probes out of the suite.
+   */
+  function isolateLlmDetectors() {
+    const llm = require_('../../src/main/llm-runtime-detector.js');
+    llmOriginals = {
+      detectOllamaModels: llm.detectOllamaModels,
+      detectLMStudioModels: llm.detectLMStudioModels,
+    };
+    llm.detectOllamaModels = async () => ({ running: false, models: [] });
+    llm.detectLMStudioModels = async () => ({ running: false, models: [] });
+  }
+
+  /** Restore llm-runtime-detector's real probes. */
+  function restoreLlmDetectors() {
+    const llm = require_('../../src/main/llm-runtime-detector.js');
+    llm.detectOllamaModels = llmOriginals.detectOllamaModels;
+    llm.detectLMStudioModels = llmOriginals.detectLMStudioModels;
+  }
+
+  /**
+   * Drain the promise chains a scan leaves behind. Neither path schedules a timer,
+   * so advancing by 0 only flushes microtasks; several rounds cover the nested awaits
+   * inside the real network provider (reverse DNS, then forward confirmation).
+   * @param {number} [rounds]
+   * @returns {Promise<void>}
+   */
+  async function flush(rounds = 8) {
+    for (let i = 0; i < rounds; i++) await vi.advanceTimersByTimeAsync(0);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const scanLoopPath = require_.resolve('../../src/main/scan-loop.js');
+    delete require_.cache[scanLoopPath];
+    isolateResourceMonitor();
+    isolateExternalDetectors();
+    isolateLlmDetectors();
+
+    scanner = require_('../../src/main/process-scanner.js');
+    listProcesses = vi.fn().mockResolvedValue([{ name: 'chrome', pid: 1 }]);
+    scanner._resetForTest();
+    scanner._setPlatformForTest({ listProcesses });
+    scanner.init({ trackSeenAgent: vi.fn() });
+    scanner.peakAgents = 0;
+
+    network = require_('../../src/main/network-monitor.js');
+    getRawTcpConnections = vi
+      .fn()
+      .mockResolvedValue([{ pid: 42, ip: '8.8.8.8', port: 443, state: 'Established' }]);
+    network._resetForTest();
+    network._setDepsForTest({
+      getRawTcpConnections,
+      dnsReverse: vi.fn().mockRejectedValue(new Error('ENOTFOUND')),
+      dnsResolve: vi.fn().mockResolvedValue([]),
+    });
+
+    scanLoop = require_('../../src/main/scan-loop.js');
+  });
+
+  afterEach(async () => {
+    scanLoop.stopScanIntervals();
+    await vi.advanceTimersByTimeAsync(0);
+    vi.useRealTimers();
+    restoreLlmDetectors();
+    isolateResourceMonitor();
+    const ide = require_('../../src/main/ide-extension-detector.js');
+    ide._resetForTest();
+    const wsl = require_('../../src/main/wsl-detector.js');
+    wsl._resetForTest();
+  });
+
+  /**
+   * Every collaborator a scan reaches, stubbed inert. `scanner` and `network` default
+   * to the REAL modules; a caller that wants a spy passes its own.
+   * @param {Object} [overrides]
+   * @returns {Object}
+   */
+  function makeDeps(overrides = {}) {
+    return {
+      scanner,
+      network,
+      procUtil: {
+        enrichWithParentChains: vi.fn().mockResolvedValue(),
+        annotateHostApps: vi.fn(),
+        annotateWorkingDirs: vi.fn().mockResolvedValue(),
+      },
+      watcher: {
+        pruneKnownHandles: vi.fn(),
+        scanAllFileHandles: vi.fn().mockResolvedValue([]),
+      },
+      baselines: { recordNetworkEndpoint: vi.fn() },
+      anomaly: {
+        checkDeviations: vi.fn().mockReturnValue([]),
+        calculateAnomalyScore: vi.fn().mockReturnValue({ score: 0 }),
+      },
+      audit: { log: vi.fn() },
+      tray: { updateTrayIcon: vi.fn(), notifySensitive: vi.fn() },
+      logger: { error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      sendToRenderer: vi.fn(),
+      fileAccessBatcher: { push: vi.fn() },
+      statsUpdateBatcher: { push: vi.fn() },
+      getStats: vi.fn().mockReturnValue({}),
+      getResourceUsage: vi.fn().mockReturnValue({}),
+      getLatestAgents: vi.fn().mockReturnValue([]),
+      setAgents: vi.fn(),
+      setLatestNetConnections: vi.fn(),
+      getPreviousPids: vi.fn().mockReturnValue(new Map()),
+      setPreviousPids: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  /**
+   * A `sendToRenderer` that throws on ONE channel only. An unconditional thrower
+   * would fire from `updateScanStatus('scan-status')`, which sits OUTSIDE the try —
+   * the throw would escape `doProcessScan` before the provider was ever called and
+   * leave the reentrancy guard latched.
+   * @param {string} channel
+   * @returns {Function}
+   */
+  function throwingSendOn(channel) {
+    return vi.fn((ch) => {
+      if (ch === channel) throw new Error(`renderer-send-failed:${ch}`);
+    });
+  }
+
+  /** One deviation, so the anomaly-alert audit write is reached with an empty fleet. */
+  const ONE_DEVIATION = [
+    { agent: 'Claude Code', instanceId: '42:t', type: 'burst', message: 'm', anomalyScore: 9 },
+  ];
+
+  /** Agents the network scan is scoped to — a pid the stubbed TCP table answers for. */
+  const NET_AGENTS = [{ agent: 'Claude Code', pid: 42, instanceId: '42:t', category: 'ai' }];
+
+  /**
+   * Run exactly one `doProcessScan`. It is not exported, so the 3s startup timer is
+   * the entry point; `paused = true` keeps the warm-up intervals out of the way.
+   * @returns {Promise<void>}
+   */
+  async function runOneProcessScan() {
+    scanLoop.staggeredStartup(5000, true);
+    await vi.advanceTimersByTimeAsync(3000);
+    await flush();
+  }
+
+  /** Run exactly one `doNetworkScan` and drain its chain. @returns {Promise<void>} */
+  async function runOneNetworkScan() {
+    scanLoop.doNetworkScan();
+    await flush();
+  }
+
+  // ── process leaf ──
+
+  describe('process leaf', () => {
+    it('a renderer-send throw after a successful scanProcesses leaves the record HEALTHY', async () => {
+      const deps = makeDeps({ sendToRenderer: throwingSendOn('scan-batch') });
+      scanLoop.init(deps);
+      await runOneProcessScan();
+
+      expect(listProcesses).toHaveBeenCalledTimes(1);
+      expect(deps.sendToRenderer).toHaveBeenCalledWith('scan-batch', expect.any(Object));
+      const h = scanner.getProcessSensorHealth();
+      expect(h.state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+      expect(h.consecutiveFailures).toBe(0);
+      expect(h.lastError).toBeNull();
+      expect(scanner.isProcessPopulationReliable()).toBe(true);
+    });
+
+    it('an audit-write throw after a successful scanProcesses leaves the record HEALTHY', async () => {
+      const deps = makeDeps({
+        anomaly: {
+          checkDeviations: vi.fn().mockReturnValue(ONE_DEVIATION),
+          calculateAnomalyScore: vi.fn().mockReturnValue({ score: 0 }),
+        },
+        audit: {
+          log: vi.fn(() => {
+            throw new Error('audit-write-failed');
+          }),
+        },
+      });
+      scanLoop.init(deps);
+      await runOneProcessScan();
+
+      expect(deps.audit.log).toHaveBeenCalled();
+      const h = scanner.getProcessSensorHealth();
+      expect(h.state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+      expect(h.consecutiveFailures).toBe(0);
+      expect(scanner.isProcessPopulationReliable()).toBe(true);
+    });
+
+    it('a downstream throw never calls noteProcessScanHardFailure', async () => {
+      const note = vi.fn();
+      const deps = makeDeps({
+        scanner: {
+          scanProcesses: vi.fn().mockResolvedValue({ agents: [], changed: false, reliable: true }),
+          noteProcessScanHardFailure: note,
+        },
+        sendToRenderer: throwingSendOn('scan-batch'),
+      });
+      scanLoop.init(deps);
+      await runOneProcessScan();
+
+      expect(deps.scanner.scanProcesses).toHaveBeenCalledTimes(1);
+      expect(note).not.toHaveBeenCalled();
+    });
+
+    it('a provider throw from _listProcesses still marks the record FAILED', async () => {
+      listProcesses.mockRejectedValue(new Error('spawn ENOENT'));
+      const deps = makeDeps();
+      scanLoop.init(deps);
+      await runOneProcessScan();
+
+      const h = scanner.getProcessSensorHealth();
+      expect(h.state).toBe(SENSOR_HEALTH_STATE.FAILED);
+      expect(h.consecutiveFailures).toBe(1);
+      expect(h.lastError).toMatch(/ENOENT/);
+      expect(h.detail).toBe('hard-scan-failure');
+      expect(scanner.isProcessPopulationReliable()).toBe(false);
+      // The observation never returned, so the population was never replaced.
+      expect(deps.setAgents).not.toHaveBeenCalled();
+    });
+
+    it('a provider throw calls noteProcessScanHardFailure exactly once', async () => {
+      const note = vi.fn();
+      const deps = makeDeps({
+        scanner: {
+          scanProcesses: vi.fn().mockRejectedValue(new Error('spawn ENOENT')),
+          noteProcessScanHardFailure: note,
+        },
+      });
+      scanLoop.init(deps);
+      await runOneProcessScan();
+
+      expect(note).toHaveBeenCalledTimes(1);
+      expect(note.mock.calls[0][0].message).toMatch(/ENOENT/);
+    });
+
+    it('both paths keep the existing "Process scan failed" log', async () => {
+      const downstream = makeDeps({ sendToRenderer: throwingSendOn('scan-batch') });
+      scanLoop.init(downstream);
+      await runOneProcessScan();
+      expect(downstream.logger.error).toHaveBeenCalledWith('main', 'Process scan failed', {
+        error: 'renderer-send-failed:scan-batch',
+      });
+
+      scanLoop.stopScanIntervals();
+      listProcesses.mockRejectedValue(new Error('spawn ENOENT'));
+      const provider = makeDeps();
+      scanLoop.init(provider);
+      await runOneProcessScan();
+      expect(provider.logger.error).toHaveBeenCalledWith('main', 'Process scan failed', {
+        error: 'spawn ENOENT',
+      });
+    });
+
+    it('a downstream throw does not wedge the loop — the next tick still enumerates', async () => {
+      const deps = makeDeps({ sendToRenderer: throwingSendOn('scan-batch') });
+      scanLoop.init(deps);
+      scanLoop.startScanIntervals(5000);
+      await vi.advanceTimersByTimeAsync(5000);
+      await flush();
+      await vi.advanceTimersByTimeAsync(5000);
+      await flush();
+
+      expect(listProcesses).toHaveBeenCalledTimes(2);
+      expect(scanner.getProcessSensorHealth().state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+    });
+  });
+
+  // ── network leaf ──
+
+  describe('network leaf', () => {
+    it('a renderer-send throw after a successful provider run leaves the record HEALTHY', async () => {
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS),
+        sendToRenderer: throwingSendOn('network-update'),
+      });
+      scanLoop.init(deps);
+      await runOneNetworkScan();
+
+      expect(getRawTcpConnections).toHaveBeenCalledTimes(1);
+      expect(deps.sendToRenderer).toHaveBeenCalledWith('network-update', expect.any(Array));
+      const h = network.getNetworkSensorHealth();
+      expect(h.state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+      expect(h.consecutiveFailures).toBe(0);
+      expect(h.lastError).toBeNull();
+      expect(h.lastSuccessAt).toBeTypeOf('number');
+    });
+
+    it('an audit-write throw after a successful provider run leaves the record HEALTHY', async () => {
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS),
+        audit: {
+          log: vi.fn(() => {
+            throw new Error('audit-write-failed');
+          }),
+        },
+      });
+      scanLoop.init(deps);
+      await runOneNetworkScan();
+
+      expect(deps.audit.log).toHaveBeenCalledWith('network-connection', expect.any(Object));
+      const h = network.getNetworkSensorHealth();
+      expect(h.state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+      expect(h.consecutiveFailures).toBe(0);
+    });
+
+    it('a downstream throw never calls noteNetworkScanHardFailure', async () => {
+      const note = vi.fn();
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS),
+        network: {
+          isNetworkScanRunning: vi.fn().mockReturnValue(false),
+          setNetworkScanRunning: vi.fn(),
+          scanNetworkConnections: vi
+            .fn()
+            .mockResolvedValue([
+              { agent: 'Claude Code', pid: 42, remoteIp: '8.8.8.8', remotePort: 443 },
+            ]),
+          getNetworkSensorHealth: vi.fn().mockReturnValue({ state: 'HEALTHY' }),
+          noteNetworkScanHardFailure: note,
+        },
+        sendToRenderer: throwingSendOn('network-update'),
+      });
+      scanLoop.init(deps);
+      await runOneNetworkScan();
+
+      expect(deps.network.scanNetworkConnections).toHaveBeenCalledTimes(1);
+      expect(note).not.toHaveBeenCalled();
+      // The reentrancy flag is still released on the downstream-throw path.
+      expect(deps.network.setNetworkScanRunning).toHaveBeenLastCalledWith(false);
+    });
+
+    it('a provider throw still marks the record FAILED, counted once', async () => {
+      getRawTcpConnections.mockRejectedValue(new Error('spawn ETIMEDOUT'));
+      const deps = makeDeps({ getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS) });
+      scanLoop.init(deps);
+      await runOneNetworkScan();
+
+      const h = network.getNetworkSensorHealth();
+      expect(h.state).toBe(SENSOR_HEALTH_STATE.FAILED);
+      // One increment: scanNetworkConnections marked FAILED before rethrowing, so the
+      // scan-loop fallback must have short-circuited rather than written a second time.
+      expect(h.consecutiveFailures).toBe(1);
+      expect(h.lastError).toMatch(/ETIMEDOUT/i);
+      expect(h.lastSuccessAt).toBeNull();
+      expect(deps.sendToRenderer).not.toHaveBeenCalledWith('network-update', expect.anything());
+    });
+
+    it('a provider rejection notes hard failure when the provider left health non-FAILED', async () => {
+      const note = vi.fn();
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS),
+        network: {
+          isNetworkScanRunning: vi.fn().mockReturnValue(false),
+          setNetworkScanRunning: vi.fn(),
+          scanNetworkConnections: vi.fn().mockRejectedValue(new Error('spawn ETIMEDOUT')),
+          getNetworkSensorHealth: vi.fn().mockReturnValue({ state: 'STARTING' }),
+          noteNetworkScanHardFailure: note,
+        },
+      });
+      scanLoop.init(deps);
+      await runOneNetworkScan();
+
+      expect(note).toHaveBeenCalledTimes(1);
+      expect(note.mock.calls[0][0].message).toMatch(/ETIMEDOUT/);
+      expect(deps.network.setNetworkScanRunning).toHaveBeenLastCalledWith(false);
+    });
+
+    it('both paths keep the existing "Network scan failed" log', async () => {
+      const downstream = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS),
+        sendToRenderer: throwingSendOn('network-update'),
+      });
+      scanLoop.init(downstream);
+      await runOneNetworkScan();
+      expect(downstream.logger.error).toHaveBeenCalledWith('main', 'Network scan failed', {
+        error: 'renderer-send-failed:network-update',
+      });
+
+      network._resetForTest();
+      network._setDepsForTest({
+        getRawTcpConnections: vi.fn().mockRejectedValue(new Error('spawn ETIMEDOUT')),
+        dnsReverse: vi.fn().mockRejectedValue(new Error('ENOTFOUND')),
+        dnsResolve: vi.fn().mockResolvedValue([]),
+      });
+      const provider = makeDeps({ getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS) });
+      scanLoop.init(provider);
+      await runOneNetworkScan();
+      expect(provider.logger.error).toHaveBeenCalledWith('main', 'Network scan failed', {
+        error: 'spawn ETIMEDOUT',
+      });
+    });
+
+    it('a downstream throw does not wedge the loop — the next scan still queries', async () => {
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS),
+        sendToRenderer: throwingSendOn('network-update'),
+      });
+      scanLoop.init(deps);
+      await runOneNetworkScan();
+      await runOneNetworkScan();
+
+      expect(getRawTcpConnections).toHaveBeenCalledTimes(2);
+      expect(network.getNetworkSensorHealth().state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+    });
+  });
+});


### PR DESCRIPTION
## Stage-1 step A — provider-health ownership boundaries

`doProcessScan` wrapped the whole pipeline in one `try`, so a throw from
enrichment, session reconcile, an audit write, anomaly processing or a renderer
send reached the `catch` that calls `noteProcessScanHardFailure`. **`process =
FAILED` therefore proved nothing about whether the machine was enumerated** — a
`sendToRenderer` throw produced the same leaf state as `tasklist` dying.

`doNetworkScan` had the mirror defect: `.then(continuation).catch(handler)` let a
throw raised *inside the continuation* reach the same handler, see
`state !== 'FAILED'`, and rewrite a **successful** TCP observation into FAILED.

### The rule

> A leaf health record is written only by the code that performed or refused the
> provider observation that leaf names. Nothing downstream of the provider's
> return value may write it.

### Changes

| file | change |
|---|---|
| `src/main/scan-loop.js` | `doProcessScan`: an inner `try` encloses **only** `scanner.scanProcesses()`; it notes the hard failure and rethrows, so the outer catch keeps the single existing log and writes no health. `doNetworkScan`: `.then(onFulfilled, onProviderRejected)` splits the handlers; the rejection handler notes and rethrows into a log-only `.catch`. |
| `src/main/process-scanner.js` | comment only — the old text said "leave health update to noteProcessScanHardFailure (scan-loop catch)", which now implied the wide catch. |
| `tests/main/scan-loop-provider-health.test.js` | 14 tests, both leaves driven through their **real** modules so every assertion reads the health record, not a spy. |

**No health record is added.** Downstream failures keep their existing logging and
no longer touch sensor health; the pipeline axis stays unowned, by design.

### Mutation proofs

Reverting each boundary to the old wide catch, one leaf at a time:

- **process** — 4 failed / 3 passed. `expected 'FAILED' to be 'HEALTHY'` on the
  record assertion for both the renderer-send and the audit-write injection; the
  provider-throw tests stayed green.
- **network** — 4 failed / 3 passed, same assertion and the same split.

### Gates

`build:renderer`, `format:check` + `lint`, `typecheck` + `typecheck:svelte` (385
files, 0 errors), `test:coverage` (100 files, 1743 passed / 4 skipped),
`npm audit --audit-level=high --omit=dev` (0 vulnerabilities) — all green locally.

### Out of scope

Steps A-prime, G-prime, S and later stay out of this PR.
