### PR TITLE
fix(counts): make largest-file counters derived-only so prose cannot drift

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -2,7 +2,7 @@
 alwaysApply: true
 ---
 # Code Quality Rules
-- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (largest: file-watcher.js 1099, scan-loop.js 772, process-utils.js 608), tests go up to 1553. Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - No `any` type. Use proper types from src/shared/types/
 - GPG signing on all commits
 - Verify after EVERY change: npm test && npm run build && npm run typecheck (NOT `npx tsc --noEmit` — the root tsconfig is a solution file and checks nothing)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ coverage thresholds are configured in `vitest.config.js`, so coverage cannot fai
 
 ## Code conventions
 
-- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (largest: file-watcher.js 1099, scan-loop.js 772, process-utils.js 608), tests go up to 1553. Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - **Main process:** CommonJS (`require`/`module.exports`). Never use `import` in `src/main/`.
 - **Renderer:** ES modules (`import`/`export`). Never use `require()` in `src/renderer/`.
 - **Svelte 5 runes:** `$state`, `$derived`, `$effect`, `$props`. No legacy `let` reactivity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ regenerating a lockfile.
 ## Critical Rules
 1. Read memory-bank/ai-mistakes.md before ANY code change
 2. Do ONLY what the prompt says — no extra features, no unrequested changes
-3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 30 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; largest: file-watcher.js 1099, scan-loop.js 772, process-utils.js 608), tests go up to 1553. Don't split an existing file just to hit the number; do extract when adding to one that's already over
+3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 30 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"

--- a/scripts/counts.js
+++ b/scripts/counts.js
@@ -207,8 +207,14 @@ const mainAll = trackedUnder('src/main', (p) => p.endsWith('.js'));
 const mainTop = trackedTopLevel('src/main', (f) => f.endsWith('.js'));
 
 /**
- * The counted set. `key` is what a scanner emits, `command` is the hand-runnable
- * derivation printed in the report.
+ * The CHECKED set. Every entry here MUST be declared by at least one tracked prose
+ * file: the undeclared gate goes red when one is not, which is the invariant that
+ * keeps a counter from quietly ceasing to be checked. `key` is what a scanner emits,
+ * `command` is the hand-runnable derivation printed in the report.
+ *
+ * A counter earns a place here only if prose can restate its value and stay true for
+ * more than one commit. One that moves on an ordinary single-line edit belongs in
+ * `DERIVED_ONLY` below instead.
  * @type {Array<{key: string, label: string, value: number, command: string}>}
  */
 const COUNTERS = [
@@ -330,6 +336,29 @@ const COUNTERS = [
     command:
       "git ls-files -z src | grep -zv '\\.json$' | xargs -0 wc -l | awk '$1 > 300 && $2 != \"total\"' | wc -l",
   },
+];
+
+/**
+ * DERIVED-ONLY counters: printed on every run, declared by nothing, checked against
+ * nothing. They sit outside `COUNTERS`, so no scanner emits their keys and neither the
+ * stale gate nor the undeclared gate can ever see them. That is the whole mechanism:
+ * there is no skip flag on the declaration-matching path for anyone to forget to set.
+ *
+ * Write the guarantee, not the impression (ai-mistakes #27): moving a counter here
+ * REMOVES a guarantee. Nothing catches prose that restates one of these numbers
+ * wrongly, because prose is not meant to state them at all. The trade is deliberate.
+ * Each pins the exact length of ONE live file, so any commit that added or removed a
+ * single line in that file falsified every prose copy at once and turned a required
+ * status context red on a change that had nothing to do with the docs. That is the
+ * failure PR #241 made blocking, on files among the most frequently edited in the repo.
+ * A figure nobody may restate cannot drift, and `npm run counts:check` stays the one
+ * live answer.
+ *
+ * The bar is narrow and `size.over300` deliberately fails it: that one moves only when
+ * a file crosses the 300-line threshold, so it stays in `COUNTERS` and stays checked.
+ * @type {Array<{key: string, label: string, value: number, command: string}>}
+ */
+const DERIVED_ONLY = [
   {
     key: 'size.largestSrc',
     label: `largest src file (${sizes.largestSrc.file})`,
@@ -344,7 +373,11 @@ const COUNTERS = [
   },
 ];
 
-/** @type {Map<string, {key: string, label: string, value: number, command: string}>} */
+/**
+ * Checked counters only. A `DERIVED_ONLY` key is absent from this map by construction,
+ * which is what stops the stale gate from ever resolving one.
+ * @type {Map<string, {key: string, label: string, value: number, command: string}>}
+ */
 const BY_KEY = new Map(COUNTERS.map((c) => [c.key, c]));
 
 // ---------------------------------------------------------------------------
@@ -557,22 +590,14 @@ const SCANNERS = [
   },
   {
     id: 'file-size-budget',
-    // Write the guarantee, not the impression (ai-mistakes #27). `size.largestSrc`
-    // reads only the FIRST pair of "largest: file-watcher.js 654, audit-logger.js 600,
-    // ipc-handlers.js 503" — this checks the largest file's line count, and neither the
-    // runners-up nor any of the three FILENAMES. A sweep that corrects only the leading
-    // number passes green while the line still names the wrong second and third files;
-    // CLAUDE.md:71 carries the correct triple to copy from.
-    locate: new RegExp(
-      `\\bexceeds?\\s+it\\b|${DIGITS}\\s+existing\\b|tests go up to\\b|\\blargest:`,
-      'i',
-    ),
-    parse: (line) =>
-      pick(line, [
-        ['size.over300', new RegExp(`${DIGITS}\\s+existing\\b`, 'i')],
-        ['size.largestSrc', new RegExp(`largest:\\s*[\\w.-]+\\s+${DIGITS}`, 'i')],
-        ['size.largestTest', new RegExp(`tests go up to\\s+${DIGITS}`, 'i')],
-      ]),
+    // Write the guarantee, not the impression (ai-mistakes #27): this scanner covers
+    // `size.over300` and nothing else about file size. The exact length of the largest
+    // src file and of the largest test file is DERIVED_ONLY: prose is not meant to
+    // restate either, so there is deliberately no locator for them here and a line that
+    // does state one is NOT checked. Run `npm run counts:check` for those two figures
+    // rather than quoting them; having no declaration site is what stops them drifting.
+    locate: new RegExp(`\\bexceeds?\\s+it\\b|${DIGITS}\\s+existing\\b`, 'i'),
+    parse: (line) => pick(line, [['size.over300', new RegExp(`${DIGITS}\\s+existing\\b`, 'i')]]),
   },
 ];
 
