### PR TITLE
test(renderer): bring all of tests/renderer under the typecheck gate

### DIFF
--- a/tests/renderer/agent-action-keys.test.ts
+++ b/tests/renderer/agent-action-keys.test.ts
@@ -7,18 +7,37 @@ import { get } from 'svelte/store';
 import {
   acknowledgementInstanceId,
   watchlistSignature,
-} from '../../src/renderer/lib/utils/agent-action-keys.ts';
+} from '../../src/renderer/lib/utils/agent-action-keys';
 import {
   acknowledgedAgents,
   toggleAcknowledged,
   isAcknowledged,
   clearAcknowledged,
 } from '../../src/renderer/lib/stores/acknowledged.js';
+import type { EnrichedAgent } from '../../src/shared/types';
 
 const ID_A = '5511:start-A';
 const ID_B = '7720:start-B';
 const ID_REUSE_A = '1234:start-A';
 const ID_REUSE_B = '1234:start-B';
+
+/**
+ * Card-shaped agent fixture — the four optional fields AgentActions.svelte declares
+ * for its `agent` prop, derived from the enriched record so a rename there turns
+ * these tests red. Every field is optional because a keyless or nameless agent is
+ * modelled by leaving one out, which is exactly what the assertions below pin.
+ */
+type AgentFixture = Partial<Pick<EnrichedAgent, 'name' | 'agent' | 'pid' | 'instanceId'>>;
+
+/**
+ * Gives a fixture its declared type without leaving it a fresh object literal at the
+ * call site. The helpers under test take deliberately narrow parameters, and the
+ * surplus `pid`/`name` fields are the point here — they must be ignored, not rejected.
+ * Used only where a fixture carries a field the callee does not declare.
+ * @param agent - Card-shaped fixture
+ * @returns The same object, typed as AgentFixture
+ */
+const fixture = (agent: AgentFixture): AgentFixture => agent;
 
 describe('agent-action-keys — identity split', () => {
   it('acknowledgement key is instanceId only; watchlist key is display name only', () => {
@@ -35,17 +54,19 @@ describe('agent-action-keys — identity split', () => {
   });
 
   it('null instanceId cannot fall back to name or pid for acknowledgement', () => {
-    const keyless = { name: 'Claude Code', agent: 'Claude Code', pid: 300 };
+    const keyless = fixture({ name: 'Claude Code', agent: 'Claude Code', pid: 300 });
     expect(acknowledgementInstanceId(keyless)).toBeNull();
-    expect(acknowledgementInstanceId({ instanceId: null, name: 'Claude Code' })).toBeNull();
-    expect(acknowledgementInstanceId({ instanceId: '', name: 'Claude Code' })).toBeNull();
+    expect(
+      acknowledgementInstanceId(fixture({ instanceId: null, name: 'Claude Code' })),
+    ).toBeNull();
+    expect(acknowledgementInstanceId(fixture({ instanceId: '', name: 'Claude Code' }))).toBeNull();
     // Watchlist still has a durable name.
     expect(watchlistSignature(keyless)).toBe('Claude Code');
   });
 
   it('watchlist signature never uses instanceId or bare pid', () => {
-    expect(watchlistSignature({ instanceId: ID_A, pid: 99 })).toBeNull();
-    expect(watchlistSignature({ agent: 'opencode', pid: 1 })).toBe('opencode');
+    expect(watchlistSignature(fixture({ instanceId: ID_A, pid: 99 }))).toBeNull();
+    expect(watchlistSignature(fixture({ agent: 'opencode', pid: 1 }))).toBe('opencode');
     expect(watchlistSignature({ name: 'Cursor' })).toBe('Cursor');
   });
 });
@@ -73,17 +94,21 @@ describe('acknowledgement by instance — C4', () => {
     expect(isAcknowledged(ID_REUSE_A)).toBe(true);
     // Process B: same pid, new birth → new instanceId.
     expect(isAcknowledged(ID_REUSE_B)).toBe(false);
-    expect(acknowledgementInstanceId({ pid: 1234, instanceId: ID_REUSE_B })).toBe(ID_REUSE_B);
+    expect(acknowledgementInstanceId(fixture({ pid: 1234, instanceId: ID_REUSE_B }))).toBe(
+      ID_REUSE_B,
+    );
   });
 
   it('same instanceId stays acknowledged across re-reads (not frame-local)', () => {
     toggleAcknowledged(ID_A);
     // Simulate a later scan batch re-deriving the same stamped id.
-    const again = acknowledgementInstanceId({
-      name: 'Claude Code',
-      instanceId: ID_A,
-      pid: 5511,
-    });
+    const again = acknowledgementInstanceId(
+      fixture({
+        name: 'Claude Code',
+        instanceId: ID_A,
+        pid: 5511,
+      }),
+    );
     expect(again).toBe(ID_A);
     expect(isAcknowledged(again!)).toBe(true);
     expect(get(acknowledgedAgents).has(ID_A)).toBe(true);
@@ -91,7 +116,7 @@ describe('acknowledgement by instance — C4', () => {
 
   it('null instance cannot steal a same-name agent acknowledgement', () => {
     toggleAcknowledged(ID_A);
-    const keyless = { name: 'Claude Code', pid: 300 };
+    const keyless = fixture({ name: 'Claude Code', pid: 300 });
     expect(acknowledgementInstanceId(keyless)).toBeNull();
     // Store still only has the stamped key.
     expect(isAcknowledged(ID_A)).toBe(true);
@@ -116,11 +141,13 @@ describe('acknowledgement by instance — C4', () => {
   });
 
   it('normal single-instance acknowledge / unacknowledge toggle', () => {
-    const id = acknowledgementInstanceId({
-      name: 'opencode',
-      instanceId: ID_A,
-      pid: 42,
-    })!;
+    const id = acknowledgementInstanceId(
+      fixture({
+        name: 'opencode',
+        instanceId: ID_A,
+        pid: 42,
+      }),
+    )!;
     expect(toggleAcknowledged(id)).toBe(true);
     expect(isAcknowledged(id)).toBe(true);
     expect(toggleAcknowledged(id)).toBe(false);

--- a/tests/renderer/agent-panel-utils.test.ts
+++ b/tests/renderer/agent-panel-utils.test.ts
@@ -2,7 +2,7 @@
  * AgentPanel grouping — F-W05 population consistency.
  */
 import { describe, it, expect } from 'vitest';
-import { groupAgentsForPanel } from '../../src/renderer/lib/utils/agent-panel-utils.ts';
+import { groupAgentsForPanel } from '../../src/renderer/lib/utils/agent-panel-utils';
 
 describe('groupAgentsForPanel (F-W05)', () => {
   it('returns empty for no agents', () => {

--- a/tests/renderer/agent-selection.test.ts
+++ b/tests/renderer/agent-selection.test.ts
@@ -9,20 +9,42 @@ import {
   resolveSelectedAgent,
   toggleInstanceSelection,
   focusInstanceId,
-} from '../../src/renderer/lib/utils/agent-selection.ts';
+} from '../../src/renderer/lib/utils/agent-selection';
+import type { EnrichedAgent } from '../../src/shared/types';
 
 const ID_A = '1234:start-A';
 const ID_B = '1234:start-B';
 const ID_OTHER = '9999:start-C';
 
+/**
+ * Live agent / focus source as the selection helpers receive it — the same four
+ * optional fields AgentActions.svelte declares for its `agent` prop, derived from the
+ * enriched record so a rename there turns these tests red. `instanceId` is optional
+ * because a keyless agent is modelled by leaving it out, which several tests pin.
+ */
+type AgentFixture = Partial<Pick<EnrichedAgent, 'name' | 'agent' | 'pid' | 'instanceId'>>;
+
+/**
+ * Gives a fixture its declared type without leaving it a fresh object literal at the
+ * call site. The helpers under test take deliberately narrow parameters, and the
+ * surplus `pid`/`name` fields are the point here — selection must ignore them, not
+ * reject them. Used only where a fixture carries a field the callee does not declare.
+ * @param agent - Live agent or focus-source fixture
+ * @returns The same object, typed as AgentFixture
+ */
+const fixture = (agent: AgentFixture): AgentFixture => agent;
+
 describe('agent-selection — PID reuse (step 8)', () => {
   it('does not rebind selection when a new process reuses the old pid', () => {
     // Process A was selected by its canonical instance key.
-    const selected = toggleInstanceSelection(null, {
-      pid: 1234,
-      instanceId: ID_A,
-      agent: 'Claude Code',
-    });
+    const selected = toggleInstanceSelection(
+      null,
+      fixture({
+        pid: 1234,
+        instanceId: ID_A,
+        agent: 'Claude Code',
+      }),
+    );
     expect(selected).toBe(ID_A);
 
     // A is gone; B appears with the same pid, different birth time → different instanceId.
@@ -52,7 +74,7 @@ describe('agent-selection — same name, distinct instances', () => {
 
 describe('agent-selection — null / missing instanceId', () => {
   it('cannot select a keyless agent via pid or name', () => {
-    const keyless = { pid: 300, agent: 'Claude Code', name: 'Claude Code' };
+    const keyless = fixture({ pid: 300, agent: 'Claude Code', name: 'Claude Code' });
     const keyed = { pid: 100, instanceId: ID_A, agent: 'Claude Code', name: 'Claude Code' };
 
     // Toggle on keyless leaves selection unchanged (no fabrication).
@@ -68,8 +90,8 @@ describe('agent-selection — null / missing instanceId', () => {
   });
 
   it('focusInstanceId refuses pid-only sources', () => {
-    expect(focusInstanceId({ pid: 1234 })).toBeNull();
-    expect(focusInstanceId({ pid: 1234, instanceId: ID_A })).toBe(ID_A);
+    expect(focusInstanceId(fixture({ pid: 1234 }))).toBeNull();
+    expect(focusInstanceId(fixture({ pid: 1234, instanceId: ID_A }))).toBe(ID_A);
     expect(focusInstanceId(null)).toBeNull();
   });
 });
@@ -96,8 +118,8 @@ describe('agent-selection — normal single-instance select / deselect', () => {
 
 describe('agent-selection — focus path is independent of selection', () => {
   it('focus and selection hold separate instance ids without pid coupling', () => {
-    const selected = toggleInstanceSelection(null, { instanceId: ID_A, pid: 10 });
-    const focused = focusInstanceId({ instanceId: ID_OTHER, pid: 10 });
+    const selected = toggleInstanceSelection(null, fixture({ instanceId: ID_A, pid: 10 }));
+    const focused = focusInstanceId(fixture({ instanceId: ID_OTHER, pid: 10 }));
     // Same pid on both sources would have collapsed them under the old stores.
     expect(selected).toBe(ID_A);
     expect(focused).toBe(ID_OTHER);

--- a/tests/renderer/fleet-risk.test.ts
+++ b/tests/renderer/fleet-risk.test.ts
@@ -8,7 +8,7 @@ import {
   processCardinalityNoun,
   FLEET_AVG_HEALTH_LABEL,
   FLEET_WORST_RISK_TITLE,
-} from '../../src/renderer/lib/utils/fleet-risk.ts';
+} from '../../src/renderer/lib/utils/fleet-risk';
 
 describe('fleetAverageHealth (F-W09 Header)', () => {
   it('returns null for empty', () => {

--- a/tests/renderer/summary-metrics.test.ts
+++ b/tests/renderer/summary-metrics.test.ts
@@ -15,7 +15,15 @@ import {
   formatMonitoringDuration,
   MONITORING_DURATION_LABEL,
   FILE_ACTIVITY_CHIP_LABEL,
-} from '../../src/renderer/lib/utils/summary-metrics.ts';
+} from '../../src/renderer/lib/utils/summary-metrics';
+import type { DetectedAgent } from '../../src/shared/types';
+
+/**
+ * A raw scan row as the summary cards receive it before enrichment. `DetectedAgent`
+ * declares no `name` at all, so the field is optional here and left absent — that
+ * absence is the historical F-W02 collapse the test below reproduces.
+ */
+type RawAgentRow = Pick<DetectedAgent, 'agent' | 'pid'> & { readonly name?: string };
 
 describe('countUniqueAgents (F-W02)', () => {
   it('counts multiple agents that only carry the raw `agent` field', () => {
@@ -29,7 +37,7 @@ describe('countUniqueAgents (F-W02)', () => {
   });
 
   it('does not collapse to 1 when every row lacks .name (historical failure)', () => {
-    const agents = [
+    const agents: readonly RawAgentRow[] = [
       { agent: 'A', pid: 1 },
       { agent: 'B', pid: 2 },
     ];

--- a/tests/renderer/timeline-utils.test.ts
+++ b/tests/renderer/timeline-utils.test.ts
@@ -17,7 +17,7 @@ import {
   clusterTrajectoryKey,
   readTimelineInstanceId,
   UNKNOWN_SOURCE_LABEL,
-} from '../../src/renderer/lib/utils/timeline-utils.ts';
+} from '../../src/renderer/lib/utils/timeline-utils';
 
 /** Identity projection — buildClusters only needs a number back. */
 const tsToX = (ts: number) => ts;

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -5,5 +5,5 @@
     "moduleResolution": "Bundler",
     "types": ["node"]
   },
-  "include": ["src/renderer/**/*", "src/shared/**/*", "tests/renderer/components/**/*"]
+  "include": ["src/renderer/**/*", "src/shared/**/*", "tests/renderer/**/*"]
 }


### PR DESCRIPTION
## What

`tsconfig.renderer.json` included only `tests/renderer/components/**/*`. The 22 files at the top level of `tests/renderer` were never read by `npm run typecheck` or `svelte-check` — a permanent blind spot in the `svelte-check` context. This widens the include to `tests/renderer/**/*` with no per-file exceptions and fixes everything that surfaced.

## Errors surfaced and how each was fixed

Widening the include produced **26 errors in 6 files**. All 26 were test-side; none pointed at a `src` bug.

| Code | Count | Fix |
|---|---|---|
| TS5097 | 6 | `.ts` extension dropped from import specifiers |
| TS2559 / TS2353 | 19 | Fixtures given a declared type derived from the real record |
| TS2339 | 1 | Raw scan-row fixture type pins `agent`/`pid` to `DetectedAgent`, declares `name?` |

**Import extensions** — `agent-action-keys`, `agent-panel-utils`, `agent-selection`, `fleet-risk`, `summary-metrics` and `timeline-utils` imported their `.ts` sources with the `.ts` extension. Now extensionless, which is what **every** `.ts` → `.ts` import under `src/` already uses (`command-registry`, `fuzzy-search`, `grouped-feed-utils`, `trust-badge-utils`, `path-utils`, `timeline-utils`, the `shared/types` barrel). `.js` specifiers for genuinely-`.js` sources are untouched. `allowImportingTsExtensions` was **not** enabled.

**Fixture types** — `agent-selection.ts` and `agent-action-keys.ts` take deliberately narrow parameters (`{ readonly instanceId?: string | null }`, `{ readonly name?: string; readonly agent?: string }`). The fixtures carry the surplus `pid`/`name` fields *on purpose*: several assertions exist precisely to prove those fields are ignored — `watchlist signature never uses instanceId or bare pid`, `focusInstanceId refuses pid-only sources`. Stripping them would have gutted the tests, so instead the fixtures now declare

```ts
type AgentFixture = Partial<Pick<EnrichedAgent, 'name' | 'agent' | 'pid' | 'instanceId'>>;
```

which is exactly the four optional fields `AgentActions.svelte` declares for its `agent` prop — the real card contract. A rename on the enriched record now turns these tests red.

**summary-metrics** — the historical-collapse test reads `.name` off raw scan rows to reproduce the F-W02 bug (`new Set(rows.map(r => r.name)).size === 1`). `DetectedAgent` declares no `name` at all, so the row type pins `agent`/`pid` to it and adds `name?` explicitly. Every value stays absent; the assertion is unchanged.

## Not done

- No compiler option changed (`strict`, `checkJs`, `module`, `moduleResolution` all as they were)
- No `@ts-ignore` / `@ts-expect-error` / type assertion added
- No `src/` file and no `tests/main/` file touched
- Every runtime value and every assertion is byte-identical to before — the fixtures only gained declared types

## Coverage proven, not assumed

Per ai-mistakes #21, a gate that exits 0 over a file set it never loaded proves nothing:

- `tsc --listFiles` over the renderer project: **32 of 32** `tests/renderer` files loaded, was **10**
- A deliberate `const x: number = "str"` injected into `fleet-risk.test.ts` — one of the newly covered files — turned `npm run typecheck` **red** (`TS2322`), then reverted
- Honest boundary: the 12 `.js` test files are in the file set but stay **unchecked**, because `checkJs: false` is a compiler option this PR must not change

## Gates

All 9 local pre-merge commands green:

`build:renderer` · `format:check` · `lint` (0 errors) · `typecheck` · `typecheck:svelte` (407 files, 0 errors) · `test:coverage` · `verify:gate` (4/4 mutants killed) · `counts:check` · `npm audit`

Test count unchanged: **102 files, 1808 passed / 4 skipped (1812)** — identical to the pre-change baseline.
