### PR TITLE
docs(canon): close the three Kernel-File recon leftovers

### DIFF
--- a/memory-bank/RESEARCH-BASELINE.md
+++ b/memory-bank/RESEARCH-BASELINE.md
@@ -114,8 +114,17 @@ providesStartTime=true on win32, false on linux/darwin.
 - Sidecar = separate process, named pipe / stdio, length-prefixed frames. A native crash must
   never take down the Electron control/UI process.
 - Sidecar language is a **reversible implementation choice** — the wire boundary is the stable
-  contract. Block 1 physically picks one; the canon keeps it open (C#/TraceEvent vs Rust/ferrisetw
-  re-evaluated when the streaming sensor becomes real).
+  contract. Block 1 physically picks one; the canon keeps the choice formally open, but **not
+  neutral**. Per `docs/recon/kernel-file-etw.md` (DESIGN DECISION), for the Kernel-File streaming
+  sensor: **C#/TraceEvent is the preferred and implementation-evidenced option** — direct evidence
+  for session APIs, filtering surface, samples and parser behavior; **Rust/ferrisetw is NOT the
+  preferred candidate** — maintenance maturity and weaker implementation evidence, though its
+  `ByPids` issue is no provider-specific proof that this provider cannot be consumed correctly;
+  krabsetw stays an actively maintained native candidate whose equivalent Kernel-File real-time and
+  filter behavior was **not established** — never presented as equally evidenced. Package freshness
+  is not feature-parity evidence. The re-evaluation when the streaming sensor becomes real starts
+  from that preference, not from a blank slate; nothing here decides the Block 1 procsnap sidecar,
+  which carries no ETW.
 - Never cite Encore's 2-4 ms as one sidecar-boundary cost (it was a multi-hop path). Benchmark
   AEGIS's own IPC.
 
@@ -137,6 +146,10 @@ providesStartTime=true on win32, false on linux/darwin.
   capture plus user-mode attribution is the required fallback; event-ID filtering runs after
   generation and may cut delivered volume, never provider cost. `0x190` is spec-consistent with
   10/12/15; 13/14 need FILEIO keyword `0x20`; `0x1B0` is a CANDIDATE, 13/14's necessity unratified.
+- **Collection cost for File-read must NOT be estimated from the callback rate of AEGIS-relevant
+  processes** — PID-scoped enablement on this GUID is unproven and event-ID filtering runs after
+  generation, so an AEGIS-process rate is no proxy for provider cost; the real figures (idle, npm
+  and build event-15 rates; CPU/memory/buffer and loss counters under load) are HARDWARE-GATED.
 - Independent confirmation: deterministic scenario catalogue + Procmon (file-IRP) + controlled 4663
   with pre-set SACL. **The SUT's own provider is never its own oracle** (common-mode rule): no clean
   independent per-event oracle for 15 was established — Procmon observes file activity, not that 15
@@ -176,7 +189,9 @@ NDJSON). Decide naming BEFORE freezing Bench Replay schema. OCSF = possible late
 - Method: generate an expected-event catalogue per scenario, confirm with independent oracles.
   Never diff two live streams. Never self-oracle.
 - Oracle columns are separate: Sysmon (EID 1/2/3/5/11/22/**26**) = security-event reference;
-  Procmon = file-IRP reference; Kernel-File ETW appears only as SUT when it is the sensor.
+  Procmon = independent file-IRP **confirmation column for file activity** — it does NOT prove that
+  Kernel-File emitted Read 15, so it is no per-event oracle for that event (section 6); Kernel-File
+  ETW appears only as SUT when it is the sensor.
 - **Ratified 2026-08-14 (B2.3).** (a) **EID 26 FileDeleteDetected** joins the oracle column: it is
   the deletion observation that does NOT archive the file. **EID 23 FileDelete is never enabled
   merely to observe a deletion** — Microsoft documents 23 as additionally saving the deleted file


### PR DESCRIPTION
Closes the three leftovers named after the section 6 canon patch (#234), all against the frozen recon `docs/recon/kernel-file-etw.md`, which is untouched here.

**Section 10 — Procmon's oracle status.** The bullet listed `Procmon = file-IRP reference` inside the oracle columns, the exact claim section 6 had already downgraded. Recon 100-102: no clean independent per-event oracle for Read 15 was established, and Procmon is an independent observation column for file activity that does not prove Kernel-File emitted event 15. Procmon is now a file-IRP **confirmation column for file activity**, explicitly not a per-event oracle for Read 15. Sysmon and Procmon stay two separate columns, and arm B (`Sysmon + Procmon`, oracle calibration in `bench/`) is unaffected.

**Section 5 — sidecar library preference.** The canon kept `C#/TraceEvent vs Rust/ferrisetw` open as equals. Recon 68-75 (design decision) is not neutral: TraceEvent is the preferred and implementation-evidenced option, ferrisetw is not the preferred candidate (maintenance maturity, weaker implementation evidence; its `ByPids` issue is no provider-specific proof), krabsetw is an actively maintained candidate whose equivalent Kernel-File real-time and filter behavior was not established. The choice stays a formally reversible implementation choice with the wire boundary as the contract; the preference is scoped to the Kernel-File streaming sensor and decides nothing about the Block 1 procsnap sidecar, which carries no ETW.

**Section 6 — collection cost.** Recon 86-87 was the one design-decision statement not yet in the canon: collection cost for File-read must not be estimated from the callback rate of AEGIS-relevant processes. Added as one bullet, with the rationale drawn from what section 6 already carries (PID-scoped enablement unproven, recon 62-64; event-ID filtering runs after generation, recon 43-44) and the real figures left HARDWARE-GATED (recon 129-130).

No claim is stated above its recon label.

**Local gates (all 7 commands behind the 5 required contexts):** `build:renderer` ✅ · `format:check` ✅ · `lint` ✅ (0 errors, 28 pre-existing warnings) · `typecheck` ✅ · `typecheck:svelte` ✅ 385 files / 0 errors · `test:coverage` ✅ 102 files, 1797 passed / 4 skipped · `npm audit --audit-level=high --omit=dev` ✅ 0 vulnerabilities. None of them reads `memory-bank/*.md` — they prove the tree is unbroken, not that this doc edit is correct (ai-mistakes #21).