@@ -800,6 +825,17 @@ for (const c of COUNTERS) {
   console.log(`  ${' '.repeat(20)}     declared at ${sites} site${sites === 1 ? '' : 's'}`);
 }
 
+head('Derived only — no declaration sites by design');
+console.log('  Printed on every run, checked against nothing. Each pins the exact length');
+console.log('  of one live file, so a one-line edit anywhere in it falsifies a prose copy.');
+console.log('  They sit outside COUNTERS: no scanner emits their keys, so neither the stale');
+console.log('  gate nor the undeclared gate applies. Quote this output, never the number.');
+for (const c of DERIVED_ONLY) {
+  console.log(`  ${c.key.padEnd(20)} = ${String(c.value).padStart(5)}   ${c.label}`);
+  console.log(`  ${' '.repeat(20)}     ${c.command}`);
+  console.log(`  ${' '.repeat(20)}     derived-only — no declaration sites by design`);
+}
+
 console.log(
   `\nDeclaration scan: ${scannedFiles} of ${TRACKED.length} tracked files, read from the index
 ` +
@@ -873,6 +909,8 @@ if (failed) {
 }
 
 console.log(
-  `\ncounts:check OK — ${COUNTERS.length} counters derived from the tree, ` +
-    `${declarations.length} declaration sites agree.`,
+  `\ncounts:check OK — ${COUNTERS.length} checked counters derived from the tree, ` +
+    `${declarations.length} declaration sites agree; ` +
+    `${DERIVED_ONLY.length} derived-only counters printed and declared nowhere by ` +
+    `design (${COUNTERS.length + DERIVED_ONLY.length} counters derived in total).`,
 );


### PR DESCRIPTION
## Problem

PR #241 made `counts:check` blocking inside the required `test` job. Two counters
pinned the exact line count of a single live file each:

- `size.largestSrc` — `src/main/file-watcher.js` (1099)
- `size.largestTest` — `tests/main/scan-loop.test.js` (1553)

Any commit adding or removing one line in either file turned the required status
context red until three prose files were corrected in the same PR. `scan-loop.test.js`
is among the most frequently edited files in the repo, so this fires on changes that
have nothing to do with documentation.

## Approach

The checker is not weakened and no allowlist or skip flag was added to the
declaration-matching path. The counter set is split structurally instead.

- **`COUNTERS` keeps its invariant intact.** Every entry must still be declared by at
  least one tracked prose file; the undeclared gate still goes red when one is not.
- **New `DERIVED_ONLY` array** holds the two largest-file counters. It sits outside
  `COUNTERS`, so no scanner emits their keys and neither the stale gate nor the
  undeclared gate can ever see them. The separation is structural, not a flag.
- **Both still print on every run**, under an explicit heading that states they have no
  declaration sites by design, so the live figures stay one command away.

The `file-size-budget` scanner loses its `largest:` and `tests go up to` locators and
both parse rules; it now covers `size.over300` and nothing else.

`size.over300` is deliberately untouched and **still declared at 4 sites** — it moves
only when a file crosses the 300-line threshold, which prose can restate and stay true.

## New output

```
Derived only — no declaration sites by design
─────────────────────────────────────────────
  Printed on every run, checked against nothing. Each pins the exact length
  of one live file, so a one-line edit anywhere in it falsifies a prose copy.
  They sit outside COUNTERS: no scanner emits their keys, so neither the stale
  gate nor the undeclared gate applies. Quote this output, never the number.
  size.largestSrc      =  1099   largest src file (src/main/file-watcher.js)
                           git ls-files -z src | grep -zv '\.json$' | xargs -0 wc -l | sort -rn | sed -n 2p
                           derived-only — no declaration sites by design
  size.largestTest     =  1553   largest test file (tests/main/scan-loop.test.js)
                           git ls-files -z tests | xargs -0 wc -l | sort -rn | sed -n 2p
                           derived-only — no declaration sites by design
```

Summary line now reads `19 checked counters ... 2 derived-only ... (21 counters derived
in total)`, so 19 cannot be misread as two counters having been silently dropped.

## Prose sites

All three sentences kept the `30 existing src files already exceed it` clause verbatim
(that is `size.over300`, untouched) and replaced the file-name-plus-number trio with a
pointer to the live command:

| File | Was | Now |
|---|---|---|
| `.claude/rules/code-quality.md:5` | `(largest: file-watcher.js 1099, scan-loop.js 772, process-utils.js 608), tests go up to 1553` | `` (`npm run counts:check` prints the current largest src and test files) `` |
| `AGENTS.md:65` | same trio | same pointer |
| `CLAUDE.md:73` | same trio, after the inline `git ls-files` command | same pointer, inline command kept |

No tracked prose file states an exact line count for the largest src or test file any
more; `1099` and `1553` appear nowhere in tracked prose.

## Stale self-pointer

The scanner comment said *"CLAUDE.md:71 carries the correct triple to copy from"* — the
line was actually 73, so it was already off by two and would have dangled entirely after
this change. Removed rather than corrected: no hardcoded prose line number remains in
`counts.js`.

## Verification

| Gate | Result |
|---|---|
| `npm run counts:check` | 0 — 19 checked + 2 derived-only |
| `npm run test:coverage` | 0 — 102 test files passed |
| `npm run lint` | 0 — 0 errors (28 pre-existing warnings) |
| `npm run format:check` | 0 |
| `npm run typecheck` | 0 |
| `npm run verify:gate` | 0 — every mutant killed |

## Trade-off, stated explicitly

Moving a counter to `DERIVED_ONLY` removes a guarantee: nothing now catches prose that
restates one of these two numbers wrongly, because prose is not meant to state them at
all. That is deliberate and documented in the array's docblock, per ai-mistakes #27.
