### PR TITLE
chore(rules): redact the clone path from the code-quality rule

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -17,7 +17,7 @@ alwaysApply: true
 - Feature branch → PR → merge --no-ff → delete branch
 - Один PR = одна логическая задача
 - Squash мелких коммитов перед PR (docs: 6 коммитов → 1)
-- Git via PowerShell: powershell.exe -NoProfile -Command "cd 'X:\Future\ESCAPE\AEGIS'; git ..."
+- Git via PowerShell: powershell.exe -NoProfile -Command "cd 'X:\dev\project\AEGIS'; git ..."
 - НИКОГДА не добавлять Co-Authored-By headers
 - Conventional commits: feat|fix|refactor|perf|chore|docs|test(scope): message
 


### PR DESCRIPTION
Follow-up to #230, which missed one file.

`.claude/rules/code-quality.md:20` still carried the absolute clone path in its
PowerShell template. It is now the placeholder `X:\dev\project\AEGIS`, matching
`CLAUDE.md` rule 7, `BRANCHING.md`, and the `prompt-craft` and `ship` skill templates
under `.claude/skills/` and `.agents/skills/`.

## Why #230's verification missed it

`.gitignore:22` is `.claude/*`, with negations only for `skills/`, `agents/`, `commands/`,
`hooks/` and `settings.json`. `.claude/rules/` is therefore an ignored directory — but
`code-quality.md` inside it is **tracked**, so it is published while living somewhere git's
worktree walk does not go.

`git grep --untracked` skips it. Concretely, on this tree:

```
$ git grep -nE 'X:[\\/]{1,2}Future'
.claude/rules/code-quality.md:20:- Git via PowerShell: powershell.exe ... "cd 'X:\Future\ESCAPE\AEGIS'; git ..."

$ git grep -nE --untracked 'X:[\\/]{1,2}Future'
(no output)
```

The `--untracked` form is the one #230 was verified with, and adding that flag to widen
the search is exactly what narrowed it.

## The sweep that does not have that hole

Enumerate the index and read the files directly, so no walk heuristic is involved:

```
git ls-files -z | xargs -0 grep -nHinE 'murtu|X:[\\/]{1,2}Future|Future[\\/-]+ESCAPE|X--Future'
```

449 tracked files checked, 0 hits after this change.

## Gates

All seven pre-merge commands green locally: `build:renderer`, `format:check`, `lint`
(0 errors), `typecheck`, `typecheck:svelte` (385 files, 0 errors), `test:coverage`
(102 files, 1797 passed / 4 skipped), `npm audit --audit-level=high --omit=dev`
(0 vulnerabilities). This change touches a markdown file that no gate reads, so those are
regression evidence, not coverage of the edit — the edit's evidence is the sweep above.
