### PR TITLE
feat(main): derive chokidar health from a watch-root plan registry

### DIFF
--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -142,10 +142,15 @@ function createInitialFsHealth() {
 /**
  * Reset FS health records (tests / intentional reinit). Does not clear residual
  * production loss mid-lifetime except by creating new records.
+ *
+ * Drops the watch plan with them: the plan is what writes the chokidar record, so a
+ * plan that outlived its record would recompute W from roots the new record never
+ * saw registered.
  * @returns {void}
  */
 function _resetFsHealth() {
   _fsHealth = createInitialFsHealth();
+  _resetWatchPlan();
 }
 
 /**
@@ -368,24 +373,327 @@ function getIgnoredDirFilter(config) {
     );
 }
 
-function bindWatcherEvents(watcher) {
-  watcher.on('add', (p) => handleWatcherEvent('created', p));
-  watcher.on('change', (p) => handleWatcherEvent('modified', p));
-  watcher.on('unlink', (p) => handleWatcherEvent('deleted', p));
-  // B2: chokidar may keep running after some errors — DEGRADED not FAILED.
-  // No lossCount: chokidar does not expose a quantitative lost-event counter.
-  watcher.on('error', (err) => {
-    const now = Date.now();
-    _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.markDegraded(_fsHealth[FS_SENSOR.CHOKIDAR], now, {
-      error: healthErrorMessage(err),
-      detail: 'chokidar-error',
+// ── Watch-root registry (design §1) ─────────────────────────────────────────────
+// `fs-chokidar` is ONE health record over SEVERAL FSWatcher objects. Reading it off
+// whichever object spoke last made a single `ready` claim the whole mechanism healthy
+// and a single `error` condemn it. The registry separates INTENT (the plan, fixed
+// before the first registration) from OUTCOME (what each root actually did), and W is
+// derived from the whole plan.
+
+/**
+ * The four watch-root groups `setupFileWatchers` registers. Two are preflighted,
+ * two are unconditional — which is why the plan can never be empty (§1.2).
+ * @type {Readonly<Record<string, string>>}
+ * @since 0.12.0
+ */
+const WATCH_GROUP = Object.freeze({
+  CREDENTIAL_DIRS: 'credential-dirs',
+  AGENT_CONFIG_DIRS: 'agent-config-dirs',
+  PROJECT_DIR: 'project-dir',
+  ENV_FILES: 'env-files',
+});
+
+/**
+ * Lifecycle states of one watch root (§1.3).
+ *
+ * `not-applicable` is the ONLY exclusion from the plan, and it rests on a completed
+ * probe — never on a throw. `registration-failed`, `not-attempted` and `errored` are
+ * all terminal: nothing in this module recreates a watcher object (gap P).
+ * @type {Readonly<Record<string, string>>}
+ * @since 0.12.0
+ */
+const WATCH_ROOT_STATE = Object.freeze({
+  NOT_APPLICABLE: 'not-applicable',
+  PLANNED: 'planned',
+  NOT_ATTEMPTED: 'not-attempted',
+  REGISTRATION_FAILED: 'registration-failed',
+  REGISTERED: 'registered',
+  READY: 'ready',
+  ERRORED: 'errored',
+});
+
+/** States that name a planned root as unavailable — a CONFIRMED loss of coverage. */
+const UNAVAILABLE_ROOT_STATES = new Set([
+  WATCH_ROOT_STATE.ERRORED,
+  WATCH_ROOT_STATE.REGISTRATION_FAILED,
+  WATCH_ROOT_STATE.NOT_ATTEMPTED,
+]);
+
+/**
+ * @typedef {Object} WatchRoot
+ * @property {string} id - one of {@link WATCH_GROUP}
+ * @property {string} state - one of {@link WATCH_ROOT_STATE}
+ * @property {object|null} watcher - the LIVE FSWatcher object, or null if none exists
+ * @property {string|null} lastError
+ * @property {number} deliveredCount - callbacks this root has delivered
+ * @property {number|null} lastEventAt
+ */
+
+/**
+ * The plan: planned roots in registration order. Empty until `setupFileWatchers`
+ * builds it, and immutable in membership for the record lifetime.
+ * @type {Map<string, WatchRoot>}
+ */
+let _watchPlan = new Map();
+
+/** Groups a completed preflight proved absent — excluded from the plan (§1.2). */
+let _absentGroups = [];
+
+/** @returns {void} */
+function _resetWatchPlan() {
+  _watchPlan = new Map();
+  _absentGroups = [];
+}
+
+/**
+ * Fix the plan. Called once per health-record lifetime, AFTER both preflights and
+ * BEFORE the first `chokidar.watch` — a registration failure can then never shrink it.
+ * @param {Array<{id: string, applicable: boolean}>} groups - in registration order
+ * @returns {void}
+ */
+function buildWatchPlan(groups) {
+  _resetWatchPlan();
+  for (const g of groups) {
+    if (!g.applicable) {
+      _absentGroups.push(g.id);
+      continue;
+    }
+    _watchPlan.set(g.id, {
+      id: g.id,
+      state: WATCH_ROOT_STATE.PLANNED,
+      watcher: null,
+      lastError: null,
+      deliveredCount: 0,
+      lastEventAt: null,
     });
+  }
+}
+
+/**
+ * @param {string} id
+ * @param {object} watcher - the object `chokidar.watch` returned
+ * @returns {void}
+ */
+function markRootRegistered(id, watcher) {
+  const root = _watchPlan.get(id);
+  if (!root) return;
+  root.state = WATCH_ROOT_STATE.REGISTERED;
+  root.watcher = watcher;
+}
+
+/**
+ * `chokidar.watch` threw for this group — no watcher object exists for it.
+ * @param {string} id
+ * @param {unknown} err
+ * @returns {void}
+ */
+function markRootRegistrationFailed(id, err) {
+  const root = _watchPlan.get(id);
+  if (!root) return;
+  root.state = WATCH_ROOT_STATE.REGISTRATION_FAILED;
+  root.watcher = null;
+  root.lastError = healthErrorMessage(err);
+}
+
+/**
+ * Setup aborted before these groups were reached — their state is read off plan
+ * position, not off anything they did.
+ * @returns {void}
+ */
+function markUnreachedRootsNotAttempted() {
+  for (const root of _watchPlan.values()) {
+    if (root.state === WATCH_ROOT_STATE.PLANNED) {
+      root.state = WATCH_ROOT_STATE.NOT_ATTEMPTED;
+    }
+  }
+}
+
+/**
+ * `ready` fired for this root's watcher object.
+ * @param {string} id
+ * @returns {void}
+ */
+function markRootReady(id) {
+  const root = _watchPlan.get(id);
+  if (!root) return;
+  // §1.4 — `errored` is TERMINAL for this watcher object's lifetime. Whether chokidar
+  // closes itself on a fatal error or hangs silent is unresolved (roadmap U3), so
+  // nothing the same object says afterwards can be read as recovery. Only a NEW object
+  // clears it, and no code creates one today (gap P). Without this guard a root that
+  // errored during its initial walk and then emitted `ready` would count as clean
+  // coverage, and W would reach HEALTHY over a root nobody can vouch for.
+  if (root.state === WATCH_ROOT_STATE.ERRORED) return;
+  root.state = WATCH_ROOT_STATE.READY;
+  applyWatchPlaneHealth(Date.now());
+}
+
+/**
+ * An `error` event arrived for this root. The watcher OBJECT is kept: chokidar may
+ * still be partially operating, and W FAILED is a statement about object existence,
+ * never a count of errors (§1.5).
+ * @param {string} id
+ * @param {unknown} err
+ * @returns {void}
+ */
+function markRootErrored(id, err) {
+  const root = _watchPlan.get(id);
+  if (!root) return;
+  root.state = WATCH_ROOT_STATE.ERRORED;
+  root.lastError = healthErrorMessage(err);
+  applyWatchPlaneHealth(Date.now());
+}
+
+/**
+ * Record that this root delivered one callback. Reality only, and deliberately no
+ * state: a delivered `add`/`change`/`unlink` proves ONE callback arrived, never that
+ * a watcher recovered — §1.4 retracts that claim outright. So it does not clear
+ * `errored`, and it does not promote a `registered` root that never said `ready`.
+ * @param {string} id
+ * @returns {void}
+ */
+function noteRootDelivery(id) {
+  const root = _watchPlan.get(id);
+  if (!root) return;
+  root.deliveredCount += 1;
+  root.lastEventAt = Date.now();
+}
+
+/**
+ * W over the plan — ordered and total (§1.6). Rule 1 before 2 because a root can be
+ * both `errored` and the only live one; rule 2 before 3 because a confirmed failure
+ * outranks a not-yet.
+ * @returns {string} a {@link sensorHealth.SENSOR_HEALTH_STATE} value
+ * @throws {Error} when called with no plan — §1.2 asserts the plan is never empty.
+ */
+function deriveWatchPlaneState() {
+  const roots = [..._watchPlan.values()];
+  if (roots.length === 0) {
+    throw new Error('file-watcher: watch plan is empty');
+  }
+  // 1. Zero live watcher objects — PROVEN zero coverage: there is nothing to observe
+  //    with. This is the only source of FAILED. N `errored` roots are N unknowns, not
+  //    a proven death (§1.5), so error events never reach this line.
+  if (!roots.some((r) => r.watcher !== null)) {
+    return sensorHealth.SENSOR_HEALTH_STATE.FAILED;
+  }
+  // 2. Any planned root confirmed unavailable.
+  if (roots.some((r) => UNAVAILABLE_ROOT_STATES.has(r.state))) {
+    return sensorHealth.SENSOR_HEALTH_STATE.DEGRADED;
+  }
+  // 3. Some root has not proven readiness. A root stuck at `registered` whose `ready`
+  //    never fires holds W here forever — honest under U3, and out of HEALTHY.
+  if (
+    roots.some(
+      (r) => r.state === WATCH_ROOT_STATE.PLANNED || r.state === WATCH_ROOT_STATE.REGISTERED,
+    )
+  ) {
+    return sensorHealth.SENSOR_HEALTH_STATE.STARTING;
+  }
+  return sensorHealth.SENSOR_HEALTH_STATE.HEALTHY;
+}
+
+/**
+ * `<id>:<reason>` for every unavailable root, in PLAN order so the string does not
+ * depend on which event happened to land first.
+ * @returns {string}
+ */
+function unavailableRootSummary() {
+  const parts = [];
+  for (const root of _watchPlan.values()) {
+    if (UNAVAILABLE_ROOT_STATES.has(root.state)) {
+      parts.push(`${root.id}:${root.lastError || root.state}`);
+    }
+  }
+  return parts.join('; ').slice(0, 200);
+}
+
+/**
+ * Write the derived W into the existing `fs-chokidar` record. The record is the
+ * mechanism's health; the plan is where its state now comes from.
+ *
+ * STARTING is not written: `createSensorHealth` already starts the record there,
+ * sensor-health has no markStarting, and a plan only ever leaves STARTING forward —
+ * roots never return to `planned`/`registered`, and every unavailable state is
+ * terminal. Consequence worth naming: `lastSuccessAt` now advances only when EVERY
+ * planned root is ready, where before one `ready` advanced it for all of them.
+ * @param {number} now
+ * @returns {void}
+ */
+function applyWatchPlaneHealth(now) {
+  const state = deriveWatchPlaneState();
+  const rec = _fsHealth[FS_SENSOR.CHOKIDAR];
+  if (state === sensorHealth.SENSOR_HEALTH_STATE.FAILED) {
+    _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.markFailed(rec, now, {
+      error: unavailableRootSummary() || 'no-live-watcher',
+      detail: 'no-live-watcher',
+    });
+  } else if (state === sensorHealth.SENSOR_HEALTH_STATE.DEGRADED) {
+    // No lossCount: chokidar exposes no quantitative lost-event counter.
+    _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.markDegraded(rec, now, {
+      error: unavailableRootSummary(),
+      detail: 'watch-roots-unavailable',
+    });
+  } else if (state === sensorHealth.SENSOR_HEALTH_STATE.HEALTHY) {
+    _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.markHealthy(rec, now);
+  }
+}
+
+/**
+ * Plain serializable view of the plan — callers must not mutate. The live FSWatcher
+ * objects are deliberately not exposed; `hasLiveWatcher` is the only fact about them
+ * W is allowed to rest on.
+ * @returns {{state: string, groups: Array<object>, absentGroups: string[], liveWatcherCount: number, unavailableGroups: Array<{id: string, state: string, reason: string}>}}
+ * @since 0.12.0
+ */
+function getWatchPlan() {
+  const groups = [..._watchPlan.values()].map((r) => ({
+    id: r.id,
+    state: r.state,
+    hasLiveWatcher: r.watcher !== null,
+    lastError: r.lastError,
+    deliveredCount: r.deliveredCount,
+    lastEventAt: r.lastEventAt,
+  }));
+  return {
+    // Before setup has run there is no plan, and deriving from an empty one is the
+    // case §1.2 asserts away rather than branches on — so report the record's own
+    // starting state instead of throwing out of a getter.
+    state:
+      groups.length === 0 ? sensorHealth.SENSOR_HEALTH_STATE.STARTING : deriveWatchPlaneState(),
+    groups,
+    absentGroups: [..._absentGroups],
+    liveWatcherCount: groups.filter((g) => g.hasLiveWatcher).length,
+    unavailableGroups: groups
+      .filter((g) => UNAVAILABLE_ROOT_STATES.has(g.state))
+      .map((g) => ({ id: g.id, state: g.state, reason: g.lastError || g.state })),
+  };
+}
+
+/**
+ * @param {object} watcher - the FSWatcher this binding belongs to
+ * @param {string} rootId - the watch group it was registered for
+ * @returns {void}
+ */
+function bindWatcherEvents(watcher, rootId) {
+  // noteRootDelivery lives HERE, not in handleWatcherEvent: the handler is exported
+  // and called directly with no root context by the attribution/ignore suites.
+  watcher.on('add', (p) => {
+    noteRootDelivery(rootId);
+    handleWatcherEvent('created', p);
   });
-  // ready = successful initialization of this FSWatcher instance.
-  watcher.on('ready', () => {
-    const now = Date.now();
-    _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.markHealthy(_fsHealth[FS_SENSOR.CHOKIDAR], now);
+  watcher.on('change', (p) => {
+    noteRootDelivery(rootId);
+    handleWatcherEvent('modified', p);
   });
+  watcher.on('unlink', (p) => {
+    noteRootDelivery(rootId);
+    handleWatcherEvent('deleted', p);
+  });
+  // B2: chokidar may keep running after some errors — DEGRADED not FAILED, and the
+  // scope of the degradation is this ROOT, not the mechanism.
+  watcher.on('error', (err) => markRootErrored(rootId, err));
+  // ready = successful initialization of this FSWatcher instance — that one root.
+  watcher.on('ready', () => markRootReady(rootId));
 }
 
 function handleWatcherEvent(action, filePath) {
@@ -478,63 +786,113 @@ function handleWatcherEvent(action, filePath) {
   if (_state.onFileEvent) _state.onFileEvent(event);
 }
 
-/** @returns {Promise<void>} @since v0.1.0 */
+/**
+ * Register the production watch roots and record what each one actually did.
+ *
+ * The rejection is deliberately re-thrown after the plan is written: main.js already
+ * reports it (`File watcher setup failed`), and this module owns the plan (§10 step B).
+ * @returns {Promise<void>}
+ * @throws {Error} whatever `chokidar.watch` threw, after the plan records the abort.
+ * @since v0.1.0
+ */
 async function setupFileWatchers() {
-  // Reinit chokidar health lifetime when production recreates the watcher set.
-  _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.createSensorHealth(FS_SENSOR.CHOKIDAR);
   const homeDir = os.homedir();
-  const sensitiveDirCandidates = SENSITIVE_AGENT_DIRS.map((d) => path.join(homeDir, d));
-  const sensitiveDirs = await filterExistingDirs(sensitiveDirCandidates);
   const projectDir = path.join(__dirname, '..', '..');
-  if (sensitiveDirs.length > 0) {
-    const w = chokidar.watch(sensitiveDirs, {
-      persistent: true,
-      ignoreInitial: true,
-      usePolling: false,
-      followSymlinks: false,
-      depth: 1,
-    });
-    bindWatcherEvents(w);
-    _state.watchers.push(w);
-  }
+  // BOTH preflights complete before ANY registration (§1.2). The plan separates
+  // intent from outcome: a group may leave it only because a completed probe proved
+  // there is nothing to watch — never because a registration threw. Under the old
+  // order the second probe ran after the first `chokidar.watch`, so an abort in
+  // between produced a plan that had never heard of the agent-config group, and one
+  // ready root was enough to call the whole mechanism HEALTHY.
+  const sensitiveDirs = await filterExistingDirs(
+    SENSITIVE_AGENT_DIRS.map((d) => path.join(homeDir, d)),
+  );
   // AI agent config directories (Hudson Rock threat vector — critical)
   const sensitiveDirNames = new Set(SENSITIVE_AGENT_DIRS);
-  const agentConfigCandidates = AGENT_CONFIG_PATHS.filter((d) => !sensitiveDirNames.has(d)).map(
-    (d) => path.join(homeDir, d),
+  const agentConfigDirs = await filterExistingDirs(
+    AGENT_CONFIG_PATHS.filter((d) => !sensitiveDirNames.has(d)).map((d) => path.join(homeDir, d)),
   );
-  const agentConfigDirs = await filterExistingDirs(agentConfigCandidates);
-  if (agentConfigDirs.length > 0) {
-    const cw = chokidar.watch(agentConfigDirs, {
-      persistent: true,
-      ignoreInitial: true,
-      usePolling: false,
-      followSymlinks: false,
-      depth: 2,
-    });
-    bindWatcherEvents(cw);
-    _state.watchers.push(cw);
+  // Reinit chokidar health lifetime when production recreates the watcher set — and
+  // the plan with it, since the plan is what writes into that record.
+  _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.createSensorHealth(FS_SENSOR.CHOKIDAR);
+  buildWatchPlan([
+    { id: WATCH_GROUP.CREDENTIAL_DIRS, applicable: sensitiveDirs.length > 0 },
+    { id: WATCH_GROUP.AGENT_CONFIG_DIRS, applicable: agentConfigDirs.length > 0 },
+    // Unconditional: no preflight can exclude them, so the plan is never empty.
+    { id: WATCH_GROUP.PROJECT_DIR, applicable: true },
+    { id: WATCH_GROUP.ENV_FILES, applicable: true },
+  ]);
+  /** @type {string|null} The group whose registration is in flight. */
+  let attempted = null;
+  try {
+    const config = _state.getSettings ? _state.getSettings() : {};
+    const dirFilter = getIgnoredDirFilter(config);
+    /** Registration order IS plan order — `not-attempted` is read off plan position. */
+    const registrations = [
+      [
+        WATCH_GROUP.CREDENTIAL_DIRS,
+        () =>
+          chokidar.watch(sensitiveDirs, {
+            persistent: true,
+            ignoreInitial: true,
+            usePolling: false,
+            followSymlinks: false,
+            depth: 1,
+          }),
+      ],
+      [
+        WATCH_GROUP.AGENT_CONFIG_DIRS,
+        () =>
+          chokidar.watch(agentConfigDirs, {
+            persistent: true,
+            ignoreInitial: true,
+            usePolling: false,
+            followSymlinks: false,
+            depth: 2,
+          }),
+      ],
+      [
+        WATCH_GROUP.PROJECT_DIR,
+        () =>
+          chokidar.watch(projectDir, {
+            persistent: true,
+            ignoreInitial: true,
+            ignored: (filePath) => dirFilter(filePath) || /package-lock\.json$/.test(filePath),
+            usePolling: false,
+            followSymlinks: false,
+            depth: 5,
+          }),
+      ],
+      [
+        WATCH_GROUP.ENV_FILES,
+        () =>
+          chokidar.watch(path.join(homeDir, '.env*'), {
+            persistent: true,
+            ignoreInitial: true,
+            depth: 0,
+            usePolling: false,
+            followSymlinks: false,
+          }),
+      ],
+    ];
+    for (const [id, register] of registrations) {
+      if (!_watchPlan.has(id)) continue; // not-applicable — proven absent by preflight
+      attempted = id;
+      const w = register();
+      markRootRegistered(id, w);
+      bindWatcherEvents(w, id);
+      _state.watchers.push(w);
+    }
+  } catch (err) {
+    // §1.3: the group that threw is `registration-failed`; every planned group the
+    // loop never reached is `not-attempted`, read off plan position. Both are recorded
+    // before the rejection leaves this function.
+    if (attempted) markRootRegistrationFailed(attempted, err);
+    markUnreachedRootsNotAttempted();
+    applyWatchPlaneHealth(Date.now());
+    throw err;
   }
-  const config = _state.getSettings ? _state.getSettings() : {};
-  const dirFilter = getIgnoredDirFilter(config);
-  const pw = chokidar.watch(projectDir, {
-    persistent: true,
-    ignoreInitial: true,
-    ignored: (filePath) => dirFilter(filePath) || /package-lock\.json$/.test(filePath),
-    usePolling: false,
-    followSymlinks: false,
-    depth: 5,
-  });
-  bindWatcherEvents(pw);
-  _state.watchers.push(pw);
-  const ew = chokidar.watch(path.join(homeDir, '.env*'), {
-    persistent: true,
-    ignoreInitial: true,
-    depth: 0,
-    usePolling: false,
-    followSymlinks: false,
-  });
-  bindWatcherEvents(ew);
-  _state.watchers.push(ew);
+  applyWatchPlaneHealth(Date.now());
 }
 
 /**
@@ -964,8 +1322,11 @@ module.exports = {
   handleWatcherEvent,
   getIgnoredDirFilter,
   getFileSensorHealth,
+  getWatchPlan,
   noteFileScanSkip,
   FS_SENSOR,
+  WATCH_GROUP,
+  WATCH_ROOT_STATE,
   DEFAULT_IGNORED_DIRS,
   FILE_SCAN_CONCURRENCY,
   _setDepsForTest,

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -35,7 +35,15 @@ export type AttributionEvidence =
   | 'self-config-path'
   | 'cwd-containment'
   | 'no-owner-match'
-  | 'no-ai-agents-online';
+  | 'no-ai-agents-online'
+  /**
+   * The process sensor could not vouch for the agent population at this instant, so no
+   * owner was looked for. Distinct from both other negative codes: `no-ai-agents-online`
+   * asserts nobody was online, `no-owner-match` asserts a match was attempted — here the
+   * population is UNKNOWN and no match ran. The path observation itself stays valid.
+   * @since v0.12.0
+   */
+  | 'population-unavailable';
 
 /**
  * Attribution record carried by a file event. Deliberately carries NO numeric

--- a/tests/main/file-watcher-attribution.test.js
+++ b/tests/main/file-watcher-attribution.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'fs';
 import fileWatcher from '../../src/main/file-watcher.js';
 import { EVIDENCE_CODES, deriveStatus } from '../../src/main/attribution.js';
 
@@ -283,8 +284,6 @@ describe('attribution evidence is a closed list (case 8)', () => {
     // The list is closed on purpose and deriveStatus throws on anything outside it, so this
     // assertion is the gate: adding a code means deciding its status here, in events.ts, and
     // in PID_EVIDENCE/HEURISTIC_EVIDENCE — not just at a call site.
-    // `population-unavailable` is the exception on the events.ts half: the typed mirror is
-    // the second part of gap S and ships in the pass allowed to edit src/shared/.
     expect([...EVIDENCE_CODES]).toEqual([
       'rm-holder-pid',
       'handle-scan-pid',
@@ -301,6 +300,25 @@ describe('attribution evidence is a closed list (case 8)', () => {
     // It must never read as PID proof or as a heuristic match: nothing was matched,
     // and the reason is that there was no trustworthy list to match against.
     expect(deriveStatus(['population-unavailable'])).toBe('unattributed');
+  });
+
+  it('the typed AttributionEvidence union mirrors EVIDENCE_CODES exactly', () => {
+    // The union is the enforced boundary for every TypeScript consumer, and `tsc` cannot
+    // see the runtime list — so nothing but this test connects the two halves of a closed
+    // list that lives in two languages. Order included: EVIDENCE_CODES is declaration
+    // order, and a mirror that agrees only as a set hides which code was appended where.
+    const src = readFileSync(new URL('../../src/shared/types/events.ts', import.meta.url), 'utf-8');
+    const union = src.match(/export type AttributionEvidence =([\s\S]*?);/);
+    expect(union).not.toBeNull();
+    // Strip the per-member JSDoc first: a comment may legally contain quoted text, and a
+    // naive literal scan would then read prose as a member.
+    const members = [
+      ...union[1]
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/.*$/gm, '')
+        .matchAll(/'([^']+)'/g),
+    ].map((m) => m[1]);
+    expect(members).toEqual([...EVIDENCE_CODES]);
   });
 
   it('every code emitted by real watcher events belongs to the closed list', async () => {

--- a/tests/main/file-watcher-subscription.test.js
+++ b/tests/main/file-watcher-subscription.test.js
@@ -234,13 +234,17 @@ describe('file-watcher production subscription wiring (F-S01)', () => {
     expect(state.onFileEvent).not.toHaveBeenCalled();
   });
 
-  it('B2: setup starts fs-chokidar STARTING; ready → HEALTHY; error → DEGRADED', async () => {
+  it('B2: setup starts fs-chokidar STARTING; ALL roots ready → HEALTHY; error → DEGRADED', async () => {
     const state = makeState();
     fileWatcher.init(state);
     await fileWatcher.setupFileWatchers();
     expect(fileWatcher.getFileSensorHealth()['fs-chokidar'].state).toBe('STARTING');
 
-    fakeWatchers[0].emit('ready');
+    // Step B: the record covers the whole watch plan, so readiness is total over it —
+    // one root's `ready` no longer speaks for the mechanism. The registry's own suite
+    // (file-watcher-watch-roots.test.js) pins the partial case; here the point is that
+    // the B2 record still ends up where B2 said it would.
+    for (const w of fakeWatchers) w.emit('ready');
     expect(fileWatcher.getFileSensorHealth()['fs-chokidar'].state).toBe('HEALTHY');
 
     fakeWatchers[0].emit('error', new Error('watch failed'));

--- a/tests/main/file-watcher-watch-roots.test.js
+++ b/tests/main/file-watcher-watch-roots.test.js
@@ -1,0 +1,423 @@
+/**
+ * Step B — the chokidar watch-root registry and the W-plane lifecycle derived from it.
+ *
+ * `fs-chokidar` is ONE health record over SEVERAL FSWatcher objects. The defect this
+ * suite pins is that the record used to be written by whichever object spoke last: one
+ * `ready` made the whole mechanism HEALTHY even while three other roots had never been
+ * registered, and the "expected set" was whatever setup happened to reach, so an abort
+ * after the first successful `chokidar.watch` produced a plan of exactly one root and a
+ * falsely clean W.
+ *
+ * Three rules carry the correction, and each has a test written to go red if the rule is
+ * removed rather than merely to describe it:
+ *   (a) `errored` is terminal — nothing the same watcher object says afterwards clears it
+ *       (chokidar's post-error semantics are unresolved, roadmap U3);
+ *   (b) W FAILED comes from ZERO live watcher objects and from nothing else — N errored
+ *       roots are N unknowns, not a proven death;
+ *   (c) a delivered add/change/unlink is recorded as a delivery and moves no state.
+ *
+ * Nothing here spies on file-watcher itself: the module under test is the real one, with
+ * only `chokidar.watch` and the preflight `fs.promises.access` replaced — the two edges
+ * that would otherwise touch the host filesystem and make the plan host-dependent.
+ */
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import Module from 'module';
+import path from 'path';
+import os from 'os';
+import { createRequire } from 'module';
+
+const require_ = createRequire(import.meta.url);
+const fsMod = require_('fs');
+const originalLoad = Module._load;
+
+/** @type {typeof import('../../src/main/file-watcher.js')} */
+let fileWatcher;
+/** @type {Array<{on: Function, close: Function, emit: Function, _paths: unknown}>} */
+let fakeWatchers = [];
+/** The plan exactly as it stood when `chokidar.watch` was called for the FIRST time. */
+let planAtFirstRegistration = null;
+
+/**
+ * @param {{failOnCall?: number|null}} [opts] - 1-based index of the watch() call that throws
+ * @returns {void}
+ */
+function installChokidarMock({ failOnCall = null } = {}) {
+  fakeWatchers = [];
+  planAtFirstRegistration = null;
+  let calls = 0;
+  const watchMock = vi.fn((paths) => {
+    calls += 1;
+    // Read the plan from INSIDE the first registration: this is the direct evidence
+    // that the plan was fixed before any watcher existed, not assembled as they came.
+    if (calls === 1) planAtFirstRegistration = fileWatcher.getWatchPlan();
+    if (failOnCall !== null && calls === failOnCall) {
+      throw new Error(`watch refused #${calls}`);
+    }
+    const handlers = new Map();
+    const w = {
+      on: vi.fn((event, cb) => {
+        if (!handlers.has(event)) handlers.set(event, []);
+        handlers.get(event).push(cb);
+        return w;
+      }),
+      close: vi.fn(),
+      _paths: paths,
+      emit(event, ...args) {
+        for (const cb of handlers.get(event) || []) cb(...args);
+      },
+    };
+    fakeWatchers.push(w);
+    return w;
+  });
+
+  Module._load = function (request) {
+    if (request === 'chokidar') return { watch: watchMock };
+    return originalLoad.apply(this, arguments);
+  };
+}
+
+function loadFileWatcher() {
+  const fwPath = require_.resolve('../../src/main/file-watcher.js');
+  delete require_.cache[fwPath];
+  return require_('../../src/main/file-watcher.js');
+}
+
+function restoreChokidar() {
+  Module._load = originalLoad;
+  const fwPath = require_.resolve('../../src/main/file-watcher.js');
+  delete require_.cache[fwPath];
+  try {
+    delete require_.cache[require_.resolve('chokidar')];
+  } catch {
+    // optional if resolve fails after the mock
+  }
+}
+
+/**
+ * Decide the preflight outcome for the whole run. Without this the plan depends on
+ * which dot-directories exist in the runner's home — four groups on a developer box,
+ * two on a fresh CI runner — and every count assertion below would be host-luck.
+ * @param {boolean} present
+ * @returns {void}
+ */
+function stubPreflight(present) {
+  vi.spyOn(fsMod.promises, 'access').mockImplementation(async () => {
+    if (!present) throw new Error('ENOENT');
+  });
+}
+
+function makeState(overrides = {}) {
+  return {
+    getCustomRules: () => [],
+    getSettings: () => ({}),
+    getLatestAgents: () => [],
+    getLatestAiAgents: () => [],
+    isMonitoringPaused: () => false,
+    isOtherPanelExpanded: () => false,
+    activityLog: [],
+    knownHandles: new Map(),
+    watchers: [],
+    recordFileAccess: vi.fn(),
+    onFileEvent: vi.fn(),
+    onActivityPush: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Non-ignored path, so a delivered event reaches the real processing path. */
+function samplePath(name) {
+  return path.join(os.tmpdir(), name);
+}
+
+const ALL_GROUPS = ['credential-dirs', 'agent-config-dirs', 'project-dir', 'env-files'];
+
+/** @param {object} plan @returns {string[]} */
+function ids(plan) {
+  return plan.groups.map((g) => g.id);
+}
+
+/** @param {object} plan @param {string} id @returns {object} */
+function root(plan, id) {
+  const found = plan.groups.find((g) => g.id === id);
+  expect(found, `group ${id} missing from the plan`).toBeDefined();
+  return found;
+}
+
+function chokidarHealth() {
+  return fileWatcher.getFileSensorHealth()['fs-chokidar'];
+}
+
+/** Every watcher created so far reports a successful initialization. */
+function readyAll() {
+  for (const w of fakeWatchers) w.emit('ready');
+}
+
+describe('chokidar watch-root registry (step B)', () => {
+  let state;
+
+  beforeEach(() => {
+    installChokidarMock();
+    fileWatcher = loadFileWatcher();
+    state = makeState();
+    fileWatcher.init(state);
+    fileWatcher._resetForTest();
+    stubPreflight(true);
+  });
+
+  afterEach(() => {
+    fileWatcher._resetForTest();
+    vi.restoreAllMocks();
+    restoreChokidar();
+  });
+
+  afterAll(() => {
+    restoreChokidar();
+  });
+
+  describe('the plan (§1.2)', () => {
+    it('is complete at the first registration, and every root is still only planned', async () => {
+      await fileWatcher.setupFileWatchers();
+
+      expect(ids(planAtFirstRegistration)).toEqual(ALL_GROUPS);
+      expect(planAtFirstRegistration.liveWatcherCount).toBe(0);
+      for (const g of planAtFirstRegistration.groups) {
+        expect(g.state).toBe(fileWatcher.WATCH_ROOT_STATE.PLANNED);
+        expect(g.hasLiveWatcher).toBe(false);
+      }
+      // Membership is immutable for the record lifetime — registration only fills it in.
+      expect(ids(fileWatcher.getWatchPlan())).toEqual(ids(planAtFirstRegistration));
+    });
+
+    it('excludes a group ONLY on a completed probe, and keeps it out of W', async () => {
+      stubPreflight(false);
+
+      await fileWatcher.setupFileWatchers();
+      const plan = fileWatcher.getWatchPlan();
+
+      expect(ids(plan)).toEqual(['project-dir', 'env-files']);
+      expect(plan.absentGroups).toEqual(['credential-dirs', 'agent-config-dirs']);
+      // Plan ∪ absent is total over the four groups: nothing is silently forgotten.
+      expect([...ids(plan), ...plan.absentGroups].sort()).toEqual([...ALL_GROUPS].sort());
+      // A proven-absent group must not hold the mechanism below HEALTHY forever.
+      readyAll();
+      expect(fileWatcher.getWatchPlan().state).toBe('HEALTHY');
+    });
+
+    it('does not shrink to the groups registration reached', async () => {
+      restoreChokidar();
+      installChokidarMock({ failOnCall: 1 });
+      fileWatcher = loadFileWatcher();
+      fileWatcher.init(state);
+      fileWatcher._resetForTest();
+      stubPreflight(true);
+
+      await expect(fileWatcher.setupFileWatchers()).rejects.toThrow(/watch refused #1/);
+
+      const plan = fileWatcher.getWatchPlan();
+      // The old code computed the expected set from what setup managed to register —
+      // an abort here would have left a one-root (or empty) denominator.
+      expect(ids(plan)).toEqual(ALL_GROUPS);
+      expect(ids(plan)).toEqual(ids(planAtFirstRegistration));
+      expect(root(plan, 'credential-dirs').state).toBe(
+        fileWatcher.WATCH_ROOT_STATE.REGISTRATION_FAILED,
+      );
+      expect(root(plan, 'credential-dirs').lastError).toMatch(/watch refused #1/);
+      for (const id of ['agent-config-dirs', 'project-dir', 'env-files']) {
+        expect(root(plan, id).state).toBe(fileWatcher.WATCH_ROOT_STATE.NOT_ATTEMPTED);
+        expect(root(plan, id).hasLiveWatcher).toBe(false);
+      }
+    });
+  });
+
+  describe('W FAILED comes from zero live watcher objects (§1.5)', () => {
+    it('an abort before any watcher exists is FAILED on the fs-chokidar record', async () => {
+      restoreChokidar();
+      installChokidarMock({ failOnCall: 1 });
+      fileWatcher = loadFileWatcher();
+      fileWatcher.init(state);
+      fileWatcher._resetForTest();
+      stubPreflight(true);
+
+      await expect(fileWatcher.setupFileWatchers()).rejects.toThrow(/watch refused #1/);
+
+      const plan = fileWatcher.getWatchPlan();
+      expect(plan.liveWatcherCount).toBe(0);
+      expect(plan.state).toBe('FAILED');
+      const h = chokidarHealth();
+      expect(h.state).toBe('FAILED');
+      expect(h.detail).toBe('no-live-watcher');
+      expect(h.lastError).toMatch(/credential-dirs:watch refused #1/);
+      expect(h.lastError).toMatch(/env-files:not-attempted/);
+    });
+
+    it('a partial abort keeps the live root and lands on DEGRADED, not FAILED', async () => {
+      restoreChokidar();
+      installChokidarMock({ failOnCall: 2 });
+      fileWatcher = loadFileWatcher();
+      fileWatcher.init(state);
+      fileWatcher._resetForTest();
+      stubPreflight(true);
+
+      await expect(fileWatcher.setupFileWatchers()).rejects.toThrow(/watch refused #2/);
+
+      const plan = fileWatcher.getWatchPlan();
+      expect(plan.liveWatcherCount).toBe(1);
+      expect(root(plan, 'credential-dirs').state).toBe(fileWatcher.WATCH_ROOT_STATE.REGISTERED);
+      expect(root(plan, 'agent-config-dirs').state).toBe(
+        fileWatcher.WATCH_ROOT_STATE.REGISTRATION_FAILED,
+      );
+      expect(plan.state).toBe('DEGRADED');
+      expect(chokidarHealth().state).toBe('DEGRADED');
+      expect(chokidarHealth().detail).toBe('watch-roots-unavailable');
+      expect(plan.unavailableGroups.map((g) => g.id)).toEqual([
+        'agent-config-dirs',
+        'project-dir',
+        'env-files',
+      ]);
+    });
+
+    it('EVERY root errored is still DEGRADED — an error event proves nothing about the object', async () => {
+      // Mutation target (b): deriving FAILED from "all planned groups errored" flips this
+      // to FAILED. chokidar is classified DEGRADED on error precisely because it may keep
+      // partially operating; counting unknowns does not turn them into a proven zero.
+      await fileWatcher.setupFileWatchers();
+      readyAll();
+      expect(fileWatcher.getWatchPlan().state).toBe('HEALTHY');
+
+      for (const w of fakeWatchers) w.emit('error', new Error('EPERM scandir'));
+
+      const plan = fileWatcher.getWatchPlan();
+      expect(plan.groups.every((g) => g.state === fileWatcher.WATCH_ROOT_STATE.ERRORED)).toBe(true);
+      // Every object still exists — that is the fact FAILED is allowed to rest on.
+      expect(plan.liveWatcherCount).toBe(plan.groups.length);
+      expect(plan.state).toBe('DEGRADED');
+      const h = chokidarHealth();
+      expect(h.state).toBe('DEGRADED');
+      expect(h.consecutiveFailures).toBe(0);
+      expect(h.lossCount).toBe(0); // no quantitative lost-event counter exists
+    });
+  });
+
+  describe('readiness is total over the plan (§1.6)', () => {
+    it('one ready root no longer speaks for the mechanism', async () => {
+      await fileWatcher.setupFileWatchers();
+      expect(fileWatcher.getWatchPlan().state).toBe('STARTING');
+      expect(chokidarHealth().state).toBe('STARTING');
+
+      for (const w of fakeWatchers.slice(0, -1)) w.emit('ready');
+
+      expect(fileWatcher.getWatchPlan().state).toBe('STARTING');
+      const partial = chokidarHealth();
+      expect(partial.state).toBe('STARTING');
+      // The honest consequence of the correction: no success is claimed until the
+      // whole plan is ready, so lastSuccessAt cannot advance on one root's ready.
+      expect(partial.lastSuccessAt).toBeNull();
+
+      fakeWatchers[fakeWatchers.length - 1].emit('ready');
+
+      expect(fileWatcher.getWatchPlan().state).toBe('HEALTHY');
+      const full = chokidarHealth();
+      expect(full.state).toBe('HEALTHY');
+      expect(full.lastSuccessAt).toBeTypeOf('number');
+    });
+
+    it('one errored root degrades the mechanism and names itself in the record', async () => {
+      await fileWatcher.setupFileWatchers();
+      readyAll();
+
+      fakeWatchers[1].emit('error', new Error('watch failed'));
+
+      const plan = fileWatcher.getWatchPlan();
+      expect(plan.unavailableGroups).toEqual([
+        { id: 'agent-config-dirs', state: 'errored', reason: 'watch failed' },
+      ]);
+      expect(plan.state).toBe('DEGRADED');
+      expect(root(plan, 'project-dir').state).toBe(fileWatcher.WATCH_ROOT_STATE.READY);
+      const h = chokidarHealth();
+      expect(h.state).toBe('DEGRADED');
+      expect(h.lastError).toMatch(/watch failed/);
+    });
+  });
+
+  describe('errored is terminal (§1.4, gap P)', () => {
+    it('a later ready from the same object does NOT return the root to ready', async () => {
+      // Mutation target (a): deleting the ERRORED guard in markRootReady turns this
+      // green-to-red. chokidar routinely emits an error during its initial walk and then
+      // `ready` on the same object — without the guard the mechanism reaches HEALTHY over
+      // a root nobody can vouch for.
+      await fileWatcher.setupFileWatchers();
+      fakeWatchers[0].emit('error', new Error('EPERM scandir'));
+
+      readyAll();
+
+      const plan = fileWatcher.getWatchPlan();
+      expect(root(plan, 'credential-dirs').state).toBe(fileWatcher.WATCH_ROOT_STATE.ERRORED);
+      expect(root(plan, 'project-dir').state).toBe(fileWatcher.WATCH_ROOT_STATE.READY);
+      expect(plan.state).toBe('DEGRADED');
+      expect(chokidarHealth().state).toBe('DEGRADED');
+    });
+
+    it('a delivered event is recorded as a delivery and clears nothing', async () => {
+      // Mutation target (c): the retracted v2 §E.3 rule — "a delivered event returns the
+      // root to ready" — reinstated in noteRootDelivery turns this red. A delivered
+      // callback proves ONE callback arrived, which is not recovery (U3).
+      await fileWatcher.setupFileWatchers();
+      readyAll();
+      fakeWatchers[0].emit('error', new Error('EPERM scandir'));
+
+      fakeWatchers[0].emit('change', samplePath('watch-root-delivery.js'));
+
+      const plan = fileWatcher.getWatchPlan();
+      const errored = root(plan, 'credential-dirs');
+      expect(errored.state).toBe(fileWatcher.WATCH_ROOT_STATE.ERRORED);
+      expect(errored.deliveredCount).toBe(1);
+      expect(errored.lastEventAt).toBeTypeOf('number');
+      expect(plan.state).toBe('DEGRADED');
+      expect(chokidarHealth().state).toBe('DEGRADED');
+      // …and the event itself is NOT dropped: chokidar keeps observing, the plane is
+      // simply honest about not being able to vouch for that root's coverage.
+      expect(state.activityLog).toHaveLength(1);
+      expect(state.activityLog[0].action).toBe('modified');
+    });
+
+    it('counts deliveries per root, not per mechanism', async () => {
+      await fileWatcher.setupFileWatchers();
+
+      fakeWatchers[0].emit('add', samplePath('watch-root-a.js'));
+      fakeWatchers[2].emit('add', samplePath('watch-root-b.js'));
+      fakeWatchers[2].emit('unlink', samplePath('watch-root-c.js'));
+
+      const plan = fileWatcher.getWatchPlan();
+      expect(root(plan, 'credential-dirs').deliveredCount).toBe(1);
+      expect(root(plan, 'project-dir').deliveredCount).toBe(2);
+      expect(root(plan, 'env-files').deliveredCount).toBe(0);
+      // Delivery never promotes a root that has not said `ready`.
+      expect(root(plan, 'project-dir').state).toBe(fileWatcher.WATCH_ROOT_STATE.REGISTERED);
+      expect(plan.state).toBe('STARTING');
+    });
+  });
+
+  it('reports no plan at all before setup has run, without throwing', () => {
+    const plan = fileWatcher.getWatchPlan();
+    expect(plan).toEqual({
+      state: 'STARTING',
+      groups: [],
+      absentGroups: [],
+      liveWatcherCount: 0,
+      unavailableGroups: [],
+    });
+  });
+
+  it('registers exactly one handler per event on every root', async () => {
+    await fileWatcher.setupFileWatchers();
+
+    expect(fakeWatchers).toHaveLength(ALL_GROUPS.length);
+    for (const w of fakeWatchers) {
+      const events = w.on.mock.calls.map((c) => c[0]);
+      for (const e of ['add', 'change', 'unlink', 'error', 'ready']) {
+        expect(events.filter((x) => x === e)).toHaveLength(1);
+      }
+    }
+    expect(state.watchers).toEqual(fakeWatchers);
+  });
+});


### PR DESCRIPTION
Step **B** of the app-state design delta v3 (section 1), plus the leftover typed half of step **S**.

## The defect

`fs-chokidar` is ONE health record over SEVERAL `FSWatcher` objects, and it was written by whichever object spoke last. One `ready` marked the whole mechanism HEALTHY while three other roots had never been registered; one `error` condemned all four. The "expected set" was whatever setup happened to reach, so an abort after the first successful `chokidar.watch` produced a denominator of one — falsely HEALTHY on a partial setup.

## What changed

**Plan before registration (section 1.2).** Both preflights (`filterExistingDirs`) now complete before the first `chokidar.watch`. The plan is built from the completed probes and is immutable in membership for the record lifetime. A group leaves the plan only as `not-applicable` — proven absent by a probe — never because a registration threw. `project-dir` and `env-files` are unconditional, so the plan is never empty.

**Honest outcome states (section 1.3).** `planned` / `registered` / `ready` / `errored`, plus `registration-failed` recorded at the throw point and `not-attempted` for every planned group the loop never reached. The rejection is re-thrown afterwards; `main.js` reports it exactly as before and is not touched.

**`errored` is terminal (section 1.4).** Whether chokidar closes itself on a fatal error or hangs silent is unresolved (roadmap U3), so nothing the same watcher object says afterwards is read as recovery — not a later `ready`, not a delivered `add`/`change`/`unlink`. Only a new watcher object could clear it, and nothing creates one: watcher recreation stays **gap P**, DEFERRED. The registry records reality, it does not repair it.

**W FAILED means zero live watcher objects, and only that (section 1.5).** N errored roots are N unknowns, not a proven death, so error events never reach the FAILED branch. The derived plane state is written into the existing `fs-chokidar` record; `aggregateSensorHealth` is unchanged.

**Step S, typed half.** `population-unavailable` joins the `AttributionEvidence` union in `src/shared/types/events.ts`, so it mirrors `EVIDENCE_CODES` again. A new test parses `events.ts` and compares the two lists in declaration order — nothing else connects a closed list that lives in two languages.

## Proof by mutation

Each rule has a test written to go red when the rule is removed, not merely to describe it:

| mutation | test that goes red |
|---|---|
| delete the `errored` guard in `markRootReady` | `a later ready from the same object does NOT return the root to ready` — got `ready`, expected `errored` |
| add `every root errored -> FAILED` to the derivation | `EVERY root errored is still DEGRADED` — got `FAILED`, expected `DEGRADED` |
| reinstate the retracted "a delivered event returns the root to ready" | `a delivered event is recorded as a delivery and clears nothing` (+ `counts deliveries per root`) |
| drop `population-unavailable` from the union | `the typed AttributionEvidence union mirrors EVIDENCE_CODES exactly` |

All four were run and reverted. Nothing is spied on inside the unit under test: the real module runs with only `chokidar.watch` and the preflight `fs.promises.access` replaced — the two edges that would otherwise make the plan depend on which dot-directories exist on the host.

## Follow-up, not done here

`src/main/attribution.js` lines 64-72 still say `population-unavailable` is "**not yet in that union**". That claim stopped being true with this PR. attribution.js was out of scope by instruction, so the sentence is left for a follow-up (ai-mistakes #27: grep the claim, not the file).
