### PR TITLE
docs: align counted declarations with derived values, counts:check blocking

### DIFF
--- a/.agents/skills/aegis-context/SKILL.md
+++ b/.agents/skills/aegis-context/SKILL.md
@@ -22,8 +22,8 @@ Read package.json for exact versions. NEVER hardcode.
 Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs: false`** — `src/main/*.js` bodies are NOT type-checked, their JSDoc is documentation. Two projects (`tsconfig.main.json` CommonJS / `tsconfig.renderer.json` ESM) share `tsconfig.base.json`; root `tsconfig.json` is a solution file, so gate with `npm run typecheck`, never a bare `npx tsc --noEmit`.
 
 ## Architecture
-- Main process (Node.js): src/main/ — 46 CJS modules (37 top-level + 7 platform/ + 2 token-adapters/)
-- Renderer (Svelte 5): src/renderer/ — 46 components + 11 stores + 16 utils via IPC bridge
+- Main process (Node.js): src/main/ — 51 CJS modules (39 top-level + 10 platform/ + 2 token-adapters/)
+- Renderer (Svelte 5): src/renderer/ — 47 components + 13 stores + 21 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 40 invoke + 9 push = 49 channels
 - Data: src/shared/agent-database.json (110 agents / 262 name signatures)
 - Rules: rules/*.yaml — 73 active rules across 8 categories, validated against rules/_schema.json

--- a/.agents/skills/electron-main/SKILL.md
+++ b/.agents/skills/electron-main/SKILL.md
@@ -5,7 +5,7 @@ description: Electron main process patterns for Aegis. CJS modules, platform abs
 # Electron Main Process
 
 ## Architecture
-- 46 CJS modules loaded directly by Node.js (37 top-level + 7 platform/ + 2 token-adapters/, NO build step)
+- 51 CJS modules loaded directly by Node.js (39 top-level + 10 platform/ + 2 token-adapters/, NO build step)
 - Platform dispatcher: src/main/platform/index.js → win32|darwin|linux
 - IPC: 40 invoke + 9 push = 49 channels, scan-batch consolidation
 - File watcher: chokidar 3.6, function-form ignored (NOT glob)

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -2,7 +2,7 @@
 alwaysApply: true
 ---
 # Code Quality Rules
-- 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 654, audit-logger.js 600, ipc-handlers.js 503), tests go up to 734. Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (largest: file-watcher.js 1099, scan-loop.js 772, process-utils.js 608), tests go up to 1553. Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - No `any` type. Use proper types from src/shared/types/
 - GPG signing on all commits
 - Verify after EVERY change: npm test && npm run build && npm run typecheck (NOT `npx tsc --noEmit` — the root tsconfig is a solution file and checks nothing)

--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -22,8 +22,8 @@ Read package.json for exact versions. NEVER hardcode.
 Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs: false`** — `src/main/*.js` bodies are NOT type-checked, their JSDoc is documentation. Two projects (`tsconfig.main.json` CommonJS / `tsconfig.renderer.json` ESM) share `tsconfig.base.json`; root `tsconfig.json` is a solution file, so gate with `npm run typecheck`, never a bare `npx tsc --noEmit`.
 
 ## Architecture
-- Main process (Node.js): src/main/ — 46 CJS modules (37 top-level + 7 platform/ + 2 token-adapters/)
-- Renderer (Svelte 5): src/renderer/ — 46 components + 11 stores + 16 utils via IPC bridge
+- Main process (Node.js): src/main/ — 51 CJS modules (39 top-level + 10 platform/ + 2 token-adapters/)
+- Renderer (Svelte 5): src/renderer/ — 47 components + 13 stores + 21 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 40 invoke + 9 push = 49 channels
 - Data: src/shared/agent-database.json (110 agents / 262 name signatures)
 - Rules: rules/*.yaml — 73 active rules across 8 categories, validated against rules/_schema.json

--- a/.claude/skills/electron-main/SKILL.md
+++ b/.claude/skills/electron-main/SKILL.md
@@ -5,7 +5,7 @@ description: Electron main process patterns for Aegis. CJS modules, platform abs
 # Electron Main Process
 
 ## Architecture
-- 46 CJS modules loaded directly by Node.js (37 top-level + 7 platform/ + 2 token-adapters/, NO build step)
+- 51 CJS modules loaded directly by Node.js (39 top-level + 10 platform/ + 2 token-adapters/, NO build step)
 - Platform dispatcher: src/main/platform/index.js → win32|darwin|linux
 - IPC: 40 invoke + 9 push = 49 channels, scan-batch consolidation
 - File watcher: chokidar 3.6, function-form ignored (NOT glob)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,21 +55,19 @@ jobs:
       - run: npm ci
       - run: npm run test:coverage
       # Injection proof, inside the existing job so no required status context
-      # changes: it breaks the generation-witness gate three ways and requires the
-      # witness suite to go red for each. A green suite otherwise only proves the
-      # suite ran (memory-bank/ai-mistakes.md #21).
+      # changes: 4 mutants over TWO properties — m1-m3 break the generation-witness
+      # comparison, m4 breaks the birth-time freshness link — and the witness suite
+      # must go red for each. A green suite otherwise only proves the suite ran
+      # (memory-bank/ai-mistakes.md #21).
       - name: Verify the generation-witness gate is load-bearing
         run: npm run verify:gate
-      # Derives the repo's countable facts from the tree and names every tracked file
-      # that declares a different number (memory-bank/ai-mistakes.md #24: nothing goes
-      # red when a hand-maintained count stops being true). REPORT-ONLY for now: the
-      # declarations it was written to catch are stale TODAY, and `test` is one of the
-      # five required contexts, so a failing step here would block every merge —
-      # including the docs sweep that clears the drift. Drop continue-on-error in the
-      # PR that lands that sweep; the full diff is in this step's log meanwhile.
+      # Derives the repo's countable facts from the tree and fails on every tracked
+      # file that declares a different number (memory-bank/ai-mistakes.md #24: nothing
+      # went red when a hand-maintained count stopped being true). BLOCKING since the
+      # sweep that cleared the drift: `test` is a required context, so a stale count
+      # now stops the merge instead of being reported into a log nobody opens.
       - name: Check derived counts against declared ones
         run: npm run counts:check
-        continue-on-error: true
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ npm run lint             # ESLint — no errors
 npm run typecheck        # one command, two tsc projects: tsconfig.main.json && tsconfig.renderer.json
 npm run typecheck:svelte # svelte-check — reads .svelte templates, which tsc never does
 npm run test:coverage    # vitest run --coverage — this, not npm test, is what CI runs
+npm run verify:gate      # injection proof: 4 mutants must turn the witness suite red
+npm run counts:check     # derived counts vs the numbers tracked files declare
 npm audit --audit-level=high --omit=dev   # production dependencies only
 ```
 
@@ -47,10 +49,11 @@ Three counts, deliberately kept apart:
   `gh api repos/antropos17/Aegis/branches/master/protection --jq '.required_status_checks'`
   (`strict: true`, so the branch must also be up to date). `/rulesets` and
   `/rules/branches/master` both return `[]` — nothing else is enforced.
-- **7 verification commands** inside those 5 jobs. The counts differ because `lint` runs
-  `format:check` then `lint`, and `svelte-check` runs `typecheck` then `typecheck:svelte`.
-  `format:check` is a step, not a job, and has no status context of its own.
-- **7 local pre-merge commands** — the block above, one per verification command.
+- **9 verification commands** inside those 5 jobs. The counts differ because `lint` runs
+  `format:check` then `lint`, `svelte-check` runs `typecheck` then `typecheck:svelte`, and
+  `test` runs `test:coverage`, `verify:gate`, then `counts:check`. `format:check` is a step,
+  not a job, and has no status context of its own.
+- **9 local pre-merge commands** — the block above, one per verification command.
 
 `npm test` (`vitest run`) is a convenience alias, not a gate: CI runs `npm run test:coverage`
 (`vitest run --coverage`). Same suite, plus v8 instrumentation and an lcov artifact. No
@@ -59,7 +62,7 @@ coverage thresholds are configured in `vitest.config.js`, so coverage cannot fai
 
 ## Code conventions
 
-- 300 lines/file is a target for NEW files, not an invariant — 18 existing src files already exceed it (largest: file-watcher.js 654, audit-logger.js 600, ipc-handlers.js 503), tests go up to 734. Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (largest: file-watcher.js 1099, scan-loop.js 772, process-utils.js 608), tests go up to 1553. Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - **Main process:** CommonJS (`require`/`module.exports`). Never use `import` in `src/main/`.
 - **Renderer:** ES modules (`import`/`export`). Never use `require()` in `src/renderer/`.
 - **Svelte 5 runes:** `$state`, `$derived`, `$effect`, `$props`. No legacy `let` reactivity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ npm run lint              # ESLint
 npm run format            # Prettier
 npm test                  # Vitest — the suite prints its own counts; do not copy them here
 npm run verify:gate       # Injection proof: 4 mutants (witness gate + birth-time freshness) must go red
+npm run counts:check      # Every counted fact derived from the tree; a stale declaration is red
 npm run dist              # Electron-builder NSIS installer
 
 ## Verification — three different counts, do not merge them
@@ -19,20 +20,20 @@ npm run dist              # Electron-builder NSIS installer
 date before merge). No rulesets add more: `/rulesets` and `/rules/branches/master` return `[]`.
 A context is a JOB, not a command — `lint` and `svelte-check` run two commands each.
 
-**8 verification commands** live inside those 5 jobs (`.github/workflows/ci.yml`):
+**9 verification commands** live inside those 5 jobs (`.github/workflows/ci.yml`):
 
 | required context | commands the job runs, after `npm ci` |
 |---|---|
 | build | `npm run build:renderer` |
 | lint | `npm run format:check`, then `npm run lint` |
 | svelte-check | `npm run typecheck`, then `npm run typecheck:svelte` |
-| test | `npm run test:coverage`, then `npm run verify:gate` |
+| test | `npm run test:coverage`, `npm run verify:gate`, then `npm run counts:check` |
 | audit | `npm audit --audit-level=high --omit=dev` |
 
-`format:check` is a STEP of `lint` and `verify:gate` a STEP of `test` — neither is a job, and
-neither is a context of its own.
+`format:check` is a STEP of `lint`, and `verify:gate` and `counts:check` are STEPS of `test` —
+none is a job, and none is a context of its own.
 
-## Local pre-merge set — the same 8 commands
+## Local pre-merge set — the same 9 commands
 npm run build:renderer
 npm run format:check      # the checker; `npm run format` WRITES and is not a gate
 npm run lint
@@ -40,6 +41,7 @@ npm run typecheck         # ONE command, TWO tsc projects: main.json && renderer
 npm run typecheck:svelte  # svelte-check; tsc never reads .svelte templates
 npm run test:coverage     # what CI runs — `npm test` (vitest run) is NOT the CI command
 npm run verify:gate       # a STEP of the `test` job: a surviving mutant fails that context
+npm run counts:check      # a STEP of the `test` job: derives every counted fact from the tree
 npm audit --audit-level=high --omit=dev   # production deps only, not your diff
 Every job also runs `npm ci`, which is not `npm install` — see ai-mistakes 23 before
 regenerating a lockfile.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -295,7 +295,7 @@ Key token namespaces:
 
 ## Conventions
 
-- **300-line soft limit** per file — a target for NEW files, not an invariant; 18 existing `src/` files already exceed it. Not enforced by the linter
+- **300-line soft limit** per file — a target for NEW files, not an invariant; 30 existing `src/` files already exceed it. Not enforced by the linter
 - **JSDoc on all exported functions**: `@param`, `@returns`, `@since`
 - **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `security:`
 - **IPC channel names**: `kebab-case`

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -54,18 +54,21 @@ not evidence for `src/main/*.js` (`checkJs: false`).
 
 ---
 
-## Ground truth (counts re-measured at `d027f0c`, 2026-08-13)
+## Ground truth (counts re-measured at `fa85837`, 2026-08-21)
 
 The audit's original table compared documented figures against a 2026-08-08 tree and marked five
 rows "match". Four of those figures have since moved. The table below is a fresh measurement, not
-the audit's; each row carries the command that produced it.
+the audit's; each row carries the command that produced it. Every row except the attribution
+evidence codes is now re-derived on each CI run by `npm run counts:check`, which fails the `test`
+job when a tracked file declares a different number — those rows stop being a snapshot somebody
+has to remember to redo. The evidence-code row is not covered and still is one.
 
 | Quantity | Command | Measured |
 |---|---|---|
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **50** = 38 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **51** = 39 top-level + 10 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |
@@ -74,8 +77,8 @@ the audit's; each row carries the command that produced it.
 | Attribution evidence codes | `require('./src/main/attribution.js').EVIDENCE_CODES` | **7** |
 
 At audit time these read 46 main modules, 47 components (against 46 documented), 13 stores, 16
-utils. The main-module figure moved twice — see `ai-mistakes.md` #24, which names an earlier version
-of *this file* among the eight places a dead count sat.
+utils. The main-module figure has moved again since (46 → 50 → 51) — see `ai-mistakes.md` #24,
+which names an earlier version of *this file* among the eight places a dead count sat.
 
 **Dead / half-wired production surfaces, re-checked at `d027f0c`:**
 

--- a/docs/social-preview-animated.html
+++ b/docs/social-preview-animated.html
@@ -144,7 +144,7 @@
     <div class="pills" id="pills">
       <span class="pill">568 tests</span>
       <span class="pill">110 agents</span>
-      <span class="pill">70 rules</span>
+      <span class="pill">73 rules</span>
       <span class="pill">MIT Licensed</span>
     </div>
   </div>

--- a/docs/social-preview.html
+++ b/docs/social-preview.html
@@ -92,7 +92,7 @@
     <div class="pills">
       <span class="pill">568 tests</span>
       <span class="pill">110 agents</span>
-      <span class="pill">70 rules</span>
+      <span class="pill">73 rules</span>
       <span class="pill">MIT Licensed</span>
     </div>
   </div>

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,13 +1,13 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 46 CommonJS modules (37 top-level + 7 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 51 CommonJS modules (39 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle
 - scan-loop.js — periodic scan intervals, staggered startup, event dedup
 - ipc-batcher.js — batches high-frequency IPC events (append/latest modes)
 - ipc-handlers.js — all IPC handlers (invoke + listeners)
-- preload.js — IPC bridge (window.aegis via contextBridge, 39 invoke + 9 events = 48 channels)
+- preload.js — IPC bridge (window.aegis via contextBridge, 40 invoke + 9 events = 49 channels)
 - process-scanner.js — AI agent detection (tasklist + pattern matching)
 - process-utils.js — parent chain resolution + editor annotation
 - file-watcher.js — chokidar watchers + handle scanning
@@ -26,7 +26,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (src/renderer/) — Svelte 5 + Vite 7
-46 Svelte components, 11 stores, 16 utils, scoped CSS + tokens.css/global.css
+47 Svelte components, 13 stores, 21 utils, scoped CSS + tokens.css/global.css
 
 ### Components (src/renderer/lib/components/)
 - App.svelte — root layout, tab routing, settings modal

--- a/src/renderer/lib/utils/command-registry.ts
+++ b/src/renderer/lib/utils/command-registry.ts
@@ -2,7 +2,7 @@
  * @file command-registry.ts — Static command definitions for Command Palette
  * @module renderer/lib/utils/command-registry
  * @description Provides all static commands grouped by category.
- * Per-agent commands (110 signatures) are excluded — loaded dynamically via
+ * Per-agent commands (110 agents, 262 name signatures) are excluded — loaded dynamically via
  * fuzzy search. Agent *action* commands (kill/suspend the selected agent) are
  * static and live here under the `agent` category.
  */


