### PR TITLE
feat(main): gate every agent-scoped consumer on population reliability

### DIFF
--- a/src/main/attribution.js
+++ b/src/main/attribution.js
@@ -39,6 +39,12 @@
  * Negative (→ `unattributed`):
  * - `no-owner-match` — no self-config and no cwd containment matched any AI agent.
  * - `no-ai-agents-online` — no AI-category agent was online to own the event.
+ * - `population-unavailable` — the process sensor could not vouch for the agent
+ *   population at this instant, so no owner was even looked for. Deliberately NOT
+ *   `no-ai-agents-online` (which asserts nobody was online — possibly false, the
+ *   population is UNKNOWN, not empty) and not `no-owner-match` (which asserts a
+ *   match was attempted and failed). The path observation itself stays valid: what
+ *   is unavailable is the list of candidate owners, not the event.
  * @type {Readonly<Object<string, string>>}
  * @since v0.11.0
  */
@@ -50,11 +56,20 @@ const EVIDENCE = Object.freeze({
   CWD_CONTAINMENT: 'cwd-containment',
   NO_OWNER_MATCH: 'no-owner-match',
   NO_AI_AGENTS_ONLINE: 'no-ai-agents-online',
+  POPULATION_UNAVAILABLE: 'population-unavailable',
 });
 
 /**
- * Every legal evidence code, in declaration order. Mirrors the
- * `AttributionEvidence` union in src/shared/types/events.ts.
+ * Every legal evidence code, in declaration order.
+ *
+ * The `AttributionEvidence` union in src/shared/types/events.ts mirrors the first
+ * SEVEN codes. `population-unavailable` is **not yet in that union** — the typed
+ * mirror is the second half of gap S in the app-state design and ships in the pass
+ * that is allowed to edit `src/shared/`. Nothing breaks meanwhile: the renderer
+ * switches on `attribution.status`, never on an individual code, and the write path
+ * is guarded by {@link deriveStatus} rather than by the union. State it here rather
+ * than let the old blanket "mirrors the union" sentence claim a parity that stopped
+ * holding (ai-mistakes #27).
  * @type {ReadonlyArray<string>}
  * @since v0.11.0
  */

--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -39,6 +39,32 @@ const FS_SENSOR = Object.freeze({
   RM: 'fs-rm',
 });
 
+/** Reason recorded by every surface that refuses to observe an untrusted population. */
+const SCOPE_UNAVAILABLE_REASON = 'process-observation-unavailable';
+
+/**
+ * Reader for the ProcessCapabilities contract (design §3), resolved lazily.
+ *
+ * Required directly rather than injected through `_state`: that object is built in
+ * main.js and does not carry the contract, and §3 is explicit that a dependant must
+ * consume the capability struct — never a plane roll-up — to decide whether an
+ * agent-scoped observation may run. process-scanner requires nothing from here, so
+ * there is no cycle.
+ * @type {(() => {populationReliable: boolean}) | null}
+ */
+let _getProcessCapabilities = null;
+
+/**
+ * Whether the agent population may be used as an observation scope right now.
+ * @returns {boolean}
+ */
+function populationReliable() {
+  if (!_getProcessCapabilities) {
+    _getProcessCapabilities = require('./process-scanner').getProcessCapabilities;
+  }
+  return _getProcessCapabilities().populationReliable === true;
+}
+
 /**
  * Default directories to ignore in file watchers.
  * @type {string[]}
@@ -161,6 +187,41 @@ function getFileSensorHealth() {
   return out;
 }
 
+/**
+ * Orchestration-only skip: the read mechanisms were NOT run this tick because the
+ * agent population could not be trusted as an observation scope (design §2.4).
+ *
+ * Marks the ACTIVE read mechanism — RM when the RM path owns observation, the handle
+ * pool otherwise — because that is the sensor whose observation was actually lost.
+ * DEGRADED, never FAILED: no provider failed. Never HEALTHY: no read happened, so
+ * there is no scoped success to claim, and `lastSuccessAt` must not advance.
+ *
+ * The scoped-HEALTHY `confirmed-zero-in-scope` case is the effective-read-scope step
+ * and is deliberately NOT implemented here — it needs the mechanism's own filtered
+ * list, which this function never sees.
+ * @param {'process-observation-unavailable'|string} reason
+ * @returns {void}
+ * @since 0.12.0
+ */
+function noteFileScanSkip(reason) {
+  const now = Date.now();
+  const id = rmEnabled() ? FS_SENSOR.RM : FS_SENSOR.HANDLE;
+  const rec = _fsHealth[id];
+  // markDegraded throws from both states, and RM is UNSUPPORTED on every platform
+  // that has no Restart Manager — a skip must not turn that into an error.
+  if (
+    rec.state === sensorHealth.SENSOR_HEALTH_STATE.UNSUPPORTED ||
+    rec.state === sensorHealth.SENSOR_HEALTH_STATE.DISABLED
+  ) {
+    return;
+  }
+  const scoped = reason === SCOPE_UNAVAILABLE_REASON;
+  _fsHealth[id] = sensorHealth.markDegraded(rec, now, {
+    error: scoped ? SCOPE_UNAVAILABLE_REASON : healthErrorMessage(reason),
+    detail: scoped ? SCOPE_UNAVAILABLE_REASON : 'file-scan-skip',
+  });
+}
+
 /** @internal Override dependencies (for tests). */
 function _setDepsForTest(overrides) {
   if (overrides.getFileHandles) _getFileHandles = overrides.getFileHandles;
@@ -175,6 +236,7 @@ function _setDepsForTest(overrides) {
     }
   }
   if (overrides.getHotSensitiveHolders) _getHotSensitiveHolders = overrides.getHotSensitiveHolders;
+  if (overrides.getProcessCapabilities) _getProcessCapabilities = overrides.getProcessCapabilities;
   if (Object.prototype.hasOwnProperty.call(overrides, 'isReadDetectionAvailable')) {
     _isReadDetectionAvailableOverride = overrides.isReadDetectionAvailable;
   }
@@ -186,6 +248,17 @@ function _resetForTest() {
   _getHotSensitiveHolders = undefined;
   _rmScanInFlight = false;
   _isReadDetectionAvailableOverride = undefined;
+  // Same contract as the RM dep above: a test opts INTO the population gate via
+  // _setDepsForTest. The real process-scanner sits at STARTING until something drives
+  // a scan, which is honestly "cannot vouch" — but a test asserting attribution logic
+  // is not asserting population health, and making every one of them drive a process
+  // scan first would couple two unrelated sensors. Production never calls this.
+  _getProcessCapabilities = () => ({
+    populationState: 'HEALTHY',
+    populationReliable: true,
+    populationAsOf: null,
+    identityQuality: 'unknown',
+  });
   _resetFsHealth();
 }
 
@@ -332,7 +405,14 @@ function handleWatcherEvent(action, filePath) {
     if (watcherDebounce.size > 500) watcherDebounce.clear();
   }
   const reason = classifySensitive(filePath);
