### PR TITLE
feat(bench): virtual clock and the preload that installs it

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -116,6 +116,9 @@ bench/
   trace/environment.js                      # what a trace pins about the machine and the tree, and the comparison that refuses a mismatch
   trace/writer.js                           # observations → chained records → the exact bytes a trace directory holds
   trace/reader.js                           # reads a trace directory, or refuses it by name
+  trace/clock.js                            # the virtual clock as a value, and the switch that puts it in front of the real one
+  trace/clock-env.js                        # which environment variables name a clock, and the bootstrap that applies them
+  trace/preload.js                          # the `node --require` entrypoint; acts on load, throws loudly when the environment names no clock
   runs/                                     # run artefacts — gitignored, created on first run
   README.md
 ```
@@ -726,11 +729,51 @@ replayed on Linux would only look faithful. The practical consequence is that th
 can run in CI are the format, chain and refusal ones; verifying a recorded Windows trace stays a
 local command, exactly as the rest of the bench does.
 
+### The virtual clock
+
+A replay reads the wall clock in more than twenty places, and one of them has no injection
+point at all: `src/main/audit-logger.js` stamps `new Date().toISOString()` on every record it
+writes. Its `init({now})` hook covers day rotation only. `src/main/baselines.js` reads
+`new Date().getHours()`. Both are globals, and a global has to move before the module that
+closes over it is compiled — which is why the clock arrives through `node --require` and not
+through a seam:
+
+```
+AEGIS_TRACE_CLOCK_EPOCH_MS=<header.clock.epochMs> AEGIS_TRACE_TZ=<header.tz.name>   node --require bench/trace/preload.js <entrypoint>
+```
+
+Nothing in `src/` is patched. `Date` is replaced by a **proxy** over the real constructor, so
+`Date.parse`, `Date.UTC`, `Date.prototype`, `instanceof` and calling `Date()` without `new` all
+keep working, and `new Date(x)` with an argument is untouched — it names an instant the caller
+already has. `performance.now()` reads as milliseconds since the clock's own epoch.
+
+`setTimeout` and `setInterval` are **not** touched. A replay never starts the product's scan
+intervals — cadence comes from the trace, as `clock.advance` records — and the one live timer
+left is the audit logger's flush, stopped by calling the product's own `shutdown()`.
+
+Time moves forward only, and only when a record says so. Going backwards is refused rather than
+clamped: holding the clock still instead would let the watcher's 2 s debounce and the scan
+loop's 30 s dedup window answer questions about an ordering the recording never had. Two
+observations may share a millisecond, because machines do that.
+
+**The failure this is shaped around is a preload that did not run.** A misspelled `--require`,
+an unset variable, a wrapper that dropped the flag — each looks exactly like a preload that
+worked, right up until the verdict cannot be reproduced. So the clock stamps a global marker and
+`isInstalled` / `installedEpochMs` refuse by name without it; `readEpochMs` accepts only a string
+of digits, because `Number('')` is `0` and `Number(' 12 ')` is `12`, so a lax parse would turn an
+unset variable into the Unix epoch and a typo into a plausible instant and both would *run*; and
+the throw is not caught, so Node exits non-zero before an entrypoint can produce a verdict on the
+wrong clock. The suite spawns the negative case — same script, no flag — because a gate that only
+ever exercises the working path proves the command ran, not that it inspected anything.
+
+The time zone is applied **before** the clock, and that order is load-bearing: `process.env.TZ`
+decides what the local-time getters answer, which is what `audit-logger.js` builds a daily file's
+*name* out of.
+
 ### Arriving later
 
-`trace/clock.js` and `trace/preload.js` (the virtual clock, installed before any `src/` module
-loads), `trace/harness.js` and `trace/replay-trace.js` (the replay proper), `trace/fingerprint.js`
-and `trace/verdict.js` (what a run outputs, and the byte comparison), and `trace/record-trace.js`
+`trace/harness.js` and `trace/replay-trace.js` (the replay proper), `trace/fingerprint.js` and
+`trace/verdict.js` (what a run outputs, and the byte comparison), and `trace/record-trace.js`
 (deriving a trace from a recorded run). Nothing in that list exists yet; it is here so the
 subtree's shape is legible, not so it reads as built.
 

--- a/bench/trace/clock-env.js
+++ b/bench/trace/clock-env.js
@@ -1,0 +1,107 @@
+/**
+ * @file bench/trace/clock-env.js
+ * @module bench/trace/clock-env
+ * @description How a preload learns which clock to install: the environment variables
+ *   it reads, and the bootstrap that applies them.
+ *
+ *   Split from `preload.js` because that file has to ACT ON LOAD — being required for
+ *   its side effect is its entire job — and a module that installs a clock the moment
+ *   anything imports it cannot be tested by importing it. The split is the same one
+ *   `bench/run.js` and `bench/lib/*` already draw: an entrypoint that does something,
+ *   and a library that can be asked about it.
+ *
+ *   CONFIGURED BY ENVIRONMENT, BECAUSE `--require` TAKES NO ARGUMENTS. That makes a
+ *   missing variable the most likely failure, so it is also the loudest one:
+ *   {@link readEpochMs} throws rather than defaulting, and `preload.js` lets the throw
+ *   escape so Node exits non-zero before the entrypoint runs. A preload that quietly
+ *   declined to install would leave a replay running on the wall clock and looking
+ *   exactly like one that was not.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+const clockModule = require('./clock');
+
+/** @type {string} Environment variable naming the instant the virtual clock starts at. */
+const EPOCH_ENV = 'AEGIS_TRACE_CLOCK_EPOCH_MS';
+
+/** @type {string} Environment variable naming the IANA time zone the trace was recorded in. */
+const TZ_ENV = 'AEGIS_TRACE_TZ';
+
+/**
+ * Read the seed instant out of the environment, or refuse.
+ *
+ * Deliberately strict: only a string of digits is accepted. `Number('')` is `0` and
+ * `Number(' 12 ')` is `12`, so a lax parse would turn an unset variable into the Unix
+ * epoch and a typo into a plausible instant — and either one produces a replay that
+ * RUNS, and whose verdict names an instant nobody recorded.
+ * @param {Object} env - Usually `process.env`.
+ * @returns {number} The seed instant.
+ * @throws {import('./clock').ClockError} `clock-invalid` when the variable is absent
+ *   or unusable.
+ */
+function readEpochMs(env) {
+  const raw = env[EPOCH_ENV];
+  if (typeof raw !== 'string' || !/^\d+$/.test(raw)) {
+    throw new clockModule.ClockError(
+      'clock-invalid',
+      `${EPOCH_ENV} must be a string of digits — milliseconds since the epoch, taken from the ` +
+        `trace header's clock.epochMs. It was ${JSON.stringify(raw)}. Without it this preload ` +
+        'would install nothing and the replay would run on the wall clock',
+    );
+  }
+  const epochMs = Number(raw);
+  if (!Number.isSafeInteger(epochMs)) {
+    throw new clockModule.ClockError(
+      'clock-invalid',
+      `${EPOCH_ENV}=${raw} is not a safe integer of milliseconds`,
+    );
+  }
+  return epochMs;
+}
+
+/**
+ * Apply the recorded time zone, when one was named.
+ *
+ * The zone is not decoration: `src/main/audit-logger.js` builds a daily file's NAME
+ * out of local-time getters, and `src/main/baselines.js` buckets activity by local
+ * hour. A replay in the wrong zone writes a differently-named file.
+ *
+ * It is optional HERE so the preload can be exercised on its own without pretending to
+ * a zone nobody recorded: an unset variable leaves the process in whatever zone it was
+ * already in, and the trace reader then either accepts or refuses that by name. In a
+ * real replay the header always carries one.
+ * @param {Object} env - Usually `process.env`.
+ * @returns {string|null} The zone that was applied, or `null` when none was named.
+ */
+function applyTimeZone(env) {
+  const tz = env[TZ_ENV];
+  if (typeof tz !== 'string' || tz.length === 0) return null;
+  env.TZ = tz;
+  return tz;
+}
+
+/**
+ * Install the time zone and then the clock.
+ *
+ * ORDER IS LOAD-BEARING. `process.env.TZ` decides what the local-time getters answer,
+ * so it is applied before anything in this process reads one.
+ * @param {Object} [opts]
+ * @param {Object} [opts.env] - Environment to read. Defaults to `process.env`.
+ * @param {Object} [opts.target] - Global to patch. Defaults to `globalThis`.
+ * @returns {{epochMs: number, tz: string|null, uninstall: () => void}}
+ * @throws {import('./clock').ClockError} When the environment does not name a clock.
+ */
+function bootstrap(opts = {}) {
+  const env = opts.env || process.env;
+  const tz = applyTimeZone(env);
+  const epochMs = readEpochMs(env);
+  const clock = clockModule.createClock(epochMs);
+  const uninstall = clockModule.install(clock, opts.target || globalThis);
+  return { epochMs, tz, uninstall };
+}
+
+module.exports = { EPOCH_ENV, TZ_ENV, applyTimeZone, bootstrap, readEpochMs };

