### PR TITLE
fix: bound the audit read path and cut secrets-rule path false positives

### DIFF
--- a/rules/secrets.yaml
+++ b/rules/secrets.yaml
@@ -21,7 +21,7 @@ rules:
 
   - id: "SC003"
     name: "Password file"
-    pattern: "[\\\\\/][^\\\\\\/]*password[^\\\\\\/]*$"
+    pattern: '[\\\/](?:[^\\\/]*[._-])?passwords?(?:[._-][^\\\/]*)?\.(?:txt|csv|json|ya?ml|xml|ini|conf|cfg|toml|properties|key|pem|bak|old|gpg|enc)$|[\\\/](?:[^\\\/]*[._-])?passwords?$'
     reason: "Password file"
     category: "secrets"
     risk: critical
@@ -37,7 +37,7 @@ rules:
 
   - id: "SC005"
     name: "Secret file"
-    pattern: "[\\\\\/]secret"
+    pattern: '[\\\/]\.?secrets?[\\\/]|[\\\/](?:[^\\\/]*[._-])?secrets?(?:[._-][^\\\/]*)?\.(?:json|ya?ml|env|txt|xml|ini|conf|cfg|toml|properties|key|pem)$|[\\\/](?:[^\\\/]*[._-])?secrets?$'
     reason: "Secret file"
     category: "secrets"
     risk: critical
@@ -45,7 +45,7 @@ rules:
 
   - id: "SC006"
     name: "API token"
-    pattern: "[\\\\\/][^\\\\\\/]*token[^\\\\\\/]*$"
+    pattern: '[\\\/](?:[^\\\/]*[._-])?tokens?(?:[._-][^\\\/]*)?\.(?:txt|json|ya?ml|env|ini|conf|cfg)$|[\\\/](?:[^\\\/]*[._-])?tokens?$'
     reason: "API token"
     category: "secrets"
     risk: critical

