### PR TITLE
docs(event-schema-status): date the Gate 3 coverage figure against the current tree

### DIFF
--- a/docs/current-state/EVENT-SCHEMA-STATUS.md
+++ b/docs/current-state/EVENT-SCHEMA-STATUS.md
@@ -291,6 +291,13 @@ $ npx tsc --noEmit -p tsconfig.renderer.json --listFiles 2>/dev/null | grep -v n
 44 non-`node_modules` files type-checked — the project PR #184 fixed after it had been
 checking nothing.
 
+> **As of `b3ca4c0` (PR #243, 2026-08-21) this command prints 80.** At `743e330`
+> `tsconfig.renderer.json` included only `tests/renderer/components/**/*`; the include now
+> covers `tests/renderer/**/*`, which adds the 22 test files at the top level of
+> `tests/renderer`. The 44 above is what the gate covered on the tree this report was
+> written against and is left as recorded — as are the other figures in §6, which come
+> from the same session.
+
 ### Gate 4 — `npm run lint`
 
 ```


### PR DESCRIPTION
## What

`docs/current-state/EVENT-SCHEMA-STATUS.md` §6 is a **read-only transcript** of a shell session run against `743e330` on `feat/event-schema-v1` at `0.10.0-alpha`. Its Gate 3 coverage block records:

```
$ npx tsc --noEmit -p tsconfig.renderer.json --listFiles 2>/dev/null | grep -v node_modules | wc -l
44
```

The same command on `b3ca4c0` now prints **80**, because #243 widened `tsconfig.renderer.json` from `tests/renderer/components/**/*` to `tests/renderer/**/*`, adding the 22 test files at the top level of `tests/renderer`.

## Why a note and not an overwrite

The `44` is left exactly as recorded, with a dated "as of" note beneath it.

Rewriting `44` → `80` inside the fenced block would claim the command printed 80 **in that session**. It could not have: at `743e330` those files were not in the include at all. It would also split §6 against itself — the neighbouring figures come from the same run and would still describe the old tree:

| §6 figure | recorded | today |
|---|---|---|
| Gate 3 — renderer files | 44 | 80 |
| Gate 2 — main files | 56 | 63 |
| Gate 1 — test files / cases | 66 / 1048 passed | 102 / 1808 passed |

The note says that out loud, so a reader knows the rest of §6 is deliberately left as recorded rather than overlooked.

## Not a tracked counter

`scripts/counts.js` does not reference this file, so nothing went red when the figure aged — `counts:check` was green before this PR and is green after (19 checked counters, 131 declaration sites agree). That is precisely why the figure needed a dated note rather than a silent correction: it is a historical observation, not a live inventory.

## Gates

Markdown-only change. Local: `format:check` · `lint` · `typecheck` · `counts:check` green.
