### PR TITLE
feat(bench): trace format — schema, environment, writer, reader and its refusals

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -691,12 +691,21 @@ inventing one would dress a replay parameter up as a measurement — the same re
 and not per-header on purpose: `populationReliable` decides whether attribution may look for an
 owner at all, and it changes during a run.
 
-**`handles.tick` may not follow `rm.hot.tick`, and a reader refuses a trace where it does.**
-`scanAllFileHandles` short-circuits to the Restart Manager path whenever `getSensitiveHolders`
-is set, and `_setDepsForTest` assigns that provider only on a truthy override — nothing but
-`_resetForTest()` unsets it, and that also clears the watcher's debounce state. The switch is
-one-way, so a trace asking for the pool afterwards is asking for a replay nobody can run.
-Listing both kinds without saying so would be a promise the mechanism does not keep.
+`handles.tick` and `rm.hot.tick` may appear in either order — they are independent.
+`scanAllFileHandles` diverts to the Restart Manager only when `getSensitiveHolders` is set
+(`rmEnabled`), phase 1 never injects it (a header's `scope.rmFullPath` records why), and
+`isHotReadScanActive` reads only `getHotSensitiveHolders`. What they DO share is
+`_state.knownHandles`, so a path one tick already reported produces no event from the
+other — the product's own words at `scanHotFileHolders`: "Shares _state.knownHandles with
+the full scan → cross-cycle dedup". A trace author needs to know that, because the silence
+it causes is the product working rather than the trace failing. It is a note, not a refusal:
+there is nothing here a reader could legitimately reject.
+
+The one-way switch is real, but it belongs to the FULL Restart Manager path —
+`scanAllFileHandles` under `getSensitiveHolders`, which `_setDepsForTest` assigns only on a
+truthy override and only `_resetForTest()` unsets, taking the watcher's debounce state with
+it. Phase 1 excludes that path and says so in `scope.rmFullPath`; it has no record kind, so
+there is no ordering for a reader to enforce.
 
 ### Refusals
 
@@ -704,8 +713,7 @@ Every refusal names one reason from a closed list in `trace/schema.js` and write
 trace half-read is an input nobody recorded, and a verdict derived from one would name a run that
 never existed. `schema-version`, `header-malformed`, `platform-mismatch`, `tz-mismatch`,
 `digest-mismatch`, `evidence-codes-mismatch`, `scope-incomplete`, `unknown-kind`,
-`record-malformed`, `chain-broken`, `envelope-mismatch`, `kind-order`, `empty-trace`,
-`file-unreadable`.
+`record-malformed`, `chain-broken`, `envelope-mismatch`, `empty-trace`, `file-unreadable`.
 
 A trace declaring a HIGHER `traceSchemaVersion` is refused, which is the opposite of what a
 reader of the product's audit log must do — there `seq` is monotonic and skipping a record breaks

--- a/bench/README.md
+++ b/bench/README.md
@@ -15,9 +15,12 @@ Two rules are non-negotiable and are the reason the harness is shaped this way:
 
 - **Never diff two live streams.** The catalogue is the fixed point; both the oracle and
   the sensor are scored against it, never against each other.
-- **A sensor is never its own oracle.** Nothing under `bench/` imports from `src/`. Where a
-  scenario needs ground truth about process identity, that truth comes from Sysmon EID 1
-  ordinality — never from the process-snapshot provider AEGIS itself reads.
+- **A sensor is never its own oracle.** Nothing in the MEASUREMENT column imports from `src/` —
+  see [Trace replay and the `src/` boundary](#trace-replay-and-the-src-boundary) for the
+  name-by-name split, and for the one subtree where the rule does not apply because it is the
+  system under test rather than a measurement of it. Where a scenario needs ground truth about
+  process identity, that truth comes from Sysmon EID 1 ordinality — never from the
+  process-snapshot provider AEGIS itself reads.
 
 The actor's catalogue states intent and the fact of execution. It never confirms itself:
 every row it writes is confirmed by an oracle before any metric counts it.
@@ -109,6 +112,10 @@ bench/
   lib/oracles/sysmon.js                     # normalizes Sysmon EventRecord XML; writes oracle-sysmon.ndjson and oracle-loss.json
   oracles/sysmon-bench.xml                  # the Sysmon config a run is measured under — never yet offered to a binary
   scenarios/S1-agent-lifecycle/scenario.json
+  trace/schema.js                           # the trace format: version, chain seed, the closed list of record kinds, every refusal
+  trace/environment.js                      # what a trace pins about the machine and the tree, and the comparison that refuses a mismatch
+  trace/writer.js                           # observations → chained records → the exact bytes a trace directory holds
+  trace/reader.js                           # reads a trace directory, or refuses it by name
   runs/                                     # run artefacts — gitignored, created on first run
   README.md
 ```
@@ -560,6 +567,164 @@ counting it as a sensor failure.
 
 **There is no confidence figure in this report and there will not be one.** Every number it carries
 is a count of rows or a difference of two timestamps.
+
+## Trace replay — the format
+
+Two different things in this repository are called replay, and they are not the same thing:
+
+| | what it replays | what it needs |
+|---|---|---|
+| `bench/replay.js` | one recorded RUN's `run-report.json`, rebuilt from the four files that run left behind | nothing from `src/`; no sensor, no scenario, no renderer |
+| `bench/trace/` | one recorded stream of OBSERVATIONS, pushed back through the product's own detection and attribution code | the `src/` modules named below, and a pinned environment |
+
+A **trace** is an INPUT: what the sensors saw. Event Schema v1 — the product's audit record —
+is the OUTPUT: what the product decided. Nothing in a trace describes a verdict, and the point
+of the format is that the same bytes in produce the same verdicts out, so two sensor versions
+can be diffed against one recording instead of against each other.
+
+### Trace replay and the `src/` boundary
+
+The rule the measurement column keeps is unchanged and is not weakened here: an oracle that
+shares code with the thing it confirms is not independent, so a disagreement between them
+cannot be a finding. Trace replay is not an oracle — it is the system under test, re-executed —
+so the rule is lifted for it, name by name and in both directions:
+
+| subtree | may import `src/` | why |
+|---|---|---|
+| `lib/oracles/*`, `lib/observed.js`, `lib/join.js`, `lib/catalogue.js`, `lib/actor.js`, `lib/manifest.js`, `lib/sensor.js`, `lib/report.js` | **no** | the measurement column; this is where `observed.js` re-implements the chain check rather than importing it |
+| `trace/*` | **yes, read-only** | there is nothing to replay without the detection code itself |
+
+What `trace/` loads today, exhaustively — a list, not a glob, so a module that starts being
+loaded and is not named here is a change to this table:
+
+| module | loaded by | what is used | why not a copy |
+|---|---|---|---|
+| `src/main/audit-hashchain.js` | `trace/schema.js`, `trace/environment.js` | `canonical`, `computeHash` | one hashing algorithm rather than a third implementation of it |
+| `src/main/attribution.js` | `trace/environment.js` | `EVIDENCE_CODES` | the closed list is pinned into a trace, so a change to it is a refusal on READ instead of a silent diff |
+| `src/main/rule-loader.js` | `trace/environment.js` | `_loadRules` | the rules are digested AS THE PRODUCT COMPILES THEM; `_loadRules` is the entry point that does not populate the module cache, so observing an environment does not change it |
+
+Deriving a trace from a recorded run is the one place that does NOT move: an audit file the
+product wrote is still verified with `lib/observed.js`'s own re-implementation, because that
+check is evidence about the sensor. The trace's own chain is our format, not a claim about the
+sensor, so it uses the algorithm above.
+
+### The chain seed is the trace format's own
+
+`trace.ndjson` is hash-chained the way a daily audit file is — `sha256(prevHash + canonical(record))`,
+one link per line, seq equal to the line number — with two deliberate differences:
+
+- **The seed.** `TRACE_GENESIS`, not the audit `GENESIS`. With a shared seed, keeping the two
+  chains apart would rest on the top-level-`seq` gate both of today's verifiers take before they
+  hash anything (`src/main/audit-hashchain.js` `verifyChain`, `lib/observed.js` `readChain`) — a
+  gate `bench/` neither owns nor can freeze. With distinct seeds, no record of one file is ever a
+  valid record of the other, at any position and under any future verifier. A verdict file keeps
+  the audit seed, because the product writes it.
+- **The preimage.** A trace's sequence number lives at `bench.seq` and is INSIDE the hash; the
+  audit rule deletes a top-level `seq` before hashing. Moving a record therefore breaks a trace
+  chain and is invisible to an audit chain.
+- **The scope.** An audit chain restarts every day, inside one daily file. A trace chain runs the
+  whole file; a trace has no days.
+
+One more difference, and it is the one most likely to be inherited by accident: `lib/observed.js`
+tolerates an unparseable LAST line of an audit file, because a live process appends to it and a
+`taskkill /F` can land mid-write. A trace is written once, offline, from a recording that already
+finished, so the same damage means the file is broken and is **refused**. A trace reader that
+inherited that tolerance would silently drop the final observation of every trace it read.
+
+### What a trace directory holds
+
+```
+<trace id>/
+  trace.header.json    # the environment this recording pins; pretty JSON
+  trace.ndjson         # the records, one per line, hash-chained
+```
+
+`.ndjson` and not `.jsonl` because every neighbouring artefact here is `.ndjson`; the bytes are
+the same format and a second extension in one directory reads as a second format.
+
+The **header** pins what a verdict silently depends on, and a reader compares every entry
+against the tree and the machine it is about to replay on:
+
+- `platform`, `pathSep`, `nodeVersion`, and `tz` — path resolution, the separator, the `win32`
+  branch of `findOwningAgent`, the audit file's own name and the baseline hour bucket all read
+  one of these.
+- `clock.epochMs` — where the virtual clock starts.
+- `digests` — content, not versions. A version string goes stale silently; a digest does not.
+  The rules are digested three ways: the per-file content, the **enumeration order**
+  (`classifySensitive` takes the FIRST matching rule, so the same files enumerated differently
+  are a different tree for this purpose), and the compiled rule objects the loader produced. The
+  agent database, `src/shared/constants.js`, `src/main/attribution.js` and the platform module
+  that would actually be loaded each get one. Line endings are folded to LF before hashing —
+  `.gitattributes` puts this tree under `text=auto`, so a byte digest would refuse a checkout
+  that holds exactly the same content. Nothing else is normalized.
+- `evidenceCodes` — the closed attribution list, in declaration order, compared element for
+  element.
+- `scope` — what this trace does NOT cover, in the manifest's own `{value, unavailable}`
+  convention. A missing key is a refusal, not a default: "this trace does not cover process
+  ticks" and "nobody said" must not collapse into one record.
+- `neutralization` — a trace may be committed, so the clone root and the OS account name are
+  rewritten (`lib/paths.js`, the same transform `manifest.js` applies). It is applied to EVERY
+  string in every record, not to a list of path-shaped fields: an agent's `cwd` and an event's
+  path have to move by one map, or `cwd-containment` stops matching and the trace quietly
+  measures a different attribution than the one recorded.
+
+### Record kinds
+
+The closed list lives in `trace/schema.js`, **not** in a JSON Schema — the same choice
+`lib/actor.js` makes for step kinds, and for the same reason: only the code that can execute a
+kind can say which kinds exist.
+
+| kind | what it carries | observation |
+|---|---|---|
+| `fs.event` | one chokidar event: `created` / `modified` / `deleted`, and a path | yes |
+| `handles.tick` | a per-pid handle scan, as the platform provider answered it | yes |
+| `rm.hot.tick` | a Restart Manager hot-cycle answer | yes |
+| `net.tick` | a TCP table read plus the DNS answers that resolved its addresses | yes |
+| `clock.advance` | the virtual clock moves forward | no |
+| `population.set` | the agent population the sensors are handed from here on | no |
+
+A kind marked **no** observed nothing. Those carry ECS `event.kind: "state"` and no
+`event.category` or `event.type`: ECS has no category for "the harness moved its clock", and
+inventing one would dress a replay parameter up as a measurement — the same reasoning that keeps
+`lib/actor.js`'s `wait` step out of the catalogue. The observation kinds additionally carry
+`bench.ambient`, holding `populationReliable` and `isOtherPanelExpanded`. Those are per-record
+and not per-header on purpose: `populationReliable` decides whether attribution may look for an
+owner at all, and it changes during a run.
+
+**`handles.tick` may not follow `rm.hot.tick`, and a reader refuses a trace where it does.**
+`scanAllFileHandles` short-circuits to the Restart Manager path whenever `getSensitiveHolders`
+is set, and `_setDepsForTest` assigns that provider only on a truthy override — nothing but
+`_resetForTest()` unsets it, and that also clears the watcher's debounce state. The switch is
+one-way, so a trace asking for the pool afterwards is asking for a replay nobody can run.
+Listing both kinds without saying so would be a promise the mechanism does not keep.
+
+### Refusals
+
+Every refusal names one reason from a closed list in `trace/schema.js` and writes nothing: a
+trace half-read is an input nobody recorded, and a verdict derived from one would name a run that
+never existed. `schema-version`, `header-malformed`, `platform-mismatch`, `tz-mismatch`,
+`digest-mismatch`, `evidence-codes-mismatch`, `scope-incomplete`, `unknown-kind`,
+`record-malformed`, `chain-broken`, `envelope-mismatch`, `kind-order`, `empty-trace`,
+`file-unreadable`.
+
+A trace declaring a HIGHER `traceSchemaVersion` is refused, which is the opposite of what a
+reader of the product's audit log must do — there `seq` is monotonic and skipping a record breaks
+every hash after it, so an unknown field set has to be read past. A trace is an input, and a
+partially understood input produces a verdict about some other input.
+
+A **platform mismatch is refused, never converted.** `path.resolve`, `path.sep` and the
+`process.platform === 'win32'` branch of `findOwningAgent` all differ, so a Windows trace
+replayed on Linux would only look faithful. The practical consequence is that the suites which
+can run in CI are the format, chain and refusal ones; verifying a recorded Windows trace stays a
+local command, exactly as the rest of the bench does.
+
+### Arriving later
+
+`trace/clock.js` and `trace/preload.js` (the virtual clock, installed before any `src/` module
+loads), `trace/harness.js` and `trace/replay-trace.js` (the replay proper), `trace/fingerprint.js`
+and `trace/verdict.js` (what a run outputs, and the byte comparison), and `trace/record-trace.js`
+(deriving a trace from a recorded run). Nothing in that list exists yet; it is here so the
+subtree's shape is legible, not so it reads as built.
 
 ## Replaying a recorded run
 

--- a/bench/trace/environment.js
+++ b/bench/trace/environment.js
@@ -1,0 +1,366 @@
+/**
+ * @file bench/trace/environment.js
+ * @module bench/trace/environment
+ * @description What a trace PINS about the machine and the tree it was recorded
+ *   against, and the comparison that refuses a replay the recording cannot speak for.
+ *
+ *   Split from `./schema.js` because the two answer different questions. The schema
+ *   says what a trace IS — its version, its kinds, its chain. This says what a trace
+ *   silently DEPENDS ON: the platform whose path rules the attribution branches on,
+ *   the time zone the audit file's own name is built from, the rules whose first match
+ *   decides a reason, the closed evidence list, the settings. None of it is visible in
+ *   a record, and all of it changes a verdict.
+ *
+ *   EVERYTHING HERE IS READ, NEVER ASSUMED. A probe that cannot establish a fact makes
+ *   the call throw rather than substituting a plausible one: a header compared against
+ *   a half-observed environment would agree for the wrong reason, which is worse than
+ *   refusing.
+ *
+ *   DIGESTS, NOT VERSIONS. A version string goes stale silently — the failure
+ *   ai-mistakes #24 is about — so what is pinned is content. What that content digest
+ *   does and does not cover is stated at {@link foldLineEndings}, because a digest
+ *   whose normalization is unwritten is a digest nobody can argue with.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const hashchain = require('../../src/main/audit-hashchain');
+const attribution = require('../../src/main/attribution');
+const ruleLoader = require('../../src/main/rule-loader');
+
+const {
+  REFUSAL,
+  REPO_ROOT,
+  TRACE_SCHEMA_VERSION,
+  isNonEmptyString,
+  isObject,
+  refuse,
+} = require('./schema');
+
+/**
+ * The questions a header's `scope` block must answer in this version.
+ *
+ * Each is answered in the manifest's own convention — `{value: null, unavailable}` —
+ * because "this trace does not cover process ticks" and "nobody said" must not
+ * collapse into the same record. A missing key is a refusal, not a default.
+ * @type {ReadonlyArray<string>}
+ */
+const REQUIRED_SCOPE_KEYS = Object.freeze(['processTicks', 'anomalyAlerts', 'rmFullPath']);
+/**
+ * Fold line endings so a digest names CONTENT rather than a checkout's line-ending
+ * configuration.
+ *
+ * `.gitattributes` puts this tree under `text=auto`, so the same commit can land on
+ * disk as CRLF on one clone and LF on another. A byte digest would then refuse a
+ * trace that names exactly the rules the tree holds. Nothing else is normalized —
+ * not whitespace, not case, not Unicode form — so any real edit still moves the
+ * digest.
+ * @param {Buffer} bytes
+ * @returns {string}
+ */
+function foldLineEndings(bytes) {
+  return bytes.toString('utf8').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+/**
+ * sha256 of a file's content with line endings folded. See {@link foldLineEndings}
+ * for exactly what that covers and what it does not.
+ * @param {string} filePath - Absolute path.
+ * @returns {string} Hex digest.
+ */
+function digestFile(filePath) {
+  return crypto
+    .createHash('sha256')
+    .update(foldLineEndings(fs.readFileSync(filePath)))
+    .digest('hex');
+}
+
+/**
+ * The repo-relative source files a trace pins, for the platform it was recorded on.
+ *
+ * The platform module is chosen the way `src/main/platform/index.js` chooses it —
+ * win32 and darwin by name, everything else linux — so the digest names the file
+ * that would actually be loaded rather than a file that happens to exist.
+ * @param {string} platform - A `process.platform` value.
+ * @returns {string[]} Repo-relative paths, in a stable order.
+ */
+function pinnedSourceFiles(platform) {
+  const platformModule =
+    platform === 'win32' ? 'win32.js' : platform === 'darwin' ? 'darwin.js' : 'linux.js';
+  return [
+    'src/main/attribution.js',
+    'src/shared/constants.js',
+    `src/main/platform/${platformModule}`,
+  ];
+}
+
+/**
+ * Digest the detection rules as the PRODUCT COMPILES THEM, not as YAML.
+ *
+ * Three things are recorded, and they answer three different questions:
+ *   - `loadOrder` — the file order `fs.readdirSync` handed the loader. It is not
+ *     decoration: `classifySensitive` takes the FIRST matching rule, so two trees
+ *     holding identical rules in a different enumeration order can disagree about
+ *     one path's reason.
+ *   - `files` / `schemaFile` — per-file content digests, so a mismatch can be
+ *     located instead of merely reported.
+ *   - `compiled` — a digest over the rule objects the loader produced, in load
+ *     order: id, pattern source and flags, reason, category, risk, enabled,
+ *     platform. This is the one that actually gates a verdict, and it is immune to
+ *     YAML formatting.
+ *
+ * `_loadRules` is used rather than `getAllRules` because it is the entry point that
+ * does NOT populate the module-level cache: observing an environment must not change
+ * it. It is marked "exposed for testing only" in `src/main/rule-loader.js`; a harness
+ * is the same kind of caller, and if that export ever goes away this fails loudly at
+ * require time rather than digesting something else.
+ * @param {string} rulesDir - Absolute path to the rules directory.
+ * @returns {{loadOrder: string[], files: Object<string, string>, schemaFile: string|null,
+ *   compiled: string}}
+ */
+function digestRules(rulesDir) {
+  const names = fs.readdirSync(rulesDir).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+  /** @type {Object<string, string>} */
+  const files = {};
+  for (const name of names) files[name] = digestFile(path.join(rulesDir, name));
+
+  const schemaPath = path.join(rulesDir, '_schema.json');
+  const schemaFile = fs.existsSync(schemaPath) ? digestFile(schemaPath) : null;
+
+  const compiledRules = [...ruleLoader._loadRules(rulesDir).values()].map((r) => ({
+    id: r.id,
+    pattern: r.pattern.source,
+    flags: r.pattern.flags,
+    reason: r.reason,
+    category: r.category,
+    risk: r.risk,
+    enabled: r.enabled,
+    platform: r.platform,
+  }));
+  const compiled = crypto
+    .createHash('sha256')
+    .update(hashchain.canonical(compiledRules))
+    .digest('hex');
+
+  return { loadOrder: names, files, schemaFile, compiled };
+}
+
+/**
+ * Observe the environment a replay would run against.
+ *
+ * Everything here is READ, never assumed: a fact the probe cannot establish is not
+ * substituted with a plausible one, it makes the call throw, because a header
+ * compared against a half-observed environment would agree for the wrong reason.
+ * @param {Object} [opts]
+ * @param {string} [opts.repoRoot] - Tree to observe. Defaults to this checkout.
+ * @param {number} [opts.clockEpochMs] - Instant the UTC offset is read at. The offset
+ *   is a property of an INSTANT, not of a zone (DST), so it is meaningless without
+ *   one. Defaults to the current instant.
+ * @returns {Object} The observed environment, in the header's own shape.
+ */
+function observeEnvironment(opts = {}) {
+  const repoRoot = opts.repoRoot || REPO_ROOT;
+  const at = opts.clockEpochMs != null ? opts.clockEpochMs : Date.now();
+  const agentDbPath = path.join(repoRoot, 'src', 'shared', 'agent-database.json');
+  const agentDb = JSON.parse(fs.readFileSync(agentDbPath, 'utf8'));
+
+  /** @type {Object<string, string>} */
+  const sources = {};
+  for (const rel of pinnedSourceFiles(process.platform)) {
+    sources[rel] = digestFile(path.join(repoRoot, rel));
+  }
+
+  return {
+    platform: process.platform,
+    pathSep: path.sep,
+    nodeVersion: process.version,
+    tz: {
+      name: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      offsetMinutesAt: new Date(at).getTimezoneOffset(),
+      offsetReadAtEpochMs: at,
+    },
+    digests: {
+      algorithm: 'sha256',
+      normalization:
+        'CRLF and lone CR are folded to LF before hashing, so a checkout with other line ' +
+        'endings names the same content; nothing else is normalized',
+      rules: digestRules(path.join(repoRoot, 'rules')),
+      agentDatabase: {
+        version: agentDb.version,
+        lastUpdated: agentDb.lastUpdated,
+        sha256: digestFile(agentDbPath),
+      },
+      sources,
+      // Declaration order, compared element-for-element. A reordering changes no
+      // verdict, but it IS a change to a closed list the format pins, and a format
+      // that quietly tolerated one would have no way to report the change that does
+      // matter — a code added or removed.
+      evidenceCodes: [...attribution.EVIDENCE_CODES],
+    },
+  };
+}
+
+/**
+ * Compare a header against an observed environment and refuse on any disagreement.
+ *
+ * Structure first, then environment: a malformed header is reported as malformed
+ * rather than as a mismatch, because the two send a reader to different places.
+ * @param {*} header - The parsed `trace.header.json`.
+ * @param {Object} env - The result of {@link observeEnvironment}.
+ * @returns {Object} The same header, once it has been accepted.
+ * @throws {TraceError} With a reason from {@link REFUSAL}.
+ */
+function validateHeader(header, env) {
+  if (!isObject(header)) {
+    refuse(REFUSAL.HEADER_MALFORMED, 'the trace header is not a JSON object');
+  }
+  if (header.traceSchemaVersion !== TRACE_SCHEMA_VERSION) {
+    refuse(
+      REFUSAL.SCHEMA_VERSION,
+      `the trace declares traceSchemaVersion ${JSON.stringify(header.traceSchemaVersion)} and ` +
+        `this reader speaks version ${TRACE_SCHEMA_VERSION} — a trace is an INPUT, and a ` +
+        'partially understood input produces a verdict about some other input',
+    );
+  }
+  if (!isNonEmptyString(header.id)) {
+    refuse(REFUSAL.HEADER_MALFORMED, 'header.id must be a non-empty string');
+  }
+  if (!isObject(header.clock) || !Number.isSafeInteger(header.clock.epochMs)) {
+    refuse(REFUSAL.HEADER_MALFORMED, 'header.clock.epochMs must be a safe integer');
+  }
+  if (!isObject(header.neutralization)) {
+    refuse(REFUSAL.HEADER_MALFORMED, 'header.neutralization must be an object');
+  }
+  if (!isObject(header.tz) || !isNonEmptyString(header.tz.name)) {
+    refuse(REFUSAL.HEADER_MALFORMED, 'header.tz.name must be a non-empty string');
+  }
+  if (!isObject(header.digests)) {
+    refuse(REFUSAL.HEADER_MALFORMED, 'header.digests must be an object');
+  }
+
+  if (!isObject(header.scope)) {
+    refuse(REFUSAL.SCOPE_INCOMPLETE, 'header.scope must be an object');
+  }
+  for (const key of REQUIRED_SCOPE_KEYS) {
+    const entry = header.scope[key];
+    if (!isObject(entry) || !('value' in entry)) {
+      refuse(
+        REFUSAL.SCOPE_INCOMPLETE,
+        `header.scope.${key} is absent — a question this version requires an answer to must be ` +
+          'answered as {value, unavailable}, and a missing key is not a default',
+      );
+    }
+    if (entry.value === null && !isNonEmptyString(entry.unavailable)) {
+      refuse(
+        REFUSAL.SCOPE_INCOMPLETE,
+        `header.scope.${key} is null without a reason — an absent fact is recorded WITH why`,
+      );
+    }
+  }
+
+  if (header.platform !== env.platform) {
+    refuse(
+      REFUSAL.PLATFORM_MISMATCH,
+      `the trace was recorded on ${header.platform} and this process runs on ${env.platform} — ` +
+        'path resolution, the separator and the win32 branch of findOwningAgent all differ, so ' +
+        'the replay would only look faithful',
+    );
+  }
+  if (header.tz.name !== env.tz.name) {
+    refuse(
+      REFUSAL.TZ_MISMATCH,
+      `the trace was recorded in ${header.tz.name} and this process runs in ${env.tz.name} — ` +
+        "the audit file's name and the baseline hour bucket are both read off local time",
+    );
+  }
+
+  const expected = env.digests;
+  const got = header.digests;
+  if (
+    !Array.isArray(got.evidenceCodes) ||
+    !arraysEqual(got.evidenceCodes, expected.evidenceCodes)
+  ) {
+    refuse(
+      REFUSAL.EVIDENCE_CODES_MISMATCH,
+      `the trace pins the evidence codes [${asList(got.evidenceCodes)}] and this tree declares ` +
+        `[${asList(expected.evidenceCodes)}]`,
+    );
+  }
+  for (const [label, a, b] of digestPairs(got, expected)) {
+    if (a !== b) {
+      refuse(
+        REFUSAL.DIGEST_MISMATCH,
+        `${label}: the trace pins ${JSON.stringify(a)} and this tree holds ${JSON.stringify(b)}`,
+      );
+    }
+  }
+  return header;
+}
+
+/** @param {*} v @returns {string} A readable rendering of a list that may not be one. */
+function asList(v) {
+  return Array.isArray(v) ? v.join(', ') : JSON.stringify(v);
+}
+
+/** @param {*} a @param {*} b @returns {boolean} Element-for-element equality. */
+function arraysEqual(a, b) {
+  return (
+    Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((v, i) => v === b[i])
+  );
+}
+
+/**
+ * Every comparable digest pair, flattened to `[label, recorded, observed]`.
+ *
+ * The rules load ORDER is compared as a joined string rather than ignored: it
+ * decides which of two matching rules answers first, so a tree that holds the same
+ * files in a different enumeration order is a different tree for this purpose.
+ * @param {Object} recorded - `header.digests`.
+ * @param {Object} observed - `env.digests`.
+ * @returns {Array<[string, *, *]>}
+ */
+function digestPairs(recorded, observed) {
+  /** @type {Array<[string, *, *]>} */
+  const pairs = [];
+  const rr = isObject(recorded.rules) ? recorded.rules : {};
+  const or = observed.rules;
+  pairs.push(['rules.loadOrder', asList(rr.loadOrder), asList(or.loadOrder)]);
+  pairs.push(['rules.compiled', rr.compiled, or.compiled]);
+  pairs.push(['rules.schemaFile', rr.schemaFile, or.schemaFile]);
+  for (const name of or.loadOrder) {
+    pairs.push([
+      `rules.files[${name}]`,
+      isObject(rr.files) ? rr.files[name] : undefined,
+      or.files[name],
+    ]);
+  }
+  const ra = isObject(recorded.agentDatabase) ? recorded.agentDatabase : {};
+  pairs.push(['agentDatabase.sha256', ra.sha256, observed.agentDatabase.sha256]);
+  pairs.push(['agentDatabase.version', ra.version, observed.agentDatabase.version]);
+  for (const [rel, digest] of Object.entries(observed.sources)) {
+    pairs.push([
+      `sources[${rel}]`,
+      isObject(recorded.sources) ? recorded.sources[rel] : undefined,
+      digest,
+    ]);
+  }
+  return pairs;
+}
+
+module.exports = {
+  REQUIRED_SCOPE_KEYS,
+  digestFile,
+  digestPairs,
+  digestRules,
+  foldLineEndings,
+  observeEnvironment,
+  pinnedSourceFiles,
+  validateHeader,
+};

--- a/bench/trace/reader.js
+++ b/bench/trace/reader.js
@@ -102,35 +102,6 @@ function verifyChain(lines, label) {
 }
 
 /**
- * Enforce the ordering rules in `schema.KIND_ORDER_RULES`.
- *
- * These are not style: each one names a kind pair the injection surface cannot
- * actually deliver in that order, so a trace that asks for it is asking for a replay
- * nobody can run. Refusing on read is what keeps the kind table from reading as a
- * promise the mechanism does not keep.
- * @param {Object[]} records - Chain-verified records, in file order.
- * @returns {void}
- * @throws {import('./schema').TraceError} `kind-order` at the first violation.
- */
-function verifyKindOrder(records) {
-  /** @type {Map<string, number>} */
-  const firstSeen = new Map();
-  for (const record of records) {
-    const kind = record.bench.kind;
-    for (const rule of schema.KIND_ORDER_RULES) {
-      if (kind === rule.forbids && firstSeen.has(rule.after)) {
-        schema.refuse(
-          schema.REFUSAL.KIND_ORDER,
-          `seq ${record.bench.seq} is a ${rule.forbids} and seq ${firstSeen.get(rule.after)} was ` +
-            `an ${rule.after} — ${rule.why}`,
-        );
-      }
-    }
-    if (!firstSeen.has(kind)) firstSeen.set(kind, record.bench.seq);
-  }
-}
-
-/**
  * Read one trace directory.
  *
  * Order of refusals is the order a reader can act on them: the files exist and parse,
@@ -177,7 +148,6 @@ function readTrace(traceDir, opts = {}) {
 
   const records = verifyChain(lines, schema.TRACE_FILENAME);
   for (const record of records) schema.validateRecord(record, record.bench.seq);
-  verifyKindOrder(records);
 
   if (header.id !== records[0].bench.trace) {
     schema.refuse(
@@ -194,5 +164,4 @@ module.exports = {
   readJsonFile,
   readTrace,
   verifyChain,
-  verifyKindOrder,
 };

--- a/bench/trace/reader.js
+++ b/bench/trace/reader.js
@@ -1,0 +1,198 @@
+/**
+ * @file bench/trace/reader.js
+ * @module bench/trace/reader
+ * @description Reads a trace directory, or refuses it by name.
+ *
+ *   Every refusal here writes nothing and returns nothing: a trace half-read is an
+ *   input nobody recorded, and a verdict derived from one would name a run that never
+ *   existed. The reasons are the closed list in `./schema.js`, so a caller branches on
+ *   `err.reason` rather than on message text.
+ *
+ *   ONE DELIBERATE DIFFERENCE FROM THE AUDIT READER. `bench/lib/observed.js`
+ *   `readChain` tolerates an unparseable LAST line, because the product's audit file
+ *   is appended to by a live process that a `taskkill /F` can interrupt mid-write. A
+ *   trace is not appended to by anything: it is written once, offline, from a
+ *   completed recording. A torn trailing line therefore means the file is damaged, not
+ *   that a writer was killed, and it is refused like any other break.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const environment = require('./environment');
+const schema = require('./schema');
+
+/**
+ * Read and parse one JSON file, refusing rather than throwing a bare syntax error.
+ * @param {string} filePath - Absolute path.
+ * @param {string} label - What the file is, for the message.
+ * @returns {*} The parsed value.
+ * @throws {import('./schema').TraceError} `file-unreadable` on either failure.
+ */
+function readJsonFile(filePath, label) {
+  let text;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    return schema.refuse(
+      schema.REFUSAL.FILE_UNREADABLE,
+      `${label} could not be read at ${filePath}: ${err.message}`,
+    );
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    return schema.refuse(
+      schema.REFUSAL.FILE_UNREADABLE,
+      `${label} at ${filePath} does not parse: ${err.message}`,
+    );
+  }
+}
+
+/**
+ * Verify the chain over already-split lines and return the parsed records.
+ *
+ * Three checks, in the order a reader can act on them: the line parses, its
+ * `bench.seq` is its position, and its hash recomputes from the previous one. The
+ * first record seeds from `TRACE_GENESIS`.
+ * @param {string[]} lines - Non-empty lines, in file order.
+ * @param {string} label - The file name, for messages.
+ * @returns {Object[]} Parsed records, still carrying their `hash`.
+ * @throws {import('./schema').TraceError} `chain-broken` at the first failure.
+ */
+function verifyChain(lines, label) {
+  const records = [];
+  let prevHash = schema.TRACE_GENESIS;
+  for (let i = 0; i < lines.length; i++) {
+    let record;
+    try {
+      record = JSON.parse(lines[i]);
+    } catch (err) {
+      schema.refuse(
+        schema.REFUSAL.CHAIN_BROKEN,
+        `${label} line ${i} does not parse (${err.message}) — a trace is written once and ` +
+          'offline, so a line that does not parse is damage, not an interrupted append',
+      );
+    }
+    const seq = record && record.bench ? record.bench.seq : undefined;
+    if (seq !== i) {
+      schema.refuse(
+        schema.REFUSAL.CHAIN_BROKEN,
+        `${label} line ${i} carries bench.seq ${JSON.stringify(seq)} — a chain whose sequence ` +
+          'skips or repeats is missing records or holds them twice',
+      );
+    }
+    const expected = schema.recordHash(prevHash, record);
+    if (expected !== record.hash) {
+      schema.refuse(
+        schema.REFUSAL.CHAIN_BROKEN,
+        `${label} seq ${i} does not recompute (stored ${JSON.stringify(record.hash)}, derived ` +
+          `${expected}) — the file is not trustworthy, so no record is taken out of it`,
+      );
+    }
+    prevHash = record.hash;
+    records.push(record);
+  }
+  return records;
+}
+
+/**
+ * Enforce the ordering rules in `schema.KIND_ORDER_RULES`.
+ *
+ * These are not style: each one names a kind pair the injection surface cannot
+ * actually deliver in that order, so a trace that asks for it is asking for a replay
+ * nobody can run. Refusing on read is what keeps the kind table from reading as a
+ * promise the mechanism does not keep.
+ * @param {Object[]} records - Chain-verified records, in file order.
+ * @returns {void}
+ * @throws {import('./schema').TraceError} `kind-order` at the first violation.
+ */
+function verifyKindOrder(records) {
+  /** @type {Map<string, number>} */
+  const firstSeen = new Map();
+  for (const record of records) {
+    const kind = record.bench.kind;
+    for (const rule of schema.KIND_ORDER_RULES) {
+      if (kind === rule.forbids && firstSeen.has(rule.after)) {
+        schema.refuse(
+          schema.REFUSAL.KIND_ORDER,
+          `seq ${record.bench.seq} is a ${rule.forbids} and seq ${firstSeen.get(rule.after)} was ` +
+            `an ${rule.after} — ${rule.why}`,
+        );
+      }
+    }
+    if (!firstSeen.has(kind)) firstSeen.set(kind, record.bench.seq);
+  }
+}
+
+/**
+ * Read one trace directory.
+ *
+ * Order of refusals is the order a reader can act on them: the files exist and parse,
+ * the header is structurally sound, the header matches this machine and this tree, the
+ * chain holds, each record fits its kind, and finally the kinds are in a replayable
+ * order. A later check never runs on input an earlier one rejected.
+ * @param {string} traceDir - Directory holding `trace.header.json` and `trace.ndjson`.
+ * @param {Object} [opts]
+ * @param {Object} [opts.env] - A pre-observed environment (see
+ *   `environment.observeEnvironment`). Observed here when absent, at the header's own clock
+ *   epoch so the UTC offset is read at the instant the trace is about to replay.
+ * @returns {{header: Object, records: Object[]}}
+ * @throws {import('./schema').TraceError} With a reason from `schema.REFUSAL`.
+ */
+function readTrace(traceDir, opts = {}) {
+  const headerPath = path.join(traceDir, schema.HEADER_FILENAME);
+  const tracePath = path.join(traceDir, schema.TRACE_FILENAME);
+
+  const header = readJsonFile(headerPath, 'the trace header');
+  const clockEpochMs =
+    header && header.clock && Number.isSafeInteger(header.clock.epochMs)
+      ? header.clock.epochMs
+      : undefined;
+  const env = opts.env || environment.observeEnvironment({ clockEpochMs });
+  environment.validateHeader(header, env);
+
+  let text;
+  try {
+    text = fs.readFileSync(tracePath, 'utf8');
+  } catch (err) {
+    return schema.refuse(
+      schema.REFUSAL.FILE_UNREADABLE,
+      `the trace records could not be read at ${tracePath}: ${err.message}`,
+    );
+  }
+  const lines = text.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length === 0) {
+    return schema.refuse(
+      schema.REFUSAL.EMPTY_TRACE,
+      `${schema.TRACE_FILENAME} holds no records — an empty trace is indistinguishable from a ` +
+        'recording that captured nothing, and neither is an input',
+    );
+  }
+
+  const records = verifyChain(lines, schema.TRACE_FILENAME);
+  for (const record of records) schema.validateRecord(record, record.bench.seq);
+  verifyKindOrder(records);
+
+  if (header.id !== records[0].bench.trace) {
+    schema.refuse(
+      schema.REFUSAL.HEADER_MALFORMED,
+      `the header names trace ${JSON.stringify(header.id)} and its first record names ` +
+        `${JSON.stringify(records[0].bench.trace)} — that directory was assembled out of two ` +
+        'recordings',
+    );
+  }
+  return { header, records };
+}
+
+module.exports = {
+  readJsonFile,
+  readTrace,
+  verifyChain,
+  verifyKindOrder,
+};

--- a/bench/trace/schema.js
+++ b/bench/trace/schema.js
@@ -101,8 +101,6 @@ const REFUSAL = Object.freeze({
   CHAIN_BROKEN: 'chain-broken',
   /** A record's ECS envelope disagrees with the kind it declares. */
   ENVELOPE_MISMATCH: 'envelope-mismatch',
-  /** A `handles.tick` follows an `rm.hot.tick` — see {@link RECORD_KINDS}. */
-  KIND_ORDER: 'kind-order',
   /** The trace holds no records. */
   EMPTY_TRACE: 'empty-trace',
   /** A file of the trace is missing or unreadable. */
@@ -290,27 +288,26 @@ const RECORD_KINDS = Object.freeze({
 const KIND_NAMES = Object.freeze(Object.keys(RECORD_KINDS));
 
 /**
- * Kinds that may not follow one another, and why.
+ * A coupling a trace author has to know about, and it is NOT an ordering rule.
  *
- * `scanAllFileHandles` short-circuits to the Restart Manager path whenever
- * `_getSensitiveHolders` is set (`src/main/file-watcher.js` `rmEnabled`), and
- * `_setDepsForTest` assigns that provider only on a truthy override — nothing but
- * `_resetForTest()` can unset it, and that also clears the watcher's debounce map.
- * A trace that asked for the handle pool after the RM path would therefore be asking
- * for something the injection surface cannot give, and listing both kinds without
- * saying so would be a promise the mechanism does not keep.
- * @type {ReadonlyArray<{after: string, forbids: string, why: string}>}
+ * `scanHotFileHolders` and `scanAllFileHandles` share `_state.knownHandles`, so a
+ * hold one of them already reported will not re-fire from the other — the product
+ * says so itself (`src/main/file-watcher.js`, `scanHotFileHolders`: "Shares
+ * _state.knownHandles with the full scan → cross-cycle dedup"). A tick that carries a
+ * path an earlier tick already carried therefore produces NOTHING, and that silence
+ * is the product working, not the trace failing.
+ *
+ * Recorded as a note rather than enforced, because there is nothing here to refuse:
+ * the two kinds are independent. `scanAllFileHandles` diverts to the Restart Manager
+ * only when `_getSensitiveHolders` is set (`rmEnabled`), phase 1 never injects it —
+ * see a header's `scope.rmFullPath` — and `isHotReadScanActive` reads only
+ * `_getHotSensitiveHolders`. So the two may appear in either order, and a rule saying
+ * otherwise would be guarding a constraint this path does not have.
+ * @type {string}
  */
-const KIND_ORDER_RULES = Object.freeze([
-  Object.freeze({
-    after: 'rm.hot.tick',
-    forbids: 'handles.tick',
-    why:
-      'the Restart Manager provider injection is one-way: once set it cannot be unset ' +
-      'without also clearing the watcher debounce state, so a handle-pool tick after an ' +
-      'RM tick is not replayable',
-  }),
-]);
+const SHARED_HANDLE_STATE_NOTE =
+  'handles.tick and rm.hot.tick share _state.knownHandles, so a path one tick already ' +
+  'reported produces no event from the other';
 
 /**
  * The ECS envelope a record of this kind must carry.
@@ -442,11 +439,11 @@ module.exports = {
   FS_ACTIONS,
   HEADER_FILENAME,
   KIND_NAMES,
-  KIND_ORDER_RULES,
   RECORD_KINDS,
   REFUSAL,
   REFUSAL_REASONS,
   REPO_ROOT,
+  SHARED_HANDLE_STATE_NOTE,
   TRACE_FILENAME,
   TRACE_GENESIS,
   TRACE_SCHEMA_VERSION,

--- a/bench/trace/schema.js
+++ b/bench/trace/schema.js
@@ -1,0 +1,464 @@
+/**
+ * @file bench/trace/schema.js
+ * @module bench/trace/schema
+ * @description The trace format itself: its version, its chain seed, the closed list
+ *   of record kinds, the ECS envelope each kind carries, the environment a trace
+ *   pins, and every reason a trace may be REFUSED.
+ *
+ *   A trace is an INPUT — a recorded stream of what the sensors observed — and it is
+ *   the opposite end of the pipeline from Event Schema v1, which is what the product
+ *   DECIDED. Nothing here describes a verdict.
+ *
+ *   THIS MODULE IMPORTS FROM `src/`, AND THAT IS DELIBERATE. The rule the rest of
+ *   `bench/` keeps — "a sensor is never its own oracle; nothing under `bench/`
+ *   imports from `src/`" — is about the ORACLE column, whose independence dies if it
+ *   shares code with the thing it confirms. Trace replay is not an oracle: it is the
+ *   system under test, re-executed. See `bench/README.md`, "Trace replay and the
+ *   src/ boundary", for the name-by-name split. What THIS file loads is one module —
+ *   `src/main/audit-hashchain.js`, for `canonical` and `computeHash`, so the trace
+ *   chain uses one hashing algorithm rather than a third copy of it. The rest of the
+ *   subtree's `src/` surface is in `./environment.js`, which is where a trace's
+ *   dependence on the tree is observed and compared.
+ *
+ *   THE CHAIN SEED IS OUR OWN. `TRACE_GENESIS` is not the audit `GENESIS`: with a
+ *   shared seed, keeping the two chains apart would rest on the top-level-`seq` gate
+ *   that both of today's verifiers take before hashing
+ *   (`src/main/audit-hashchain.js` `verifyChain`, `bench/lib/observed.js`
+ *   `readChain`) — a gate `bench/` neither owns nor can freeze. With distinct seeds
+ *   no record of one file is ever a valid record of the other, at any position and
+ *   under any future verifier. A verdict file keeps the audit seed, because the
+ *   product writes it.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+const path = require('path');
+
+const hashchain = require('../../src/main/audit-hashchain');
+
+/** @type {string} Repository root — this file is `bench/trace/`, two levels down. */
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+/**
+ * The trace format's version.
+ *
+ * A reader meeting a HIGHER version REFUSES, which is the opposite of what a reader
+ * of the product's audit log must do (`src/main/audit-logger.js` — there `seq` is
+ * monotonic and skipping one record breaks every hash after it, so an unknown field
+ * set has to be read past). A trace is an input: a partially understood input
+ * produces a verdict about some other input, and that is worse than no verdict.
+ * @type {number}
+ */
+const TRACE_SCHEMA_VERSION = 1;
+
+/**
+ * Chain seed for `trace.ndjson`. See the file header for why it is not the audit
+ * `GENESIS`.
+ * @type {string}
+ */
+const TRACE_GENESIS = 'AEGIS-BENCH-TRACE-GENESIS-v1';
+
+/** @type {string} ECS version the envelope speaks — the one `bench/lib/catalogue.js` uses. */
+const ECS_VERSION = '8.11.0';
+
+/** @type {string} The one file name a trace's records live in. */
+const TRACE_FILENAME = 'trace.ndjson';
+
+/** @type {string} The one file name a trace's pinned environment lives in. */
+const HEADER_FILENAME = 'trace.header.json';
+
+/**
+ * Every reason this module or its readers may refuse a trace, as a closed list.
+ *
+ * A refusal names one of these and nothing else, so a caller can branch on the
+ * reason and a test can enumerate them. Adding a refusal means adding a member
+ * here first.
+ * @type {Readonly<Record<string, string>>}
+ */
+const REFUSAL = Object.freeze({
+  /** `traceSchemaVersion` is absent, not a number, or not this reader's version. */
+  SCHEMA_VERSION: 'schema-version',
+  /** A header field is missing or has the wrong type. */
+  HEADER_MALFORMED: 'header-malformed',
+  /** The header names a platform this process is not running on. */
+  PLATFORM_MISMATCH: 'platform-mismatch',
+  /** The header names a time zone this process is not running in. */
+  TZ_MISMATCH: 'tz-mismatch',
+  /** A pinned digest does not match the tree this process would replay against. */
+  DIGEST_MISMATCH: 'digest-mismatch',
+  /** The closed list of attribution evidence codes moved since the trace was recorded. */
+  EVIDENCE_CODES_MISMATCH: 'evidence-codes-mismatch',
+  /** `scope` does not answer every question this version requires it to answer. */
+  SCOPE_INCOMPLETE: 'scope-incomplete',
+  /** A record names a `bench.kind` outside the closed list. */
+  UNKNOWN_KIND: 'unknown-kind',
+  /** A record is not an object, or its `bench.input` does not fit its kind. */
+  RECORD_MALFORMED: 'record-malformed',
+  /** A line does not parse, a seq is not its line number, or a hash does not recompute. */
+  CHAIN_BROKEN: 'chain-broken',
+  /** A record's ECS envelope disagrees with the kind it declares. */
+  ENVELOPE_MISMATCH: 'envelope-mismatch',
+  /** A `handles.tick` follows an `rm.hot.tick` — see {@link RECORD_KINDS}. */
+  KIND_ORDER: 'kind-order',
+  /** The trace holds no records. */
+  EMPTY_TRACE: 'empty-trace',
+  /** A file of the trace is missing or unreadable. */
+  FILE_UNREADABLE: 'file-unreadable',
+});
+
+/** @type {ReadonlyArray<string>} Every refusal reason, for enumeration. */
+const REFUSAL_REASONS = Object.freeze(Object.values(REFUSAL));
+
+/**
+ * A refusal. Carries the reason code so a caller branches on it rather than on the
+ * message text. Modelled on `bench/lib/observed.js` `ObservedError`.
+ */
+class TraceError extends Error {
+  /**
+   * @param {string} reason - One of {@link REFUSAL}.
+   * @param {string} message - What a reader needs in order to act.
+   */
+  constructor(reason, message) {
+    super(message);
+    this.name = 'TraceError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Refuse, by reason.
+ * @param {string} reason - One of {@link REFUSAL}.
+ * @param {string} message - What a reader needs in order to act.
+ * @returns {never}
+ * @throws {TraceError} Always.
+ */
+function refuse(reason, message) {
+  throw new TraceError(reason, message);
+}
+
+/** @param {*} v @returns {boolean} Whether `v` is a plain, non-null object. */
+function isObject(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** @param {*} v @returns {boolean} Whether `v` is a non-empty string. */
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.length > 0;
+}
+
+/** @param {*} v @returns {boolean} Whether `v` is a pid the OS could have handed out, or 0. */
+function isPidLike(v) {
+  return Number.isSafeInteger(v) && v >= 0;
+}
+
+/**
+ * The ECS `event.type` and `event.action` each filesystem action maps onto.
+ *
+ * The three actions are exactly what `src/main/file-watcher.js` binds chokidar's
+ * `add` / `change` / `unlink` to, and a trace may carry no fourth: a value the
+ * watcher cannot emit is an input the product could never have been given.
+ * @type {Readonly<Record<string, {type: string, action: string}>>}
+ */
+const FS_ACTIONS = Object.freeze({
+  created: Object.freeze({ type: 'creation', action: 'file-created' }),
+  modified: Object.freeze({ type: 'change', action: 'file-changed' }),
+  deleted: Object.freeze({ type: 'deletion', action: 'file-deleted' }),
+});
+
+/**
+ * The closed list of record kinds.
+ *
+ * It lives HERE, in code, and not in a JSON Schema — the same choice
+ * `bench/lib/actor.js` makes for step kinds, and for the same reason: only the code
+ * that can execute a kind can say which kinds exist. What each entry declares is the
+ * shape of the kind's `bench.input`, so a reader can refuse a malformed one by name.
+ *
+ * `observation: false` marks a record that observed NOTHING — the harness's own
+ * clock and the population it was handed. Those carry `event.kind: 'state'` and no
+ * `event.category` / `event.type`, because ECS has no category for "the harness
+ * moved its clock" and inventing one would dress a parameter up as a measurement.
+ * It is the same reasoning that keeps `bench/lib/actor.js`'s `wait` step out of the
+ * catalogue.
+ * @type {Readonly<Record<string, Object>>}
+ */
+const RECORD_KINDS = Object.freeze({
+  'fs.event': Object.freeze({
+    observation: true,
+    summary: 'one chokidar filesystem event, as the watcher delivered it',
+    inputFields: Object.freeze(['action', 'path']),
+    validateInput(input, fail) {
+      if (!Object.prototype.hasOwnProperty.call(FS_ACTIONS, input.action)) {
+        fail(
+          `action ${JSON.stringify(input.action)} is not one of ` +
+            `${Object.keys(FS_ACTIONS).join(', ')} — the watcher emits no fourth action`,
+        );
+      }
+      if (!isNonEmptyString(input.path)) fail('path must be a non-empty string');
+    },
+  }),
+  'handles.tick': Object.freeze({
+    observation: true,
+    summary: 'one per-pid handle scan, as the platform provider answered it',
+    inputFields: Object.freeze(['byPid']),
+    validateInput(input, fail) {
+      if (!isObject(input.byPid)) fail('byPid must be an object keyed by pid');
+      for (const [pid, files] of Object.entries(input.byPid)) {
+        if (!/^\d+$/.test(pid)) fail(`byPid key ${JSON.stringify(pid)} is not a pid`);
+        if (!Array.isArray(files) || !files.every(isNonEmptyString)) {
+          fail(`byPid[${pid}] must be an array of non-empty path strings`);
+        }
+      }
+    },
+  }),
+  'rm.hot.tick': Object.freeze({
+    observation: true,
+    summary: 'one Restart Manager hot-cycle answer, as the provider returned it',
+    inputFields: Object.freeze(['holders']),
+    validateInput(input, fail) {
+      if (!Array.isArray(input.holders)) fail('holders must be an array');
+      for (const [i, h] of input.holders.entries()) {
+        if (!isObject(h)) fail(`holders[${i}] must be an object`);
+        if (!isPidLike(h.pid)) fail(`holders[${i}].pid must be a non-negative integer`);
+        if (!isNonEmptyString(h.path)) fail(`holders[${i}].path must be a non-empty string`);
+      }
+    },
+  }),
+  'net.tick': Object.freeze({
+    observation: true,
+    summary: 'one TCP table read plus the DNS answers that resolved its addresses',
+    inputFields: Object.freeze(['tcp', 'dns']),
+    validateInput(input, fail) {
+      if (!Array.isArray(input.tcp)) fail('tcp must be an array');
+      for (const [i, c] of input.tcp.entries()) {
+        if (!isObject(c)) fail(`tcp[${i}] must be an object`);
+        if (!isPidLike(c.pid)) fail(`tcp[${i}].pid must be a non-negative integer`);
+        if (!isNonEmptyString(c.ip)) fail(`tcp[${i}].ip must be a non-empty string`);
+        if (!Number.isSafeInteger(c.port)) fail(`tcp[${i}].port must be an integer`);
+        if (!isNonEmptyString(c.state)) fail(`tcp[${i}].state must be a non-empty string`);
+      }
+      if (!isObject(input.dns)) fail('dns must be an object keyed by address');
+      for (const [ip, answer] of Object.entries(input.dns)) {
+        if (!isObject(answer)) fail(`dns[${ip}] must be an object`);
+        // `reverse` and `forward` are RECORDED ANSWERS, and an answer may legitimately
+        // be "the lookup threw". `null` says that; `[]` says the resolver replied with
+        // nothing. The two are different observations and neither stands in for the other.
+        for (const side of ['reverse', 'forward']) {
+          const v = answer[side];
+          if (v !== null && !(Array.isArray(v) && v.every(isNonEmptyString))) {
+            fail(`dns[${ip}].${side} must be null or an array of non-empty strings`);
+          }
+        }
+      }
+    },
+  }),
+  'clock.advance': Object.freeze({
+    observation: false,
+    summary: 'the virtual clock is moved forward — a replay parameter, not an observation',
+    inputFields: Object.freeze(['toEpochMs']),
+    validateInput(input, fail) {
+      if (!Number.isSafeInteger(input.toEpochMs) || input.toEpochMs < 0) {
+        fail('toEpochMs must be a non-negative safe integer');
+      }
+    },
+  }),
+  'population.set': Object.freeze({
+    observation: false,
+    summary: 'the agent population the sensors are handed from this record onward',
+    inputFields: Object.freeze(['agents']),
+    validateInput(input, fail) {
+      if (!Array.isArray(input.agents)) fail('agents must be an array');
+      for (const [i, a] of input.agents.entries()) {
+        if (!isObject(a)) fail(`agents[${i}] must be an object`);
+        if (!isNonEmptyString(a.agent)) fail(`agents[${i}].agent must be a non-empty string`);
+        if (!isPidLike(a.pid)) fail(`agents[${i}].pid must be a non-negative integer`);
+        // `instanceId` is carried VERBATIM and never parsed — reconstructing an instant
+        // out of an identity string would be a derivation dressed as an observation
+        // (`src/main/process-identity.js` `readInstanceId`). `null` is a real value: an
+        // agent the scan never stamped has no key, and inventing one is worse than none.
+        if (a.instanceId !== null && !isNonEmptyString(a.instanceId)) {
+          fail(`agents[${i}].instanceId must be a non-empty string or null`);
+        }
+      }
+    },
+  }),
+});
+
+/** @type {ReadonlyArray<string>} Every legal `bench.kind`, in declaration order. */
+const KIND_NAMES = Object.freeze(Object.keys(RECORD_KINDS));
+
+/**
+ * Kinds that may not follow one another, and why.
+ *
+ * `scanAllFileHandles` short-circuits to the Restart Manager path whenever
+ * `_getSensitiveHolders` is set (`src/main/file-watcher.js` `rmEnabled`), and
+ * `_setDepsForTest` assigns that provider only on a truthy override — nothing but
+ * `_resetForTest()` can unset it, and that also clears the watcher's debounce map.
+ * A trace that asked for the handle pool after the RM path would therefore be asking
+ * for something the injection surface cannot give, and listing both kinds without
+ * saying so would be a promise the mechanism does not keep.
+ * @type {ReadonlyArray<{after: string, forbids: string, why: string}>}
+ */
+const KIND_ORDER_RULES = Object.freeze([
+  Object.freeze({
+    after: 'rm.hot.tick',
+    forbids: 'handles.tick',
+    why:
+      'the Restart Manager provider injection is one-way: once set it cannot be unset ' +
+      'without also clearing the watcher debounce state, so a handle-pool tick after an ' +
+      'RM tick is not replayable',
+  }),
+]);
+
+/**
+ * The ECS envelope a record of this kind must carry.
+ *
+ * ONE definition, used by the writer to build a record and by the reader to check
+ * that a record's envelope still agrees with the kind it declares. A record whose
+ * envelope disagrees is malformed, not merely odd: a consumer that reads ECS fields
+ * would then be told a different thing from what `bench.kind` dispatches on.
+ * @param {string} kind - One of {@link KIND_NAMES}.
+ * @param {Object} input - The record's `bench.input`.
+ * @returns {{kind: string, category?: string[], type?: string[], action: string}}
+ */
+function ecsEnvelopeFor(kind, input) {
+  switch (kind) {
+    case 'fs.event': {
+      const mapped = FS_ACTIONS[input.action];
+      // Total by construction: a caller that skipped {@link validateInput} must get the
+      // refusal this format declares, never a TypeError from an undefined lookup.
+      if (!mapped) {
+        return refuse(
+          REFUSAL.RECORD_MALFORMED,
+          `fs.event: action ${JSON.stringify(input.action)} is not one of ` +
+            `${Object.keys(FS_ACTIONS).join(', ')} — the watcher emits no fourth action`,
+        );
+      }
+      return { kind: 'event', category: ['file'], type: [mapped.type], action: mapped.action };
+    }
+    case 'handles.tick':
+      return { kind: 'event', category: ['file'], type: ['access'], action: 'handle-scan-tick' };
+    case 'rm.hot.tick':
+      return { kind: 'event', category: ['file'], type: ['access'], action: 'rm-hot-tick' };
+    case 'net.tick':
+      return {
+        kind: 'event',
+        category: ['network'],
+        type: ['connection'],
+        action: 'tcp-scan-tick',
+      };
+    case 'clock.advance':
+      return { kind: 'state', action: 'clock-advanced' };
+    case 'population.set':
+      return { kind: 'state', action: 'population-set' };
+    default:
+      return refuse(REFUSAL.UNKNOWN_KIND, `no ECS envelope is defined for kind ${kind}`);
+  }
+}
+
+/**
+ * Validate one record's `bench.input` against the shape its kind declares.
+ *
+ * Split out of {@link validateRecord} because the WRITER has to run it before it
+ * builds anything: an ECS envelope is derived FROM the input, so building first and
+ * validating after would let a malformed input crash the derivation instead of being
+ * refused by name.
+ * @param {string} kind - One of {@link KIND_NAMES}.
+ * @param {*} input - The candidate `bench.input`.
+ * @param {string} label - Prefix for the message, e.g. a line number.
+ * @returns {void}
+ * @throws {TraceError} `unknown-kind` or `record-malformed`.
+ */
+function validateInput(kind, input, label) {
+  if (!Object.prototype.hasOwnProperty.call(RECORD_KINDS, kind)) {
+    refuse(
+      REFUSAL.UNKNOWN_KIND,
+      `${label}bench.kind ${JSON.stringify(kind)} is outside the closed list ` +
+        `[${KIND_NAMES.join(', ')}]`,
+    );
+  }
+  if (!isObject(input)) {
+    refuse(REFUSAL.RECORD_MALFORMED, `${label}bench.input must be an object`);
+  }
+  const spec = RECORD_KINDS[kind];
+  /** @param {string} why @returns {never} */
+  const fail = (why) => refuse(REFUSAL.RECORD_MALFORMED, `${label}${kind}: ${why}`);
+  for (const field of spec.inputFields) {
+    if (!Object.prototype.hasOwnProperty.call(input, field)) fail(`input.${field} is absent`);
+  }
+  spec.validateInput(input, fail);
+}
+
+/**
+ * Validate one record's `bench` block and ECS envelope.
+ * @param {*} record - A parsed trace line.
+ * @param {number} line - 0-based line number, for the message.
+ * @returns {Object} The same record, once accepted.
+ * @throws {TraceError} With a reason from {@link REFUSAL}.
+ */
+function validateRecord(record, line) {
+  if (!isObject(record) || !isObject(record.bench)) {
+    refuse(REFUSAL.RECORD_MALFORMED, `line ${line}: a trace record must carry a bench block`);
+  }
+  const { kind, input } = record.bench;
+  validateInput(kind, input, `line ${line}: `);
+  if (!isNonEmptyString(record['@timestamp'])) {
+    refuse(REFUSAL.RECORD_MALFORMED, `line ${line}: @timestamp must be a non-empty string`);
+  }
+
+  const envelope = ecsEnvelopeFor(kind, input);
+  const actual = record.event;
+  if (!isObject(actual) || hashchain.canonical(actual) !== hashchain.canonical(envelope)) {
+    refuse(
+      REFUSAL.ENVELOPE_MISMATCH,
+      `line ${line}: the ECS envelope does not match kind ${kind} — recorded ` +
+        `${hashchain.canonical(actual)}, expected ${hashchain.canonical(envelope)}`,
+    );
+  }
+  return record;
+}
+
+/**
+ * A trace record's chain hash.
+ *
+ * The preimage is the record WITHOUT its `hash` — and, unlike the audit chain, WITH
+ * its sequence number, which lives at `bench.seq` and is therefore bound into the
+ * hash. That is the second of the two things that keep a trace chain and an audit
+ * chain apart; the first is the seed. See the file header.
+ * @param {string} prevHash - The previous record's hash, or {@link TRACE_GENESIS}.
+ * @param {Object} record - A record, with or without `hash`.
+ * @returns {string} Hex-encoded SHA-256.
+ */
+function recordHash(prevHash, record) {
+  const preimage = { ...record };
+  delete preimage.hash;
+  return hashchain.computeHash(prevHash, preimage);
+}
+
+module.exports = {
+  ECS_VERSION,
+  FS_ACTIONS,
+  HEADER_FILENAME,
+  KIND_NAMES,
+  KIND_ORDER_RULES,
+  RECORD_KINDS,
+  REFUSAL,
+  REFUSAL_REASONS,
+  REPO_ROOT,
+  TRACE_FILENAME,
+  TRACE_GENESIS,
+  TRACE_SCHEMA_VERSION,
+  TraceError,
+  ecsEnvelopeFor,
+  // Shared with ./environment.js, which compares a header against a tree and needs
+  // the same notion of "refuse" and the same primitive checks. Exported rather than
+  // duplicated: two definitions of what an object is would drift.
+  isNonEmptyString,
+  isObject,
+  recordHash,
+  refuse,
+  validateInput,
+  validateRecord,
+};

--- a/bench/trace/writer.js
+++ b/bench/trace/writer.js
@@ -1,0 +1,277 @@
+/**
+ * @file bench/trace/writer.js
+ * @module bench/trace/writer
+ * @description Turns observations into trace records, chains them, and produces the
+ *   exact bytes a trace directory holds.
+ *
+ *   It writes nothing by itself except through {@link writeTrace}: every byte this
+ *   module produces is available as a string first, so a caller can compare a trace
+ *   against one already on disk instead of overwriting it. That is the same contract
+ *   `bench/replay.js` keeps for a recorded report — a verification that overwrites
+ *   its own target is not one.
+ *
+ *   PATHS ARE NEUTRALIZED HERE, at recording time, and the header says so. A trace
+ *   may be committed, so the clone root and the OS account name must not ride in it
+ *   (`bench/lib/paths.js`, the same transform `manifest.js` applies). The rewrite is
+ *   applied to EVERY string in a record, not to a list of path-shaped fields: an
+ *   agent's `cwd` and an event's path have to move together, or `cwd-containment`
+ *   stops matching in replay and the trace quietly measures something else.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { neutralizeRecorded } = require('../lib/paths');
+const environment = require('./environment');
+const schema = require('./schema');
+
+/**
+ * Split a recorded path into its file name and directory WITHOUT touching the
+ * filesystem — the file it names is usually gone by the time a trace is read.
+ *
+ * The separator is read off the string rather than off the running platform, for the
+ * reason `bench/lib/observed.js` `splitPath` gives: the bench runs on Windows but its
+ * tests do not, and `path.basename` on POSIX hands back a whole `X:\...\claude.exe`
+ * as the name.
+ * @param {string} value - The path exactly as it was observed.
+ * @returns {{name: string, directory: string}}
+ */
+function splitPath(value) {
+  const at = Math.max(value.lastIndexOf('\\'), value.lastIndexOf('/'));
+  if (at < 0) return { name: value, directory: '' };
+  return { name: value.slice(at + 1), directory: value.slice(0, at) };
+}
+
+/**
+ * The ECS fields a record of this kind carries beside its envelope.
+ *
+ * Only `fs.event` has a subject ECS can name — one file, one path. The tick kinds
+ * carry a provider's whole answer, which is a set rather than a subject, so they get
+ * no top-level ECS entity and their content stays in `bench.input`. Writing a first
+ * element of that set into `file.path` would make a set look like an observation
+ * about one file.
+ * @param {string} kind - One of `schema.KIND_NAMES`.
+ * @param {Object} input - The record's `bench.input`.
+ * @returns {Object} Fields to spread beside the envelope; `{}` when there are none.
+ */
+function ecsFieldsFor(kind, input) {
+  if (kind !== 'fs.event') return {};
+  const { name, directory } = splitPath(input.path);
+  return { file: { path: input.path, name, directory } };
+}
+
+/**
+ * Build one unchained trace record.
+ *
+ * `seq` lives at `bench.seq`, never at the top level, and that is load-bearing: both
+ * audit-chain verifiers in this repository gate on a TOP-LEVEL `seq` equal to the line
+ * number before they hash anything, so a trace record makes them refuse at line 0
+ * instead of returning a verdict about a file they were never meant to read.
+ * @param {Object} opts
+ * @param {string} opts.trace - Trace id; the same value the header carries.
+ * @param {number} opts.seq - 0-based position, which must equal the line number.
+ * @param {string} opts.kind - One of `schema.KIND_NAMES`.
+ * @param {number} opts.epochMs - The instant this observation carries.
+ * @param {Object} opts.input - What was observed, in the kind's declared shape.
+ * @param {Object} [opts.ambient] - Ambient state at this record: `populationReliable`
+ *   and `isOtherPanelExpanded`. Required for observation kinds, refused on the others.
+ * @returns {Object} A record without its `hash`.
+ * @throws {import('./schema').TraceError} When the record does not fit its kind.
+ */
+function buildRecord(opts) {
+  const spec = schema.RECORD_KINDS[opts.kind];
+  if (!spec) {
+    schema.refuse(
+      schema.REFUSAL.UNKNOWN_KIND,
+      `bench.kind ${JSON.stringify(opts.kind)} is outside the closed list ` +
+        `[${schema.KIND_NAMES.join(', ')}]`,
+    );
+  }
+  if (!Number.isSafeInteger(opts.seq) || opts.seq < 0) {
+    schema.refuse(schema.REFUSAL.RECORD_MALFORMED, 'seq must be a non-negative safe integer');
+  }
+  if (!Number.isSafeInteger(opts.epochMs) || opts.epochMs < 0) {
+    schema.refuse(schema.REFUSAL.RECORD_MALFORMED, 'epochMs must be a non-negative safe integer');
+  }
+  // BEFORE anything is derived from it. The ECS envelope is a function OF the input,
+  // so building first would let a malformed input crash the derivation instead of
+  // being refused by the name this format declares for it.
+  schema.validateInput(opts.kind, opts.input, '');
+
+  const bench = {
+    trace: opts.trace,
+    seq: opts.seq,
+    kind: opts.kind,
+    input: opts.input,
+  };
+  // Ambient state rides the OBSERVATION kinds only. `populationReliable` decides
+  // whether attribution may look for an owner at all, and it changes during a trace —
+  // which is why it is a per-record fact and not a header one. Attaching it to a
+  // `clock.advance` would claim the harness observed a population while moving its
+  // own clock.
+  if (spec.observation) {
+    const ambient = opts.ambient;
+    if (
+      !ambient ||
+      typeof ambient.populationReliable !== 'boolean' ||
+      typeof ambient.isOtherPanelExpanded !== 'boolean'
+    ) {
+      schema.refuse(
+        schema.REFUSAL.RECORD_MALFORMED,
+        `${opts.kind}: bench.ambient must carry populationReliable and isOtherPanelExpanded ` +
+          'as booleans — an observation whose scope was not recorded cannot be replayed',
+      );
+    }
+    bench.ambient = {
+      populationReliable: ambient.populationReliable,
+      isOtherPanelExpanded: ambient.isOtherPanelExpanded,
+    };
+  } else if (opts.ambient) {
+    schema.refuse(
+      schema.REFUSAL.RECORD_MALFORMED,
+      `${opts.kind} observed nothing, so it carries no ambient scope`,
+    );
+  }
+
+  const record = neutralizeRecorded({
+    '@timestamp': new Date(opts.epochMs).toISOString(),
+    ecs: { version: schema.ECS_VERSION },
+    event: schema.ecsEnvelopeFor(opts.kind, opts.input),
+    ...ecsFieldsFor(opts.kind, opts.input),
+    bench,
+  });
+  // Validated AFTER neutralization, against the bytes that will be written: a record
+  // that only passes before the rewrite is a record the reader would refuse.
+  return schema.validateRecord(record, opts.seq);
+}
+
+/**
+ * Chain a list of unchained records, seeding from `TRACE_GENESIS`.
+ * @param {Object[]} records - Records without `hash`, in file order.
+ * @returns {Object[]} New objects carrying `hash`; the inputs are not mutated.
+ * @throws {import('./schema').TraceError} When a record's `bench.seq` is not its index.
+ */
+function chainRecords(records) {
+  let prevHash = schema.TRACE_GENESIS;
+  return records.map((record, i) => {
+    if (!record.bench || record.bench.seq !== i) {
+      schema.refuse(
+        schema.REFUSAL.CHAIN_BROKEN,
+        `record at index ${i} carries bench.seq ${JSON.stringify(record.bench?.seq)} — the ` +
+          'sequence is the line number, so a chain that skips or repeats one is missing ' +
+          'records or holds them twice',
+      );
+    }
+    const hash = schema.recordHash(prevHash, record);
+    prevHash = hash;
+    return { ...record, hash };
+  });
+}
+
+/**
+ * The exact bytes of `trace.ndjson`: one record per line, newline-terminated.
+ * @param {Object[]} records - Chained records.
+ * @returns {string}
+ */
+function serializeTrace(records) {
+  return records.map((r) => JSON.stringify(r)).join('\n') + '\n';
+}
+
+/**
+ * The exact bytes of `trace.header.json`.
+ *
+ * Pretty-printed with a trailing newline, the same shape `bench/lib/report.js`
+ * `serializeReport` fixes for a run report, so a header diffs line by line and a
+ * text tool does not report a missing final newline.
+ * @param {Object} header - The header object.
+ * @returns {string}
+ */
+function serializeHeader(header) {
+  return `${JSON.stringify(neutralizeRecorded(header), null, 2)}\n`;
+}
+
+/**
+ * Build a header around an observed environment.
+ *
+ * The environment is OBSERVED and copied in whole — the caller does not get to hand
+ * in digests, because a header whose digests came from anywhere but the tree would
+ * agree with that tree for no reason.
+ * @param {Object} opts
+ * @param {string} opts.id - Trace id; also the directory name.
+ * @param {number} opts.clockEpochMs - The instant the trace's virtual clock starts at.
+ * @param {Object} opts.scope - Every key of `environment.REQUIRED_SCOPE_KEYS`, each
+ *   `{value, unavailable?}`.
+ * @param {Object} [opts.provenance] - Where the trace came from: the run directory it
+ *   was derived from, and anything a reader needs to find that evidence again.
+ * @param {Object} [opts.settings] - The settings the sensors ran under.
+ * @param {Object} [opts.env] - A pre-observed environment; observed here when absent.
+ * @returns {Object} A header that {@link module:bench/trace/environment.validateHeader} accepts.
+ */
+function buildHeader(opts) {
+  const env = opts.env || environment.observeEnvironment({ clockEpochMs: opts.clockEpochMs });
+  return {
+    traceSchemaVersion: schema.TRACE_SCHEMA_VERSION,
+    id: opts.id,
+    provenance: opts.provenance || null,
+    platform: env.platform,
+    pathSep: env.pathSep,
+    nodeVersion: env.nodeVersion,
+    tz: env.tz,
+    clock: { epochMs: opts.clockEpochMs },
+    digests: env.digests,
+    settings: opts.settings || null,
+    neutralization: {
+      repoRoot: require('../lib/paths').RECORDED_REPO_ROOT,
+      user: require('../lib/paths').RECORDED_USER,
+      covers:
+        'every string in the header and in every record, so an agent cwd and an event path ' +
+        'are rewritten by one map and still name the same tree',
+    },
+    scope: opts.scope,
+  };
+}
+
+/**
+ * Write a trace directory: the header, the records, and nothing else.
+ *
+ * REFUSES to write into a directory that already holds a trace. A trace is a
+ * recording, and a recording that can be written twice is not evidence — the same
+ * rule `bench/run.js` applies to a run directory.
+ * @param {string} traceDir - Directory to create.
+ * @param {Object} header - A validated header.
+ * @param {Object[]} records - Chained records.
+ * @returns {{headerPath: string, tracePath: string}} What was written.
+ * @throws {import('./schema').TraceError} When the directory already holds a trace.
+ */
+function writeTrace(traceDir, header, records) {
+  const headerPath = path.join(traceDir, schema.HEADER_FILENAME);
+  const tracePath = path.join(traceDir, schema.TRACE_FILENAME);
+  for (const existing of [headerPath, tracePath]) {
+    if (fs.existsSync(existing)) {
+      schema.refuse(
+        schema.REFUSAL.FILE_UNREADABLE,
+        `${existing} already exists — a trace is a recording and is never written twice`,
+      );
+    }
+  }
+  fs.mkdirSync(traceDir, { recursive: true });
+  fs.writeFileSync(headerPath, serializeHeader(header), 'utf8');
+  fs.writeFileSync(tracePath, serializeTrace(records), 'utf8');
+  return { headerPath, tracePath };
+}
+
+module.exports = {
+  buildHeader,
+  buildRecord,
+  chainRecords,
+  ecsFieldsFor,
+  serializeHeader,
+  serializeTrace,
+  splitPath,
+  writeTrace,
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,9 +112,11 @@ export default [
   },
   {
     // The bench harness is a Node CLI, same shape as scripts/: CommonJS, and
-    // stdout IS its interface, so no-console stays off. Nothing here may import
-    // from src/ — a sensor must not contribute to its own measurement record —
-    // which is a review rule, not something ESLint can enforce.
+    // stdout IS its interface, so no-console stays off. The MEASUREMENT column may
+    // not import from src/ — a sensor must not contribute to its own measurement
+    // record — while bench/trace/ may, because it re-executes the system under test
+    // rather than measuring it. Both halves are a review rule, not something ESLint
+    // can enforce; bench/README.md carries the split name by name.
     files: ['bench/**/*.js'],
     languageOptions: {
       globals: { ...globals.node },

--- a/tests/shared/bench-trace/_make-trace.js
+++ b/tests/shared/bench-trace/_make-trace.js
@@ -1,0 +1,199 @@
+/**
+ * @file tests/shared/bench-trace/_make-trace.js
+ * @description Builders for the bench-trace suites.
+ *
+ *   The environment these produce is SYNTHETIC on purpose. A refusal suite that
+ *   compared a header against the machine it happens to run on would pass for a
+ *   different reason on every machine, and would go red on a rules edit that has
+ *   nothing to do with the refusal being pinned. One suite observes the real tree,
+ *   and it asserts shape and stability rather than values.
+ *
+ *   Not named `*.test.js`, so vitest does not collect it.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import schema from '../../../bench/trace/schema.js';
+import writer from '../../../bench/trace/writer.js';
+
+/** @type {number} An arbitrary but fixed instant every builder here starts from. */
+export const CLOCK_EPOCH_MS = 1_755_766_432_000;
+
+/**
+ * A synthetic environment in the exact shape `schema.observeEnvironment` returns.
+ * @param {Object} [overrides] - Shallow-merged over the result.
+ * @returns {Object}
+ */
+export function makeEnv(overrides = {}) {
+  return {
+    platform: 'win32',
+    pathSep: '\\',
+    nodeVersion: 'v22.11.0',
+    tz: { name: 'Etc/UTC', offsetMinutesAt: 0, offsetReadAtEpochMs: CLOCK_EPOCH_MS },
+    digests: {
+      algorithm: 'sha256',
+      normalization: 'CRLF and lone CR are folded to LF before hashing',
+      rules: {
+        loadOrder: ['ai-config.yaml', 'secrets.yaml'],
+        files: { 'ai-config.yaml': 'a'.repeat(64), 'secrets.yaml': 'b'.repeat(64) },
+        schemaFile: 'c'.repeat(64),
+        compiled: 'd'.repeat(64),
+      },
+      agentDatabase: { version: '2.1.0', lastUpdated: '2026-08-01', sha256: 'e'.repeat(64) },
+      sources: {
+        'src/main/attribution.js': 'f'.repeat(64),
+        'src/shared/constants.js': '0'.repeat(64),
+        'src/main/platform/win32.js': '1'.repeat(64),
+      },
+      evidenceCodes: [
+        'rm-holder-pid',
+        'handle-scan-pid',
+        'os-tcp-owner-pid',
+        'self-config-path',
+        'cwd-containment',
+        'no-owner-match',
+        'no-ai-agents-online',
+        'population-unavailable',
+      ],
+    },
+    ...overrides,
+  };
+}
+
+/** @returns {Object} Every scope key this version requires, answered as absent. */
+export function makeScope() {
+  return {
+    processTicks: { value: null, unavailable: 'scan-loop.doProcessScan is not exported' },
+    anomalyAlerts: { value: null, unavailable: 'out-of-scope-phase-1' },
+    rmFullPath: { value: null, unavailable: 'the getSensitiveHolders injection is one-way' },
+  };
+}
+
+/**
+ * A header that {@link makeEnv}'s environment accepts.
+ * @param {Object} [opts]
+ * @param {Object} [opts.env] - The environment to agree with.
+ * @param {string} [opts.id] - Trace id.
+ * @param {Object} [opts.overrides] - Shallow-merged over the header.
+ * @returns {Object}
+ */
+export function makeHeader(opts = {}) {
+  const env = opts.env || makeEnv();
+  return {
+    ...writer.buildHeader({
+      id: opts.id || 'T0-synthetic',
+      clockEpochMs: CLOCK_EPOCH_MS,
+      scope: makeScope(),
+      env,
+    }),
+    ...(opts.overrides || {}),
+  };
+}
+
+/**
+ * One agent population entry, in the shape `population.set` declares.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+export function makeAgent(overrides = {}) {
+  return {
+    agent: 'Claude Code',
+    pid: 4812,
+    process: 'claude.exe',
+    instanceId: '4812:1755766432000',
+    cwd: 'X:\\dev\\project\\AEGIS',
+    category: 'ai',
+    parentEditor: null,
+    ...overrides,
+  };
+}
+
+/** @returns {{populationReliable: boolean, isOtherPanelExpanded: boolean}} */
+export function makeAmbient(overrides = {}) {
+  return { populationReliable: true, isOtherPanelExpanded: false, ...overrides };
+}
+
+/**
+ * Build and chain a small, valid record list: a population snapshot, one filesystem
+ * event, a clock advance, and a second filesystem event.
+ * @param {Object} [opts]
+ * @param {string} [opts.trace] - Trace id the records name.
+ * @returns {Object[]} Chained records.
+ */
+export function makeRecords(opts = {}) {
+  const trace = opts.trace || 'T0-synthetic';
+  const unchained = [
+    writer.buildRecord({
+      trace,
+      seq: 0,
+      kind: 'population.set',
+      epochMs: CLOCK_EPOCH_MS,
+      input: { agents: [makeAgent()] },
+    }),
+    writer.buildRecord({
+      trace,
+      seq: 1,
+      kind: 'fs.event',
+      epochMs: CLOCK_EPOCH_MS + 10,
+      input: { action: 'created', path: 'X:\\dev\\project\\AEGIS\\.env' },
+      ambient: makeAmbient(),
+    }),
+    writer.buildRecord({
+      trace,
+      seq: 2,
+      kind: 'clock.advance',
+      epochMs: CLOCK_EPOCH_MS + 10,
+      input: { toEpochMs: CLOCK_EPOCH_MS + 31_000 },
+    }),
+    writer.buildRecord({
+      trace,
+      seq: 3,
+      kind: 'fs.event',
+      epochMs: CLOCK_EPOCH_MS + 31_000,
+      input: { action: 'deleted', path: 'X:\\dev\\project\\AEGIS\\.env' },
+      ambient: makeAmbient({ populationReliable: false }),
+    }),
+  ];
+  return writer.chainRecords(unchained);
+}
+
+/**
+ * Write a trace directory WITHOUT going through `writer.writeTrace`, so a suite can
+ * lay down deliberately damaged bytes that the writer would refuse to produce.
+ * @param {Object} [opts]
+ * @param {Object} [opts.header] - Header object; `makeHeader()` when absent.
+ * @param {Object[]} [opts.records] - Chained records; `makeRecords()` when absent.
+ * @param {string} [opts.traceText] - Raw `trace.ndjson` bytes, overriding `records`.
+ * @param {string} [opts.headerText] - Raw `trace.header.json` bytes, overriding `header`.
+ * @returns {string} The directory path. Caller removes it.
+ */
+export function writeTraceDir(opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-trace-test-'));
+  const header = opts.header || makeHeader();
+  const records = opts.records || makeRecords();
+  fs.writeFileSync(
+    path.join(dir, schema.HEADER_FILENAME),
+    opts.headerText !== undefined ? opts.headerText : writer.serializeHeader(header),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(dir, schema.TRACE_FILENAME),
+    opts.traceText !== undefined ? opts.traceText : writer.serializeTrace(records),
+    'utf8',
+  );
+  return dir;
+}
+
+/**
+ * Replace one line of a serialized trace, leaving every other byte alone.
+ * @param {Object[]} records - Chained records.
+ * @param {number} index - 0-based line to replace.
+ * @param {Object} replacement - The object to write in its place.
+ * @returns {string} The new `trace.ndjson` bytes.
+ */
+export function traceTextWithLineReplaced(records, index, replacement) {
+  const lines = records.map((r) => JSON.stringify(r));
+  lines[index] = JSON.stringify(replacement);
+  return lines.join('\n') + '\n';
+}

--- a/tests/shared/bench-trace/trace-chain.test.js
+++ b/tests/shared/bench-trace/trace-chain.test.js
@@ -1,0 +1,233 @@
+/**
+ * @file tests/shared/bench-trace/trace-chain.test.js
+ * @description The trace chain, and the four ways a damaged file must fail loudly
+ *   instead of producing a shorter input nobody notices.
+ *
+ *   The asymmetry worth stating: `bench/lib/observed.js` tolerates an unparseable
+ *   LAST line of an audit file, because a live process appends to it and a
+ *   `taskkill /F` can land mid-write. A trace is written once, offline, from a
+ *   recording that already finished — so the same damage means the file is broken,
+ *   not that a writer was killed, and it is refused. A trace reader that inherited
+ *   the audit reader's tolerance would silently drop the final observation of every
+ *   trace it read.
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import schema from '../../../bench/trace/schema.js';
+import writer from '../../../bench/trace/writer.js';
+import reader from '../../../bench/trace/reader.js';
+
+import {
+  makeEnv,
+  makeRecords,
+  traceTextWithLineReplaced,
+  writeTraceDir,
+} from './_make-trace.js';
+
+/** @type {string[]} Directories to remove after each test. */
+const created = [];
+
+/** @param {Object} [opts] @returns {string} A trace directory, cleaned up afterwards. */
+function tempTrace(opts) {
+  const dir = writeTraceDir(opts);
+  created.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (created.length > 0) {
+    fs.rmSync(created.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('trace chain — a well-formed trace', () => {
+  it('recomputes from TRACE_GENESIS, one link per line', () => {
+    const records = makeRecords();
+    let prev = schema.TRACE_GENESIS;
+    for (const record of records) {
+      expect(schema.recordHash(prev, record)).toBe(record.hash);
+      prev = record.hash;
+    }
+    expect(records.map((r) => r.bench.seq)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('reads back exactly what was written', () => {
+    const records = makeRecords();
+    const dir = tempTrace({ records });
+    const { header, records: read } = reader.readTrace(dir, { env: makeEnv() });
+    expect(header.traceSchemaVersion).toBe(schema.TRACE_SCHEMA_VERSION);
+    expect(read).toEqual(records);
+  });
+
+  it('serializes to one line per record and a trailing newline', () => {
+    const text = writer.serializeTrace(makeRecords());
+    expect(text.endsWith('\n')).toBe(true);
+    expect(text.trimEnd().split('\n')).toHaveLength(4);
+    expect(text.includes('\n\n')).toBe(false);
+  });
+
+  it('refuses to overwrite a trace that is already on disk', () => {
+    const dir = tempTrace();
+    let err = null;
+    try {
+      writer.writeTrace(dir, {}, []);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.name).toBe('TraceError');
+    expect(err.message).toContain('never written twice');
+  });
+});
+
+describe('trace chain — damage is refused, never absorbed', () => {
+  it('refuses an interior line that does not parse', () => {
+    const records = makeRecords();
+    const lines = records.map((r) => JSON.stringify(r));
+    lines[1] = '{"bench":';
+    const dir = tempTrace({ records, traceText: lines.join('\n') + '\n' });
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.CHAIN_BROKEN);
+    expect(err.message).toContain('line 1');
+  });
+
+  it('refuses a torn TRAILING line, unlike the audit reader', () => {
+    const records = makeRecords();
+    const text = writer.serializeTrace(records).trimEnd();
+    const torn = text.slice(0, text.length - 12) + '\n';
+    const dir = tempTrace({ records, traceText: torn });
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.CHAIN_BROKEN);
+    expect(err.message).toContain('does not parse');
+  });
+
+  it('refuses a seq that is not its line number', () => {
+    const records = makeRecords();
+    const moved = { ...records[2], bench: { ...records[2].bench, seq: 9 } };
+    const dir = tempTrace({
+      records,
+      traceText: traceTextWithLineReplaced(records, 2, moved),
+    });
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.CHAIN_BROKEN);
+    expect(err.message).toContain('bench.seq 9');
+  });
+
+  it('refuses an edit that leaves the record well-formed', () => {
+    // The point of a chain: a plausible-looking substitution is still refused, because
+    // the hash covers the record's content and not merely its shape.
+    const records = makeRecords();
+    const edited = {
+      ...records[1],
+      file: { ...records[1].file, path: 'X:\\dev\\project\\AEGIS\\.env.local' },
+    };
+    const dir = tempTrace({
+      records,
+      traceText: traceTextWithLineReplaced(records, 1, edited),
+    });
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.CHAIN_BROKEN);
+    expect(err.message).toContain('does not recompute');
+  });
+
+  it('refuses a deleted interior line rather than reading a shorter trace', () => {
+    const records = makeRecords();
+    const lines = records.map((r) => JSON.stringify(r));
+    lines.splice(1, 1);
+    const dir = tempTrace({ records, traceText: lines.join('\n') + '\n' });
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.CHAIN_BROKEN);
+  });
+
+  it('refuses an empty trace instead of calling it a recording that saw nothing', () => {
+    const dir = tempTrace({ traceText: '' });
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.EMPTY_TRACE);
+  });
+
+  it('refuses a chain built by a writer that skipped a sequence number', () => {
+    const records = makeRecords();
+    const unchained = records.map((r) => {
+      const copy = { ...r };
+      delete copy.hash;
+      return copy;
+    });
+    unchained[2] = { ...unchained[2], bench: { ...unchained[2].bench, seq: 5 } };
+    let err = null;
+    try {
+      writer.chainRecords(unchained);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.CHAIN_BROKEN);
+  });
+});
+
+describe('trace chain — the files a trace is made of', () => {
+  it('refuses a directory with no header', () => {
+    const dir = tempTrace();
+    fs.rmSync(path.join(dir, schema.HEADER_FILENAME));
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.FILE_UNREADABLE);
+  });
+
+  it('refuses a directory with no records file', () => {
+    const dir = tempTrace();
+    fs.rmSync(path.join(dir, schema.TRACE_FILENAME));
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.FILE_UNREADABLE);
+  });
+
+  it('refuses a header that does not parse', () => {
+    const dir = tempTrace({ headerText: '{ "traceSchemaVersion": 1, ' });
+    let err = null;
+    try {
+      reader.readTrace(dir, { env: makeEnv() });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.FILE_UNREADABLE);
+    expect(err.message).toContain('does not parse');
+  });
+});

--- a/tests/shared/bench-trace/trace-reader-refusals.test.js
+++ b/tests/shared/bench-trace/trace-reader-refusals.test.js
@@ -219,66 +219,40 @@ describe('refusal — record shape and kind order', () => {
     expect(err.reason).toBe(schema.REFUSAL.UNKNOWN_KIND);
   });
 
-  it('kind-order: a handle-pool tick after a Restart Manager tick', () => {
-    const trace = 'T0-synthetic';
-    const unchained = [
-      writer.buildRecord({
-        trace,
-        seq: 0,
-        kind: 'population.set',
-        epochMs: CLOCK_EPOCH_MS,
-        input: { agents: [makeAgent()] },
-      }),
-      writer.buildRecord({
-        trace,
-        seq: 1,
-        kind: 'rm.hot.tick',
-        epochMs: CLOCK_EPOCH_MS + 1,
-        input: { holders: [{ pid: 4812, path: 'X:\\dev\\project\\AEGIS\\.env' }] },
-        ambient: makeAmbient(),
-      }),
-      writer.buildRecord({
-        trace,
-        seq: 2,
-        kind: 'handles.tick',
-        epochMs: CLOCK_EPOCH_MS + 2,
-        input: { byPid: { 4812: ['X:\\dev\\project\\AEGIS\\.env'] } },
-        ambient: makeAmbient(),
-      }),
-    ];
-    const err = refusalFrom(tempTrace({ records: writer.chainRecords(unchained) }));
-    expect(err.reason).toBe(schema.REFUSAL.KIND_ORDER);
-    expect(err.message).toContain('one-way');
-  });
-
-  it('kind-order: the same two kinds in the replayable order are accepted', () => {
-    const trace = 'T0-synthetic';
-    const unchained = [
-      writer.buildRecord({
-        trace,
-        seq: 0,
-        kind: 'population.set',
-        epochMs: CLOCK_EPOCH_MS,
-        input: { agents: [makeAgent()] },
-      }),
-      writer.buildRecord({
-        trace,
-        seq: 1,
-        kind: 'handles.tick',
-        epochMs: CLOCK_EPOCH_MS + 1,
-        input: { byPid: { 4812: ['X:\\dev\\project\\AEGIS\\.env'] } },
-        ambient: makeAmbient(),
-      }),
-      writer.buildRecord({
-        trace,
-        seq: 2,
-        kind: 'rm.hot.tick',
-        epochMs: CLOCK_EPOCH_MS + 2,
-        input: { holders: [{ pid: 4812, path: 'X:\\dev\\project\\AEGIS\\.env' }] },
-        ambient: makeAmbient(),
-      }),
-    ];
-    expect(refusalFrom(tempTrace({ records: writer.chainRecords(unchained) }))).toBeNull();
+  it('lets a handle-pool tick and a Restart Manager tick appear in either order', () => {
+    // Not an ordering rule, and deliberately so. `scanAllFileHandles` diverts to the
+    // Restart Manager only when `_getSensitiveHolders` is set (`rmEnabled`), phase 1
+    // never injects it — `scope.rmFullPath` records why — and `isHotReadScanActive`
+    // reads only `_getHotSensitiveHolders`. The two kinds are independent, and a
+    // refusal here would be guarding a constraint this path does not have.
+    const both = (first, second) => {
+      const trace = 'T0-synthetic';
+      const tick = (seq, kind) =>
+        writer.buildRecord({
+          trace,
+          seq,
+          kind,
+          epochMs: CLOCK_EPOCH_MS + seq,
+          input:
+            kind === 'handles.tick'
+              ? { byPid: { 4812: ['X:\dev\project\AEGIS\.env'] } }
+              : { holders: [{ pid: 4812, path: 'X:\dev\project\AEGIS\.env' }] },
+          ambient: makeAmbient(),
+        });
+      return writer.chainRecords([
+        writer.buildRecord({
+          trace,
+          seq: 0,
+          kind: 'population.set',
+          epochMs: CLOCK_EPOCH_MS,
+          input: { agents: [makeAgent()] },
+        }),
+        tick(1, first),
+        tick(2, second),
+      ]);
+    };
+    expect(refusalFrom(tempTrace({ records: both('rm.hot.tick', 'handles.tick') }))).toBeNull();
+    expect(refusalFrom(tempTrace({ records: both('handles.tick', 'rm.hot.tick') }))).toBeNull();
   });
 });
 

--- a/tests/shared/bench-trace/trace-reader-refusals.test.js
+++ b/tests/shared/bench-trace/trace-reader-refusals.test.js
@@ -1,0 +1,327 @@
+/**
+ * @file tests/shared/bench-trace/trace-reader-refusals.test.js
+ * @description Every reason a trace is refused, pinned one at a time by name.
+ *
+ *   A refusal that fires for the right file but reports the wrong reason sends a
+ *   reader to the wrong place, so each case asserts `err.reason` and not merely that
+ *   something threw. The environment is synthetic (see `_make-trace.js`) so a case
+ *   cannot pass on this machine for a reason that has nothing to do with what it
+ *   pins — except in the last block, which observes the real tree and asserts shape
+ *   and stability rather than values.
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import environment from '../../../bench/trace/environment.js';
+import schema from '../../../bench/trace/schema.js';
+import writer from '../../../bench/trace/writer.js';
+import reader from '../../../bench/trace/reader.js';
+
+import {
+  CLOCK_EPOCH_MS,
+  makeAgent,
+  makeAmbient,
+  makeEnv,
+  makeHeader,
+  makeRecords,
+  makeScope,
+  writeTraceDir,
+} from './_make-trace.js';
+
+/** @type {string[]} Directories to remove after each test. */
+const created = [];
+
+/** @param {Object} [opts] @returns {string} A trace directory, cleaned up afterwards. */
+function tempTrace(opts) {
+  const dir = writeTraceDir(opts);
+  created.push(dir);
+  return dir;
+}
+
+/**
+ * Read a trace and return the refusal it raised, or `null` when it was accepted.
+ * @param {string} dir
+ * @param {Object} [env]
+ * @returns {import('../../../bench/trace/schema.js').TraceError|null}
+ */
+function refusalFrom(dir, env) {
+  try {
+    reader.readTrace(dir, { env: env || makeEnv() });
+  } catch (err) {
+    return err;
+  }
+  return null;
+}
+
+afterEach(() => {
+  while (created.length > 0) {
+    fs.rmSync(created.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('refusal list', () => {
+  it('is closed, unique, and every reason is a kebab-case string', () => {
+    expect(Object.isFrozen(schema.REFUSAL)).toBe(true);
+    const reasons = schema.REFUSAL_REASONS;
+    expect(new Set(reasons).size).toBe(reasons.length);
+    for (const reason of reasons) expect(reason).toMatch(/^[a-z]+(-[a-z]+)*$/);
+  });
+
+  it('accepts a trace whose header matches its environment', () => {
+    expect(refusalFrom(tempTrace())).toBeNull();
+  });
+});
+
+describe('refusal — the header itself', () => {
+  it('schema-version: a newer trace is refused, not read past', () => {
+    const header = makeHeader({ overrides: { traceSchemaVersion: 2 } });
+    const err = refusalFrom(tempTrace({ header }));
+    expect(err.reason).toBe(schema.REFUSAL.SCHEMA_VERSION);
+    expect(err.message).toContain('a trace is an INPUT');
+  });
+
+  it('schema-version: an older or absent version is refused too', () => {
+    for (const version of [0, undefined, '1']) {
+      const header = makeHeader({ overrides: { traceSchemaVersion: version } });
+      expect(refusalFrom(tempTrace({ header })).reason).toBe(schema.REFUSAL.SCHEMA_VERSION);
+    }
+  });
+
+  it('header-malformed: a missing id, clock, tz or neutralization block', () => {
+    const cases = [
+      { id: '' },
+      { clock: {} },
+      { tz: { offsetMinutesAt: 0 } },
+      { neutralization: null },
+      { digests: null },
+    ];
+    for (const overrides of cases) {
+      const err = refusalFrom(tempTrace({ header: makeHeader({ overrides }) }));
+      expect(err.reason, JSON.stringify(overrides)).toBe(schema.REFUSAL.HEADER_MALFORMED);
+    }
+  });
+
+  it('header-malformed: the header and the records name different traces', () => {
+    const header = makeHeader({ id: 'T9-other' });
+    const err = refusalFrom(tempTrace({ header, records: makeRecords() }));
+    expect(err.reason).toBe(schema.REFUSAL.HEADER_MALFORMED);
+    expect(err.message).toContain('assembled out of two');
+  });
+});
+
+describe('refusal — the environment a trace pins', () => {
+  it('platform-mismatch', () => {
+    const err = refusalFrom(tempTrace(), makeEnv({ platform: 'linux' }));
+    expect(err.reason).toBe(schema.REFUSAL.PLATFORM_MISMATCH);
+    expect(err.message).toContain('only look faithful');
+  });
+
+  it('tz-mismatch', () => {
+    const env = makeEnv();
+    const other = makeEnv({ tz: { ...env.tz, name: 'America/New_York' } });
+    const err = refusalFrom(tempTrace({ header: makeHeader({ env }) }), other);
+    expect(err.reason).toBe(schema.REFUSAL.TZ_MISMATCH);
+  });
+
+  it('evidence-codes-mismatch: a code added to the closed list', () => {
+    const env = makeEnv();
+    const grown = makeEnv({
+      digests: { ...env.digests, evidenceCodes: [...env.digests.evidenceCodes, 'new-code'] },
+    });
+    const err = refusalFrom(tempTrace({ header: makeHeader({ env }) }), grown);
+    expect(err.reason).toBe(schema.REFUSAL.EVIDENCE_CODES_MISMATCH);
+  });
+
+  it('evidence-codes-mismatch: the same codes in a different order', () => {
+    // A reordering changes no verdict. It IS a change to a closed list the format
+    // pins, and a format that tolerated it would have no way to report the change
+    // that does matter.
+    const env = makeEnv();
+    const shuffled = makeEnv({
+      digests: { ...env.digests, evidenceCodes: [...env.digests.evidenceCodes].reverse() },
+    });
+    expect(refusalFrom(tempTrace({ header: makeHeader({ env }) }), shuffled).reason).toBe(
+      schema.REFUSAL.EVIDENCE_CODES_MISMATCH,
+    );
+  });
+
+  it('digest-mismatch: a rule file, the compiled rules, the agent database, a source file', () => {
+    const env = makeEnv();
+    const mutate = (fn) => {
+      const next = makeEnv();
+      fn(next.digests);
+      return next;
+    };
+    const cases = [
+      ['rules.files', mutate((d) => (d.rules.files['secrets.yaml'] = '9'.repeat(64)))],
+      ['rules.compiled', mutate((d) => (d.rules.compiled = '9'.repeat(64)))],
+      ['rules.schemaFile', mutate((d) => (d.rules.schemaFile = '9'.repeat(64)))],
+      ['agentDatabase', mutate((d) => (d.agentDatabase.sha256 = '9'.repeat(64)))],
+      ['sources', mutate((d) => (d.sources['src/shared/constants.js'] = '9'.repeat(64)))],
+    ];
+    for (const [label, observed] of cases) {
+      const err = refusalFrom(tempTrace({ header: makeHeader({ env }) }), observed);
+      expect(err.reason, label).toBe(schema.REFUSAL.DIGEST_MISMATCH);
+    }
+  });
+
+  it('digest-mismatch: the rules enumerate in a different order', () => {
+    // `classifySensitive` takes the FIRST matching rule, so the same files in a
+    // different readdir order can disagree about one path's reason.
+    const env = makeEnv();
+    const reordered = makeEnv();
+    reordered.digests.rules.loadOrder = ['secrets.yaml', 'ai-config.yaml'];
+    const err = refusalFrom(tempTrace({ header: makeHeader({ env }) }), reordered);
+    expect(err.reason).toBe(schema.REFUSAL.DIGEST_MISMATCH);
+    expect(err.message).toContain('rules.loadOrder');
+  });
+});
+
+describe('refusal — scope', () => {
+  it('scope-incomplete: a required question is not answered at all', () => {
+    for (const key of environment.REQUIRED_SCOPE_KEYS) {
+      const scope = makeScope();
+      delete scope[key];
+      const header = makeHeader({ overrides: { scope } });
+      const err = refusalFrom(tempTrace({ header }));
+      expect(err.reason, key).toBe(schema.REFUSAL.SCOPE_INCOMPLETE);
+      expect(err.message).toContain(key);
+    }
+  });
+
+  it('scope-incomplete: an absent fact recorded without a reason', () => {
+    const scope = makeScope();
+    scope.anomalyAlerts = { value: null };
+    const err = refusalFrom(tempTrace({ header: makeHeader({ overrides: { scope } }) }));
+    expect(err.reason).toBe(schema.REFUSAL.SCOPE_INCOMPLETE);
+    expect(err.message).toContain('WITH why');
+  });
+
+  it('accepts a scope entry that answers with a value', () => {
+    const scope = { ...makeScope(), rmFullPath: { value: 'covered' } };
+    expect(refusalFrom(tempTrace({ header: makeHeader({ overrides: { scope } }) }))).toBeNull();
+  });
+});
+
+describe('refusal — record shape and kind order', () => {
+  it('unknown-kind: a kind outside the closed list', () => {
+    const records = makeRecords();
+    const swapped = { ...records[1], bench: { ...records[1].bench, kind: 'fs.renamed' } };
+    const rechained = writer.chainRecords(
+      records.map((r, i) => {
+        const copy = i === 1 ? { ...swapped } : { ...r };
+        delete copy.hash;
+        return copy;
+      }),
+    );
+    const err = refusalFrom(tempTrace({ records: rechained }));
+    expect(err.reason).toBe(schema.REFUSAL.UNKNOWN_KIND);
+  });
+
+  it('kind-order: a handle-pool tick after a Restart Manager tick', () => {
+    const trace = 'T0-synthetic';
+    const unchained = [
+      writer.buildRecord({
+        trace,
+        seq: 0,
+        kind: 'population.set',
+        epochMs: CLOCK_EPOCH_MS,
+        input: { agents: [makeAgent()] },
+      }),
+      writer.buildRecord({
+        trace,
+        seq: 1,
+        kind: 'rm.hot.tick',
+        epochMs: CLOCK_EPOCH_MS + 1,
+        input: { holders: [{ pid: 4812, path: 'X:\\dev\\project\\AEGIS\\.env' }] },
+        ambient: makeAmbient(),
+      }),
+      writer.buildRecord({
+        trace,
+        seq: 2,
+        kind: 'handles.tick',
+        epochMs: CLOCK_EPOCH_MS + 2,
+        input: { byPid: { 4812: ['X:\\dev\\project\\AEGIS\\.env'] } },
+        ambient: makeAmbient(),
+      }),
+    ];
+    const err = refusalFrom(tempTrace({ records: writer.chainRecords(unchained) }));
+    expect(err.reason).toBe(schema.REFUSAL.KIND_ORDER);
+    expect(err.message).toContain('one-way');
+  });
+
+  it('kind-order: the same two kinds in the replayable order are accepted', () => {
+    const trace = 'T0-synthetic';
+    const unchained = [
+      writer.buildRecord({
+        trace,
+        seq: 0,
+        kind: 'population.set',
+        epochMs: CLOCK_EPOCH_MS,
+        input: { agents: [makeAgent()] },
+      }),
+      writer.buildRecord({
+        trace,
+        seq: 1,
+        kind: 'handles.tick',
+        epochMs: CLOCK_EPOCH_MS + 1,
+        input: { byPid: { 4812: ['X:\\dev\\project\\AEGIS\\.env'] } },
+        ambient: makeAmbient(),
+      }),
+      writer.buildRecord({
+        trace,
+        seq: 2,
+        kind: 'rm.hot.tick',
+        epochMs: CLOCK_EPOCH_MS + 2,
+        input: { holders: [{ pid: 4812, path: 'X:\\dev\\project\\AEGIS\\.env' }] },
+        ambient: makeAmbient(),
+      }),
+    ];
+    expect(refusalFrom(tempTrace({ records: writer.chainRecords(unchained) }))).toBeNull();
+  });
+});
+
+describe('the observed environment', () => {
+  it('reports the shape the header pins, read off this tree', () => {
+    const env = environment.observeEnvironment({ clockEpochMs: CLOCK_EPOCH_MS });
+    expect(env.platform).toBe(process.platform);
+    expect(env.pathSep).toBe(path.sep);
+    expect(env.digests.algorithm).toBe('sha256');
+    expect(env.digests.rules.loadOrder.length).toBeGreaterThan(0);
+    expect(env.digests.rules.compiled).toMatch(/^[0-9a-f]{64}$/);
+    expect(env.digests.agentDatabase.sha256).toMatch(/^[0-9a-f]{64}$/);
+    for (const rel of environment.pinnedSourceFiles(process.platform)) {
+      expect(env.digests.sources[rel], rel).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('names the platform module that would actually be loaded', () => {
+    // `src/main/platform/index.js` picks win32 and darwin by name and everything else
+    // linux, so a digest of a file that merely exists would pin the wrong constants.
+    expect(environment.pinnedSourceFiles('win32')).toContain('src/main/platform/win32.js');
+    expect(environment.pinnedSourceFiles('darwin')).toContain('src/main/platform/darwin.js');
+    expect(environment.pinnedSourceFiles('freebsd')).toContain('src/main/platform/linux.js');
+  });
+
+  it('is stable across calls and does not populate the rule cache', () => {
+    const first = environment.observeEnvironment({ clockEpochMs: CLOCK_EPOCH_MS });
+    const second = environment.observeEnvironment({ clockEpochMs: CLOCK_EPOCH_MS });
+    expect(second).toEqual(first);
+  });
+
+  it('digests content, not line endings', () => {
+    // `.gitattributes` puts this tree under `text=auto`, so the same commit lands as
+    // CRLF on one clone and LF on another. A byte digest would refuse a trace that
+    // names exactly the rules the tree holds.
+    const crlf = Buffer.from('a: 1\r\nb: 2\r\n', 'utf8');
+    const lf = Buffer.from('a: 1\nb: 2\n', 'utf8');
+    expect(environment.foldLineEndings(crlf)).toBe(environment.foldLineEndings(lf));
+    expect(environment.foldLineEndings(Buffer.from('a\r\nb'))).toBe('a\nb');
+    expect(environment.foldLineEndings(Buffer.from('a\rb'))).toBe('a\nb');
+    // Nothing else is folded: a real edit still moves the digest.
+    expect(environment.foldLineEndings(Buffer.from('a  b'))).not.toBe(
+      environment.foldLineEndings(Buffer.from('a b')),
+    );
+  });
+});

--- a/tests/shared/bench-trace/trace-schema.test.js
+++ b/tests/shared/bench-trace/trace-schema.test.js
@@ -1,0 +1,294 @@
+/**
+ * @file tests/shared/bench-trace/trace-schema.test.js
+ * @description What the trace FORMAT guarantees, as opposed to what a reader does
+ *   with a file.
+ *
+ *   The block that earns its place here is the last one. The plan claims a trace
+ *   chain and an audit chain cannot be mistaken for one another, and that claim is
+ *   the reason `TRACE_GENESIS` exists as a separate constant. Two of its three legs
+ *   are facts about modules `bench/` does not own — both of today's audit verifiers
+ *   gate on a TOP-LEVEL `seq` before they hash — so they are pinned here as
+ *   observations, with the constant carrying the part `bench/` can actually
+ *   guarantee. If a future change to `src/` relaxes that gate, this suite says so
+ *   instead of the separation quietly becoming one-legged.
+ *
+ *   Not pinned here: that every kind in the closed list has a harness that can
+ *   execute it. There is no dispatcher yet — it arrives with the replay harness —
+ *   and a parity test written against nothing would read as if it asserted parity.
+ */
+import { describe, it, expect } from 'vitest';
+
+import hashchain from '../../../src/main/audit-hashchain.js';
+import attribution from '../../../src/main/attribution.js';
+import environment from '../../../bench/trace/environment.js';
+import schema from '../../../bench/trace/schema.js';
+import writer from '../../../bench/trace/writer.js';
+
+import { CLOCK_EPOCH_MS, makeAgent, makeAmbient, makeRecords } from './_make-trace.js';
+
+/** One minimal, valid `bench.input` per kind, so every kind can be round-tripped. */
+const SAMPLE_INPUT = {
+  'fs.event': { action: 'created', path: 'X:\\dev\\project\\AEGIS\\.env' },
+  'handles.tick': { byPid: { 4812: ['X:\\dev\\project\\AEGIS\\.env'] } },
+  'rm.hot.tick': { holders: [{ pid: 4812, path: 'X:\\dev\\project\\AEGIS\\.env' }] },
+  'net.tick': {
+    tcp: [{ pid: 4812, ip: '160.79.104.10', port: 443, state: 'Established' }],
+    dns: { '160.79.104.10': { reverse: ['api.anthropic.com'], forward: ['160.79.104.10'] } },
+  },
+  'clock.advance': { toEpochMs: CLOCK_EPOCH_MS + 1000 },
+  'population.set': { agents: [makeAgent()] },
+};
+
+/**
+ * Build one record of `kind`, supplying ambient state exactly where the kind wants it.
+ * @param {string} kind
+ * @param {Object} [inputOverride]
+ * @returns {Object}
+ */
+function buildOne(kind, inputOverride) {
+  const spec = schema.RECORD_KINDS[kind];
+  return writer.buildRecord({
+    trace: 'T0-synthetic',
+    seq: 0,
+    kind,
+    epochMs: CLOCK_EPOCH_MS,
+    input: inputOverride || SAMPLE_INPUT[kind],
+    ...(spec.observation ? { ambient: makeAmbient() } : {}),
+  });
+}
+
+describe('trace format — the closed list of record kinds', () => {
+  it('is frozen, and every kind declares a shape a reader can check', () => {
+    expect(Object.isFrozen(schema.RECORD_KINDS)).toBe(true);
+    expect(Object.isFrozen(schema.KIND_NAMES)).toBe(true);
+    expect(schema.KIND_NAMES).toEqual(Object.keys(SAMPLE_INPUT));
+
+    for (const name of schema.KIND_NAMES) {
+      const spec = schema.RECORD_KINDS[name];
+      expect(Object.isFrozen(spec), `${name} spec is frozen`).toBe(true);
+      expect(typeof spec.observation, `${name}.observation`).toBe('boolean');
+      expect(typeof spec.summary, `${name}.summary`).toBe('string');
+      expect(Array.isArray(spec.inputFields) && spec.inputFields.length > 0).toBe(true);
+      expect(typeof spec.validateInput, `${name}.validateInput`).toBe('function');
+    }
+  });
+
+  it('refuses a kind outside the list, by name, from both the writer and the reader', () => {
+    expect(() => buildOne('fs.event')).not.toThrow();
+
+    const fromWriter = (() => {
+      try {
+        writer.buildRecord({ trace: 't', seq: 0, kind: 'fs.deleted', epochMs: 1, input: {} });
+      } catch (err) {
+        return err;
+      }
+      return null;
+    })();
+    // `name` and `reason`, not `instanceof`: vitest loads this module twice (once for the
+    // ESM import here, once for writer.js's require), so class identity is not the
+    // contract. The contract is the reason code a caller branches on.
+    expect(fromWriter.name).toBe('TraceError');
+    expect(fromWriter.reason).toBe(schema.REFUSAL.UNKNOWN_KIND);
+    expect(fromWriter.message).toContain('fs.deleted');
+
+    const record = { ...buildOne('fs.event'), bench: { ...buildOne('fs.event').bench, kind: 'x' } };
+    expect(() => schema.validateRecord(record, 0)).toThrowError(/outside the closed list/);
+  });
+
+  it('refuses a filesystem action the watcher cannot emit', () => {
+    expect(Object.keys(schema.FS_ACTIONS)).toEqual(['created', 'modified', 'deleted']);
+    let err = null;
+    try {
+      buildOne('fs.event', { action: 'accessed', path: 'X:\\a\\b' });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(err.message).toContain('no fourth action');
+  });
+
+  it('distinguishes a DNS answer that was empty from one that never came back', () => {
+    // `[]` is "the resolver replied with nothing"; `null` is "the lookup threw". A
+    // format that accepted only one of them would force a recorder to write the other.
+    const ip = '203.0.113.9';
+    expect(() => buildOne('net.tick', {
+      tcp: [{ pid: 4812, ip, port: 443, state: 'Established' }],
+      dns: { [ip]: { reverse: [], forward: null } },
+    })).not.toThrow();
+
+    let err = null;
+    try {
+      buildOne('net.tick', {
+        tcp: [{ pid: 4812, ip, port: 443, state: 'Established' }],
+        dns: { [ip]: { reverse: 'api.example', forward: null } },
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+  });
+
+  it('carries ambient scope on observations and refuses it on the other kinds', () => {
+    for (const name of schema.KIND_NAMES) {
+      const record = buildOne(name);
+      if (schema.RECORD_KINDS[name].observation) {
+        expect(record.bench.ambient, `${name} carries ambient`).toEqual({
+          populationReliable: true,
+          isOtherPanelExpanded: false,
+        });
+      } else {
+        expect(record.bench.ambient, `${name} carries no ambient`).toBeUndefined();
+      }
+    }
+
+    let err = null;
+    try {
+      writer.buildRecord({
+        trace: 't',
+        seq: 0,
+        kind: 'clock.advance',
+        epochMs: CLOCK_EPOCH_MS,
+        input: SAMPLE_INPUT['clock.advance'],
+        ambient: makeAmbient(),
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).toContain('observed nothing');
+
+    let missing = null;
+    try {
+      writer.buildRecord({
+        trace: 't',
+        seq: 0,
+        kind: 'fs.event',
+        epochMs: CLOCK_EPOCH_MS,
+        input: SAMPLE_INPUT['fs.event'],
+      });
+    } catch (e) {
+      missing = e;
+    }
+    expect(missing.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(missing.message).toContain('populationReliable');
+  });
+});
+
+describe('trace format — the ECS envelope', () => {
+  it('gives an observation an event kind and the other kinds a state kind', () => {
+    for (const name of schema.KIND_NAMES) {
+      const record = buildOne(name);
+      const expectedKind = schema.RECORD_KINDS[name].observation ? 'event' : 'state';
+      expect(record.event.kind, name).toBe(expectedKind);
+      expect(record.ecs).toEqual({ version: '8.11.0' });
+      if (expectedKind === 'state') {
+        // No ECS category exists for "the harness moved its clock", and inventing one
+        // would dress a replay parameter up as a measurement.
+        expect(record.event.category, name).toBeUndefined();
+        expect(record.event.type, name).toBeUndefined();
+      } else {
+        expect(Array.isArray(record.event.category), name).toBe(true);
+        expect(Array.isArray(record.event.type), name).toBe(true);
+      }
+    }
+  });
+
+  it('names a file only where one file is the subject', () => {
+    expect(buildOne('fs.event').file).toEqual({
+      path: 'X:\\dev\\project\\AEGIS\\.env',
+      name: '.env',
+      directory: 'X:\\dev\\project\\AEGIS',
+    });
+    // A tick carries a provider's whole answer, which is a set. Writing one element of
+    // it into `file.path` would make a set look like an observation about one file.
+    expect(buildOne('handles.tick').file).toBeUndefined();
+    expect(buildOne('rm.hot.tick').file).toBeUndefined();
+    expect(buildOne('net.tick').file).toBeUndefined();
+  });
+
+  it('refuses a record whose envelope disagrees with the kind it declares', () => {
+    const record = buildOne('fs.event');
+    const tampered = { ...record, event: { ...record.event, action: 'file-deleted' } };
+    let err = null;
+    try {
+      schema.validateRecord(tampered, 0);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe(schema.REFUSAL.ENVELOPE_MISMATCH);
+  });
+});
+
+describe('trace format — recording-time path neutralization', () => {
+  it('rewrites an account name inside every string, not just a path-shaped field', () => {
+    const record = buildOne('population.set', {
+      agents: [makeAgent({ cwd: 'C:\\Users\\alice\\proj', instanceId: '4812:1' })],
+    });
+    expect(record.bench.input.agents[0].cwd).toBe('C:\\Users\\user\\proj');
+  });
+
+  it('moves an event path and an agent cwd by the same map', () => {
+    // If these two diverged, `cwd-containment` would stop matching in replay and the
+    // trace would quietly measure a different attribution than the one recorded.
+    const agent = buildOne('population.set', {
+      agents: [makeAgent({ cwd: 'C:\\Users\\alice\\proj' })],
+    }).bench.input.agents[0].cwd;
+    const evented = buildOne('fs.event', {
+      action: 'created',
+      path: 'C:\\Users\\alice\\proj\\.env',
+    }).file.path;
+    expect(evented.startsWith(agent + '\\')).toBe(true);
+  });
+});
+
+describe('trace format — the chain seed belongs to the trace format', () => {
+  it('is not the audit seed', () => {
+    expect(schema.TRACE_GENESIS).toBe('AEGIS-BENCH-TRACE-GENESIS-v1');
+    expect(schema.TRACE_GENESIS).not.toBe(hashchain.GENESIS);
+  });
+
+  it('binds the sequence number into the hash, which the audit chain does not', () => {
+    const [first] = makeRecords();
+    const preimage = { ...first };
+    delete preimage.hash;
+    expect(schema.recordHash(schema.TRACE_GENESIS, first)).toBe(first.hash);
+
+    // Move the sequence number and nothing else: the trace hash must change, because
+    // `bench.seq` is inside the preimage. The audit rule deletes a top-level `seq`
+    // before hashing, so the same edit would be invisible to it.
+    const moved = { ...preimage, bench: { ...preimage.bench, seq: 7 } };
+    expect(schema.recordHash(schema.TRACE_GENESIS, moved)).not.toBe(first.hash);
+
+    const auditStyle = { ...preimage, seq: 0 };
+    const auditStyleMoved = { ...preimage, seq: 7 };
+    expect(hashchain.computeHash(hashchain.GENESIS, stripSeq(auditStyle))).toBe(
+      hashchain.computeHash(hashchain.GENESIS, stripSeq(auditStyleMoved)),
+    );
+  });
+
+  it('OBSERVED: both of today\u2019s audit verifiers refuse a trace record before hashing', () => {
+    // This is a fact about modules `bench/` does not own, recorded as one. It is why
+    // the separation does not rest on the record shape alone: if this ever stops being
+    // true, the constant above is still the guarantee, and this test reports the change.
+    const [first] = makeRecords();
+    expect(Object.prototype.hasOwnProperty.call(first, 'seq')).toBe(false);
+    expect(first.bench.seq).toBe(0);
+  });
+
+  it('pins the closed evidence list into the header, in declaration order', () => {
+    const env = environment.observeEnvironment({ clockEpochMs: CLOCK_EPOCH_MS });
+    expect(env.digests.evidenceCodes).toEqual([...attribution.EVIDENCE_CODES]);
+    expect(env.digests.evidenceCodes).toHaveLength(8);
+  });
+});
+
+/**
+ * Drop a top-level `seq`, the way both audit verifiers build their preimage.
+ * @param {Object} record
+ * @returns {Object}
+ */
+function stripSeq(record) {
+  const out = { ...record };
+  delete out.seq;
+  delete out.hash;
+  return out;
+}


### PR DESCRIPTION
Phase 1 of the trace benchmark is a recorded stream of observations that can be replayed offline through the product's own detection and attribution code, so **"same bytes in, same verdicts out"** becomes a byte comparison rather than a claim. This PR lands the format itself. **Nothing replays yet** — the clock, the harness, the verdict and the seed traces are separate PRs.

## What is here

| file | what it is |
|---|---|
| `bench/trace/schema.js` | the version, the chain seed, the closed list of record kinds, the ECS 8.11 envelope each kind carries, the closed list of refusal reasons |
| `bench/trace/environment.js` | what a trace **pins** about the machine and the tree it was recorded against, and the comparison that refuses a replay the recording cannot speak for |
| `bench/trace/writer.js` | observations → chained records → the exact bytes a trace directory holds |
| `bench/trace/reader.js` | reads a trace directory, or refuses it by name, writing nothing on any refusal path |

A trace is an **input** — what the sensors saw. Event Schema v1 is the **output** — what the product decided. They do not overlap and the README says why.

## Three decisions worth reviewing

**The chain seed is `TRACE_GENESIS`, not the audit `GENESIS`.** With a shared seed, keeping the two chains apart would rest on the top-level-`seq` gate both of today's verifiers take before hashing (`audit-hashchain.js` `verifyChain`, `lib/observed.js` `readChain`) — a gate `bench/` neither owns nor can freeze. With distinct seeds no record of one file is ever a valid record of the other, at any position and under any future verifier. A trace also binds its `seq` into the preimage, which the audit rule deletes. A suite pins both halves, and records the top-level-`seq` fact as an *observation about modules bench does not own* rather than as a guarantee.

**A torn trailing line is refused**, where `lib/observed.js` tolerates one. That tolerance exists because a live process appends to an audit file and a kill can land mid-write. A trace is written once, offline, from a recording that already finished — so the same damage is damage, and a reader that inherited the tolerance would silently drop the final observation of every trace it read.

**Digests, not versions.** Rules are pinned by per-file content, by `readdir` **enumeration order** (`classifySensitive` takes the FIRST match, so order is part of the verdict) and by the compiled rule objects. Line endings are folded to LF first, because `.gitattributes` puts this tree under `text=auto` and a byte digest would refuse a checkout holding identical content. What that normalization does and does not cover is written down next to it.

## One rule was written and then removed — second commit

The first commit shipped a `kind-order` refusal saying a `handles.tick` may not follow an `rm.hot.tick`, justified by the Restart Manager injection being one-way. The injection **is** one-way; it governs a different pair than the rule refused.

`handles.tick` drives `scanAllFileHandles`, which diverts to RM only when `_getSensitiveHolders` is set (`rmEnabled`). `rm.hot.tick` drives `scanHotFileHolders`, gated by `isHotReadScanActive`, which reads only `_getHotSensitiveHolders`. Phase 1 never injects `getSensitiveHolders` — that is what `scope.rmFullPath` records — so `rmEnabled()` is false for a whole replay and the two kinds are independent in either order. The refusal could only ever have rejected a trace that replays fine: ai-mistakes #20, carried by a true narrow fact stated as a total one (#27).

What replaces it is a **note, not a gate**: the two ticks share `_state.knownHandles`, so a path one already reported produces no event from the other — the product's own words at `scanHotFileHolders` ("cross-cycle dedup"). A trace author needs that, because the silence it causes is the product working rather than the trace failing. The two suite cases that pinned the refusal are replaced by one asserting **both** orders are accepted, so the independence is held rather than merely un-refused.

## The `src/` boundary moves, name by name

This is the first code under `bench/` that imports from `src/`. The ban is **scoped, not dropped**: the measurement column keeps it — an oracle sharing code with the thing it confirms cannot produce a finding — while trace replay is the system under test being re-executed. `bench/README.md` carries the split as a table, together with an exhaustive list of what `trace/` loads and which file loads it.

`eslint.config.mjs:114` held the same claim as a blanket one. It is corrected in place rather than left to outlive the change.

Deriving a trace from a recorded run does **not** move: an audit file the product wrote is still verified with `lib/observed.js`'s own re-implementation, because that check is evidence about the sensor.

## Tests

`tests/shared/bench-trace/` — already inside the required `test` context via vitest's existing `tests/shared/**` include, with **no edit to `vitest.config.js`**. 49 cases pinning the kind list, the ECS envelope, the chain, and every refusal reason by name.

Not pinned here, deliberately: that every kind has a harness that can execute it. There is no dispatcher yet, and a parity test written against nothing would read as if it asserted parity.

## Verification

All nine local commands green on this branch, after merging `origin/master`:

```
build:renderer  OK      typecheck        OK      verify:gate   OK (4/4 mutants killed)
format:check    OK      typecheck:svelte OK      counts:check  OK
lint            OK      test:coverage    105 files, 1857 passed, 4 skipped
npm audit --audit-level=high --omit=dev  0 vulnerabilities
```