--- a/src/main/audit-logger.js
+++ b/src/main/audit-logger.js
@@ -40,6 +40,21 @@ const RETENTION_DAYS = 30;
 const BUFFER_CAP = 500;
 
 /**
+ * Default page size for {@link getEntriesBefore} when the caller passes no usable limit.
+ * @type {number}
+ */
+const DEFAULT_READ_LIMIT = 100;
+
+/**
+ * Hard ceiling on entries a single {@link getEntriesBefore} call can return. The limit
+ * arrives over IPC straight from the renderer, so it is untrusted input: without a cap,
+ * one call with `Infinity` (or any huge number) pulls the entire audit corpus into a
+ * single IPC response. Like {@link BUFFER_CAP} it is a COUNT, not a byte budget.
+ * @type {number}
+ */
+const MAX_READ_LIMIT = 500;
+
+/**
  * Event Schema version stamped on every record this module writes.
  *
  * Records without the field are v0 — but ONLY when they parse and their hash verifies. A
@@ -492,14 +507,6 @@ function shutdown() {
 }
 
 /**
- * Return up to `limit` audit entries with timestamps strictly before `beforeTs`.
- * Reads log files in reverse-chronological order for efficiency.
- * @param {string} beforeTs - ISO timestamp upper bound (exclusive)
- * @param {number} [limit=100] - Max entries to return
- * @returns {Object[]} Entries sorted oldest-first
- * @since v0.5.0
- */
-/**
  * Read lines from the end of a file without loading the whole thing.
  * Reads in reverse chunks and yields complete lines newest-first.
  * @param {string} filePath
@@ -535,7 +542,37 @@ function readLinesReverse(filePath, onLine, chunkSize = 4096) {
   }
 }
 
-function getEntriesBefore(beforeTs, limit = 100) {
+/**
+ * Return up to `limit` audit entries with timestamps strictly before `beforeTs`.
+ * Reads log files in reverse-chronological order for efficiency.
+ *
+ * Both parameters cross the IPC boundary raw (ipc-handlers.js passes them through), so
+ * both are validated HERE rather than at the handler — every caller gets the same
+ * guarantees:
+ * - `limit` is clamped to an integer in [1, {@link MAX_READ_LIMIT}]; anything
+ *   non-numeric (including missing) falls back to {@link DEFAULT_READ_LIMIT}. The
+ *   function is structurally unable to return more than {@link MAX_READ_LIMIT} entries.
+ * - a `beforeTs` that is not a `YYYY-MM-DD`-prefixed string returns `[]` via an explicit
+ *   early return that logs the reason. That path is deliberately distinct from the
+ *   generic read-failure catch below: a rejected cursor must never read as an empty log.
+ * @param {string} beforeTs - ISO timestamp upper bound (exclusive)
+ * @param {number} [limit=100] - Max entries to return (clamped, see above)
+ * @returns {Object[]} Entries sorted oldest-first
+ * @since v0.5.0
+ */
+function getEntriesBefore(beforeTs, limit = DEFAULT_READ_LIMIT) {
+  if (typeof beforeTs !== 'string' || !/^\d{4}-\d{2}-\d{2}/.test(beforeTs)) {
+    const got =
+      typeof beforeTs === 'string'
+        ? `malformed string ${JSON.stringify(beforeTs.slice(0, 40))}`
+        : typeof beforeTs;
+    console.warn(`[audit-logger] getEntriesBefore: invalid beforeTs (${got}) — returning []`);
+    return [];
+  }
+  limit =
+    typeof limit === 'number' && !Number.isNaN(limit)
+      ? Math.min(MAX_READ_LIMIT, Math.max(1, Math.floor(limit)))
+      : DEFAULT_READ_LIMIT;
   flush();
   if (!_logDir) return [];
   const results = [];
@@ -597,4 +634,5 @@ module.exports = {
   getLogDir: () => _logDir,
   normalizeAuditEntry,
   SCHEMA_VERSION,
+  MAX_READ_LIMIT,
 };

--- a/tests/main/audit-logger.test.js
+++ b/tests/main/audit-logger.test.js
@@ -303,4 +303,118 @@ describe('audit-logger', () => {
     expect(seqs).toEqual([0, 1]);
     expect(auditLogger.verifyChain(fp).valid).toBe(true);
   });
+
+  // --- getEntriesBefore: clamped limit + validated beforeTs ------------------
+
+  describe('getEntriesBefore — bounded read path', () => {
+    const FAR_FUTURE = '9999-01-01T00:00:00.000Z';
+
+    /**
+     * Write `count` synthetic entries straight into YESTERDAY's audit file, bypassing
+     * log(). Yesterday, not a fixed past date: init() schedules cleanOldLogs() on the
+     * REAL clock, so a fixed date eventually sits past RETENTION_DAYS, where any await
+     * in a test body would let the sweep delete the fixture. Yesterday is always inside
+     * retention. getEntriesBefore only needs JSON lines with a timestamp — no seq/hash.
+     */
+    function seedEntries(count) {
+      const auditDir = path.join(tmpDir, 'audit-logs');
+      const d = new Date(Date.now() - 86400000);
+      const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      const lines = [];
+      for (let i = 0; i < count; i++) {
+        const ms = String(i % 1000).padStart(3, '0');
+        lines.push(
+          JSON.stringify({ timestamp: `${dateStr}T00:00:00.${ms}Z`, type: 't', agent: `a${i}` }),
+        );
+      }
+      fs.writeFileSync(path.join(auditDir, `aegis-audit-${dateStr}.json`), lines.join('\n') + '\n');
+    }
+
+    it('exports the cap and keeps it at a sane, non-trivial value', () => {
+      expect(auditLogger.MAX_READ_LIMIT).toBe(500);
+    });
+
+    it('limit Infinity is clamped to the cap', () => {
+      auditLogger.init({ userDataPath: tmpDir });
+      seedEntries(520);
+      const entries = auditLogger.getEntriesBefore(FAR_FUTURE, Infinity);
+      expect(entries).toHaveLength(auditLogger.MAX_READ_LIMIT);
+    });
+
+    it('limit 10000 is clamped to the cap', () => {
+      auditLogger.init({ userDataPath: tmpDir });
+      seedEntries(520);
+      expect(auditLogger.getEntriesBefore(FAR_FUTURE, 10000)).toHaveLength(
+        auditLogger.MAX_READ_LIMIT,
+      );
+    });
+
+    it('limit -5 is clamped up to 1', () => {
+      auditLogger.init({ userDataPath: tmpDir });
+      seedEntries(10);
+      expect(auditLogger.getEntriesBefore(FAR_FUTURE, -5)).toHaveLength(1);
+    });
+
+    it("limit 'abc' falls back to the default of 100", () => {
+      auditLogger.init({ userDataPath: tmpDir });
+      seedEntries(120);
+      expect(auditLogger.getEntriesBefore(FAR_FUTURE, 'abc')).toHaveLength(100);
+    });
+
+    it('missing limit falls back to the default of 100', () => {
+      auditLogger.init({ userDataPath: tmpDir });
+      seedEntries(120);
+      expect(auditLogger.getEntriesBefore(FAR_FUTURE)).toHaveLength(100);
+    });
+
+    it('a fractional limit is floored to an integer', () => {
+      auditLogger.init({ userDataPath: tmpDir });
+      seedEntries(10);
+      expect(auditLogger.getEntriesBefore(FAR_FUTURE, 3.9)).toHaveLength(3);
+    });
+
+    it('a small valid limit passes through unclamped', () => {
+      auditLogger.init({ userDataPath: tmpDir });
+      seedEntries(10);
+      expect(auditLogger.getEntriesBefore(FAR_FUTURE, 5)).toHaveLength(5);
+    });
+
+    it('still flushes buffered entries into view on a valid read', () => {
+      // Validation was added BEFORE the flush() call — a valid cursor must still see
+      // entries that are only buffered, exactly as the paginated view relies on.
+      auditLogger.init({ userDataPath: tmpDir });
+      auditLogger.log('t', { agent: 'buffered' });
+      const entries = auditLogger.getEntriesBefore(FAR_FUTURE, 10);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].agent).toBe('buffered');
+    });
+
+    // Each invalid-beforeTs case seeds real entries first, so the [] PROVES the
+    // validation path fired — a genuinely empty log would be indistinguishable
+    // otherwise. The explicit path warns with its own message; the generic catch
+    // (console.error '... getEntriesBefore failed') must stay silent.
+    for (const [label, bad] of [
+      ['null', null],
+      ['a number (42)', 42],
+      ["a malformed string ('not-a-timestamp')", 'not-a-timestamp'],
+    ]) {
+      it(`beforeTs ${label} returns [] via the explicit validated path, not the catch`, () => {
+        auditLogger.init({ userDataPath: tmpDir });
+        seedEntries(5);
+        // Spies go on AFTER init() and seeding, so they observe ONLY the call under
+        // test — the warn/error distinction below is about getEntriesBefore alone.
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+          expect(auditLogger.getEntriesBefore(bad, 100)).toEqual([]);
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+          expect(warnSpy.mock.calls[0][0]).toContain('invalid beforeTs');
+          expect(errorSpy).not.toHaveBeenCalled();
+        } finally {
+          warnSpy.mockRestore();
+          errorSpy.mockRestore();
+        }
+      });
+    }
+  });
 });

