### PR TITLE
fix(process-utils): never stamp a birth time a cache answered

### DIFF
--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -48,13 +48,16 @@ const parentChainCache = new Map();
 const PARENT_CHAIN_TTL = 60000;
 
 /**
- * Cache key for the parent-chain / startTime cache AND the cwd cache: pid PLUS
- * the process name.
+ * Cache key for the parent-chain cache AND the cwd cache: pid PLUS the process name.
  *
- * A bare pid is not enough. Windows recycles PIDs, so a live TTL entry keyed on
- * pid alone serves the DEAD process's chain and — far worse — its `startTime`,
- * the one field `instanceId` is built from. Folding the name in turns a recycled
- * pid that belongs to a different executable into a cache MISS.
+ * A bare pid is not enough. Windows recycles PIDs, so a live TTL entry keyed on pid
+ * alone serves the DEAD process's chain and cwd. Folding the name in turns a
+ * recycled pid that belongs to a different executable into a cache MISS.
+ *
+ * `startTime` is NOT among the things this key addresses, and no longer can be:
+ * neither cache stores a birth time, because a hit can be served without the
+ * provider having been called at all (`getParentChains`). The one field
+ * `instanceId` is built from is re-observed per pass or is null.
  *
  * The name is NOT the whole answer: a pid recycled by an executable with the SAME
  * name produces the same key. What separates those two instances is the GENERATION
@@ -195,6 +198,20 @@ function _witnessOf(procMap, pid) {
  * today; if something did, those entries would simply never be proven and would be
  * rebuilt — safe, only wasteful. An entry may never be reused on the strength of a
  * proof it does not hold.
+ *
+ * They also carry no `startTime`, and that absence is the guarantee, not an
+ * omission: this function returns the cached chain on a full hit WITHOUT calling the
+ * provider (see the early return below), so any birth time stored alongside would be
+ * readable by a pass that made no observation at all. That is exactly the poisoning
+ * `enrichWithParentChains` exists to prevent, and the only way to make it
+ * unreachable rather than merely unused is for the value not to be here.
+ *
+ * What stays open: the CHAIN this returns is still a cached answer, and on a
+ * platform with no per-pass observation there is nothing to prove it belongs to the
+ * process living under that pid right now — a same-name reuse inside
+ * PARENT_CHAIN_TTL keeps the dead process's parent names. That is the plain TTL
+ * contract, unchanged, and it is bounded to the chain: the identity is not built
+ * from it.
  * @param {number[]} pids
  * @param {Object} [opts]
  * @param {Map<number, string>} [opts.names] - pid → process name, used to key the
@@ -243,17 +260,13 @@ async function getParentChains(pids, opts = {}) {
     }
   }
 
-  // Walk parent chains in JS for uncached PIDs
+  // Walk parent chains in JS for uncached PIDs. The entry holds the CHAIN and
+  // nothing else that an identity is built from: a birth time written here would be
+  // readable on a later pass that never called the provider, which is the one thing
+  // no cache may answer (see the header of this function).
   for (const pid of needLookup) {
-    // The OS birth time (epoch-ms) for the agent's OWN pid comes from the same map
-    // fetch — zero extra spawn. Only win32 supplies it; darwin/linux map entries
-    // omit startTime, so this is null there (honest).
     const chain = _walkChain(procMap, pid);
-    parentChainCache.set(keyOf(pid), {
-      chain,
-      startTime: _birthTimeOf(procMap, pid),
-      timestamp: now,
-    });
+    parentChainCache.set(keyOf(pid), { chain, timestamp: now });
     result.set(pid, chain);
   }
 
@@ -313,9 +326,12 @@ async function _stampFromFreshBirthTimes(agents, forceRefresh) {
       a.parentChain = cached.chain;
     } else {
       const chain = _walkChain(procMap, a.pid);
+      // No `startTime`: the birth time is stamped on the RECORD below, from this
+      // pass's map, and is never read back out of the cache. Storing it would leave
+      // a number a later pass could serve without observing anything — the shape
+      // this entry must not be able to take (see {@link getParentChains}).
       parentChainCache.set(key, {
         chain,
-        startTime: birthTime,
         witness: witness ? witness.value : null,
         witnessSource: witness ? witness.source : null,
         timestamp: now,
@@ -329,12 +345,30 @@ async function _stampFromFreshBirthTimes(agents, forceRefresh) {
 }
 
 /**
- * Stamp `parentChain` and `startTime` on a platform that supplies NO birth time
- * (linux, darwin). Unchanged behaviour: the TTL-bounded parent-chain cache answers,
- * and a pass whose pids are all cached costs no provider call at all. Adding a
- * per-pass process map here would buy nothing — there is no birth time in it to
- * prove a generation with — and would cost a `ps` spawn or a full /proc walk every
- * scan tick.
+ * Stamp `parentChain` on a platform that declares NO per-pass birth-time
+ * observation (`providesStartTime: false` — linux, darwin). The TTL-bounded
+ * parent-chain cache answers, and a pass whose pids are all cached costs no provider
+ * call at all. Adding a per-pass process map here would buy nothing — this platform
+ * declares no birth time to prove a generation with — and would cost a `ps` spawn or
+ * a full /proc walk every scan tick.
+ *
+ * WHAT THIS PATH GUARANTEES: `startTime` is `null` on every agent it touches, so the
+ * identity it feeds {@link identify} is always the honest `"<pid>:u"` of
+ * process-identity.js space 3. The guarantee is structural, not a consequence of
+ * what the adapter happens to return: this function never reads a birth time from
+ * anywhere, and {@link getParentChains} no longer stores one. A platform that starts
+ * populating `startTime` in its process map without also declaring
+ * `providesStartTime: true` therefore CANNOT reach an `os` key here — which is the
+ * point, because the map on such a pass may not have been fetched at all. Wiring a
+ * real birth time is one switch (`providesStartTime: true`), which routes to
+ * {@link _stampFromFreshBirthTimes} and its per-pass observation.
+ *
+ * WHAT STAYS OPEN: the cached `parentChain` itself carries no generation proof on
+ * this path, so a same-name pid reuse inside PARENT_CHAIN_TTL keeps the dead
+ * process's parent names until the entry expires. That bound is the plain TTL
+ * contract and is confined to the chain — `annotateHostApps` may mislabel the host
+ * editor for up to 60 s; the instance key cannot be wrong, because it does not read
+ * this cache.
  *
  * No generation witness is stamped here, deliberately: the field stays `undefined`,
  * which {@link annotateWorkingDirs} reads as "this record established no
@@ -347,8 +381,8 @@ async function _stampFromFreshBirthTimes(agents, forceRefresh) {
  */
 async function _stampFromCachedChains(agents, forceRefresh) {
   // pid → name for the cache key. Synthetic agents all share pid 0, so the last
-  // one wins here; harmless because pid 0 is absent from the OS process map (its
-  // startTime is null either way) and identify() reads each agent's OWN name.
+  // one wins here; harmless because identify() reads each agent's OWN name and no
+  // birth time is derived on this path at all.
   const names = new Map();
   for (const a of agents) names.set(a.pid, _agentName(a));
   const chains = await getParentChains(
@@ -357,8 +391,10 @@ async function _stampFromCachedChains(agents, forceRefresh) {
   );
   for (const a of agents) {
     a.parentChain = chains.get(a.pid) || [];
-    const entry = parentChainCache.get(_cacheKey(a.pid, names.get(a.pid)));
-    a.startTime = entry && typeof entry.startTime === 'number' ? entry.startTime : null;
+    // Unconditional. Not "null because the map had none" — null because this
+    // platform makes no per-pass observation, and a birth time nobody observed this
+    // pass is not a birth time this pass may stamp.
+    a.startTime = null;
   }
 }
 

--- a/tests/main/process-utils.test.js
+++ b/tests/main/process-utils.test.js
@@ -722,6 +722,53 @@ describe('process-utils', () => {
       expect(agents[0].instanceIdSource).toBe('unknown');
     });
 
+    it('never stamps a birth time the cache answered, even when the map carries one', async () => {
+      // The shape a future linux/darwin adapter produces the day it starts reading
+      // /proc/<pid>/stat field 22 (or `ps` lstart) WITHOUT flipping providesStartTime:
+      // the map carries a birth time, but this platform makes no per-pass observation
+      // to re-read it with. Serving the cached number here is the original poisoning
+      // bug, one adapter change away — a pid Windows-style recycled inside the 60 s
+      // TTL would keep the dead process's key.
+      mockGetParentProcessMap.mockResolvedValueOnce(
+        new Map([
+          [4242, { name: 'claude', ppid: 900, startTime: 1717000000000 }],
+          [900, { name: 'bash', ppid: 0, startTime: 1716999990000 }],
+        ]),
+      );
+      const first = [{ pid: 4242, agent: 'Claude Code', process: 'claude' }];
+      await processUtils.enrichWithParentChains(first);
+      expect(first[0].startTime).toBeNull();
+      expect(first[0].instanceId).toBe('4242:u');
+      expect(first[0].instanceIdSource).toBe('unknown');
+      expect(first[0].parentChain).toEqual(['bash']);
+
+      // The pid is reissued to another `claude` 10.7 s later — inside PARENT_CHAIN_TTL,
+      // so no timer is advanced and the entry written above is still live. This map is
+      // what the OS would report; the point of the call-count assertion below is that
+      // this pass never asks for it.
+      mockGetParentProcessMap.mockResolvedValue(
+        new Map([
+          [4242, { name: 'claude', ppid: 900, startTime: 1717000010700 }],
+          [900, { name: 'bash', ppid: 0, startTime: 1716999990000 }],
+        ]),
+      );
+      const second = [{ pid: 4242, agent: 'Claude Code', process: 'claude' }];
+      await processUtils.enrichWithParentChains(second);
+
+      expect(second[0].startTime).toBeNull();
+      expect(second[0].instanceId).toBe('4242:u');
+      expect(second[0].instanceIdSource).toBe('unknown');
+      expect(second[0].instanceId).not.toBe('4242:1717000000000');
+
+      // Cache HIT, not a fresh read that happened to agree: one provider call served
+      // both passes. Without this the test reads as a test of a value rather than of
+      // where the value came from, and could not tell "answered from the cache" from
+      // "asked the OS and the OS returned the stale number".
+      expect(mockGetParentProcessMap).toHaveBeenCalledTimes(1);
+      // The chain is still what the cache is FOR — it survives, the birth time does not.
+      expect(second[0].parentChain).toEqual(['bash']);
+    });
+
     it('keeps the cwd cache — there is no generation to gate it on', async () => {
       mockGetParentProcessMap.mockResolvedValue(new Map([[100, { name: 'claude', ppid: 0 }]]));
       mockGetProcessCwds.mockResolvedValue(new Map([[100, '/home/user/project-a']]));


### PR DESCRIPTION
## What

Makes the parent-chain cache **structurally unable** to answer a birth time.

`_stampFromCachedChains` read `entry.startTime` out of `parentChainCache`, and
`getParentChains` returns on a full cache hit **without calling the provider at all**.
On any platform whose adapter starts populating `startTime` in its process map without
also declaring `providesStartTime: true`, a pid recycled to a same-named executable
inside the 60 s TTL would inherit the dead process's birth time — and with it its
`instanceId`, session, dedup set and token ledger.

Unreachable today only because `platform/linux.js` and `platform/darwin.js` write no
`startTime` into the map. That is honest by accident of the adapter, not by construction,
and it is one adapter change away from live.

## How

- `_stampFromCachedChains` stamps `a.startTime = null` **unconditionally**. This path can
  now only produce the honest `"<pid>:u"` of `process-identity.js` space 3.
- Neither cache write stores a birth time any more (`getParentChains` and
  `_stampFromFreshBirthTimes`), so there is nothing for a pass that made no observation
  to read. `grep -rn 'cached\.startTime\|entry\.startTime' src/` → no hits.
- JSDoc on both paths now states the guarantee and names what stays open (ai-mistakes #27):
  the cached **chain** still carries no generation proof on the non-birth-time path, so a
  same-name reuse keeps the dead process's parent names for up to 60 s. That bound is
  confined to the chain — the instance key does not read this cache.

Wiring a real birth time on linux/darwin stays **one switch**: `providesStartTime: true`
routes to `_stampFromFreshBirthTimes` and its per-pass observation.

## What does not change

- Observable behaviour on linux/darwin: `":u"` before and after, byte-identical.
- win32: untouched. The birth time there was already re-observed on every pass
  (`_stampFromFreshBirthTimes`) and stamped on the record, never read back from the cache.
- `instanceId` format `pid:startTime(ms)` — frozen.
- `_cacheKey` (`pid|name`), `PARENT_CHAIN_TTL`, the witness order and its cache-gating-only
  role, and `forceRefresh` semantics at both call sites.

## Test

New regression test in the existing `providesStartTime: false` describe: a map that
**does** carry `startTime`, two passes inside the TTL, pid 4242 / `claude` reused 10.7 s
apart. It asserts both passes stamp `4242:u`, that pass 2 never stamps
`4242:1717000000000` — and that **the provider was called exactly once**. Without the
call-count assertion the test reads as a test of the value rather than of where the value
came from, and could not tell "answered from the cache" from "asked the OS and the OS
returned the stale number".

Failed before the change with `expected 1717000000000 to be null`; passes after.

Local, all seven pre-merge commands green, plus `npm run verify:gate` (control green,
m1/m2/m3 all RED — the witness gate is still load-bearing).