### PR DESCRIPTION
Follow-up to #240. `npm run counts:check` reported **42 stale declarations across 13 files**; every one is fixed at its declaration site, the checker exits 0, and the CI step drops `continue-on-error`.

## Fixes

| file | counter | was | now |
|---|---|---|---|
| `.claude/skills/aegis-context/SKILL.md`, `.agents/` copy | src/main modules | 46 (37 + 7 + 2) | **51 (39 + 10 + 2)** |
| same two files | renderer inventory | 46 components / 11 stores / 16 utils | **47 / 13 / 21** |
| `.claude/skills/electron-main/SKILL.md`, `.agents/` copy | src/main modules | 46 (37 + 7 + 2) | **51 (39 + 10 + 2)** |
| `memory-bank/architecture.md` | src/main modules | 46 (37 + 7 + 2) | **51 (39 + 10 + 2)** |
| `memory-bank/architecture.md` | preload channels | 39 invoke + 9 = 48 | **40 + 9 = 49** |
| `memory-bank/architecture.md` | renderer inventory | 46 / 11 / 16 | **47 / 13 / 21** |
| `docs/current-state/CORRECTNESS-AUDIT.md` | src/main modules | 50 = 38 + 10 + 2 | **51 = 39 + 10 + 2** |
| `.claude/rules/code-quality.md`, `AGENTS.md` | files > 300 lines, largest src, largest test | 18 / 654 / 734 | **30 / 1099 / 1553** |
| `docs/DEVELOPMENT.md` | files > 300 lines | 18 | **30** |
| `docs/social-preview.html`, `-animated.html` | detection rules | 70 | **73** |
| `AGENTS.md` | CI verification commands | 7 | **9** |
| `CLAUDE.md` | CI verification commands | 8 | **9** |
| `.github/workflows/ci.yml` | verify:gate mutants | "three ways" | **4 mutants over two properties** |