--- a/bench/trace/clock.js
+++ b/bench/trace/clock.js
@@ -1,0 +1,256 @@
+/**
+ * @file bench/trace/clock.js
+ * @module bench/trace/clock
+ * @description A virtual clock, and the switch that puts it in front of the real one.
+ *
+ *   Replay has to be able to state that the same bytes in produce the same verdicts
+ *   out, and the product reads the wall clock in more than twenty places: an event's
+ *   `timestamp`, the watcher's 2 s debounce, the scan loop's 30 s dedup window, the
+ *   DNS cache TTL, a session's `firstSeen`, and — the one no injection point covers —
+ *   `src/main/audit-logger.js` stamping `new Date().toISOString()` on every record it
+ *   writes. That module takes an injectable `now` through `init({now})`, but it is
+ *   used for DAY ROTATION only; the record's own timestamp is read from the global.
+ *   So the global is what has to move.
+ *
+ *   WHAT THIS IS NOT. It is not a fake timer library and it does not touch
+ *   `setTimeout` or `setInterval`. Replay never starts the product's scan intervals —
+ *   cadence is supplied by the trace, as `clock.advance` records — so the only live
+ *   timer in a replay is the audit logger's 5 s flush, which is stopped by calling
+ *   the product's own `shutdown()`. A trace's clock moves only when a record says so.
+ *
+ *   NOTHING HERE READS OR WRITES ANYTHING. The clock is a value; `install` is the
+ *   only function with a side effect, it names its target, and it hands back the
+ *   exact undo.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+/**
+ * The global a preload stamps once the clock is in place.
+ *
+ * It exists so that "the preload did not run" is DETECTABLE rather than silent. A
+ * harness that only checked `Date.now()` against the trace's epoch would be fooled by
+ * a real clock that happens to be near it, and a replay that quietly ran on wall time
+ * would produce a plausible verdict nobody could reproduce.
+ * @type {string}
+ */
+const MARKER = '__aegisTraceClock';
+
+/** @type {number} The marker's shape version, so a mismatched pair is not read as a match. */
+const MARKER_VERSION = 1;
+
+/**
+ * The clock this process installed, if any.
+ *
+ * Module state rather than another global: a preload and the harness `require` this
+ * file by the same absolute path, so they share one instance, and one process holds
+ * exactly one clock. The global marker answers "is a clock in front of the real one";
+ * this answers "which one", and the two are deliberately separate — a caller must not
+ * be able to get a handle to a clock that was never installed.
+ * @type {Object|null}
+ */
+let _current = null;
+
+/** A clock misuse. Separate from a trace refusal: this is the harness, not the file. */
+class ClockError extends Error {
+  /**
+   * @param {string} reason - `clock-reversed` | `clock-invalid` | `clock-not-installed`.
+   * @param {string} message - What a caller needs in order to act.
+   */
+  constructor(reason, message) {
+    super(message);
+    this.name = 'ClockError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Create a virtual clock starting at an instant.
+ *
+ * Time moves FORWARD ONLY, and only when {@link VirtualClock#advanceTo} is called.
+ * Going backwards is refused rather than clamped: a trace whose records are out of
+ * order is a trace nobody recorded that way, and silently holding the clock still
+ * would let the watcher's debounce and the scan loop's dedup window answer questions
+ * about an ordering the recording never had.
+ * @param {number} startEpochMs - Milliseconds since the epoch. Must be a non-negative
+ *   safe integer: every window the product compares against is integer milliseconds.
+ * @returns {Object} The clock.
+ * @throws {ClockError} `clock-invalid` when the start is not a usable instant.
+ */
+function createClock(startEpochMs) {
+  if (!Number.isSafeInteger(startEpochMs) || startEpochMs < 0) {
+    throw new ClockError(
+      'clock-invalid',
+      `a clock starts at a non-negative safe integer of milliseconds, not ` +
+        `${JSON.stringify(startEpochMs)}`,
+    );
+  }
+  let current = startEpochMs;
+
+  return {
+    /** @returns {number} The instant the clock reads now. */
+    now() {
+      return current;
+    },
+    /** @returns {number} The instant the clock was created at; never moves. */
+    epoch() {
+      return startEpochMs;
+    },
+    /**
+     * Move the clock forward to an instant.
+     * @param {number} epochMs - The instant to move to. May equal the current one:
+     *   two observations can share a millisecond, and refusing that would make the
+     *   format unable to record what the machine actually did.
+     * @returns {number} The new instant.
+     * @throws {ClockError} `clock-invalid` or `clock-reversed`.
+     */
+    advanceTo(epochMs) {
+      if (!Number.isSafeInteger(epochMs) || epochMs < 0) {
+        throw new ClockError(
+          'clock-invalid',
+          `cannot advance to ${JSON.stringify(epochMs)} — an instant is a non-negative safe ` +
+            'integer of milliseconds',
+        );
+      }
+      if (epochMs < current) {
+        throw new ClockError(
+          'clock-reversed',
+          `cannot advance to ${epochMs} from ${current} — a virtual clock moves forward only, ` +
+            'and a recording whose instants go backwards is not one this harness can replay',
+        );
+      }
+      current = epochMs;
+      return current;
+    },
+  };
+}
+
+/**
+ * Put a clock in front of the real one, on a target global object.
+ *
+ * Three globals move, and each is read by the product:
+ *   - `Date.now()` — the watcher's debounce, the scan loop's dedup key, session
+ *     bookkeeping, the DNS cache TTL.
+ *   - `new Date()` with no arguments — `audit-logger.js`'s record timestamp and its
+ *     day-rotation string, and `baselines.js`'s local-hour bucket. `new Date(x)` with
+ *     an argument is untouched: it names an instant the caller already has.
+ *   - `performance.now()` — only ever used for durations the product logs, but it is
+ *     replaced so that no path can reach a real clock at all. It reads as
+ *     milliseconds since this clock's own epoch.
+ *
+ * `Date` is replaced by a PROXY over the real constructor rather than by a subclass,
+ * so `Date.parse`, `Date.UTC`, `instanceof`, `Date.prototype` and calling `Date()`
+ * without `new` all keep working. A subclass would quietly change identity for code
+ * that never asked for a virtual clock.
+ * @param {Object} clock - A clock from {@link createClock}.
+ * @param {Object} [target] - The global to patch. Defaults to `globalThis`.
+ * @returns {() => void} The exact undo. Calling it twice is a no-op.
+ */
+function install(clock, target = globalThis) {
+  _current = clock;
+  const RealDate = target.Date;
+  const realPerformanceNow = target.performance ? target.performance.now : null;
+
+  const VirtualDate = new Proxy(RealDate, {
+    construct(ctor, args, newTarget) {
+      const effective = args.length === 0 ? [clock.now()] : args;
+      return Reflect.construct(ctor, effective, newTarget);
+    },
+    // `Date(...)` without `new` returns a STRING and ignores its arguments — that is
+    // the language's rule, not ours, and the virtual clock only changes which instant
+    // the string describes.
+    apply() {
+      return new RealDate(clock.now()).toString();
+    },
+    get(ctor, prop, receiver) {
+      if (prop === 'now') return () => clock.now();
+      return Reflect.get(ctor, prop, receiver);
+    },
+  });
+
+  target.Date = VirtualDate;
+  if (realPerformanceNow) {
+    target.performance.now = () => clock.now() - clock.epoch();
+  }
+  target[MARKER] = Object.freeze({
+    version: MARKER_VERSION,
+    epochMs: clock.epoch(),
+    installedAt: 'preload',
+  });
+
+  let undone = false;
+  return function uninstall() {
+    if (undone) return;
+    undone = true;
+    target.Date = RealDate;
+    if (realPerformanceNow) target.performance.now = realPerformanceNow;
+    delete target[MARKER];
+    _current = null;
+  };
+}
+
+/**
+ * Whether a virtual clock is in front of the real one on this global.
+ *
+ * A caller that needs the clock must ask this BEFORE it does anything else. The
+ * failure this exists for is a preload that did not run — `--require` misspelled, an
+ * env var unset, a wrapper that dropped the flag — which otherwise looks exactly like
+ * a preload that worked, right up until the verdict file cannot be reproduced.
+ * @param {Object} [target] - The global to inspect. Defaults to `globalThis`.
+ * @returns {boolean}
+ */
+function isInstalled(target = globalThis) {
+  const marker = target[MARKER];
+  return !!marker && marker.version === MARKER_VERSION;
+}
+
+/**
+ * The instant a preloaded clock was seeded at, or refuse.
+ * @param {Object} [target] - The global to inspect. Defaults to `globalThis`.
+ * @returns {number} The seeded epoch.
+ * @throws {ClockError} `clock-not-installed` when no clock is in front of the real one.
+ */
+function installedEpochMs(target = globalThis) {
+  if (!isInstalled(target)) {
+    throw new ClockError(
+      'clock-not-installed',
+      'no virtual clock is installed on this process — run the entrypoint with ' +
+        '`node --require bench/trace/preload.js`. A replay on the wall clock produces a ' +
+        'verdict nobody can reproduce, and it looks exactly like one that can',
+    );
+  }
+  return target[MARKER].epochMs;
+}
+
+/**
+ * The clock this process installed.
+ *
+ * The handle a harness advances from `clock.advance` records. It is reachable only
+ * after {@link install} has run, so a caller cannot advance a clock nothing is
+ * reading.
+ * @returns {Object} The installed clock.
+ * @throws {ClockError} `clock-not-installed` when none is.
+ */
+function currentClock() {
+  if (!_current) {
+    throw new ClockError(
+      'clock-not-installed',
+      'no virtual clock has been installed in this process, so there is none to advance',
+    );
+  }
+  return _current;
+}
+
+module.exports = {
+  ClockError,
+  MARKER,
+  MARKER_VERSION,
+  createClock,
+  currentClock,
+  install,
+  installedEpochMs,
+  isInstalled,
+};

--- a/bench/trace/preload.js
+++ b/bench/trace/preload.js
@@ -1,0 +1,37 @@
+/**
+ * @file bench/trace/preload.js
+ * @module bench/trace/preload
+ * @description The `--require` entrypoint that puts the virtual clock and the recorded
+ *   time zone in front of the real ones, before any other module is compiled.
+ *
+ *   ```
+ *   AEGIS_TRACE_CLOCK_EPOCH_MS=1755766432000 AEGIS_TRACE_TZ=Etc/UTC \
+ *     node --require bench/trace/preload.js bench/trace/replay-trace.js <trace dir>
+ *   ```
+ *
+ *   WHY A PRELOAD AND NOT AN INJECTION POINT. Every other seam this harness uses is one
+ *   the product already exports — `init(state)`, `_setDepsForTest`, `reloadRules(dir)`.
+ *   The clock is the one thing no seam covers: `src/main/audit-logger.js` stamps
+ *   `new Date().toISOString()` on every record it writes, and `src/main/baselines.js`
+ *   reads `new Date().getHours()`. Both are globals, and a global has to move before the
+ *   module that closes over it is compiled. `--require` is the mechanism Node provides
+ *   for exactly that. Nothing in `src/` is patched.
+ *
+ *   THIS FILE ACTS ON LOAD, and that is its whole job. It is deliberately the only
+ *   thing here: everything that can be asked a question instead of doing something
+ *   lives in `./clock-env.js`, so a suite can exercise the decisions without a process
+ *   acquiring a virtual clock merely because a test imported a file.
+ *
+ *   A THROW IS THE INTENDED FAILURE MODE. It is not caught: Node reports it and exits
+ *   non-zero before the entrypoint gets a chance to produce a verdict on the wrong
+ *   clock. `tests/shared/bench-trace/clock.test.js` spawns this both ways — with the
+ *   flag and without it — because a preload that silently declined to install looks
+ *   exactly like one that worked, right up until the verdict cannot be reproduced.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+require('./clock-env').bootstrap();

--- a/tests/shared/bench-trace/clock.test.js
+++ b/tests/shared/bench-trace/clock.test.js
@@ -1,0 +1,331 @@
+/**
+ * @file tests/shared/bench-trace/clock.test.js
+ * @description The virtual clock, and — the part that actually matters — that a
+ *   preload which did NOT run is detectable.
+ *
+ *   The last block spawns real child processes instead of importing `clock.js` here.
+ *   That is the whole point: importing the module would test the clock, and the clock
+ *   is the easy half. The mechanism under test is `node --require`, whose entire job
+ *   is to run before any other module is compiled, and nothing that happens inside an
+ *   already-started vitest worker can demonstrate that. A spawn is pure Node, so it
+ *   runs wherever the suite does.
+ *
+ *   The failure being pinned is ai-mistakes #21's shape: a gate that only ever
+ *   exercises the working path proves the command ran, not that it inspected
+ *   anything. So the negative case is spawned too — same script, no `--require` — and
+ *   it must come back with no marker and a live clock.
+ *
+ *   Every in-process case patches a FAKE global. Moving vitest's own `Date` mid-run
+ *   would be a fine way to make a suite lie about itself.
+ */
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { describe, it, expect } from 'vitest';
+
+import clock from '../../../bench/trace/clock.js';
+import clockEnv from '../../../bench/trace/clock-env.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+const PRELOAD_PATH = path.join(REPO_ROOT, 'bench', 'trace', 'preload.js');
+
+/** @type {number} 2026-08-21T09:13:52.000Z — an instant, chosen once and never derived. */
+const EPOCH_MS = 1_787_303_632_000;
+
+/**
+ * A stand-in global, so no case touches the clock this suite itself runs on.
+ * @returns {Object}
+ */
+function fakeGlobal() {
+  return { Date: globalThis.Date, performance: { now: () => 123.456 } };
+}
+
+/** The script a spawned child runs: report what it can see about its own clock. */
+const PROBE = `
+const out = {
+  marker: globalThis.__aegisTraceClock || null,
+  now: Date.now(),
+  iso: new Date().toISOString(),
+  hours: new Date().getHours(),
+  tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+};
+process.stdout.write(JSON.stringify(out));
+`;
+
+/**
+ * Run the probe in a child process.
+ * @param {Object} opts
+ * @param {boolean} opts.withPreload - Whether to pass `--require`.
+ * @param {Object} [opts.env] - Extra environment for the child.
+ * @returns {{status: number, stdout: string, stderr: string, json: Object|null}}
+ */
+function runProbe(opts) {
+  const args = [];
+  if (opts.withPreload) args.push('--require', PRELOAD_PATH);
+  args.push('-e', PROBE);
+  // Built by hand rather than spread over `process.env`: a key set to `undefined` is
+  // not the same as a key that is absent, and the "no clock named" case has to be the
+  // second one.
+  const env = { ...process.env, ...(opts.env || {}) };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete env[key];
+  }
+  const result = spawnSync(process.execPath, args, { encoding: 'utf8', cwd: REPO_ROOT, env });
+  let json;
+  try {
+    json = JSON.parse(result.stdout);
+  } catch (_) {
+    // A child that refused to start prints nothing on stdout, and that is one of the
+    // cases under test — so an unparseable stdout is a result, not an error.
+    json = null;
+  }
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr, json };
+}
+
+describe('virtual clock — the value', () => {
+  it('starts where it was seeded and does not drift', () => {
+    const c = clock.createClock(EPOCH_MS);
+    expect(c.now()).toBe(EPOCH_MS);
+    expect(c.epoch()).toBe(EPOCH_MS);
+    expect(c.now()).toBe(EPOCH_MS);
+  });
+
+  it('moves only when it is told to, and only forward', () => {
+    const c = clock.createClock(EPOCH_MS);
+    expect(c.advanceTo(EPOCH_MS + 31_000)).toBe(EPOCH_MS + 31_000);
+    expect(c.now()).toBe(EPOCH_MS + 31_000);
+    expect(c.epoch()).toBe(EPOCH_MS);
+
+    let err = null;
+    try {
+      c.advanceTo(EPOCH_MS);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.name).toBe('ClockError');
+    expect(err.reason).toBe('clock-reversed');
+    expect(c.now(), 'a refused advance leaves the clock where it was').toBe(EPOCH_MS + 31_000);
+  });
+
+  it('allows two observations to share a millisecond', () => {
+    // Refusing this would make the format unable to record what the machine did.
+    const c = clock.createClock(EPOCH_MS);
+    expect(c.advanceTo(EPOCH_MS)).toBe(EPOCH_MS);
+  });
+
+  it('refuses a seed or a target that is not an instant', () => {
+    for (const bad of [-1, 1.5, NaN, '0', null, undefined]) {
+      let err = null;
+      try {
+        clock.createClock(bad);
+      } catch (e) {
+        err = e;
+      }
+      expect(err && err.reason, JSON.stringify(bad)).toBe('clock-invalid');
+    }
+    const c = clock.createClock(EPOCH_MS);
+    for (const bad of [1.5, NaN, '1', null]) {
+      let err = null;
+      try {
+        c.advanceTo(bad);
+      } catch (e) {
+        err = e;
+      }
+      expect(err && err.reason, JSON.stringify(bad)).toBe('clock-invalid');
+    }
+  });
+});
+
+describe('virtual clock — what install replaces', () => {
+  it('answers Date.now() and a zero-argument Date from the clock', () => {
+    const target = fakeGlobal();
+    const c = clock.createClock(EPOCH_MS);
+    const uninstall = clock.install(c, target);
+    try {
+      expect(target.Date.now()).toBe(EPOCH_MS);
+      expect(new target.Date().getTime()).toBe(EPOCH_MS);
+      c.advanceTo(EPOCH_MS + 5000);
+      expect(target.Date.now()).toBe(EPOCH_MS + 5000);
+      expect(new target.Date().toISOString()).toBe(new Date(EPOCH_MS + 5000).toISOString());
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('leaves a Date built from an argument alone', () => {
+    const target = fakeGlobal();
+    const uninstall = clock.install(clock.createClock(EPOCH_MS), target);
+    try {
+      expect(new target.Date(0).toISOString()).toBe('1970-01-01T00:00:00.000Z');
+      expect(new target.Date(2026, 0, 1).getFullYear()).toBe(2026);
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('keeps the static methods, the prototype and instanceof intact', () => {
+    // A subclass would quietly change identity for code that never asked for a virtual
+    // clock. A proxy over the real constructor does not.
+    const target = fakeGlobal();
+    const uninstall = clock.install(clock.createClock(EPOCH_MS), target);
+    try {
+      expect(target.Date.parse('2026-08-21T00:00:00Z')).toBe(Date.parse('2026-08-21T00:00:00Z'));
+      expect(target.Date.UTC(2026, 7, 21)).toBe(Date.UTC(2026, 7, 21));
+      expect(target.Date.prototype).toBe(Date.prototype);
+      expect(new target.Date() instanceof Date).toBe(true);
+      expect(typeof target.Date()).toBe('string');
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('reports performance.now as milliseconds since its own epoch', () => {
+    const target = fakeGlobal();
+    const c = clock.createClock(EPOCH_MS);
+    const uninstall = clock.install(c, target);
+    try {
+      expect(target.performance.now()).toBe(0);
+      c.advanceTo(EPOCH_MS + 250);
+      expect(target.performance.now()).toBe(250);
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('undoes exactly what it did, and is safe to undo twice', () => {
+    const target = fakeGlobal();
+    const realDate = target.Date;
+    const realPerf = target.performance.now;
+    const uninstall = clock.install(clock.createClock(EPOCH_MS), target);
+    expect(target.Date).not.toBe(realDate);
+    uninstall();
+    uninstall();
+    expect(target.Date).toBe(realDate);
+    expect(target.performance.now).toBe(realPerf);
+    expect(target[clock.MARKER]).toBeUndefined();
+  });
+});
+
+describe('virtual clock — a clock that is not installed says so', () => {
+  it('isInstalled is false, and installedEpochMs refuses by name', () => {
+    const target = fakeGlobal();
+    expect(clock.isInstalled(target)).toBe(false);
+    let err = null;
+    try {
+      clock.installedEpochMs(target);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.reason).toBe('clock-not-installed');
+    expect(err.message).toContain('--require');
+  });
+
+  it('refuses a marker whose version this build does not speak', () => {
+    const target = fakeGlobal();
+    target[clock.MARKER] = { version: clock.MARKER_VERSION + 1, epochMs: EPOCH_MS };
+    expect(clock.isInstalled(target)).toBe(false);
+  });
+
+  it('reports the seeded epoch once a clock is in place', () => {
+    const target = fakeGlobal();
+    const uninstall = clock.install(clock.createClock(EPOCH_MS), target);
+    try {
+      expect(clock.isInstalled(target)).toBe(true);
+      expect(clock.installedEpochMs(target)).toBe(EPOCH_MS);
+      expect(clock.currentClock().now()).toBe(EPOCH_MS);
+    } finally {
+      uninstall();
+    }
+  });
+});
+
+describe('preload — reading its environment', () => {
+  it('names the variable it needs, rather than defaulting to an instant', () => {
+    // `Number('')` is 0 and `Number(' 12 ')` is 12, so a lax parse would turn an unset
+    // variable into the Unix epoch and a typo into a plausible instant. Both would run.
+    for (const raw of [undefined, '', ' ', 'abc', '12.5', ' 1755766432000 ', '-1']) {
+      let err = null;
+      try {
+        clockEnv.readEpochMs({ [clockEnv.EPOCH_ENV]: raw });
+      } catch (e) {
+        err = e;
+      }
+      expect(err && err.reason, JSON.stringify(raw)).toBe('clock-invalid');
+      expect(err.message).toContain(clockEnv.EPOCH_ENV);
+    }
+    expect(clockEnv.readEpochMs({ [clockEnv.EPOCH_ENV]: String(EPOCH_MS) })).toBe(EPOCH_MS);
+  });
+
+  it('applies a named time zone and leaves an unnamed one alone', () => {
+    const env = {};
+    expect(clockEnv.applyTimeZone(env)).toBeNull();
+    expect(env.TZ).toBeUndefined();
+    expect(clockEnv.applyTimeZone({ ...env, [clockEnv.TZ_ENV]: 'Etc/UTC' })).toBe('Etc/UTC');
+  });
+
+  it('bootstraps a clock onto the target it was given', () => {
+    const target = fakeGlobal();
+    const env = { [clockEnv.EPOCH_ENV]: String(EPOCH_MS), [clockEnv.TZ_ENV]: 'Etc/UTC' };
+    const { epochMs, tz, uninstall } = clockEnv.bootstrap({ env, target });
+    try {
+      expect(epochMs).toBe(EPOCH_MS);
+      expect(tz).toBe('Etc/UTC');
+      expect(env.TZ).toBe('Etc/UTC');
+      expect(target.Date.now()).toBe(EPOCH_MS);
+    } finally {
+      uninstall();
+    }
+  });
+});
+
+describe('preload — the mechanism, in a real child process', () => {
+  it('installs the clock and the zone before anything else runs', () => {
+    const probe = runProbe({
+      withPreload: true,
+      env: {
+        [clockEnv.EPOCH_ENV]: String(EPOCH_MS),
+        [clockEnv.TZ_ENV]: 'Asia/Tokyo',
+      },
+    });
+    expect(probe.status, probe.stderr).toBe(0);
+    expect(probe.json.marker).toEqual({
+      version: clock.MARKER_VERSION,
+      epochMs: EPOCH_MS,
+      installedAt: 'preload',
+    });
+    expect(probe.json.now).toBe(EPOCH_MS);
+    expect(probe.json.iso).toBe(new Date(EPOCH_MS).toISOString());
+    expect(probe.json.tz).toBe('Asia/Tokyo');
+    // The zone is not decoration: `audit-logger.js` builds a daily file's NAME out of
+    // local-time getters, so a replay in the wrong zone writes a differently-named file.
+    expect(probe.json.hours).toBe(18);
+  });
+
+  it('WITHOUT the preload the same script has no marker and a live clock', () => {
+    // The case that makes the one above mean something. A gate that only ever runs the
+    // working path proves the command ran, not that it inspected anything.
+    const before = Date.now();
+    const probe = runProbe({
+      withPreload: false,
+      env: { [clockEnv.EPOCH_ENV]: String(EPOCH_MS), [clockEnv.TZ_ENV]: 'Asia/Tokyo' },
+    });
+    expect(probe.status, probe.stderr).toBe(0);
+    expect(probe.json.marker).toBeNull();
+    expect(probe.json.now).not.toBe(EPOCH_MS);
+    expect(probe.json.now).toBeGreaterThanOrEqual(before);
+  });
+
+  it('exits non-zero when the environment names no clock', () => {
+    const probe = runProbe({ withPreload: true, env: { [clockEnv.EPOCH_ENV]: undefined } });
+    expect(probe.status).not.toBe(0);
+    expect(probe.stderr).toContain(clockEnv.EPOCH_ENV);
+    expect(probe.stderr).toContain('wall clock');
+  });
+
+  it('exits non-zero on an epoch that is not a string of digits', () => {
+    const probe = runProbe({ withPreload: true, env: { [clockEnv.EPOCH_ENV]: '17e11' } });
+    expect(probe.status).not.toBe(0);
+    expect(probe.stderr).toContain('ClockError');
+  });
+});


### PR DESCRIPTION
Trace replay has to be able to state that the same bytes in produce the same verdicts out, and the product reads the wall clock in more than twenty places. This lands the clock and the mechanism that gets it in front of the real one. **Nothing uses it yet** — the harness that drives it is a separate PR.

Independent of #247: different files, no shared lines. Merge order between the two does not matter for the code. See *Documentation* below for the one thing that does.

## What is here

| file | what it is |
|---|---|
| `bench/trace/clock.js` | a virtual clock as a value, and `install` — the one function with a side effect. It names its target and hands back the exact undo |
| `bench/trace/clock-env.js` | which environment variables name a clock, and the bootstrap that applies them |
| `bench/trace/preload.js` | the `--require` entrypoint. Three lines, because everything that can be *asked a question* instead of *doing something* lives next door — so a suite can exercise the decisions without a process acquiring a virtual clock merely because a test imported a file |

## Why a preload and not an injection point

Every other seam this harness will use is one the product already exports — `init(state)`, `_setDepsForTest`, `reloadRules(dir)`. The clock is the one thing no seam covers:

- `src/main/audit-logger.js:217` stamps `new Date().toISOString()` on every record **directly**. Its injectable `now` (`:60`) is used for day rotation only.
- `src/main/baselines.js:124` reads `new Date().getHours()`.

Both are globals, and a global has to move before the module that closes over it is compiled. `--require` is the mechanism Node provides for exactly that. **Nothing in `src/` is patched.**

## What it replaces, and what it deliberately does not

`Date` is a **proxy** over the real constructor, not a subclass — so `Date.parse`, `Date.UTC`, `Date.prototype`, `instanceof` and calling `Date()` without `new` all keep working. `new Date(x)` with an argument is untouched: it names an instant the caller already has. `performance.now()` reads as milliseconds since the clock's own epoch.

`setTimeout` and `setInterval` are **not** touched. Replay never starts the product's scan intervals — cadence comes from the trace as `clock.advance` records — and the one live timer left is the audit logger's 5 s flush, stopped by calling the product's own `shutdown()`.

Time moves forward only, and only when told to. Going backwards is refused rather than clamped: silently holding the clock still would let the watcher's 2 s debounce and the scan loop's 30 s dedup window answer questions about an ordering the recording never had. Two observations may share a millisecond, because machines do that.

## The failure this is built around

A preload that **did not run** — a misspelled `--require`, an unset variable, a wrapper that dropped the flag — looks exactly like one that worked, right up until the verdict cannot be reproduced. So:

- the clock stamps a global marker, and `isInstalled` / `installedEpochMs` refuse **by name** without it;
- `readEpochMs` accepts only a string of digits. `Number('')` is `0` and `Number(' 12 ')` is `12`, so a lax parse would turn an unset variable into the Unix epoch and a typo into a plausible instant — and both would *run*;
- the throw is not caught, so Node exits non-zero before an entrypoint can produce a verdict on the wrong clock.

The time zone is applied **before** the clock, and that order is load-bearing: `process.env.TZ` decides what the local-time getters answer, which is what `audit-logger.js` builds a daily file's *name* out of.

## Tests

`tests/shared/bench-trace/clock.test.js` — 19 cases, already inside the required `test` context via vitest's existing `tests/shared/**` include, with **no edit to `vitest.config.js`**.

The last block **spawns real child processes** rather than importing `clock.js`, because the mechanism under test is `node --require`, whose entire job is to run before any other module is compiled — nothing inside an already-started vitest worker can demonstrate that. It spawns the **negative** case too: same script, no flag, and it must come back with no marker and a live clock. Without that, the suite would prove the clock works when it works and say nothing about the silent no-op.

Every in-process case patches a **fake** global. Moving vitest's own `Date` mid-run would be a fine way to make a suite lie about itself.

## Documentation

`bench/README.md` is deliberately untouched here. #247 adds the trace section and lists `clock.js` / `preload.js` under "arriving later"; that line becomes false the moment this merges. Since `strict: true` requires this branch to be up to date with master before merge anyway, the README line is corrected in the update that brings #247 in — rather than by two PRs editing the same block in parallel.

## Verification

All nine local commands green on this branch:

```
build:renderer  OK      typecheck        OK      verify:gate   OK (4/4 mutants killed)
format:check    OK      typecheck:svelte OK      counts:check  OK
lint            OK      test:coverage    103 files, 1827 passed, 4 skipped
npm audit --audit-level=high --omit=dev  0 vulnerabilities
```
