### PR TITLE
ci: pin all GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -21,8 +21,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -35,8 +35,8 @@ jobs:
   svelte-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -47,8 +47,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -62,7 +62,7 @@ jobs:
         run: npm run verify:gate
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage/
@@ -70,8 +70,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,11 +29,11 @@ jobs:
         shell: bash
         run: echo "name=${{ inputs.tag || github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.tag.outputs.name }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -137,5 +137,24 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     both survived every later reader who had seen the file "recently corrected". Grep the
     claim, not the file (cf. #24 — assume siblings; #20 — do not document what is not there).
 
+28. **`git grep --untracked` NARROWS the sweep while reading like a widening, and this repo is
+    shaped to be caught by it.** The flag switches git grep off the index and onto a working-tree
+    walk with the standard exclusions applied, so a TRACKED file living under an IGNORED path
+    drops out of a search that plain `git grep` would have answered. `.gitignore:22` ignores
+    `.claude/*` and un-ignores only `skills/`, `agents/`, `commands/`, `hooks/` and
+    `settings.json` — `.claude/rules/` is on none of those lines, yet
+    `.claude/rules/code-quality.md` is tracked and is a live rules file. Measured on git 2.52.0:
+    `git grep -n --untracked -F -e 'GPG signing on all commits'` returns NOTHING and exits 1,
+    while both `git grep -n -F -e ...` and `git ls-files -z | xargs -0 grep -n -F -e ...` return
+    `.claude/rules/code-quality.md:7` and exit 0. Adding `--no-exclude-standard` brings the hit
+    back, which is the proof that the exclusion moved and the file did not. An empty result is
+    the failure mode here: nothing goes red, and "I grepped the whole tree" is what gets written
+    down (cf. #21 — a command that ran is not a command that inspected your change).
+    **Verify against the index instead:** `git ls-files -z | xargs -0 grep -n <pattern>`
+    enumerates exactly what git is tracking, ignore rules and all, and `-z`/`-0` survive the
+    paths with spaces. Use it whenever the question is "does this string still exist anywhere in
+    the repo" — the sweep for siblings that #24 and #27 both demand is worth nothing if the walk
+    silently skips a directory.
+
 ## Rule
 NEVER change what was not asked. Do ONLY what the prompt says.


### PR DESCRIPTION
## What

Every external `uses:` reference in the three workflow files is now pinned to a full
40-character commit SHA, with the human-readable tag kept as a trailing comment.
A tag is mutable — it can be moved to different code after review; a commit SHA cannot.

14 external refs changed across `ci.yml` (11), `release-build.yml` (2) and
`release-please.yml` (1). No other bytes in those files were touched.

## How each SHA was resolved

Resolved remotely during this change, by two independent methods that agree — no SHA
came from memory or a third-party list.

```
git ls-remote --tags https://github.com/<owner>/<repo>.git   # + ^{} deref
gh api repos/<owner>/<repo>/commits/<tag> --jq .sha
```

| Action | Tag | Pinned SHA |
|---|---|---|
| `actions/checkout` | v6 | `d23441a48e516b6c34aea4fa41551a30e30af803` |
| `actions/setup-node` | v6 | `249970729cb0ef3589644e2896645e5dc5ba9c38` |
| `actions/upload-artifact` | v7 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `googleapis/release-please-action` | v5 | `45996ed1f6d02564a971a2fa1b5860e934307cf7` |

`googleapis/release-please-action@v5` is the one **annotated** tag in the set:
`refs/tags/v5` is the tag object `0dfd8538845b8e92600d271a895a5372865d4062`, and
`refs/tags/v5^{}` / `commits/v5` is the commit `45996ed1…`. The commit is what is pinned.
The other three are lightweight tags, where both reads return the same object.

## Left unpinned, deliberately

`release-please.yml:31` — `uses: ./.github/workflows/release-build.yml` is a relative
local path. GitHub resolves a local reusable workflow from the same commit as the caller,
so there is no mutable third-party ref to pin.

## Also

`memory-bank/ai-mistakes.md` #28: `git grep --untracked` narrows a sweep while reading
like a widening — it trades the index for a working-tree walk with the standard
exclusions applied, so a **tracked** file under an **ignored** path drops out of the
result. This repo has exactly that shape (`.gitignore:22` ignores `.claude/*` and does
not un-ignore `rules/`, yet `.claude/rules/code-quality.md` is tracked). Measured:
`git grep --untracked -F -e 'GPG signing on all commits'` returns nothing and exits 1,
while plain `git grep` and `git ls-files -z | xargs -0 grep` both return
`.claude/rules/code-quality.md:7`. Verify against the index instead.

## Verification

All 5 required contexts run locally green before push (7 commands + the in-job
injection proof):

| context | commands | result |
|---|---|---|
| build | `npm run build:renderer` | ✅ built in 1.83s |
| lint | `npm run format:check`, `npm run lint` | ✅ / ✅ 0 errors, 28 pre-existing warnings |
| svelte-check | `npm run typecheck`, `npm run typecheck:svelte` | ✅ / ✅ 385 files, 0 errors |
| test | `npm run test:coverage`, `npm run verify:gate` | ✅ 102 files, 1797 passed, 4 skipped / ✅ 3/3 mutants killed |
| audit | `npm audit --audit-level=high --omit=dev` | ✅ 0 vulnerabilities |

Scope of what CI here can prove (cf. ai-mistakes #21): only `ci.yml` runs on a PR, so a
green run proves the `checkout` / `setup-node` / `upload-artifact` pins. The
`release-please-action` pin is exercised by the Release Please run on the post-merge
master push. `release-build.yml`'s two pins stay verified-by-inspection until a real
release-published event fires.