Both `.claude/skills/` and `.agents/skills/` copies got byte-identical counter edits; `electron-main` is fully identical again.

## Prose corrected alongside the numbers

A corrected number next to a stale name is still wrong (ai-mistakes #27):

- The `largest:` triple is not verified by `size.largestSrc`, which reads only the first pair. Re-derived from the same command: `file-watcher.js 654, audit-logger.js 600, ipc-handlers.js 503` → `file-watcher.js 1099, scan-loop.js 772, process-utils.js 608`.
- `AGENTS.md`'s pre-merge block was missing `verify:gate` **entirely** while claiming "one per verification command". Both `verify:gate` and `counts:check` are added, so 9 lines back 9 commands.
- `CLAUDE.md`'s CI table gains the `counts:check` step under `test`, and its pre-merge block the matching line.
- `CORRECTNESS-AUDIT.md`'s ground-truth stamp moves `d027f0c`/2026-08-13 → `fa85837`/2026-08-21 with the row it covers, and now names the one row `counts:check` does **not** cover (attribution evidence codes). The separate "Dead / half-wired surfaces, re-checked at `d027f0c`" table below was not re-measured and keeps its stamp.
- `src/renderer/lib/utils/command-registry.ts:5` called 110 "signatures". 110 is the agent count; the signature count is 262. The scanner reads prose files only, so this one is not guarded — it was fixed because it was found, not because the checker flagged it.

## ci.yml comment: kept a count, restated the claim

The comment said the step "breaks the generation-witness gate **three** ways". Bumping it to "four" would have kept an overclaim: `m4` breaks **birth-time freshness**, a separate property, not the witness gate — exactly the #27 pattern where a rewrite walks past the wrong sentence. Rewritten to name both properties, and the count is **kept** rather than dropped: counts:check now guards it, so a fifth mutant turns CI red instead of quietly outdating the comment. Removing the number to avoid maintaining it would concede the opposite lesson.

## Blocking

`continue-on-error: true` removed. Still a step of the existing `test` job, so **the five required contexts are unchanged** — but `test` is required with `strict: true`, so a stale count now blocks the merge.

## Verification

```
$ npm run counts:check
counts:check OK — 21 counters derived from the tree, 137 declaration sites agree
$ echo $?
0
```

All nine local pre-merge commands run green, `verify:gate` included (4/4 mutants killed, control green). `scripts/counts.js` is untouched — `git diff --stat -- scripts/ package.json` is empty.

## Reported, not fixed

- `.claude/skills/` vs `.agents/skills/` diverge in **3 of 11** pairs beyond counters, all rebranding: `aegis-context` (`.claude/skills/` vs `.Codex/skills/`; "Claude Code" vs "Codex"), `audit-check` (`.claude/agents/, .claude/skills/` vs `.Codex/agents/, .Codex/skills/`), `prompt-craft` ("Claude Code" vs "Codex" ×2, and "README, CLAUDE.md" vs "README, AGENTS.md"). Note the `.agents/` copies point at `.Codex/`, which is neither the tracked `.agents/skills/` nor the lowercase `.codex/` at the repo root. Left alone.
- Both social-preview pages also carry a `568 tests` pill. Tests are not a counted counter, so `counts:check` never named it — flagged, not touched.
