### PR TITLE
fix(platform): re-export getSnapshotHealth so the leaf is read through the façade

### DIFF
--- a/src/main/platform/win32.js
+++ b/src/main/platform/win32.js
@@ -474,6 +474,23 @@ module.exports = {
   providesStartTime: true,
   listProcesses,
   getParentProcessMap,
+  /**
+   * The `proc-snapshot` leaf's health record, published through the façade because
+   * this module already owns the only path to it: `getParentProcessMap` above
+   * delegates the provider choice to process-snapshot.js, so the leaf describes an
+   * observation made on THIS module's behalf and belongs on THIS module's surface.
+   *
+   * A plain reference, not a wrapper: `getSnapshotHealth` reads the submodule's own
+   * `_health` binding and takes no receiver, so re-exporting it keeps reporting the
+   * live record — including after that module's `_resetForTest` rebinds it.
+   *
+   * win32 only. linux.js and darwin.js publish no snapshot leaf and must not grow a
+   * null-returning stub for one: they also set `providesStartTime: false`, and
+   * process-scanner's `getIdentityQuality` answers on that flag before it ever asks
+   * for a witness.
+   * @type {() => import('../sensor-health').SensorHealth}
+   */
+  getSnapshotHealth: snapshot.getSnapshotHealth,
   cimParentProcessMap,
   getRawTcpConnections,
   getFileHandles,

--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -67,26 +67,27 @@ function isProcessPopulationReliable() {
 }
 
 /**
- * Read the `proc-snapshot` leaf's state without going through the platform façade.
+ * Read the `proc-snapshot` leaf's state through the platform façade.
  *
- * `platform/win32.js` requires `process-snapshot.js` but does not re-export
- * `getSnapshotHealth` — that re-export is gap F in the app-state design and is not
- * part of this pass. The façade is tried FIRST so this fallback deletes itself the
- * day F lands, and the submodule is required lazily so a POSIX host never loads the
- * sidecar client for a question it has already answered via `providesStartTime`.
- * @returns {string|null} The leaf state, or null when it cannot be read at all.
+ * Gap F is closed: `platform/win32.js` now re-exports `getSnapshotHealth`, so the
+ * façade is the ONLY path and the former lazy `require('./platform/process-snapshot')`
+ * fallback is gone. That fallback reached around the abstraction to read a leaf the
+ * façade would not name; with the export in place, keeping it would leave a second
+ * path that can disagree with the first.
+ *
+ * `null` is returned where no façade publishes the leaf — linux and darwin, which own
+ * no snapshot. That branch answers nothing in practice: both set
+ * `providesStartTime: false`, and {@link getIdentityQuality} returns on that flag
+ * before it ever reaches here. It is the honest value for "this platform carries no
+ * witness", not a fallback.
+ * @returns {string|null} The leaf state, or null when no façade publishes one.
  */
 function readSnapshotState() {
   if (_getSnapshotHealth) return _getSnapshotHealth().state;
   if (typeof _platform.getSnapshotHealth === 'function') {
     return _platform.getSnapshotHealth().state;
   }
-  try {
-    return require('./platform/process-snapshot').getSnapshotHealth().state;
-  } catch (_) {
-    // No snapshot module on this host — identity carries no witness.
-    return null;
-  }
+  return null;
 }
 
 /**

--- a/tests/main/platform/win32.test.js
+++ b/tests/main/platform/win32.test.js
@@ -525,4 +525,44 @@ describe('platform/win32', () => {
       expect(Array.isArray(win32.IGNORE_FILE_PATTERNS)).toBe(true);
     });
   });
+
+  // Gap F: the façade publishes the `proc-snapshot` leaf, so process-scanner no
+  // longer reaches around it with a lazy require. Everything here is asserted through
+  // win32's OWN surface — the submodule is deliberately not imported. This file
+  // overrides `Module._load`, and `vi.resetModules()` does not clear the transitive
+  // CJS cache behind it, so an ESM `import` of process-snapshot.js would hand back a
+  // DIFFERENT instance than the one win32 requires (the same CJS-vs-ESM split
+  // platform/index.test.js documents) and the comparison would prove nothing.
+  describe('getSnapshotHealth (gap F)', () => {
+    it('the façade publishes the proc-snapshot leaf', () => {
+      expect(typeof win32.getSnapshotHealth).toBe('function');
+    });
+
+    it('returns a real SensorHealth record, not a stub', () => {
+      const rec = win32.getSnapshotHealth();
+      expect(rec.sensorId).toBe('proc-snapshot');
+      expect(['STARTING', 'HEALTHY', 'DEGRADED', 'FAILED', 'DISABLED', 'UNSUPPORTED']).toContain(
+        rec.state,
+      );
+      expect(typeof rec.lossCount).toBe('number');
+      expect(rec).toHaveProperty('lastSuccessAt');
+    });
+
+    it('reports the live leaf, not a value captured when the façade was built', async () => {
+      // A plain function reference reads the submodule's live binding, so each call
+      // returns a fresh plain record that reflects the most recent pass. Replacing the
+      // export with a value taken at export time reds both assertions below.
+      const before = win32.getSnapshotHealth();
+      expect(win32.getSnapshotHealth()).not.toBe(before);
+
+      mockExecFile.mockImplementation((cmd, args, opts, cb) => {
+        cb(new Error('provider down'));
+      });
+      await win32.getParentProcessMap();
+
+      const after = win32.getSnapshotHealth();
+      expect(typeof after.lastAttemptAt).toBe('number');
+      expect(after.state).not.toBe('STARTING');
+    });
+  });
 });


### PR DESCRIPTION
## Gap F — the `proc-snapshot` leaf now has one path, not two

`platform/win32.js` required `process-snapshot.js` but did not re-export
`getSnapshotHealth`, so `process-scanner.readSnapshotState` reached **around** the
abstraction to read a leaf the façade would not name:

```js
try {
  return require('./platform/process-snapshot').getSnapshotHealth().state;
} catch (_) {
  return null;
}
```

The façade publishes it now, and that branch is gone. Keeping both would leave two
paths to one record that can disagree — which is the whole reason the capability
contract exists.

### What `null` means now

`null` stays as the return where no façade publishes the leaf — linux and darwin own
no snapshot — and it is the honest value for *"this platform carries no witness"*, not
a fallback. It answers nothing in practice: both set `providesStartTime: false`, and
`getIdentityQuality` returns on that flag before it ever reaches the read.

### Why a plain reference

`getSnapshotHealth: snapshot.getSnapshotHealth` — not a wrapper. The function reads the
submodule's own `_health` binding and takes no receiver, so re-exporting it keeps
reporting the live record, including after that module's `_resetForTest` rebinds it.
linux.js and darwin.js deliberately do **not** grow a null-returning stub: a stub would
make `typeof platform.getSnapshotHealth === 'function'` true on a platform that has no
leaf.

### The comment went with the code

The old JSDoc promised *"this fallback deletes itself the day F lands"*. This is that
day, so the sentence is deleted rather than left standing next to code that no longer
matches it — ai-mistakes #27 is about exactly the overclaim that survives the rewrite
touching its own lines.

### Not changed

`src/main/platform/index.js` is untouched. It is `module.exports = impl`, so the win32
export reaches the façade with no edit there — the plan had listed it, and it turned out
to need nothing.

## Tests

Everything is asserted through win32's **own** surface, and `process-snapshot.js` is
deliberately not imported. This suite overrides `Module._load`; `vi.resetModules()` does
not clear the transitive CJS cache behind it, so an ESM `import` hands back a *different
instance* than win32 requires — the same CJS-vs-ESM split `platform/index.test.js`
already documents. A comparison across two instances would have proven nothing. (The
first draft of this test did exactly that and failed, which is how the note got written.)

| mutation | result |
|---|---|
| remove the façade export | **3 failed** / 53 passed |
| replace the reference with a value captured at export time | **1 failed** — `reports the live leaf, not a value captured when the façade was built` |

Both were run and reverted.

## Gates

`build:renderer`, `format:check` + `lint` (0 errors, 28 pre-existing warnings),
`typecheck` + `typecheck:svelte` (407 files, 0 errors), `test:coverage` (102 files,
1811 passed / 4 skipped), `verify:gate` (4/4 mutants killed), `counts:check` (19
counters, 131 declaration sites agree), `npm audit --audit-level=high --omit=dev`
(0 vulnerabilities) — all green locally.

## Scope

No health record is added and none is written. This PR only changes **where** an
existing record is read from.
