### PR TITLE
docs(canon): absorb the Kernel-File ETW recon into RESEARCH-BASELINE section 6

### DIFF
--- a/memory-bank/RESEARCH-BASELINE.md
+++ b/memory-bank/RESEARCH-BASELINE.md
@@ -128,14 +128,14 @@ providesStartTime=true on win32, false on linux/darwin.
   carrying NO pathname — only `FileObject`/`FileKey`; Create 12 = `FileObject`+`FileName`,
   NameCreate 10 = `FileKey`+`FileName`, Cleanup 13 / Close 14 exist; **no provider rundown event**.
 - **NOT FOUND — retire "PID from the event header".** Event 15's issuer is unestablished across
-  `EventHeader.ProcessId`, `ThreadId` (v0) / `IssuingThreadId` (v1) and possible PID-4 attribution.
-  A path comes only from correlating `FileObject`/`FileKey` with path-bearing events, whose lifetime
-  and reuse are unestablished too (legacy FileIo = labeled ANALOGY). No rundown event: files open
-  before session start stay `unresolved` — fail-honest, never fabricated, never upgraded.
+  `EventHeader.ProcessId`, `ThreadId`/`IssuingThreadId` (v0/v1) and possible PID-4 attribution;
+  never attribute or filter by it. A path comes only by correlating `FileObject`/`FileKey` with
+  path-bearing events, whose lifetime and reuse are unestablished (legacy FileIo = ANALOGY).
+  No rundown: files open before session start stay `unresolved` — fail-honest, never fabricated.
 - `EVENT_FILTER_TYPE_PID` on this GUID is unproven until reproduced on target hardware; machine-wide
   capture plus user-mode attribution is the required fallback, and event-ID filtering is applied
   after generation — it cuts delivered volume, not provider cost. Mask `0x190` covers 10/12/15 only;
-  13/14 need the FILEIO keyword `0x20`, so `0x1B0` is a CANDIDATE, not a ratified minimum.
+  13/14 need the FILEIO keyword `0x20`; `0x1B0` is a CANDIDATE, and 13/14's necessity is unratified.
 - Independent confirmation: deterministic scenario catalogue + Procmon (file-IRP) + controlled
   4663 with pre-set SACL. **The SUT's own provider is never its own oracle** (common-mode rule) —
   and no per-event oracle for 15 exists: Procmon proves file activity, not that 15 fired, and 4663

--- a/memory-bank/RESEARCH-BASELINE.md
+++ b/memory-bank/RESEARCH-BASELINE.md
@@ -121,15 +121,30 @@ providesStartTime=true on win32, false on linux/darwin.
 
 ## 6. FILE-READ ATTRIBUTION (Block 3)
 
-- Sensor/SUT: Microsoft-Windows-Kernel-File ETW — Read event id 15, keyword
-  KERNEL_FILE_KEYWORD_READ 0x100, PID from event header; admin/SYSTEM, no PPL required,
-  very high volume.
+- Source of record: `docs/recon/kernel-file-etw.md`. No claim below outranks its label there.
+- Sensor/SUT: Microsoft-Windows-Kernel-File ETW `{edd08927-9cc4-4e65-b970-c2560fb5c289}`;
+  admin/SYSTEM, no PPL required, very high volume. **VERIFIED, scoped to the Windows 10 build 18990
+  manifest and no other build:** Read = event 15, `KERNEL_FILE_KEYWORD_READ` `0x100`, payload
+  carrying NO pathname — only `FileObject`/`FileKey`; Create 12 = `FileObject`+`FileName`,
+  NameCreate 10 = `FileKey`+`FileName`, Cleanup 13 / Close 14 exist; **no provider rundown event**.
+- **NOT FOUND — retire "PID from the event header".** Event 15's issuer is unestablished across
+  `EventHeader.ProcessId`, `ThreadId` (v0) / `IssuingThreadId` (v1) and possible PID-4 attribution.
+  A path comes only from correlating `FileObject`/`FileKey` with path-bearing events, whose lifetime
+  and reuse are unestablished too (legacy FileIo = labeled ANALOGY). No rundown event: files open
+  before session start stay `unresolved` — fail-honest, never fabricated, never upgraded.
+- `EVENT_FILTER_TYPE_PID` on this GUID is unproven until reproduced on target hardware; machine-wide
+  capture plus user-mode attribution is the required fallback, and event-ID filtering is applied
+  after generation — it cuts delivered volume, not provider cost. Mask `0x190` covers 10/12/15 only;
+  13/14 need the FILEIO keyword `0x20`, so `0x1B0` is a CANDIDATE, not a ratified minimum.
 - Independent confirmation: deterministic scenario catalogue + Procmon (file-IRP) + controlled
