### PR TITLE
fix(session-tracker): freeze sessions on identity degradation instead of splitting them

### DIFF
--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -113,6 +113,38 @@ function getIdentityQuality() {
 }
 
 /**
+ * Whether the identity keys this tick can form are degraded RELATIVE TO WHAT THIS
+ * PLATFORM PROVIDES.
+ *
+ * Deliberately not a bare `getIdentityQuality() === 'unknown'`. That value is
+ * `unknown` PERMANENTLY on linux and darwin — neither adapter publishes a birth time
+ * at all — so acting on it there would freeze session tracking forever on platforms
+ * where `<pid>:u` is the normal, documented steady state (process-identity.js space
+ * 3), not a fault. Degradation is a RELATIVE notion: it exists only where the
+ * platform declares a birth time and the observation that carries it failed.
+ *
+ * On such a platform `unknown` means the provider fell over between one tick and the
+ * next, so every live agent's key silently changes from `<pid>:<birthMs>` to
+ * `<pid>:u`. That is a SPLIT, not an exit — the failure process-identity.js's header
+ * names as the opposite of a merge — and it forks the session, the dedup set, the
+ * baselines and the token ledger along with the key.
+ *
+ * `birth-time` (the CIM fallback) is NOT degradation here: the keys still form in
+ * the same space with the same values, so nothing splits. Only a total loss of the
+ * observation counts.
+ *
+ * SCOPE OF THE GATE: unlike `identityQuality`, which is annotation and gates nothing
+ * (design §3), this IS acted on — by session reconciliation alone, and only to
+ * FREEZE state. It never suppresses an observation and never fabricates one: the
+ * scan batch keeps carrying the honest `<pid>:u` it observed.
+ * @returns {boolean}
+ * @since 0.12.0
+ */
+function isIdentityDegraded() {
+  return _providesStartTime === true && getIdentityQuality() === 'unknown';
+}
+
+/**
  * @typedef {Object} ProcessCapabilities
  * @property {'STARTING'|'HEALTHY'|'DEGRADED'|'FAILED'} populationState - the `process`
  *   LEAF's state, never a plane roll-up
@@ -310,6 +342,10 @@ module.exports = {
   getProcessSensorHealth,
   isProcessPopulationReliable,
   getProcessCapabilities,
+  // Published as its own function rather than as a fifth ProcessCapabilities field:
+  // that struct is the POPULATION contract every agent-scoped sensor gates on, and
+  // this answers a different question for exactly one consumer.
+  isIdentityDegraded,
   noteProcessScanHardFailure,
   PROCESS_SENSOR_ID,
   _setPlatformForTest,

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -169,6 +169,25 @@ function isPopulationReliable(scanner) {
   return true;
 }
 
+/**
+ * Whether this tick's identity keys are degraded relative to what the platform can
+ * observe — a birth-time platform whose process-table observation produced nothing.
+ * See process-scanner.js `isIdentityDegraded` for why that is not the same question
+ * as `identityQuality === 'unknown'`.
+ *
+ * A scanner that does not publish the question is NOT degraded, and that default is
+ * the opposite of a guess: this flag freezes every session on the machine, so a
+ * collaborator stub that cannot answer must never be able to trigger it. The
+ * population gate above defaults the same way and for the same reason.
+ * @param {Object|undefined} scanner
+ * @returns {boolean}
+ * @since 0.12.0
+ */
+function isIdentityDegraded(scanner) {
+  if (!scanner || typeof scanner.isIdentityDegraded !== 'function') return false;
+  return scanner.isIdentityDegraded() === true;
+}
+
 function doNetworkScan() {
   const { network, baselines, audit, logger, getLatestAgents, sendToRenderer, scanner } = deps;
   const agents = getLatestAgents();
@@ -356,11 +375,29 @@ async function doProcessScan() {
     // new to the scan from being identified out of a stale cache entry. No new
     // spawn: on win32 this is the same `cim-parent` fetch the tick already pays.
     await procUtil.enrichWithParentChains(agents, { forceRefresh: result.changed === true });
+    // Read AFTER the identity stamp, never before. The snapshot leaf's health
+    // describes the process-table observation `enrichWithParentChains` just made;
+    // read at the top of the tick it would report the PREVIOUS pass's provider, and
+    // on the first tick a leaf that had never been written at all.
+    const identityDegraded = isIdentityDegraded(scanner);
+    if (identityDegraded) {
+      // A frozen reconcile emits nothing by design, so without this line an outage
+      // is indistinguishable from a quiet machine in the log.
+      logger.debug('scan', 'session-freeze', {
+        reason: 'identity-degraded',
+        agents: agents.length,
+      });
+    }
     // Eager-enter / lazy-exit session reconciliation: an agent seen in even ONE
     // scan logs session-start immediately, and a flickering or permission-denied
-    // scan never spawns a duplicate session. See session-tracker.js.
+    // scan never spawns a duplicate session. `identityDegraded` freezes the same way
+    // an unreliable scan does: when the birth-time observation is gone, every live
+    // agent's key changes without any process having started or stopped, and acting
+    // on that would report a fleet-wide exit that never happened. See
+    // session-tracker.js.
     const { entered, exited } = sessionTracker.reconcile(agents, {
       reliable: result.reliable !== false,
+      identityDegraded,
     });
     for (const s of entered)
       audit.log('agent-enter', {

--- a/src/main/session-tracker.js
+++ b/src/main/session-tracker.js
@@ -12,6 +12,12 @@
  *     consecutive RELIABLE misses, so a one-tick disappearance (flicker, late
  *     `tasklist`, or a permission-denied scan) does NOT end it and reappearance
  *     does NOT create a duplicate session.
+ *   - A scan that observed nothing usable is FROZEN: it starts, ends and ages
+ *     nothing. Two things can be missing — the population (`reliable: false`, a
+ *     permission-denied enumeration) or the identity (`identityDegraded: true`, a
+ *     birth-time platform whose observation failed, so every key collapsed to
+ *     `<pid>:u`). Both are absences of evidence, and an absence of evidence must not
+ *     be written into the audit log as a fleet-wide exit.
  *
  *   Identity is `instanceId + process name`, where `instanceId` binds the pid to
  *   the OS process-creation time (process-identity.js). The snapshot scanner
@@ -95,6 +101,29 @@ function sessionKey(agent) {
  *   enumerate processes (e.g. permission-denied → empty list). An unreliable
  *   scan tells us nothing about who left, so it neither starts, ends, nor ages
  *   any session and returns no events.
+ * @param {boolean} [opts.identityDegraded=false] - true when the platform declares
+ *   an OS birth time but this tick's observation of it failed, so every live agent's
+ *   `instanceId` collapsed from `<pid>:<birthMs>` to `<pid>:u`
+ *   (process-scanner.js `isIdentityDegraded`). Handled EXACTLY like an unreliable
+ *   scan, and for the same reason: the keys moved, the processes did not.
+ *
+ *   GUARANTEE: across a degraded stretch and its recovery, no session is started,
+ *   ended or aged, so a provider outage produces no `agent-enter` and no
+ *   `agent-exit` — and every session resumes under the key it already had, because
+ *   that key was never replaced.
+ *
+ *   WHAT STAYS OPEN, and it is not small: while frozen, a REAL start or stop is
+ *   invisible too. An agent that exits during the outage is reported only once the
+ *   observation returns and it is missed for `grace` more reliable ticks; one that
+ *   starts during it enters late. That is the same trade the `reliable` flag already
+ *   makes for a permission-denied scan — a late true event over a fleet of false
+ *   ones — and it is bounded by the outage. It is NOT free: an outage that starts
+ *   before the first tick means nothing is tracked at all, where the pre-flag
+ *   behaviour would have tracked everything under `<pid>:u` keys.
+ *
+ *   Absent or false, reconcile behaves exactly as it always did — which is what
+ *   keeps linux and darwin untouched, where `<pid>:u` is the steady state and no
+ *   caller ever sets this.
  * @param {number} [opts.now] - injectable timestamp (ms) for tests.
  * @param {number} [opts.grace=DEFAULT_EXIT_GRACE] - consecutive reliable misses
  *   before a session is reported as exited.
@@ -104,13 +133,20 @@ function sessionKey(agent) {
  */
 function reconcile(agents, opts = {}) {
   const reliable = opts.reliable !== false;
+  const identityDegraded = opts.identityDegraded === true;
   const now = opts.now != null ? opts.now : Date.now();
   const grace = opts.grace != null ? opts.grace : DEFAULT_EXIT_GRACE;
 
-  // Unreliable scan: do not start, end, or age sessions. This is what kills the
-  // EPERM false-positive storm — a transient access-denied no longer ages out
-  // every live session into a spurious exit + re-enter pair.
-  if (!reliable) return { entered: [], exited: [] };
+  // Nothing observable happened: do not start, end, or age sessions.
+  //
+  // Two causes, one response, because the two are the same mistake seen from
+  // opposite sides. An unreliable scan lost the POPULATION — this is what kills the
+  // EPERM false-positive storm, where a transient access-denied aged out every live
+  // session into a spurious exit + re-enter pair. A degraded identity lost the KEY:
+  // the same processes come back under `<pid>:u`, which reads as the whole fleet
+  // exiting and an identically-named fleet arriving. Neither says anything about
+  // who left, so neither may be answered with an event.
+  if (!reliable || identityDegraded) return { entered: [], exited: [] };
 
   const entered = [];
   const seenKeys = new Set();

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -611,6 +611,177 @@ describe('scan-loop', () => {
     });
   });
 
+  // ── identity degradation freezes sessions instead of splitting them ──
+
+  describe('identity degradation during a snapshot outage', () => {
+    /**
+     * The predicate itself, exercised on the REAL process-scanner.
+     *
+     * It lives here rather than in `process-scanner.test.js` because this is the
+     * consumer that acts on it: nothing else in the codebase gates on identity
+     * quality (`getIdentityQuality` is annotation by design), so the contract and
+     * the only thing that reads it are asserted together.
+     */
+    describe('scanner.isIdentityDegraded()', () => {
+      let scanner;
+      let SENSOR_HEALTH_STATE;
+
+      beforeEach(() => {
+        scanner = require_('../../src/main/process-scanner.js');
+        SENSOR_HEALTH_STATE = require_('../../src/main/sensor-health.js').SENSOR_HEALTH_STATE;
+        scanner._resetForTest();
+      });
+
+      afterEach(() => {
+        // Module-level overrides — restore, or a later test inherits this
+        // platform's identity story.
+        scanner._resetForTest();
+      });
+
+      /**
+       * @param {boolean} providesStartTime
+       * @param {string} snapshotState
+       * @returns {boolean}
+       */
+      function degradedWith(providesStartTime, snapshotState) {
+        scanner._setPlatformForTest({
+          providesStartTime,
+          getSnapshotHealth: () => ({ state: snapshotState }),
+        });
+        return scanner.isIdentityDegraded();
+      }
+
+      it('a birth-time platform whose observation FAILED is degraded', () => {
+        expect(degradedWith(true, SENSOR_HEALTH_STATE.FAILED)).toBe(true);
+      });
+
+      it('a birth-time platform that has not observed yet is degraded', () => {
+        expect(degradedWith(true, SENSOR_HEALTH_STATE.STARTING)).toBe(true);
+      });
+
+      it('a healthy observation is not degraded', () => {
+        expect(degradedWith(true, SENSOR_HEALTH_STATE.HEALTHY)).toBe(false);
+      });
+
+      it('the CIM fallback is not degradation — the keys still form the same way', () => {
+        expect(degradedWith(true, SENSOR_HEALTH_STATE.DEGRADED)).toBe(false);
+      });
+
+      it('linux/darwin are NEVER degraded, whatever the snapshot leaf says', () => {
+        // `<pid>:u` is their steady state, not an outage. Reading their permanent
+        // `identityQuality: 'unknown'` as degradation would freeze session tracking
+        // on those platforms forever.
+        expect(degradedWith(false, SENSOR_HEALTH_STATE.FAILED)).toBe(false);
+        expect(degradedWith(false, SENSOR_HEALTH_STATE.STARTING)).toBe(false);
+        expect(degradedWith(false, SENSOR_HEALTH_STATE.HEALTHY)).toBe(false);
+      });
+    });
+
+    /**
+     * Deps for a birth-time platform whose process map can be taken away.
+     *
+     * `enrichWithParentChains` is faithful to `_stampFromFreshBirthTimes`: the birth
+     * time comes from THIS pass's map or is null, and `identify()` does the rest —
+     * so an emptied map produces `<pid>:u` here for the same reason it does in
+     * production. `isIdentityDegraded` answers off the same map, which is the
+     * coupling process-snapshot.js publishes (an empty map is a failed observation).
+     * @param {{map: Map<number, number>}} state - mutable, so a tick can take the
+     *   observation away between two `advanceTimersByTimeAsync` calls.
+     * @returns {Object}
+     */
+    function makeOutageDeps(state) {
+      const { identify } = require_('../../src/main/process-identity.js');
+      return makeDeps({
+        scanner: {
+          scanProcesses: vi.fn().mockImplementation(async () => ({
+            agents: [
+              { agent: 'Claude Code', process: 'claude.exe', pid: 100 },
+              { agent: 'Cursor', process: 'cursor.exe', pid: 200 },
+            ],
+            changed: false,
+            reliable: true,
+          })),
+          isIdentityDegraded: vi.fn(() => state.map.size === 0),
+        },
+        procUtil: {
+          enrichWithParentChains: vi.fn(async (agents) => {
+            for (const a of agents) {
+              a.startTime = state.map.has(a.pid) ? state.map.get(a.pid) : null;
+              const id = identify(a);
+              a.instanceId = id.instanceId;
+              a.instanceIdSource = id.instanceIdSource;
+            }
+          }),
+          annotateHostApps: vi.fn(),
+          annotateWorkingDirs: vi.fn().mockResolvedValue(),
+        },
+      });
+    }
+
+    /** The birth times the two agents keep for their whole life. */
+    const LIVE_MAP = () =>
+      new Map([
+        [100, 1717000000000],
+        [200, 1717000100000],
+      ]);
+
+    /**
+     * @param {Object} deps
+     * @param {string} type
+     * @returns {Array<Object>} the audit payloads of one kind, in order.
+     */
+    function auditOf(deps, type) {
+      return deps.audit.log.mock.calls.filter((c) => c[0] === type).map((c) => c[1]);
+    }
+
+    it('a snapshot outage emits no agent-exit and no duplicate agent-enter', async () => {
+      // session-tracker holds module state that this file's cache clear does not
+      // reach, so this block starts from an empty session set explicitly.
+      require_('../../src/main/session-tracker.js')._resetForTest();
+
+      const state = { map: LIVE_MAP() };
+      const deps = makeOutageDeps(state);
+      scanLoop.init(deps);
+      scanLoop.stopScanIntervals();
+      scanLoop.startScanIntervals(5000);
+
+      await vi.advanceTimersByTimeAsync(5000); // tick 1 — both agents enter
+      state.map = new Map(); // the provider falls over
+      await vi.advanceTimersByTimeAsync(5000); // tick 2 — keys would flip to :u
+      await vi.advanceTimersByTimeAsync(5000); // tick 3 — grace 2 would fire here
+      state.map = LIVE_MAP(); // the provider comes back
+      await vi.advanceTimersByTimeAsync(5000); // tick 4 — mirror pair would fire here
+
+      const entered = auditOf(deps, 'agent-enter');
+      expect(auditOf(deps, 'agent-exit')).toHaveLength(0);
+      expect(entered).toHaveLength(2);
+      expect(entered.map((e) => e.instanceId).sort()).toEqual([
+        '100:1717000000000',
+        '200:1717000100000',
+      ]);
+    });
+
+    it('the scan-batch still carries the honest degraded key while frozen', async () => {
+      // Freezing is about SESSION state. The batch is an observation and must keep
+      // reporting what was actually observed — `<pid>:u`, not a remembered key.
+      require_('../../src/main/session-tracker.js')._resetForTest();
+
+      const state = { map: LIVE_MAP() };
+      const deps = makeOutageDeps(state);
+      scanLoop.init(deps);
+      scanLoop.stopScanIntervals();
+      scanLoop.startScanIntervals(5000);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      state.map = new Map();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const batches = deps.sendToRenderer.mock.calls.filter((c) => c[0] === 'scan-batch');
+      expect(batches).toHaveLength(2);
+      expect(batches[1][1].agents.map((a) => a.instanceId)).toEqual(['100:u', '200:u']);
+    });
+  });
+
   // ── attachModels order + instanceId stamp (local LLM runtimes) ──
 
   describe('attachModels before scan-batch', () => {

--- a/tests/main/session-tracker.test.js
+++ b/tests/main/session-tracker.test.js
@@ -112,6 +112,69 @@ describe('session-tracker', () => {
     });
   });
 
+  describe('reconcile — identity degradation (the SPLIT direction)', () => {
+    /** The same live process, keyed before and during a birth-time outage. */
+    const CLAUDE_OS = {
+      pid: 100,
+      agent: 'Claude Code',
+      process: 'claude',
+      instanceId: '100:1717000000000',
+    };
+    const CLAUDE_U = { pid: 100, agent: 'Claude Code', process: 'claude', instanceId: '100:u' };
+
+    it('a degraded scan neither ends the old session nor starts one under the new key', () => {
+      // The process never left. The snapshot provider did, so its key changed —
+      // which reconcile would otherwise read as "one agent exited, another arrived".
+      const entered = [];
+      const exited = [];
+      const tick = (agents, opts) => {
+        const res = tracker.reconcile(agents, { grace: 2, ...opts });
+        entered.push(...res.entered);
+        exited.push(...res.exited);
+      };
+
+      tick([CLAUDE_OS], { now: 0 });
+      expect(entered).toHaveLength(1);
+
+      // Three degraded ticks — one more than grace, so an aged-out session would
+      // have been reported by the third.
+      tick([CLAUDE_U], { now: 10000, identityDegraded: true });
+      tick([CLAUDE_U], { now: 20000, identityDegraded: true });
+      tick([CLAUDE_U], { now: 30000, identityDegraded: true });
+
+      // Recovery: the key is the one it always was, and the session it belongs to
+      // was still there to match it.
+      tick([CLAUDE_OS], { now: 40000 });
+
+      expect(entered).toHaveLength(1);
+      expect(entered[0].instanceId).toBe('100:1717000000000');
+      expect(exited).toHaveLength(0);
+      expect(tracker.activeCount()).toBe(1);
+    });
+
+    it('a degraded scan is not counted as a miss', () => {
+      tracker.reconcile([CLAUDE_OS], { now: 0, grace: 2 });
+      tracker.reconcile([], { now: 10000, identityDegraded: true, grace: 2 });
+      tracker.reconcile([], { now: 20000, identityDegraded: true, grace: 2 });
+      const res = tracker.reconcile([], { now: 30000, identityDegraded: true, grace: 2 });
+      expect(res.exited).toHaveLength(0);
+      expect(tracker.activeCount()).toBe(1);
+    });
+
+    it('the flag is opt-in: an absent identityDegraded reconciles exactly as before', () => {
+      // linux/darwin never set it — `<pid>:u` is their steady state, not an
+      // outage, and every enter/exit must still be reported there.
+      const { allEntered, allExited } = runScans(
+        [{ agents: [CURSOR] }, { agents: [] }, { agents: [] }],
+        0,
+        2,
+      );
+      expect(allEntered).toHaveLength(1);
+      expect(allExited).toHaveLength(1);
+      expect(tracker.activeCount()).toBe(0);
+    });
+  });
+
   describe('reconcile — PID reuse', () => {
     it('a recycled PID belonging to a different agent starts a new session', () => {
       // pid 100 is Cursor, then after Cursor exits the OS reuses 100 for Copilot.


### PR DESCRIPTION
## The failure

`proc-snapshot` is its own health leaf (`process-snapshot.js:40`), while `reconcile`'s
`reliable` comes from `scanner.scanProcesses()` — the **tasklist** leaf. Nothing joined
the two.

So when tasklist stayed HEALTHY and the snapshot map came back empty, every agent's key
flipped from `<pid>:<birthMs>` to `<pid>:u`, the session keys changed with it, and at
`grace = 2` — two ticks, 20 s — **every live agent got a false `agent-exit` in the audit
log plus a duplicate `agent-enter` under the `:u` key**. Recovery emitted the mirror pair.
Baselines, anomaly state and the token ledger forked along with the key.

This is the SPLIT that `process-identity.js`'s header names as the opposite of a merge,
and nothing gated it: `getIdentityQuality()` self-documents as annotation that gates
nothing (design §3).

## The predicate

```js
function isIdentityDegraded() {
  return _providesStartTime === true && getIdentityQuality() === 'unknown';
}
```

**Degradation is relative to what the platform provides.** A bare
`identityQuality === 'unknown'` is permanently true on linux and darwin — neither adapter
publishes a birth time at all — so acting on it there would freeze session tracking
forever on platforms where `<pid>:u` is the documented steady state
(`process-identity.js` space 3), not a fault. The `providesStartTime` conjunct is what
makes it a statement about a *failed observation* rather than about a platform.

The CIM fallback (`'birth-time'`) is deliberately **not** degradation: keys still form in
the same space with the same values, so nothing splits.

Published as its own function rather than a fifth `ProcessCapabilities` field — that
struct is the POPULATION contract every agent-scoped sensor gates on, and this answers a
different question for exactly one consumer.

## The wiring

`scan-loop` reads it **after** the identity stamp — the snapshot leaf's health describes
the observation `enrichWithParentChains` just made; read at the top of the tick it would
report the previous pass's provider, and on the first tick a leaf never written at all.
A frozen tick logs `scan/session-freeze`, or an outage is indistinguishable from a quiet
machine.

`session-tracker` treats it exactly like `!reliable`: no enters, no exits, no aging — the
same mechanism that already kills the EPERM storm. Both are absences of evidence (one lost
the population, the other lost the key), and an absence of evidence must not be written
into the audit log as a fleet-wide exit.

## What stays open — documented on `reconcile`, because it is not free

While frozen, a **real** start or stop is invisible too: an agent that exits during the
outage is reported only once the observation returns and it is missed for `grace` more
reliable ticks. And an outage that begins **before the first tick** means nothing is
tracked at all, where the pre-flag behaviour would have tracked everything under `:u`
keys. That is the same trade the `reliable` flag already makes for a permission-denied
scan — a late true event over a fleet of false ones — and it is bounded by the outage.

## Tests

Both added T2 levels **failed on master before the change**:

- `session-tracker.test.js` — `expected [ …(3) ] to have a length of 1 but got 3` (the
  split: one real enter plus two phantom ones) and `expected +0 to be 1` (the session
  aged out).
- `scan-loop.test.js` — `expected [ Array(2) ] to have a length of +0 but got 2`: two
  `agent-exit` records for two processes that never stopped.

After: four ticks (healthy → outage → outage → recovery) produce **zero `agent-exit` and
exactly two `agent-enter`**, both under the original `os` keys.

The predicate is exercised on the real `process-scanner` across five platform/health
combinations, including all three snapshot states under `providesStartTime: false` →
never degraded.

One more pinned: the scan batch **keeps** carrying the honest `<pid>:u` while frozen.
Freezing is about session state; the batch is an observation and must keep reporting what
was observed, not a remembered key.

**linux/darwin are byte-identical** — the diff to both test files is purely additive
(zero deleted lines), so every existing test proving that shape stayed green untouched.

All seven pre-merge commands green; `npm run verify:gate` still kills m1–m4.