--- a/tests/main/rule-loader.test.js
+++ b/tests/main/rule-loader.test.js
@@ -259,4 +259,73 @@ describe('rule-loader', () => {
       expect(grok.pattern.test('/home/user/.grok-build/settings.json')).toBe(true);
     });
   });
+
+  describe('secrets rules — path-word false positives (SC003 / SC005 / SC006)', () => {
+    const PROD_RULES_DIR = path.resolve(__dirname, '../../rules');
+
+    // Each rule was the top false-positive producer of its word: the old patterns
+    // matched a bare substring anywhere in the final path segment (SC005: anywhere in
+    // the path), so ordinary source files containing the word fired as critical hits.
+    // The rewritten patterns bound the word with [._-] separators (NOT \b — underscore
+    // is a word character, and api_token/client_secret are exactly the names that must
+    // keep firing) and scope loose compounds to secret-bearing data extensions.
+
+    /** @param {string} id @returns {RegExp} */
+    function pattern(id) {
+      ruleLoader.reloadRules(PROD_RULES_DIR);
+      const rule = ruleLoader.getRuleById(id, PROD_RULES_DIR);
+      expect(rule).toBeDefined();
+      return rule.pattern;
+    }
+
+    it('SC003 no longer fires on UI components and pages that merely mention "password"', () => {
+      const re = pattern('SC003');
+      expect(re.test('/app/src/components/PasswordInput.svelte')).toBe(false);
+      expect(re.test('C:\\proj\\src\\pages\\forgot-password.html')).toBe(false);
+      expect(re.test('/app/src/auth/password-reset.js')).toBe(false);
+      expect(re.test('/docs/reset-password.md')).toBe(false);
+    });
+
+    it('SC003 still fires on files that actually store passwords', () => {
+      const re = pattern('SC003');
+      expect(re.test('/home/user/passwords.txt')).toBe(true);
+      expect(re.test('C:\\Users\\me\\Documents\\wifi-password.txt')).toBe(true);
+      expect(re.test('/home/user/.password')).toBe(true);
+      expect(re.test('C:\\Users\\me\\db_password')).toBe(true);
+      expect(re.test('/home/user/password.key')).toBe(true);
+      expect(re.test('C:\\Users\\me\\app\\password.properties')).toBe(true);
+    });
+
+    it('SC005 no longer fires on segments that merely start with "secret"', () => {
+      const re = pattern('SC005');
+      expect(re.test('/app/src/pages/SecretSanta.tsx')).toBe(false);
+      expect(re.test('/home/user/docs/secretary-notes.md')).toBe(false);
+      expect(re.test('C:\\proj\\src\\SecretsManagerClient.ts')).toBe(false);
+    });
+
+    it('SC005 still fires on secret stores, and now catches client_secret.json', () => {
+      const re = pattern('SC005');
+      expect(re.test('/run/secrets/db_password')).toBe(true);
+      expect(re.test('C:\\Users\\me\\.secrets\\api')).toBe(true);
+      expect(re.test('/app/config/secrets.yaml')).toBe(true);
+      expect(re.test('/home/user/.env.secret')).toBe(true);
+      // The old pattern required "secret" straight after a slash and MISSED this one.
+      expect(re.test('C:\\Users\\me\\AppData\\client_secret.json')).toBe(true);
+    });
+
+    it("SC006 no longer fires on the project's own tokens.css or on tokenizers", () => {
+      const re = pattern('SC006');
+      expect(re.test('X:\\proj\\src\\renderer\\lib\\styles\\tokens.css')).toBe(false);
+      expect(re.test('/app/src/nlp/tokenizer.py')).toBe(false);
+      expect(re.test('/app/src/main/token-adapters/usage.js')).toBe(false);
+    });
+
+    it('SC006 still fires on credential token files', () => {
+      const re = pattern('SC006');
+      expect(re.test('/home/user/.npm_token')).toBe(true);
+      expect(re.test('/home/user/api-token.txt')).toBe(true);
+      expect(re.test('C:\\Users\\me\\.config\\gh\\access_token.json')).toBe(true);
+      expect(re.test('/home/user/github-token')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Two hardening fixes from an independent read-only appraisal, verified against the tree.

### 1. Bounded, validated audit read path (`src/main/audit-logger.js`)

`getEntriesBefore(beforeTs, limit)` receives both parameters raw over IPC (`get-audit-entries-before`), and had no clamp: a renderer call with `Infinity` (or any huge limit) pulled the entire audit corpus into one IPC response. A non-string `beforeTs` crashed into the generic catch and silently returned `[]` — indistinguishable from a genuinely empty log.

The clamp lives inside `getEntriesBefore`, not the IPC handler, so every caller is covered:

- `limit`: non-numeric (including missing) falls back to `DEFAULT_READ_LIMIT` (100); numeric input is clamped via `Math.min(MAX_READ_LIMIT, Math.max(1, Math.floor(limit)))`. `Infinity` → 500, `10000` → 500, `-5` → 1, `'abc'` → 100. The function is structurally unable to return more than `MAX_READ_LIMIT` (500, exported).
- `beforeTs`: must be a string with a `YYYY-MM-DD` prefix (the shape the `slice(0, 10)` file-skip logic depends on). Anything else returns `[]` via an explicit early return that `console.warn`s the reason — deliberately distinct from the generic `getEntriesBefore failed` catch, so a rejected cursor never reads as an empty log.

No IPC or preload change; the UI's `HISTORY_BATCH` (25) sits far below the cap.

### 2. SC003 / SC005 / SC006 — path-word false positives (`rules/secrets.yaml`)

The three top false-positive producers matched a bare word substring anywhere in the final path segment (SC005: anywhere in the path), with no boundary and no extension scoping. The rewrite bounds the word with `[._-]` separator classes — NOT `\b`, because underscore is a regex word character and `api_token` / `client_secret` are exactly the names that must keep firing — and scopes loose compounds to secret-bearing data extensions.

| Rule | fired before, no longer fires | must fire, still fires |
|---|---|---|
| SC003 (password) | `src/components/PasswordInput.svelte` | `passwords.txt`, `.password`, `wifi-password.txt` |
| SC005 (secret) | `src/pages/SecretSanta.tsx`, `docs/secretary-notes.md` | `/run/secrets/db_password`, `.env.secret`, `secrets.yaml`, `client_secret.json` (the old pattern MISSED this one — it required `secret` straight after a slash) |
| SC006 (token) | `src/renderer/lib/styles/tokens.css` (this repo's own file), `tokenizer.py` | `.npm_token`, `api-token.txt`, `access_token.json` |

Accepted residuals, stated rather than hidden (each was weighed by an adversarial review pass; per-rule FP/FN hunters also timed the patterns against long adversarial segments — linear, no ReDoS):

- SC006 still fires on `tokens.json`-style names with data extensions — a design-tokens store and a credential store are not distinguishable by path alone.
- SC005 still fires on any file literally named `secrets.yaml` (k8s/ansible convention — a legitimate hit), which includes this repo's own rules file if it were ever inside a watched directory. It also still fires on English-phrase names like `secret-menu.txt`; dropping `.txt` from its extension list would lose `secrets.txt`, a worse trade.
- All three still fire on extensionless names ending in the bounded word (`reset-password`, `github-token`) — treated as more likely secret-bearing than not.
- Compound directory names (`app-secrets/`) are still not matched — the OLD pattern did not match them either (`[\\/]secret` required the word straight after a slash), so this is a pre-existing gap, not a regression; widening the directory branch is a separate decision.
- The deprecated `SENSITIVE_RULES` copy in `src/shared/constants.js` still carries the old bare-substring patterns. It is confirmed dead code (no runtime consumer — classification reads `getAllRules()` from rule-loader everywhere) and is outside this PR's file scope.

`rules.total` unchanged (73): patterns only — ids, names, reasons, risk levels untouched.

## Tests

- `tests/main/audit-logger.test.js` — new `getEntriesBefore — bounded read path` block: cap for `Infinity`/`10000`, clamp-up for `-5`, default for `'abc'`/missing, floor for fractionals; each invalid `beforeTs` case (`null` / `42` / malformed string) seeds real entries first so `[]` proves the validation path fired, asserts the validation warning, and asserts the generic catch logged nothing.
- `tests/main/rule-loader.test.js` — before/after path cases per rule, against the production YAML through the real loader.
- Revert-check: with the two fixes reverted, 12 of the new assertions go red — the tests are not vacuous.
