### PR TITLE
docs: drop stale test-count pill, fix .Codex/ paths in Codex skills port

### DIFF
--- a/.agents/skills/aegis-context/SKILL.md
+++ b/.agents/skills/aegis-context/SKILL.md
@@ -51,7 +51,7 @@ Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs
 - Context7: fresh docs for any library (append "use context7")
 - Svelte MCP: list-sections, get-documentation, svelte-autofixer
 
-## Skills (.Codex/skills/)
+## Skills (.agents/skills/)
 - aegis-context — project overview, auto-invoked on any task
 - design-system — Fancy UI tokens, typography, glassmorphism, animation rules
 - electron-main — CJS modules, platform abstraction, IPC, file watchers

--- a/.agents/skills/audit-check/SKILL.md
+++ b/.agents/skills/audit-check/SKILL.md
@@ -15,7 +15,7 @@ description: AEGIS-specific pre-push / pre-release repo audit. Runs format:check
 4. node -e "const d=require('./src/shared/agent-database.json');console.log('Agents:', d.agents.length)" — agent count
 5. grep -c "agent" README.md — verify README references
 6. git status — clean working tree?
-7. git ls-files | grep -E "^\.agent/" — no must-stay-untracked internals tracked? (.Codex/agents/, .Codex/skills/, .mcp.json are intentionally tracked — do NOT flag them; memory-bank/ is intentionally tracked too, since e7ba29d)
+7. git ls-files | grep -E "^\.agent/" — no must-stay-untracked internals tracked? (.codex/agents/, .agents/skills/, .mcp.json are intentionally tracked — do NOT flag them; memory-bank/ is intentionally tracked too, since e7ba29d)
 8. Report pass/fail for each check
 
 ## Trigger

--- a/docs/social-preview-animated.html
+++ b/docs/social-preview-animated.html
@@ -142,7 +142,6 @@
       Agents execute code. We execute oversight.
     </div>
     <div class="pills" id="pills">
-      <span class="pill">568 tests</span>
       <span class="pill">110 agents</span>
       <span class="pill">73 rules</span>
       <span class="pill">MIT Licensed</span>

--- a/docs/social-preview.html
+++ b/docs/social-preview.html
@@ -90,7 +90,6 @@
     <div class="divider"></div>
     <div class="tagline">Agents execute code. We execute oversight.</div>
     <div class="pills">
-      <span class="pill">568 tests</span>
       <span class="pill">110 agents</span>
       <span class="pill">73 rules</span>
       <span class="pill">MIT Licensed</span>


### PR DESCRIPTION
Three prose defects, all found by earlier reports. No source file is touched.

## 1. The "568 tests" pill in both social previews

`docs/social-preview.html:93` and `docs/social-preview-animated.html:145` carried
`<span class="pill">568 tests</span>` — the v0.7.0-alpha figure. The test count is
deliberately outside the `counts:check` set (the only site that quotes it, the
README release-history row, is a named line exemption in `scripts/counts.js:704`),
so nothing went red when it went stale.

**Removed, not reworded.** A replacement claim would be unchecked in exactly the
same way, and `counts.js` scans `.html`, so a new number would either be a new
undeclared counter or a new maintenance burden. The two pills that stay —
`110 agents`, `73 rules` — are live declarations `counts:check` derives from the
tree, and `MIT Licensed` is a property. `.pills` is `flex/wrap/center` and the
animated build only fades `#pills` as a group, so three pills lay out unchanged.

## 2. `.Codex/` paths in `.agents/skills/`

`.agents/skills/` is the Codex-targeted port of `.claude/skills/`. Two of its lines
pointed at `.Codex/`, which exists nowhere in the tree:

| file | was | now |
|---|---|---|
| `aegis-context/SKILL.md:54` | `## Skills (.Codex/skills/)` | `## Skills (.agents/skills/)` |
| `audit-check/SKILL.md:18` | `.Codex/agents/, .Codex/skills/` | `.codex/agents/, .agents/skills/` |

Both replacements are tracked paths (`git ls-files .codex/agents`, `git ls-files
.agents/skills`). The agent name needed no change: `.agents/` says "Codex"
throughout and holds no "Claude" mention.

## 3. Remaining divergence between the two skills trees

`diff -rq .claude/skills .agents/skills` → three files differ, and after this PR
every surviving difference is the rebrand:

- `aegis-context/SKILL.md:60` — "prompt formula for **Claude Code** and Antigravity" → "**Codex** and Antigravity"
- `prompt-craft/SKILL.md:3,8` — "an AI coding assistant (**Claude Code** or Antigravity)" → "(**Codex** or Antigravity)"
- `prompt-craft/SKILL.md:108` — "count consistency across README, **CLAUDE.md**" → "README, **AGENTS.md**" — the Codex-side analogue, and it exists

The other eight skills plus `aegis-context-workspace/trigger-eval.json` are
byte-identical.

## Deliberately left alone

- `docs/current-state/EVENT-SCHEMA-STATUS.md:192,194-195` still contains `.Codex/`
  — as a **quotation** of the defect in a dated report (§5 records the port as it
  stood). Correcting it would falsify the record, and it is outside this PR's scope.
- `docs/social-preview.png` / `docs/social-preview.gif` are rendered artifacts and
  still show the old pill. Regenerating them is a separate change.
- `audit-check/SKILL.md:18`'s own command, `git ls-files | grep -E "^\.agent/"`
  (singular, matches nothing), is byte-identical in both trees — not a divergence,
  so not touched here.

## Verification

```
npm run counts:check   → OK — 19 checked counters, 131 declaration sites agree (exit 0)
npm run format:check   → All matched files use Prettier code style (exit 0)
```