-  const aiAgents = _state.getLatestAiAgents();
+  // G′: chokidar KEEPS OBSERVING under an untrusted population — a path event is
+  // valid evidence regardless of who owns it, and dropping it would lose real
+  // filesystem activity to a process-sensor problem. What is unavailable is the list
+  // of candidate owners, so owner inference is what gets skipped: `latestAiAgents` is
+  // not read, `findOwningAgent` is not run, and the event carries no owner. `W` is
+  // unaffected — no health record is written here.
+  const scopeUsable = populationReliable();
+  const aiAgents = scopeUsable ? _state.getLatestAiAgents() : [];
   const owner = aiAgents.length > 0 ? findOwningAgent(filePath, aiAgents) : null;
   // C-01: chokidar hands us a PATH, never a PID — so this path can be `inferred`
   // at best, and MUST be `unattributed` when no owner matches. Substituting the
@@ -340,9 +420,17 @@ function handleWatcherEvent(action, filePath) {
   // baselines, risk score, tray alert and audit trail. `pid: null`, not 0 — pid 0
   // is taken by synthetic WSL / local-runtime agents, so 0 would collide with a
   // real agent card.
-  const evidence = owner
-    ? owner.evidence
-    : [aiAgents.length > 0 ? EVIDENCE.NO_OWNER_MATCH : EVIDENCE.NO_AI_AGENTS_ONLINE];
+  let evidence;
+  if (owner) {
+    evidence = owner.evidence;
+  } else if (!scopeUsable) {
+    // Says WHY there is no owner, and says it exactly: not "nobody was online"
+    // (which would assert a fact about a population we cannot read) and not "no
+    // owner matched" (which would assert a match was attempted).
+    evidence = [EVIDENCE.POPULATION_UNAVAILABLE];
+  } else {
+    evidence = [aiAgents.length > 0 ? EVIDENCE.NO_OWNER_MATCH : EVIDENCE.NO_AI_AGENTS_ONLINE];
+  }
   const attribution = makeAttribution(evidence);
   const agent = owner ? owner.agent : null;
   // D2: the self-access exemption belongs to the agent that OWNS the path, and is
@@ -589,6 +677,15 @@ function rmEnabled() {
  * @since v0.10.0
  */
 async function scanViaRestartManager(agents, fetchHolders = _getSensitiveHolders) {
+  // G′ invariant, not a scheduling decision: _scanRmHolders maps a live holder pid
+  // onto an agent record and stamps RM_HOLDER_PID — `confirmed` — into the audit log.
+  // That stamp must be impossible against a population the process sensor cannot
+  // vouch for, whoever called us. scan-loop refuses earlier and logs the skip; this
+  // guard is what makes the invariant hold rather than the schedule.
+  if (!populationReliable()) {
+    noteFileScanSkip(SCOPE_UNAVAILABLE_REASON);
+    return [];
+  }
   // B-S09: legitimate single-flight skip — not FAILED, not a success tick.
   if (_rmScanInFlight) return [];
   _rmScanInFlight = true;
@@ -721,6 +818,13 @@ async function scanHotFileHolders(agents) {
  */
 async function scanAllFileHandles(agents) {
   const now = Date.now();
+  // G′ invariant: the handle pool stamps HANDLE_SCAN_PID — `confirmed`, same strength
+  // as the RM holder pid — so it is gated by the same rule and for the same reason.
+  // Placed ahead of the RM delegation so both mechanisms are covered from one site.
+  if (!populationReliable()) {
+    noteFileScanSkip(SCOPE_UNAVAILABLE_REASON);
+    return [];
+  }
   // win32 primary: honest read-detect via Restart Manager (no handle.exe needed).
   // Falls through to the legacy per-PID handle pool on darwin/linux, or on win32
   // when RM is unavailable (the PR-A getFileHandles→[] fallback still applies).
@@ -860,6 +964,7 @@ module.exports = {
   handleWatcherEvent,
   getIgnoredDirFilter,
   getFileSensorHealth,
+  noteFileScanSkip,
   FS_SENSOR,
   DEFAULT_IGNORED_DIRS,
   FILE_SCAN_CONCURRENCY,

--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -19,6 +19,12 @@ const { IGNORE_PROCESS_PATTERNS, EDITOR_HOSTS } = require('../shared/constants')
 const sensorHealth = require('./sensor-health');
 const _platform = require('./platform');
 let _listProcesses = _platform.listProcesses;
+// Identity-quality inputs, mirrored as overridable locals the same way process-utils.js
+// holds `providesStartTime` — so a test can state a platform's identity story without
+// pretending to be that platform.
+let _providesStartTime = _platform.providesStartTime === true;
+/** @type {(() => {state: string}) | null} Test override for the proc-snapshot leaf. */
+let _getSnapshotHealth = null;
 
 /** Authoritative process-enumeration sensor id (Block B3). One observation source. */
 const PROCESS_SENSOR_ID = 'process';
@@ -61,6 +67,81 @@ function isProcessPopulationReliable() {
 }
 
 /**
+ * Read the `proc-snapshot` leaf's state without going through the platform façade.
+ *
+ * `platform/win32.js` requires `process-snapshot.js` but does not re-export
+ * `getSnapshotHealth` — that re-export is gap F in the app-state design and is not
+ * part of this pass. The façade is tried FIRST so this fallback deletes itself the
+ * day F lands, and the submodule is required lazily so a POSIX host never loads the
+ * sidecar client for a question it has already answered via `providesStartTime`.
+ * @returns {string|null} The leaf state, or null when it cannot be read at all.
+ */
+function readSnapshotState() {
+  if (_getSnapshotHealth) return _getSnapshotHealth().state;
+  if (typeof _platform.getSnapshotHealth === 'function') {
+    return _platform.getSnapshotHealth().state;
+  }
+  try {
+    return require('./platform/process-snapshot').getSnapshotHealth().state;
+  } catch (_) {
+    // No snapshot module on this host — identity carries no witness.
+    return null;
+  }
+}
+
+/**
+ * Identity strength for the keys `identify()` is currently able to form.
+ *
+ * Annotation only: §3 of the design is explicit that nothing gates on this value.
+ * The socket→agent and holder→agent matches are by PID, and a birth witness plays
+ * no part in a PID match — so a degraded witness must never be allowed to suppress
+ * an observation.
+ *
+ * STARTING (no snapshot taken yet) maps to `unknown` with the same reasoning as
+ * FAILED: no witness has been read, so `identify()` has none to key on.
+ * @returns {'witnessed'|'birth-time'|'unknown'}
+ * @since 0.12.0
+ */
+function getIdentityQuality() {
+  // darwin/linux publish no birth time at all → identify() yields "<pid>:u".
+  if (_providesStartTime !== true) return 'unknown';
+  const state = readSnapshotState();
+  if (state === sensorHealth.SENSOR_HEALTH_STATE.HEALTHY) return 'witnessed';
+  // cim-fallback: _witnessOf drops to startTimeMs, so keys still form.
+  if (state === sensorHealth.SENSOR_HEALTH_STATE.DEGRADED) return 'birth-time';
+  return 'unknown';
+}
+
+/**
+ * @typedef {Object} ProcessCapabilities
+ * @property {'STARTING'|'HEALTHY'|'DEGRADED'|'FAILED'} populationState - the `process`
+ *   LEAF's state, never a plane roll-up
+ * @property {boolean} populationReliable - true iff populationState === 'HEALTHY'
+ * @property {number|null} populationAsOf - the leaf's lastSuccessAt: how old the list is
+ * @property {'witnessed'|'birth-time'|'unknown'} identityQuality - annotation, gates nothing
+ */
+
+/**
+ * The capability contract dependants consume — and the ONLY thing they may consume
+ * to decide whether an agent-scoped observation is allowed to run.
+ *
+ * Deliberately not the process PLANE enum: that value is a display roll-up, safe by
+ * accident for today's single cause of plane-DEGRADED and silently wrong the moment
+ * the `process` leaf itself can degrade. Dependent correctness must not be
+ * reverse-engineered out of a display value (design §3).
+ * @returns {ProcessCapabilities}
+ * @since 0.12.0
+ */
+function getProcessCapabilities() {
+  return {
+    populationState: /** @type {'STARTING'|'HEALTHY'|'DEGRADED'|'FAILED'} */ (_processHealth.state),
+    populationReliable: _processHealth.state === sensorHealth.SENSOR_HEALTH_STATE.HEALTHY,
+    populationAsOf: _processHealth.lastSuccessAt,
+    identityQuality: getIdentityQuality(),
+  };
+}
+
+/**
  * Record a hard process-scan failure that escaped scanProcesses (e.g. non-EPERM
  * throw caught by scan-loop). Does not fabricate agents.
  * @param {unknown} err
@@ -78,12 +159,18 @@ function noteProcessScanHardFailure(err) {
 /** @internal Override platform functions (for tests). */
 function _setPlatformForTest(overrides) {
   if (overrides.listProcesses) _listProcesses = overrides.listProcesses;
+  if (typeof overrides.providesStartTime === 'boolean') {
+    _providesStartTime = overrides.providesStartTime;
+  }
+  if (overrides.getSnapshotHealth) _getSnapshotHealth = overrides.getSnapshotHealth;
 }
 /** @internal Reset state (for tests). */
 function _resetForTest() {
   lastProcessPidSet = '';
   permissionDeniedScans = 0;
   _processHealth = sensorHealth.createSensorHealth(PROCESS_SENSOR_ID);
+  _providesStartTime = _platform.providesStartTime === true;
+  _getSnapshotHealth = null;
 }
 
 let _agentDb = null;
@@ -222,6 +309,7 @@ module.exports = {
   scanProcesses,
   getProcessSensorHealth,
   isProcessPopulationReliable,
+  getProcessCapabilities,
   noteProcessScanHardFailure,
   PROCESS_SENSOR_ID,
   _setPlatformForTest,

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -138,29 +138,60 @@ function stopScanIntervals() {
   }
 }
 
+/** Reason recorded by every surface that refuses to observe an untrusted population. */
+const SCOPE_UNAVAILABLE = 'process-observation-unavailable';
+
+/**
+ * Whether the agent population may be used as an observation scope right now.
+ *
+ * Reads the ProcessCapabilities contract (design §3) and NOTHING else — not the
+ * plane enum, not `agents.length`. The two older APIs are kept as an ordered
+ * fallback so a caller that injected only part of the scanner surface keeps working.
+ *
+ * A scanner exposing none of the three is treated as reliable: that is the shape a
+ * collaborator stub takes, and defaulting to "unknown" there would silently disable
+ * every sensor rather than gate a stale list.
+ * @param {Object|undefined} scanner
+ * @returns {boolean}
+ * @since 0.12.0
+ */
+function isPopulationReliable(scanner) {
+  if (!scanner) return true;
+  if (typeof scanner.getProcessCapabilities === 'function') {
+    return scanner.getProcessCapabilities().populationReliable === true;
+  }
+  if (typeof scanner.isProcessPopulationReliable === 'function') {
+    return scanner.isProcessPopulationReliable() === true;
+  }
+  if (typeof scanner.getProcessSensorHealth === 'function') {
+    return scanner.getProcessSensorHealth().state === 'HEALTHY';
+  }
+  return true;
+}
+
 function doNetworkScan() {
   const { network, baselines, audit, logger, getLatestAgents, sendToRenderer, scanner } = deps;
   const agents = getLatestAgents();
   if (network.isNetworkScanRunning()) return;
-  // B-S08: agent-scoped network sensor — empty agents still skip the TCP provider,
-  // but health must distinguish confirmed-zero (process HEALTHY) from process-unknown.
-  // Process reliability is B3's API only — never agents.length alone.
-  if (agents.length === 0) {
-    let reason = 'confirmed-zero-agents';
-    if (scanner && typeof scanner.isProcessPopulationReliable === 'function') {
-      if (!scanner.isProcessPopulationReliable()) {
-        reason = 'process-observation-unavailable';
-      }
-    } else if (
-      scanner &&
-      typeof scanner.getProcessSensorHealth === 'function' &&
-      scanner.getProcessSensorHealth().state !== 'HEALTHY'
-    ) {
-      reason = 'process-observation-unavailable';
-    }
-    logger.debug('scan', 'network-skip', { reason, agents: 0 });
+  // G′: the stale-population gate, evaluated BEFORE cardinality. After a hard
+  // enumeration failure `setAgents` never ran, so `latestAgents` still holds the
+  // previous population — querying the TCP table for those pids would resolve
+  // dead/recycled pids and stamp OS_TCP_OWNER_PID (`confirmed`) off an agent record
+  // the process sensor cannot vouch for. The list is NOT cleared (§2.3 — clearing
+  // re-creates B-S01); the consumer is gated instead.
+  if (!isPopulationReliable(scanner)) {
+    logger.debug('scan', 'network-skip', { reason: SCOPE_UNAVAILABLE, agents: agents.length });
     if (typeof network.noteNetworkSkip === 'function') {
-      network.noteNetworkSkip(reason);
+      network.noteNetworkSkip(SCOPE_UNAVAILABLE);
+    }
+    return;
+  }
+  // B-S08: agent-scoped network sensor — a reliable but empty population still skips
+  // the TCP provider, and that skip is a scoped SUCCESS, not a degradation.
+  if (agents.length === 0) {
+    logger.debug('scan', 'network-skip', { reason: 'confirmed-zero-agents', agents: 0 });
+    if (typeof network.noteNetworkSkip === 'function') {
+      network.noteNetworkSkip('confirmed-zero-agents');
     }
     return;
   }
@@ -560,8 +591,20 @@ function attachModels(agents, name, info) {
 }
 
 async function doFileScan() {
-  const { watcher, tray, logger, getStats, getLatestAgents } = deps;
+  const { watcher, tray, logger, getStats, getLatestAgents, scanner } = deps;
   const agents = getLatestAgents();
+  // G′: RM and the handle pool both map a live holder pid onto an agent record and
+  // stamp RM_HOLDER_PID / HANDLE_SCAN_PID — `confirmed` attribution. Against a
+  // population the process sensor cannot vouch for, that is a confirmed claim about
+  // a possibly-dead agent, written into the audit log. Do not scan, do not attribute;
+  // the ACTIVE read mechanism records the refusal (§2.4).
+  if (!isPopulationReliable(scanner)) {
+    logger.debug('scan', 'file-skip', { reason: SCOPE_UNAVAILABLE, agents: agents.length });
+    if (typeof watcher.noteFileScanSkip === 'function') {
+      watcher.noteFileScanSkip(SCOPE_UNAVAILABLE);
+    }
+    return;
+  }
   if (agents.length === 0) return;
   const t0 = performance.now();
   updateScanStatus(true);
@@ -594,8 +637,16 @@ async function doFileScan() {
  * @since v0.11.0-alpha
  */
 async function doHotReadScan() {
-  const { watcher, tray, logger, getStats, getLatestAgents } = deps;
+  const { watcher, tray, logger, getStats, getLatestAgents, scanner } = deps;
   const agents = getLatestAgents();
+  // G′: same holder→agent stamp as the 30s scan, ~3× more often. Same refusal.
+  if (!isPopulationReliable(scanner)) {
+    logger.debug('scan', 'hot-read-skip', { reason: SCOPE_UNAVAILABLE, agents: agents.length });
+    if (typeof watcher.noteFileScanSkip === 'function') {
+      watcher.noteFileScanSkip(SCOPE_UNAVAILABLE);
+    }
+    return;
+  }
   if (agents.length === 0) return;
   const t0 = performance.now();
   try {

--- a/tests/main/file-watcher-attribution.test.js
+++ b/tests/main/file-watcher-attribution.test.js
@@ -279,10 +279,12 @@ describe('attribution evidence is a closed list (case 8)', () => {
     fileWatcher._resetForTest();
   });
 
-  it('exposes exactly the seven documented codes', () => {
+  it('exposes exactly the eight documented codes', () => {
     // The list is closed on purpose and deriveStatus throws on anything outside it, so this
     // assertion is the gate: adding a code means deciding its status here, in events.ts, and
     // in PID_EVIDENCE/HEURISTIC_EVIDENCE — not just at a call site.
+    // `population-unavailable` is the exception on the events.ts half: the typed mirror is
+    // the second part of gap S and ships in the pass allowed to edit src/shared/.
     expect([...EVIDENCE_CODES]).toEqual([
       'rm-holder-pid',
       'handle-scan-pid',
@@ -291,7 +293,14 @@ describe('attribution evidence is a closed list (case 8)', () => {
       'cwd-containment',
       'no-owner-match',
       'no-ai-agents-online',
+      'population-unavailable',
     ]);
+  });
+
+  it('population-unavailable derives unattributed — it is a negative code', () => {
+    // It must never read as PID proof or as a heuristic match: nothing was matched,
+    // and the reason is that there was no trustworthy list to match against.
+    expect(deriveStatus(['population-unavailable'])).toBe('unattributed');
   });
 
   it('every code emitted by real watcher events belongs to the closed list', async () => {

--- a/tests/main/file-watcher-subscription.test.js
+++ b/tests/main/file-watcher-subscription.test.js
@@ -103,6 +103,18 @@ describe('file-watcher production subscription wiring (F-S01)', () => {
   beforeEach(() => {
     installChokidarMock();
     fileWatcher = loadFileWatcher();
+    // F-S01 is about subscription wiring, not population health. A freshly loaded module
+    // reads the real process leaf, which sits at STARTING until a scan succeeds — under
+    // G′ that correctly suppresses owner inference. Vouch for the population so these
+    // tests exercise the wiring they are about; the gate has its own suite.
+    fileWatcher._setDepsForTest({
+      getProcessCapabilities: () => ({
+        populationState: 'HEALTHY',
+        populationReliable: true,
+        populationAsOf: null,
+        identityQuality: 'unknown',
+      }),
+    });
   });
 
   afterEach(() => {

--- a/tests/main/population-scope-gate.test.js
+++ b/tests/main/population-scope-gate.test.js
@@ -1,0 +1,626 @@
+/**
+ * Steps A′ and G′/S — the ProcessCapabilities contract, and the stale-population
+ * scope gate on every agent-scoped consumer.
+ *
+ * The invariant under test: no agent-scoped observation may be performed against, or
+ * attributed to, a population the process sensor cannot currently vouch for. After a
+ * hard enumeration failure `setAgents` never runs, so `latestAgents` still holds the
+ * PREVIOUS population — and it is deliberately not cleared (clearing re-creates the
+ * "zero agents = nothing running" false-clean). The consumers are gated instead.
+ *
+ * Every gate is asserted twice: once unreliable (the observation must not happen) and
+ * once reliable (it must happen exactly as before). The second half is what catches a
+ * gate that fires unconditionally — a gate that never lets anything through would pass
+ * the first assertion of each pair on its own.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'module';
+import { SENSOR_HEALTH_STATE } from '../../src/main/sensor-health.js';
+
+const require_ = createRequire(import.meta.url);
+
+/** The capability struct a dependant sees while the process leaf is trustworthy. */
+const RELIABLE = Object.freeze({
+  populationState: 'HEALTHY',
+  populationReliable: true,
+  populationAsOf: 1700000000000,
+  identityQuality: 'witnessed',
+});
+
+/** The same struct after a hard enumeration failure — the list is stale. */
+const UNRELIABLE = Object.freeze({
+  populationState: 'FAILED',
+  populationReliable: false,
+  populationAsOf: 1700000000000,
+  identityQuality: 'witnessed',
+});
+
+// ── A′: the capability contract ──
+
+describe('ProcessCapabilities contract (step A′)', () => {
+  let scanner;
+  let listProcesses;
+
+  beforeEach(() => {
+    scanner = require_('../../src/main/process-scanner.js');
+    listProcesses = vi.fn().mockResolvedValue([{ name: 'chrome', pid: 1 }]);
+    scanner._resetForTest();
+    scanner._setPlatformForTest({ listProcesses });
+    scanner.init({ trackSeenAgent: vi.fn() });
+    scanner.peakAgents = 0;
+  });
+
+  afterEach(() => {
+    scanner._resetForTest();
+  });
+
+  it('publishes exactly the four contract fields', () => {
+    const caps = scanner.getProcessCapabilities();
+    expect(Object.keys(caps).sort()).toEqual([
+      'identityQuality',
+      'populationAsOf',
+      'populationReliable',
+      'populationState',
+    ]);
+  });
+
+  it('a never-scanned leaf is STARTING, not reliable, and has no asOf', () => {
+    const caps = scanner.getProcessCapabilities();
+    expect(caps.populationState).toBe(SENSOR_HEALTH_STATE.STARTING);
+    expect(caps.populationReliable).toBe(false);
+    expect(caps.populationAsOf).toBeNull();
+  });
+
+  it('a successful enumeration makes the population reliable and stamps asOf', async () => {
+    await scanner.scanProcesses();
+    const caps = scanner.getProcessCapabilities();
+    expect(caps.populationState).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+    expect(caps.populationReliable).toBe(true);
+    expect(caps.populationAsOf).toBeTypeOf('number');
+  });
+
+  it('a hard failure clears reliability but KEEPS asOf — the list is stale, not absent', async () => {
+    await scanner.scanProcesses();
+    const asOf = scanner.getProcessCapabilities().populationAsOf;
+    scanner.noteProcessScanHardFailure(new Error('spawn ENOENT'));
+
+    const caps = scanner.getProcessCapabilities();
+    expect(caps.populationState).toBe(SENSOR_HEALTH_STATE.FAILED);
+    expect(caps.populationReliable).toBe(false);
+    // How old the list is, which is exactly the question a stale-scope consumer asks.
+    expect(caps.populationAsOf).toBe(asOf);
+  });
+
+  it('permission denial is also not reliable', async () => {
+    const eperm = Object.assign(new Error('Access is denied'), { code: 'EPERM' });
+    listProcesses.mockRejectedValue(eperm);
+    await scanner.scanProcesses();
+    expect(scanner.getProcessCapabilities().populationReliable).toBe(false);
+  });
+
+  it('populationReliable agrees with the older isProcessPopulationReliable on every state', async () => {
+    expect(scanner.getProcessCapabilities().populationReliable).toBe(
+      scanner.isProcessPopulationReliable(),
+    );
+    await scanner.scanProcesses();
+    expect(scanner.getProcessCapabilities().populationReliable).toBe(
+      scanner.isProcessPopulationReliable(),
+    );
+    scanner.noteProcessScanHardFailure(new Error('boom'));
+    expect(scanner.getProcessCapabilities().populationReliable).toBe(
+      scanner.isProcessPopulationReliable(),
+    );
+  });
+
+  it('identityQuality: no platform birth time → unknown, whatever the snapshot says', () => {
+    scanner._setPlatformForTest({
+      providesStartTime: false,
+      getSnapshotHealth: () => ({ state: SENSOR_HEALTH_STATE.HEALTHY }),
+    });
+    expect(scanner.getProcessCapabilities().identityQuality).toBe('unknown');
+  });
+
+  it('identityQuality: snapshot HEALTHY → witnessed', () => {
+    scanner._setPlatformForTest({
+      providesStartTime: true,
+      getSnapshotHealth: () => ({ state: SENSOR_HEALTH_STATE.HEALTHY }),
+    });
+    expect(scanner.getProcessCapabilities().identityQuality).toBe('witnessed');
+  });
+
+  it('identityQuality: snapshot DEGRADED (cim fallback) → birth-time', () => {
+    scanner._setPlatformForTest({
+      providesStartTime: true,
+      getSnapshotHealth: () => ({ state: SENSOR_HEALTH_STATE.DEGRADED }),
+    });
+    expect(scanner.getProcessCapabilities().identityQuality).toBe('birth-time');
+  });
+
+  it('identityQuality: snapshot FAILED or STARTING → unknown (no witness was read)', () => {
+    scanner._setPlatformForTest({
+      providesStartTime: true,
+      getSnapshotHealth: () => ({ state: SENSOR_HEALTH_STATE.FAILED }),
+    });
+    expect(scanner.getProcessCapabilities().identityQuality).toBe('unknown');
+    scanner._setPlatformForTest({
+      getSnapshotHealth: () => ({ state: SENSOR_HEALTH_STATE.STARTING }),
+    });
+    expect(scanner.getProcessCapabilities().identityQuality).toBe('unknown');
+  });
+
+  it('identityQuality gates nothing: a degraded witness leaves the population reliable', async () => {
+    await scanner.scanProcesses();
+    scanner._setPlatformForTest({
+      providesStartTime: true,
+      getSnapshotHealth: () => ({ state: SENSOR_HEALTH_STATE.FAILED }),
+    });
+    const caps = scanner.getProcessCapabilities();
+    expect(caps.identityQuality).toBe('unknown');
+    expect(caps.populationReliable).toBe(true);
+  });
+});
+
+// ── G′: the orchestrator gates ──
+
+describe('stale-population scope gate — orchestration (step G′)', () => {
+  let scanLoop;
+
+  const inertExec = () => Promise.resolve('');
+
+  function isolateResourceMonitor() {
+    const rm = require_('../../src/main/resource-monitor.js');
+    rm._resetForTest();
+    rm._setLoggerForTest({ warn: vi.fn() });
+    rm._setExecForTest(inertExec);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    delete require_.cache[require_.resolve('../../src/main/scan-loop.js')];
+    isolateResourceMonitor();
+    scanLoop = require_('../../src/main/scan-loop.js');
+  });
+
+  afterEach(async () => {
+    scanLoop.stopScanIntervals();
+    await vi.advanceTimersByTimeAsync(0);
+    vi.useRealTimers();
+    isolateResourceMonitor();
+  });
+
+  /**
+   * The stale population a hard enumeration failure leaves behind: a non-empty list
+   * of agents that may already be dead, with pids the OS may have reissued.
+   */
+  const STALE_AGENTS = [
+    { agent: 'Claude Code', pid: 4242, instanceId: '4242:t', category: 'ai', cwd: '/home/user/a' },
+  ];
+
+  /**
+   * @param {boolean} reliable
+   * @param {Object} [overrides]
+   * @returns {Object}
+   */
+  function makeDeps(reliable, overrides = {}) {
+    return {
+      scanner: {
+        scanProcesses: vi.fn().mockResolvedValue({ agents: [], changed: false }),
+        getProcessCapabilities: vi.fn().mockReturnValue(reliable ? RELIABLE : UNRELIABLE),
+      },
+      network: {
+        isNetworkScanRunning: vi.fn().mockReturnValue(false),
+        setNetworkScanRunning: vi.fn(),
+        scanNetworkConnections: vi.fn().mockResolvedValue([]),
+        noteNetworkSkip: vi.fn(),
+        noteNetworkScanHardFailure: vi.fn(),
+        getNetworkSensorHealth: vi.fn().mockReturnValue({ state: 'HEALTHY' }),
+      },
+      watcher: {
+        pruneKnownHandles: vi.fn(),
+        scanAllFileHandles: vi.fn().mockResolvedValue([]),
+        scanHotFileHolders: vi.fn().mockResolvedValue([]),
+        noteFileScanSkip: vi.fn(),
+        isHotReadScanActive: vi.fn().mockReturnValue(true),
+      },
+      procUtil: {
+        enrichWithParentChains: vi.fn().mockResolvedValue(),
+        annotateHostApps: vi.fn(),
+        annotateWorkingDirs: vi.fn().mockResolvedValue(),
+      },
+      baselines: { recordNetworkEndpoint: vi.fn() },
+      anomaly: {
+        checkDeviations: vi.fn().mockReturnValue([]),
+        calculateAnomalyScore: vi.fn().mockReturnValue({ score: 0 }),
+      },
+      audit: { log: vi.fn() },
+      tray: { updateTrayIcon: vi.fn(), notifySensitive: vi.fn() },
+      logger: { error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      sendToRenderer: vi.fn(),
+      fileAccessBatcher: { push: vi.fn() },
+      statsUpdateBatcher: { push: vi.fn() },
+      getStats: vi.fn().mockReturnValue({}),
+      getResourceUsage: vi.fn().mockReturnValue({}),
+      getLatestAgents: vi.fn().mockReturnValue(STALE_AGENTS),
+      setAgents: vi.fn(),
+      setLatestNetConnections: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  /** @param {Object} deps @param {string} kind @returns {Object|undefined} */
+  function skipLine(deps, kind) {
+    return deps.logger.debug.mock.calls.find((c) => c[0] === 'scan' && c[1] === kind);
+  }
+
+  /** Drive one doFileScan: staggeredStartup fires it at 8s. @returns {Promise<void>} */
+  async function runFileScan() {
+    scanLoop.staggeredStartup(5000, true);
+    await vi.advanceTimersByTimeAsync(8000);
+    await vi.advanceTimersByTimeAsync(0);
+  }
+
+  /**
+   * Drive one doHotReadScan: it has no startup timer, only the post-warmup interval.
+   * @returns {Promise<void>}
+   */
+  async function runHotReadScan() {
+    scanLoop.startScanIntervals(60000);
+    await vi.advanceTimersByTimeAsync(10000);
+    await vi.advanceTimersByTimeAsync(0);
+  }
+
+  describe('network', () => {
+    it('unreliable population + stale non-empty list → the TCP provider is not called', () => {
+      const deps = makeDeps(false);
+      scanLoop.init(deps);
+      scanLoop.doNetworkScan();
+
+      expect(deps.network.scanNetworkConnections).not.toHaveBeenCalled();
+      expect(deps.network.noteNetworkSkip).toHaveBeenCalledWith('process-observation-unavailable');
+      expect(skipLine(deps, 'network-skip')[2]).toEqual({
+        reason: 'process-observation-unavailable',
+        agents: 1,
+      });
+    });
+
+    it('reliable population + the same list → the provider runs against those pids', async () => {
+      const deps = makeDeps(true);
+      scanLoop.init(deps);
+      scanLoop.doNetworkScan();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(deps.network.scanNetworkConnections).toHaveBeenCalledWith(STALE_AGENTS);
+      expect(deps.network.noteNetworkSkip).not.toHaveBeenCalled();
+    });
+
+    it('reliable + empty stays confirmed-zero — cardinality is still not health', () => {
+      const deps = makeDeps(true, { getLatestAgents: vi.fn().mockReturnValue([]) });
+      scanLoop.init(deps);
+      scanLoop.doNetworkScan();
+
+      expect(deps.network.noteNetworkSkip).toHaveBeenCalledWith('confirmed-zero-agents');
+      expect(deps.network.scanNetworkConnections).not.toHaveBeenCalled();
+    });
+
+    it('unreliable + empty is process-unavailable, not confirmed-zero', () => {
+      const deps = makeDeps(false, { getLatestAgents: vi.fn().mockReturnValue([]) });
+      scanLoop.init(deps);
+      scanLoop.doNetworkScan();
+
+      expect(deps.network.noteNetworkSkip).toHaveBeenCalledWith('process-observation-unavailable');
+    });
+  });
+
+  describe('file scan (RM / handle)', () => {
+    it('unreliable population → no handle scan against stale pids, skip recorded', async () => {
+      const deps = makeDeps(false);
+      scanLoop.init(deps);
+      await runFileScan();
+
+      expect(deps.watcher.scanAllFileHandles).not.toHaveBeenCalled();
+      expect(deps.watcher.noteFileScanSkip).toHaveBeenCalledWith('process-observation-unavailable');
+      expect(skipLine(deps, 'file-skip')[2]).toEqual({
+        reason: 'process-observation-unavailable',
+        agents: 1,
+      });
+    });
+
+    it('reliable population → the scan runs against exactly that list', async () => {
+      const deps = makeDeps(true);
+      scanLoop.init(deps);
+      await runFileScan();
+
+      expect(deps.watcher.scanAllFileHandles).toHaveBeenCalledWith(STALE_AGENTS);
+      expect(deps.watcher.noteFileScanSkip).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hot read', () => {
+    it('unreliable population → no hot RM poll against stale pids, skip recorded', async () => {
+      const deps = makeDeps(false);
+      scanLoop.init(deps);
+      await runHotReadScan();
+
+      expect(deps.watcher.scanHotFileHolders).not.toHaveBeenCalled();
+      expect(deps.watcher.noteFileScanSkip).toHaveBeenCalledWith('process-observation-unavailable');
+      expect(skipLine(deps, 'hot-read-skip')[2]).toEqual({
+        reason: 'process-observation-unavailable',
+        agents: 1,
+      });
+    });
+
+    it('reliable population → the hot poll runs against exactly that list', async () => {
+      const deps = makeDeps(true);
+      scanLoop.init(deps);
+      await runHotReadScan();
+
+      expect(deps.watcher.scanHotFileHolders).toHaveBeenCalledWith(STALE_AGENTS);
+      expect(deps.watcher.noteFileScanSkip).not.toHaveBeenCalled();
+    });
+  });
+
+  it('the gate never clears latestAgents — the list survives for display', async () => {
+    const deps = makeDeps(false);
+    scanLoop.init(deps);
+    // Only the GATED consumers, never a process tick: the point is that refusing to
+    // observe does not touch the population, so the display keeps its last known list
+    // instead of showing zero agents (which would re-create the flagship false-clean).
+    scanLoop.doNetworkScan();
+    await runHotReadScan();
+
+    expect(deps.setAgents).not.toHaveBeenCalled();
+    expect(deps.getLatestAgents()).toEqual(STALE_AGENTS);
+  });
+
+  it('a scanner exposing no capability API is treated as reliable (collaborator stubs)', () => {
+    const deps = makeDeps(true, { scanner: { scanProcesses: vi.fn() } });
+    scanLoop.init(deps);
+    scanLoop.doNetworkScan();
+
+    expect(deps.network.scanNetworkConnections).toHaveBeenCalled();
+  });
+});
+
+// ── G′: the in-module invariants ──
+
+describe('stale-population scope gate — file-watcher (step G′)', () => {
+  let fileWatcher;
+  let state;
+
+  /** One AI agent whose cwd contains the probe path, so an owner IS findable. */
+  const AI_AGENTS = [
+    {
+      pid: 100,
+      agent: 'Claude Code',
+      category: 'ai',
+      cwd: '/home/user/a',
+      instanceId: '100:1700000000000',
+    },
+  ];
+
+  /** @param {Object} [overrides] @returns {Object} */
+  function makeState(overrides = {}) {
+    return {
+      getCustomRules: () => [],
+      getLatestAgents: () => AI_AGENTS,
+      getLatestAiAgents: () => AI_AGENTS,
+      isMonitoringPaused: () => false,
+      isOtherPanelExpanded: () => false,
+      activityLog: [],
+      knownHandles: new Map(),
+      watchers: [],
+      recordFileAccess: vi.fn(),
+      onFileEvent: vi.fn(),
+      onActivityPush: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  /** @param {boolean} reliable @returns {void} */
+  function setPopulation(reliable) {
+    fileWatcher._setDepsForTest({
+      getProcessCapabilities: () => (reliable ? RELIABLE : UNRELIABLE),
+    });
+  }
+
+  beforeEach(() => {
+    fileWatcher = require_('../../src/main/file-watcher.js');
+    state = makeState();
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+  });
+
+  afterEach(() => {
+    fileWatcher._resetForTest();
+  });
+
+  describe('chokidar owner inference', () => {
+    it('unreliable population → path evidence kept, attribution unattributed', () => {
+      setPopulation(false);
+      fileWatcher.handleWatcherEvent('modified', '/home/user/a/src/secrets.js');
+
+      expect(state.activityLog).toHaveLength(1);
+      const ev = state.activityLog[0];
+      // The path observation is intact — chokidar saw a real write.
+      expect(ev.file).toBe(require_('path').resolve('/home/user/a/src/secrets.js'));
+      expect(ev.action).toBe('modified');
+      expect(ev.timestamp).toBeTypeOf('number');
+      // The owner is not: no stale identity anywhere on the record.
+      expect(ev.attribution).toEqual({
+        status: 'unattributed',
+        evidence: ['population-unavailable'],
+      });
+      expect(ev.agent).toBe('');
+      expect(ev.pid).toBeNull();
+      expect(ev.instanceId).toBeNull();
+      expect(ev.cwd).toBeNull();
+      expect(ev.parentEditor).toBeNull();
+    });
+
+    it('reliable population + the same path → the real owner, inferred by cwd', () => {
+      setPopulation(true);
+      fileWatcher.handleWatcherEvent('modified', '/home/user/a/src/secrets.js');
+
+      const ev = state.activityLog[0];
+      expect(ev.attribution).toEqual({ status: 'inferred', evidence: ['cwd-containment'] });
+      expect(ev.agent).toBe('Claude Code');
+      expect(ev.pid).toBe(100);
+      expect(ev.instanceId).toBe('100:1700000000000');
+    });
+
+    it('unreliable population does not consult latestAiAgents at all', () => {
+      const getLatestAiAgents = vi.fn().mockReturnValue(AI_AGENTS);
+      state = makeState({ getLatestAiAgents });
+      fileWatcher.init(state);
+      setPopulation(false);
+      fileWatcher.handleWatcherEvent('modified', '/home/user/a/src/other.js');
+
+      expect(getLatestAiAgents).not.toHaveBeenCalled();
+    });
+
+    it('an unattributed event enters no baseline — no stale bucket is created', () => {
+      setPopulation(false);
+      fileWatcher.handleWatcherEvent('modified', '/home/user/a/src/secrets.js');
+
+      expect(state.recordFileAccess).not.toHaveBeenCalled();
+    });
+
+    it('a sensitive path stays sensitive: a self-access exemption needs a proven owner', () => {
+      setPopulation(false);
+      fileWatcher.handleWatcherEvent('modified', '/home/user/.ssh/id_rsa');
+
+      const ev = state.activityLog[0];
+      expect(ev.sensitive).toBe(true);
+      expect(ev.selfAccess).toBe(false);
+      expect(ev.attribution.evidence).toEqual(['population-unavailable']);
+    });
+
+    it('chokidar health is untouched by the gate — W is not a population input', () => {
+      const before = fileWatcher.getFileSensorHealth()['fs-chokidar'];
+      setPopulation(false);
+      fileWatcher.handleWatcherEvent('modified', '/home/user/a/src/secrets.js');
+
+      expect(fileWatcher.getFileSensorHealth()['fs-chokidar']).toEqual(before);
+    });
+  });
+
+  describe('RM holder scan', () => {
+    /** Install an RM holder source that would map onto the stale agent's pid. */
+    function armRm() {
+      fileWatcher._setDepsForTest({
+        getSensitiveHolders: vi.fn(async () => [{ pid: 100, group: '/home/user/.aws' }]),
+        getHotSensitiveHolders: vi.fn(async () => [{ pid: 100, group: '/home/user/.aws' }]),
+      });
+    }
+
+    it('unreliable population → no RM_HOLDER_PID stamp, RM marked DEGRADED', async () => {
+      armRm();
+      setPopulation(false);
+      const events = await fileWatcher.scanAllFileHandles(AI_AGENTS);
+
+      expect(events).toEqual([]);
+      expect(state.activityLog).toHaveLength(0);
+      const rm = fileWatcher.getFileSensorHealth()['fs-rm'];
+      expect(rm.state).toBe(SENSOR_HEALTH_STATE.DEGRADED);
+      expect(rm.detail).toBe('process-observation-unavailable');
+      // Not a provider failure — nothing failed, the scope was refused.
+      expect(rm.consecutiveFailures).toBe(0);
+      expect(rm.lastSuccessAt).toBeNull();
+    });
+
+    it('reliable population → the holder is stamped confirmed as before', async () => {
+      armRm();
+      setPopulation(true);
+      const events = await fileWatcher.scanAllFileHandles(AI_AGENTS);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].attribution.status).toBe('confirmed');
+      expect(events[0].attribution.evidence).toContain('rm-holder-pid');
+      expect(events[0].agent).toBe('Claude Code');
+      expect(fileWatcher.getFileSensorHealth()['fs-rm'].state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+    });
+
+    it('the hot cycle is gated the same way', async () => {
+      armRm();
+      setPopulation(false);
+      const events = await fileWatcher.scanHotFileHolders(AI_AGENTS);
+
+      expect(events).toEqual([]);
+      expect(state.activityLog).toHaveLength(0);
+      expect(fileWatcher.getFileSensorHealth()['fs-rm'].state).toBe(SENSOR_HEALTH_STATE.DEGRADED);
+    });
+
+    it('the hot cycle still runs on a reliable population', async () => {
+      armRm();
+      setPopulation(true);
+      const events = await fileWatcher.scanHotFileHolders(AI_AGENTS);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].attribution.evidence).toContain('rm-holder-pid');
+    });
+  });
+
+  describe('handle pool', () => {
+    it('unreliable population → no per-pid handle scan, handle sensor DEGRADED', async () => {
+      const getFileHandles = vi.fn(async () => ['/home/user/.aws/credentials']);
+      fileWatcher._setDepsForTest({ getFileHandles });
+      setPopulation(false);
+      const events = await fileWatcher.scanAllFileHandles(AI_AGENTS);
+
+      expect(events).toEqual([]);
+      expect(getFileHandles).not.toHaveBeenCalled();
+      const handle = fileWatcher.getFileSensorHealth()['fs-handle'];
+      expect(handle.state).toBe(SENSOR_HEALTH_STATE.DEGRADED);
+      expect(handle.detail).toBe('process-observation-unavailable');
+      expect(handle.lastSuccessAt).toBeNull();
+    });
+
+    it('reliable population → the pool scans and stamps handle-scan-pid', async () => {
+      const getFileHandles = vi.fn(async () => ['/home/user/.aws/credentials']);
+      fileWatcher._setDepsForTest({ getFileHandles });
+      setPopulation(true);
+      const events = await fileWatcher.scanAllFileHandles(AI_AGENTS);
+
+      expect(getFileHandles).toHaveBeenCalled();
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0].attribution.evidence).toContain('handle-scan-pid');
+      expect(fileWatcher.getFileSensorHealth()['fs-handle'].state).toBe(
+        SENSOR_HEALTH_STATE.HEALTHY,
+      );
+    });
+  });
+
+  describe('noteFileScanSkip', () => {
+    it('marks the ACTIVE mechanism: RM when the RM path owns observation', () => {
+      fileWatcher._setDepsForTest({ getSensitiveHolders: vi.fn(async () => []) });
+      fileWatcher.noteFileScanSkip('process-observation-unavailable');
+
+      expect(fileWatcher.getFileSensorHealth()['fs-rm'].state).toBe(SENSOR_HEALTH_STATE.DEGRADED);
+      expect(fileWatcher.getFileSensorHealth()['fs-handle'].state).toBe(
+        SENSOR_HEALTH_STATE.STARTING,
+      );
+    });
+
+    it('marks the handle sensor when RM is not the active mechanism', () => {
+      fileWatcher.noteFileScanSkip('process-observation-unavailable');
+
+      expect(fileWatcher.getFileSensorHealth()['fs-handle'].state).toBe(
+        SENSOR_HEALTH_STATE.DEGRADED,
+      );
+    });
+
+    it('never advances lastSuccessAt — a refusal is not a scoped success', async () => {
+      const getFileHandles = vi.fn(async () => []);
+      fileWatcher._setDepsForTest({ getFileHandles });
+      setPopulation(true);
+      await fileWatcher.scanAllFileHandles(AI_AGENTS);
+      const successAt = fileWatcher.getFileSensorHealth()['fs-handle'].lastSuccessAt;
+      expect(successAt).toBeTypeOf('number');
+
+      fileWatcher.noteFileScanSkip('process-observation-unavailable');
+      const handle = fileWatcher.getFileSensorHealth()['fs-handle'];
+      expect(handle.state).toBe(SENSOR_HEALTH_STATE.DEGRADED);
+      expect(handle.lastSuccessAt).toBe(successAt);
+    });
+  });
+});

--- a/tests/main/scan-loop-provider-health.test.js
+++ b/tests/main/scan-loop-provider-health.test.js
@@ -333,6 +333,13 @@ describe('scan-loop provider-health ownership (Stage-1 step A)', () => {
   // ── network leaf ──
 
   describe('network leaf', () => {
+    beforeEach(async () => {
+      // The network scan is gated on population reliability (G′), and a freshly reset
+      // process leaf sits at STARTING. One real enumeration puts it at HEALTHY so these
+      // tests reach the provider at all; the gate itself is proven in its own suite.
+      await scanner.scanProcesses();
+    });
+
     it('a renderer-send throw after a successful provider run leaves the record HEALTHY', async () => {
       const deps = makeDeps({
         getLatestAgents: vi.fn().mockReturnValue(NET_AGENTS),


### PR DESCRIPTION
## Steps A′ + G′/S — the stale-population scope invariant

A hard enumeration failure never reaches `setAgents`, so `latestAgents` keeps the
**previous** population. Every agent-scoped consumer then read a list the process
sensor could not vouch for — and the first four write into the audit log:

| consumer | what a stale list did |
|---|---|
| `doNetworkScan` | queried the TCP table for dead/recycled pids, stamped `os-tcp-owner-pid` → **confirmed** |
| `doFileScan` (RM / handle) | mapped a live holder pid onto a **stale** agent record, stamped `rm-holder-pid` / `handle-scan-pid` → **confirmed** |
| `doHotReadScan` | the same, every ~10 s |
| `handleWatcherEvent` | took `cwd-containment` / `self-config-path` off a stale agent's `cwd` → **inferred** |

> **The invariant:** no agent-scoped observation may be performed against, or
> attributed to, a population the process sensor cannot currently vouch for.

`latestAgents` is **not** cleared. Clearing re-creates the flagship false-clean
("zero agents = nothing running") and buys nothing — the session tracker already
refuses to start, end or age a session on an unreliable scan. The consumers are
gated instead.

### A′ — the capability contract

`process-scanner.getProcessCapabilities()` publishes `populationState`,
`populationReliable`, `populationAsOf`, `identityQuality`. Dependants consume that
struct and never the plane roll-up, which is a display value and would be silently
wrong the moment the `process` leaf itself can degrade. `identityQuality` annotates
and **gates nothing**: the socket→agent and holder→agent matches are by pid, so a
birth witness plays no part in them.

### G′ — per-surface behaviour when the population is not reliable

| surface | behaviour | health |
|---|---|---|
| network | the TCP provider is not called | `noteNetworkSkip('process-observation-unavailable')` → DEGRADED, now reachable on the reliability gate regardless of list length |
| RM / handle / hot-read | do not scan, do not attribute | new `noteFileScanSkip(...)` → DEGRADED on the **active** read mechanism; `lastSuccessAt` never advances |
| chokidar | **stays active** — a path event is valid regardless of who owns it | no health write; only owner inference is skipped, and `latestAiAgents` is not read at all |

The RM and handle paths carry the same guard **in-module**, so the `confirmed` stamp
is impossible regardless of who called them: a gate in `scan-loop` is a scheduling
decision, a gate in `scanViaRestartManager` / `scanAllFileHandles` is the invariant.

### S — the evidence code

`population-unavailable` → `unattributed`. Neither existing negative code fits:
`no-ai-agents-online` asserts nobody was online (possibly false — the population is
*unknown*, not empty) and `no-owner-match` asserts a match was attempted and failed.

### Mutation proofs

Each gate removed on its own, one at a time:

| mutation | red on |
|---|---|
| network gate | the provider is called with the stale pid 4242; unreliable+empty regresses to `confirmed-zero-agents` |
| `doFileScan` gate | `scanAllFileHandles` is called with the stale list |
| `doHotReadScan` gate | `scanHotFileHolders` is called with the stale list |
| chokidar gate | attribution comes back `inferred` / `cwd-containment` with the stale agent's identity |
| in-module RM + handle guards | a `holding` / `accessed` event is emitted, `confirmed`, carrying `instanceId: '100:1700000000000'` |

Every gate is also asserted in its **reliable** half — the provider runs, the stamp is
unchanged — which is what would catch a gate that fires unconditionally.

### Gates

`build:renderer`, `format:check` + `lint` (0 errors), `typecheck` + `typecheck:svelte`
(385 files, 0 errors), `test:coverage` (101 files, 1780 passed / 4 skipped), `npm audit
--audit-level=high --omit=dev` (0 vulnerabilities).

### Not in this PR

- **The `events.ts` typed mirror for `population-unavailable`** — the second half of
  gap S. `src/shared/**` is out of scope for this pass, so `EVIDENCE_CODES` and the
  `AttributionEvidence` union diverge by one code. Nothing breaks: the renderer switches
  on `attribution.status`, never on an individual code, and the write path is guarded by
  `deriveStatus()`. The `attribution.js` JSDoc now states the divergence instead of
  claiming a parity that stopped holding.
- **The `populationStale` display flag** — `getStats()` lives in `main.js`, which is out
  of scope. The four sensor surfaces are gated; the display counts still present the last
  known population unlabelled.
- **Gap F** (`getSnapshotHealth` re-export from `platform/win32.js`) — `identityQuality`
  reads the façade first and falls back to the submodule, so the fallback deletes itself
  when F lands.
- Steps B, C, D, E, M and any plane composition.