-  4663 with pre-set SACL. **The SUT's own provider is never its own oracle** (common-mode rule).
-- Sysmon has NO file-read event; EID 11 = create/overwrite only.
+  4663 with pre-set SACL. **The SUT's own provider is never its own oracle** (common-mode rule) —
+  and no per-event oracle for 15 exists: Procmon proves file activity, not that 15 fired, and 4663
+  is not a per-Read oracle. Sysmon has NO file-read event; EID 11 = create/overwrite only.
 - Bounded queue / backpressure / loss counters land in THIS block, before production ingestion.
   Policies: security events never dropped (spill to disk) · benign self-churn coalesced with
-  automatic break on .ssh/.env/exe-write/unknown network · metrics latest-only.
+  automatic break on .ssh/.env/exe-write/unknown network · metrics latest-only. `EventsLost` /
+  `RealTimeBuffersLost` flag collection unreliability, never WHICH event was lost.
+- 13 HARDWARE-GATED items close only on the target machine: PID filter, issuer, Win11/2026 manifest.
 
 ## 7. NETWORK CANON
 


### PR DESCRIPTION
Section 6 (FILE-READ ATTRIBUTION, Block 3) predates `docs/recon/kernel-file-etw.md`. This patch
folds the frozen recon into the canon and adds it as the section's source of record. Nothing in
the recon file is touched, and no other section of the canon changes: +21 / -6, all inside
section 6.

**Downgraded, because the recon refused the claim**

- `PID from event header` is retired. The recon's NOT FOUND section leaves event 15's issuer
  unestablished across `EventHeader.ProcessId`, `ThreadId` (v0) / `IssuingThreadId` (v1) and
  possible PID-4 attribution (recon 93-97).
- `Procmon + controlled 4663` stay as confirmation columns but are no longer implied per-event
  oracles: Procmon does not prove Kernel-File emitted 15, and 4663 is not a per-Read oracle
  (recon 100-102).

**Carried over as VERIFIED, scoped to the Windows 10 build 18990 manifest**

Provider GUID, Read = event 15 / `KERNEL_FILE_KEYWORD_READ` `0x100` with no pathname in the
payload, `FileObject`/`FileKey`, Create 12, NameCreate 10, Cleanup 13 / Close 14, and the absence
of a provider rundown event (recon 23-34).

**Carried over as design decisions and open items**

`unresolved` as a first-class fail-honest state, `EVENT_FILTER_TYPE_PID` unproven until reproduced
on hardware with machine-wide capture as the required fallback, event-ID filtering applied after
generation, `0x190` / `0x1B0` as candidate masks rather than a ratified minimum, `EventsLost` /
`RealTimeBuffersLost` as unreliability signals that never name the lost event, and the 13
hardware-gated items (recon 41-44, 56-67, 79-87, 108-133).

Local gates, all seven CI commands: build:renderer, format:check, lint (0 errors), typecheck,
typecheck:svelte (385 files, 0 errors), test:coverage (102 files, 1797 passed / 4 skipped),
npm audit --audit-level=high --omit=dev (0 vulnerabilities).