### PR TITLE
feat(main): app-level health derivation over the sensor leaves

### DIFF
--- a/.agents/skills/aegis-context/SKILL.md
+++ b/.agents/skills/aegis-context/SKILL.md
@@ -22,7 +22,7 @@ Read package.json for exact versions. NEVER hardcode.
 Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs: false`** — `src/main/*.js` bodies are NOT type-checked, their JSDoc is documentation. Two projects (`tsconfig.main.json` CommonJS / `tsconfig.renderer.json` ESM) share `tsconfig.base.json`; root `tsconfig.json` is a solution file, so gate with `npm run typecheck`, never a bare `npx tsc --noEmit`.
 
 ## Architecture
-- Main process (Node.js): src/main/ — 51 CJS modules (39 top-level + 10 platform/ + 2 token-adapters/)
+- Main process (Node.js): src/main/ — 52 CJS modules (40 top-level + 10 platform/ + 2 token-adapters/)
 - Renderer (Svelte 5): src/renderer/ — 47 components + 13 stores + 21 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 40 invoke + 9 push = 49 channels
 - Data: src/shared/agent-database.json (110 agents / 262 name signatures)

--- a/.agents/skills/electron-main/SKILL.md
+++ b/.agents/skills/electron-main/SKILL.md
@@ -5,7 +5,7 @@ description: Electron main process patterns for Aegis. CJS modules, platform abs
 # Electron Main Process
 
 ## Architecture
-- 51 CJS modules loaded directly by Node.js (39 top-level + 10 platform/ + 2 token-adapters/, NO build step)
+- 52 CJS modules loaded directly by Node.js (40 top-level + 10 platform/ + 2 token-adapters/, NO build step)
 - Platform dispatcher: src/main/platform/index.js → win32|darwin|linux
 - IPC: 40 invoke + 9 push = 49 channels, scan-batch consolidation
 - File watcher: chokidar 3.6, function-form ignored (NOT glob)

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -2,7 +2,7 @@
 alwaysApply: true
 ---
 # Code Quality Rules
-- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 31 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - No `any` type. Use proper types from src/shared/types/
 - GPG signing on all commits
 - Verify after EVERY change: npm test && npm run build && npm run typecheck (NOT `npx tsc --noEmit` — the root tsconfig is a solution file and checks nothing)

--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -22,7 +22,7 @@ Read package.json for exact versions. NEVER hardcode.
 Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs: false`** — `src/main/*.js` bodies are NOT type-checked, their JSDoc is documentation. Two projects (`tsconfig.main.json` CommonJS / `tsconfig.renderer.json` ESM) share `tsconfig.base.json`; root `tsconfig.json` is a solution file, so gate with `npm run typecheck`, never a bare `npx tsc --noEmit`.
 
 ## Architecture
-- Main process (Node.js): src/main/ — 51 CJS modules (39 top-level + 10 platform/ + 2 token-adapters/)
+- Main process (Node.js): src/main/ — 52 CJS modules (40 top-level + 10 platform/ + 2 token-adapters/)
 - Renderer (Svelte 5): src/renderer/ — 47 components + 13 stores + 21 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 40 invoke + 9 push = 49 channels
 - Data: src/shared/agent-database.json (110 agents / 262 name signatures)

--- a/.claude/skills/electron-main/SKILL.md
+++ b/.claude/skills/electron-main/SKILL.md
@@ -5,7 +5,7 @@ description: Electron main process patterns for Aegis. CJS modules, platform abs
 # Electron Main Process
 
 ## Architecture
-- 51 CJS modules loaded directly by Node.js (39 top-level + 10 platform/ + 2 token-adapters/, NO build step)
+- 52 CJS modules loaded directly by Node.js (40 top-level + 10 platform/ + 2 token-adapters/, NO build step)
 - Platform dispatcher: src/main/platform/index.js → win32|darwin|linux
 - IPC: 40 invoke + 9 push = 49 channels, scan-batch consolidation
 - File watcher: chokidar 3.6, function-form ignored (NOT glob)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ coverage thresholds are configured in `vitest.config.js`, so coverage cannot fai
 
 ## Code conventions
 
-- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 31 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - **Main process:** CommonJS (`require`/`module.exports`). Never use `import` in `src/main/`.
 - **Renderer:** ES modules (`import`/`export`). Never use `require()` in `src/renderer/`.
 - **Svelte 5 runes:** `$state`, `$derived`, `$effect`, `$props`. No legacy `let` reactivity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ regenerating a lockfile.
 ## Critical Rules
 1. Read memory-bank/ai-mistakes.md before ANY code change
 2. Do ONLY what the prompt says — no extra features, no unrequested changes
-3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 30 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 31 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
@@ -78,7 +78,7 @@ regenerating a lockfile.
 8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` + `npm run typecheck:svelte` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths
-- src/main/ — 51 CommonJS modules (39 top-level + platform/ 10 + token-adapters/ 2)
+- src/main/ — 52 CommonJS modules (40 top-level + platform/ 10 + token-adapters/ 2)
 - src/renderer/ — Svelte 5 components + stores + utils + tokens.css/global.css
   (count: `git ls-files 'src/renderer/**/*.svelte' | wc -l`)
 - src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (8 TS files), constants.js (ignore patterns, config paths; SENSITIVE_RULES deprecated)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -295,7 +295,7 @@ Key token namespaces:
 
 ## Conventions
 
-- **300-line soft limit** per file — a target for NEW files, not an invariant; 30 existing `src/` files already exceed it. Not enforced by the linter
+- **300-line soft limit** per file — a target for NEW files, not an invariant; 31 existing `src/` files already exceed it. Not enforced by the linter
 - **JSDoc on all exported functions**: `@param`, `@returns`, `@since`
 - **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `security:`
 - **IPC channel names**: `kebab-case`

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **51** = 39 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **52** = 40 top-level + 10 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 51 CommonJS modules (39 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 52 CommonJS modules (40 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle

--- a/src/main/app-health.js
+++ b/src/main/app-health.js
@@ -1,0 +1,343 @@
+/**
+ * @file app-health.js
+ * @module main/app-health
+ * @description Pure app-level health derivation over the sensor-health leaves.
+ *
+ * One question: what can AEGIS still observe? The answer is DERIVED on every read
+ * from a snapshot of inputs — no stored machine, no latch. Each "transition" is the
+ * edge between two derivations on consecutive ticks, so every edge is a change in a
+ * named signal rather than a hidden field.
+ *
+ * NOT a worst-of roll-up. `aggregateSensorHealth` stays the single implementation of
+ * worst-of and is called from here, but its result is an INPUT, never the answer: app
+ * FAILED states that a capability is lost, and a severity maximum cannot say that.
+ *
+ * No I/O, no Electron, no timers, no wall clock, and no `mark*` call: a leaf is
+ * written only by the code that performed or refused the observation it names, and
+ * that boundary is not this module's to cross.
+ * @since 0.12.0
+ */
+'use strict';
+
+const { SENSOR_HEALTH_STATE, AGGREGATE_NONE, aggregateSensorHealth } = require('./sensor-health');
+
+/** @typedef {'BOOTING'|'SENSORS_STARTING'|'HEALTHY'|'DEGRADED'|'FAILED'} AppHealthState */
+
+/**
+ * Closed set of app-level states.
+ * @type {Readonly<Record<string, string>>}
+ */
+const APP_HEALTH_STATE = Object.freeze({
+  BOOTING: 'BOOTING',
+  SENSORS_STARTING: 'SENSORS_STARTING',
+  HEALTHY: 'HEALTHY',
+  DEGRADED: 'DEGRADED',
+  FAILED: 'FAILED',
+});
+
+/**
+ * Closed set of reason codes. DECLARATION ORDER IS THE EMITTED ORDER — `reasons` is
+ * built by walking this table, so the array never depends on evaluation order. These
+ * are reason CODES, not sensor identifiers: a reader that wants sensor names takes
+ * them from the aggregate's `failedSensorIds` / `degradedSensorIds`.
+ * @type {Readonly<Record<string, string>>}
+ */
+const APP_HEALTH_REASON = Object.freeze({
+  POPULATION_FAILED: 'population-failed',
+  POPULATION_DEGRADED: 'population-degraded',
+  POPULATION_STARTING: 'population-starting',
+  ZERO_COVERAGE: 'zero-coverage',
+  SENSOR_FAILED: 'sensor-failed',
+  SENSOR_DEGRADED: 'sensor-degraded',
+  SENSOR_STARTING: 'sensor-starting',
+  IDENTITY_DEGRADED: 'identity-degraded',
+  WATCH_ROOTS_UNAVAILABLE: 'watch-roots-unavailable',
+  WATCH_PLAN_STARTING: 'watch-plan-starting',
+  RESIDUAL_LOSS: 'residual-loss',
+});
+
+/**
+ * Which state each reason lands in. A PARTITION: every code appears in exactly one
+ * tier, which is what makes {@link deriveAppHealth} total — an empty `reasons` is the
+ * only way to reach HEALTHY. Ordered failure-first, copied from
+ * `watch-root-registry.deriveWatchPlaneState` for the same reason it holds there: a
+ * CONFIRMED FAILURE OUTRANKS A NOT-YET. With the starting tier first, a
+ * permission-denied enumeration plus one chokidar root stuck at `registered` (terminal
+ * — its `ready` may never fire) would report "starting" over a machine AEGIS cannot see.
+ * @type {ReadonlyArray<{state: string, reasons: string[]}>}
+ */
+const TIERS = Object.freeze([
+  {
+    state: APP_HEALTH_STATE.FAILED,
+    reasons: [APP_HEALTH_REASON.POPULATION_FAILED, APP_HEALTH_REASON.ZERO_COVERAGE],
+  },
+  {
+    state: APP_HEALTH_STATE.DEGRADED,
+    reasons: [
+      APP_HEALTH_REASON.POPULATION_DEGRADED,
+      APP_HEALTH_REASON.SENSOR_FAILED,
+      APP_HEALTH_REASON.SENSOR_DEGRADED,
+      APP_HEALTH_REASON.IDENTITY_DEGRADED,
+      APP_HEALTH_REASON.WATCH_ROOTS_UNAVAILABLE,
+      APP_HEALTH_REASON.RESIDUAL_LOSS,
+    ],
+  },
+  {
+    state: APP_HEALTH_STATE.SENSORS_STARTING,
+    reasons: [
+      APP_HEALTH_REASON.POPULATION_STARTING,
+      APP_HEALTH_REASON.SENSOR_STARTING,
+      APP_HEALTH_REASON.WATCH_PLAN_STARTING,
+    ],
+  },
+]);
+
+/** The one sensor the effective projection may touch. A table, not a mechanism. */
+const PROJECTED_SENSOR_ID = 'proc-snapshot';
+
+/** Why that record is projected, published so the rewrite is auditable. */
+const PROJECTION_REASON = 'identity-birth-time-fallback';
+
+/**
+ * @typedef {Object} AppHealthInput
+ * @property {boolean} bootPhase - true once the deferred modules are loaded. While
+ *   false nothing exists to read: `scanner`/`watcher` are undefined in main.js.
+ * @property {{populationState: string, populationReliable: boolean,
+ *   populationAsOf: number|null, identityQuality: string}} capabilities -
+ *   `process-scanner.getProcessCapabilities()`, verbatim.
+ * @property {boolean} identityDegraded - `process-scanner.isIdentityDegraded()`,
+ *   verbatim. Never re-derived from `identityQuality`.
+ * @property {ReadonlyArray<import('./sensor-health').SensorHealth>} records - RAW leaves.
+ * @property {{state: string, liveWatcherCount: number, unavailableGroups: Array<object>}}
+ *   watchPlan - `file-watcher.getWatchPlan()`.
+ */
+
+/**
+ * @typedef {Object} AppHealth
+ * @property {AppHealthState} state
+ * @property {string[]} reasons - every satisfied condition, in APP_HEALTH_REASON order
+ * @property {import('./sensor-health').SensorHealthAggregate|null} raw - worst-of over
+ *   the untouched records, for diagnostics. Null while BOOTING.
+ * @property {import('./sensor-health').SensorHealthAggregate|null} effective - worst-of
+ *   over the projected set, which is what the state rests on. Null while BOOTING.
+ * @property {Array<{sensorId: string, from: string, to: string, reason: string}>} projections
+ */
+
+/**
+ * Project the raw leaves onto the set allowed to affect app health.
+ *
+ * ONE row, hardcoded: an accepted CIM fallback on `proc-snapshot`. That leaf marks the
+ * fallback DEGRADED, which is true about the SOURCE — the primary provider is gone and
+ * a spare answers — and false about the application: the identity keys still form in
+ * the same space with the same values, nothing splits, and `isIdentityDegraded()`
+ * deliberately returns false. Feeding the raw worst-of straight in would hold the whole
+ * app DEGRADED for as long as an accepted operating mode lasts, and a warning that is
+ * always on is not a warning.
+ *
+ * REWRITTEN IN A COPY, never dropped. Dropping would change `participatingCount` and
+ * open {@link AGGREGATE_NONE} where it must not be reachable; rewriting leaves
+ * participation exactly as it was. The caller's records are not mutated.
+ *
+ * `lossCount === 0` is required on top of the identity conditions: `markHealthy`
+ * refuses to erase residual loss, and a projection undoing that would be a second,
+ * weaker source of truth for the same rule. Vacuous today — nothing in `src/` calls
+ * `addLoss` — and written down anyway.
+ *
+ * WHAT IT RESTS ON: `identityQuality === 'birth-time'` is true exactly when
+ * `getIdentityQuality()` saw the snapshot leaf DEGRADED on a platform publishing a
+ * birth time. "DEGRADED implies cim-fallback" is therefore a property of THAT function,
+ * so this deliberately does not also test `detail === 'cim-fallback'`: a second
+ * condition would diverge silently the day the string is renamed, and would guard
+ * against a defect belonging next door. If `proc-snapshot` gains a second cause of
+ * DEGRADED, `getIdentityQuality()` is what must change — it would already be claiming
+ * "the keys still form" about a cause it knows nothing about.
+ * @param {ReadonlyArray<import('./sensor-health').SensorHealth>} records
+ * @param {{identityQuality: string}} capabilities
+ * @param {boolean} identityDegraded
+ * @returns {{records: import('./sensor-health').SensorHealth[],
+ *   projections: Array<{sensorId: string, from: string, to: string, reason: string}>}}
+ * @since 0.12.0
+ */
+function projectEffectiveRecords(records, capabilities, identityDegraded) {
+  if (!Array.isArray(records)) throw new Error('app-health: records must be an array');
+  const accepted =
+    capabilities != null && capabilities.identityQuality === 'birth-time' && !identityDegraded;
+  /** @type {Array<{sensorId: string, from: string, to: string, reason: string}>} */
+  const projections = [];
+  const projected = records.map((rec) => {
+    if (
+      !accepted ||
+      rec.sensorId !== PROJECTED_SENSOR_ID ||
+      rec.state !== SENSOR_HEALTH_STATE.DEGRADED ||
+      rec.lossCount !== 0
+    ) {
+      return rec;
+    }
+    projections.push({
+      sensorId: rec.sensorId,
+      from: rec.state,
+      to: SENSOR_HEALTH_STATE.HEALTHY,
+      reason: PROJECTION_REASON,
+    });
+    return { ...rec, state: SENSOR_HEALTH_STATE.HEALTHY };
+  });
+  return { records: projected, projections };
+}
+
+/**
+ * Every satisfied condition, walked in {@link APP_HEALTH_REASON} declaration order.
+ *
+ * Deliberately NOT "the reason the winning rule fired": reporting only the winner needs
+ * logic deciding what a reader may not know about, which is a mechanism for hiding
+ * degradation. Two consequences are intended:
+ *
+ * - `population-failed` and `sensor-failed` co-occur. The `process` leaf participates
+ *   in the aggregate, so its failure is true from both angles — the population
+ *   capability is gone AND a participating sensor is FAILED. Suppressing the second
+ *   would hide a fact the reader can check in `effective`.
+ * - `sensor-starting` comes from the aggregate STATE while `sensor-failed` /
+ *   `sensor-degraded` come from the id ARRAYS. `aggregateSensorHealth` publishes
+ *   `failedSensorIds` and `degradedSensorIds` but no `startingSensorIds`, and deriving
+ *   a third array here would put a second view of the same set beside the existing one.
+ *
+ * `watch-roots-unavailable` covers plane DEGRADED as well as FAILED. Those coincide
+ * with a non-empty `unavailableGroups` by construction of `deriveWatchPlaneState`; all
+ * three are named so the derivation stays total over the input TYPE, not merely over
+ * the states the registry can actually produce.
+ * @param {AppHealthInput} input
+ * @param {import('./sensor-health').SensorHealthAggregate} effective
+ * @param {ReadonlyArray<import('./sensor-health').SensorHealth>} effectiveRecords
+ * @returns {string[]}
+ */
+function collectReasons(input, effective, effectiveRecords) {
+  const { capabilities: caps, identityDegraded, watchPlan } = input;
+  const S = SENSOR_HEALTH_STATE;
+  const R = APP_HEALTH_REASON;
+  const held = {
+    [R.POPULATION_FAILED]: caps.populationState === S.FAILED,
+    [R.POPULATION_DEGRADED]: caps.populationState === S.DEGRADED,
+    [R.POPULATION_STARTING]: caps.populationState === S.STARTING,
+    [R.ZERO_COVERAGE]: effective.state === AGGREGATE_NONE,
+    [R.SENSOR_FAILED]: effective.failedSensorIds.length > 0,
+    [R.SENSOR_DEGRADED]: effective.degradedSensorIds.length > 0,
+    [R.SENSOR_STARTING]: effective.state === S.STARTING,
+    [R.IDENTITY_DEGRADED]: identityDegraded === true,
+    [R.WATCH_ROOTS_UNAVAILABLE]:
+      watchPlan.unavailableGroups.length > 0 ||
+      watchPlan.state === S.DEGRADED ||
+      watchPlan.state === S.FAILED,
+    [R.WATCH_PLAN_STARTING]: watchPlan.state === S.STARTING,
+    [R.RESIDUAL_LOSS]: effectiveRecords.some((r) => r.lossCount > 0),
+  };
+  return Object.values(R).filter((code) => held[code]);
+}
+
+/**
+ * @param {AppHealthInput} input
+ * @returns {AppHealthInput}
+ */
+function assertInput(input) {
+  if (input === null || typeof input !== 'object') {
+    throw new Error('app-health: input must be a plain object');
+  }
+  if (typeof input.bootPhase !== 'boolean') {
+    throw new Error('app-health: bootPhase must be a boolean');
+  }
+  if (input.bootPhase === false) return input;
+  if (input.capabilities == null || typeof input.capabilities.populationState !== 'string') {
+    throw new Error('app-health: capabilities.populationState must be a string');
+  }
+  if (typeof input.identityDegraded !== 'boolean') {
+    throw new Error('app-health: identityDegraded must be a boolean');
+  }
+  if (input.watchPlan == null || typeof input.watchPlan.state !== 'string') {
+    throw new Error('app-health: watchPlan.state must be a string');
+  }
+  if (!Array.isArray(input.watchPlan.unavailableGroups)) {
+    throw new Error('app-health: watchPlan.unavailableGroups must be an array');
+  }
+  return input;
+}
+
+/**
+ * Derive the app-level health from one snapshot of honest signals.
+ *
+ * THE `populationReliable` CONTRACT, AND WHY THIS READS `populationState` INSTEAD.
+ * `populationReliable` is `true` **iff** `populationState === 'HEALTHY'` — literally,
+ * in `process-scanner.getProcessCapabilities()`:
+ * `populationReliable: _processHealth.state === SENSOR_HEALTH_STATE.HEALTHY`.
+ * The boolean therefore collapses `STARTING`, `DEGRADED` and `FAILED` into one
+ * `false`, and a rule of the form `!populationReliable -> FAILED` declares a NORMAL
+ * pre-first-observation startup a total observation failure: the process leaf sits at
+ * `STARTING` until the first tick, which `population-scope-gate.test.js` already pins
+ * ("a never-scanned leaf is STARTING, not reliable, and has no asOf").
+ * `populationReliable` stays what it is — the capability GATE agent-scoped consumers
+ * read before they observe — and it is not expressive enough to classify an
+ * application lifecycle. This derivation reads `populationState`.
+ *
+ * STATE IS DERIVED FROM `reasons`, not computed beside it. The conditions live once,
+ * in {@link collectReasons}; {@link TIERS} maps them onto states. A reason and a state
+ * that disagree are therefore not expressible.
+ *
+ * WHAT FAILED MEANS. Core observation capability is unavailable — about capability,
+ * never a maximum over severities. The only LIVE route is `populationState ===
+ * 'FAILED'`: that one fact closes the population gate, and with it `doNetworkScan`,
+ * `doFileScan` and `doHotReadScan` all refuse and `handleWatcherEvent` stops inferring
+ * owners, so the claim "we can see which agents are running" is false. `zero-coverage`
+ * is a defensive invariant that closes totality and is NOT reachable today: every leaf
+ * but `fs-rm` is created participating on every platform, nothing calls `markDisabled`,
+ * and the projection rewrites rather than drops. A single leaf in FAILED — `network`,
+ * `fs-rm`, `proc-snapshot`, `fs-chokidar` — reaches DEGRADED, never FAILED.
+ *
+ * ORTHOGONALITY. `monitoringPaused` is absent from {@link AppHealthInput} on purpose:
+ * operator control is a separate dimension and travels beside this value, never inside
+ * it. There is also no age-based rule anywhere here — nothing compares `lastSuccessAt`
+ * to a clock. Pause stops the intervals, so leaves simply stop being attempted and
+ * their last success ages without bound; any "no success in N ms -> DEGRADED" rule
+ * would manufacture degradation out of an operator's intent.
+ * @param {AppHealthInput} input
+ * @returns {AppHealth}
+ * @since 0.12.0
+ */
+function deriveAppHealth(input) {
+  const inp = assertInput(input);
+  if (inp.bootPhase === false) {
+    // Nothing has been observed yet, so there is no condition to report.
+    return {
+      state: APP_HEALTH_STATE.BOOTING,
+      reasons: [],
+      raw: null,
+      effective: null,
+      projections: [],
+    };
+  }
+  const records = Array.isArray(inp.records) ? inp.records : [];
+  const raw = aggregateSensorHealth(records);
+  const { records: effectiveRecords, projections } = projectEffectiveRecords(
+    records,
+    inp.capabilities,
+    inp.identityDegraded,
+  );
+  const effective = aggregateSensorHealth(effectiveRecords);
+  const reasons = collectReasons(inp, effective, effectiveRecords);
+  const tier = TIERS.find((t) => reasons.some((r) => t.reasons.includes(r)));
+  // No tier matched means `reasons` is empty, and TIERS partitions every code — so
+  // this IS a healthy application, not a fall-through.
+  return {
+    state: tier ? tier.state : APP_HEALTH_STATE.HEALTHY,
+    reasons,
+    raw,
+    effective,
+    projections,
+  };
+}
+
+module.exports = {
+  APP_HEALTH_STATE,
+  APP_HEALTH_REASON,
+  TIERS,
+  PROJECTED_SENSOR_ID,
+  PROJECTION_REASON,
+  projectEffectiveRecords,
+  deriveAppHealth,
+};

--- a/tests/main/app-health.test.js
+++ b/tests/main/app-health.test.js
@@ -1,0 +1,650 @@
+import { describe, it, expect } from 'vitest';
+import {
+  APP_HEALTH_STATE,
+  APP_HEALTH_REASON,
+  PROJECTED_SENSOR_ID,
+  PROJECTION_REASON,
+  projectEffectiveRecords,
+  deriveAppHealth,
+} from '../../src/main/app-health.js';
+import { SENSOR_HEALTH_STATE, AGGREGATE_NONE } from '../../src/main/sensor-health.js';
+
+/** Fixed literal. Nothing here reads a clock — see "no age-based rule" below. */
+const T0 = 1700000000000;
+
+/**
+ * @param {string} sensorId
+ * @param {string} state
+ * @param {object} [over]
+ */
+function rec(sensorId, state, over = {}) {
+  return {
+    sensorId,
+    state,
+    lastAttemptAt: T0,
+    lastSuccessAt: state === SENSOR_HEALTH_STATE.HEALTHY ? T0 : null,
+    lastError: null,
+    consecutiveFailures: 0,
+    lossCount: 0,
+    detail: null,
+    ...over,
+  };
+}
+
+/** `populationReliable` is kept true-iff-HEALTHY, exactly as the real contract builds it. */
+function caps(populationState, over = {}) {
+  return {
+    populationState,
+    populationReliable: populationState === SENSOR_HEALTH_STATE.HEALTHY,
+    populationAsOf: populationState === SENSOR_HEALTH_STATE.HEALTHY ? T0 : null,
+    identityQuality: 'witnessed',
+    ...over,
+  };
+}
+
+function plan(state, over = {}) {
+  return {
+    state,
+    liveWatcherCount: state === SENSOR_HEALTH_STATE.FAILED ? 0 : 4,
+    unavailableGroups: [],
+    ...over,
+  };
+}
+
+function input(over = {}) {
+  return {
+    bootPhase: true,
+    capabilities: caps(SENSOR_HEALTH_STATE.HEALTHY),
+    identityDegraded: false,
+    records: [
+      rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+      rec('network', SENSOR_HEALTH_STATE.HEALTHY),
+    ],
+    watchPlan: plan(SENSOR_HEALTH_STATE.HEALTHY),
+    ...over,
+  };
+}
+
+/** The accepted CIM fallback: snapshot leaf DEGRADED, keys still forming. */
+function birthTimeFallback(over = {}) {
+  return input({
+    capabilities: caps(SENSOR_HEALTH_STATE.HEALTHY, { identityQuality: 'birth-time' }),
+    identityDegraded: false,
+    records: [
+      rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+      rec(PROJECTED_SENSOR_ID, SENSOR_HEALTH_STATE.DEGRADED, { detail: 'cim-fallback' }),
+      rec('network', SENSOR_HEALTH_STATE.HEALTHY),
+    ],
+    ...over,
+  });
+}
+
+describe('app-health', () => {
+  describe('transitions', () => {
+    it('1. BOOTING while the deferred modules are unloaded — and it reads nothing else', () => {
+      const out = deriveAppHealth({ bootPhase: false });
+      expect(out.state).toBe(APP_HEALTH_STATE.BOOTING);
+      expect(out.reasons).toEqual([]);
+      expect(out.raw).toBeNull();
+      expect(out.effective).toBeNull();
+    });
+
+    it('1→2. bootPhase flips with every leaf still STARTING → SENSORS_STARTING', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.STARTING),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.STARTING),
+            rec('network', SENSOR_HEALTH_STATE.STARTING),
+          ],
+          watchPlan: plan(SENSOR_HEALTH_STATE.STARTING),
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.SENSORS_STARTING);
+    });
+
+    it('2. SENSORS_STARTING → HEALTHY once every leaf and the plan have observed', () => {
+      expect(deriveAppHealth(input()).state).toBe(APP_HEALTH_STATE.HEALTHY);
+    });
+
+    it('3. SENSORS_STARTING → DEGRADED: a degraded leaf is not swallowed by startup', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.STARTING),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.STARTING),
+            rec('network', SENSOR_HEALTH_STATE.DEGRADED),
+          ],
+          watchPlan: plan(SENSOR_HEALTH_STATE.STARTING),
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('4. HEALTHY → FAILED when the population enumeration fails', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.FAILED),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.FAILED),
+            rec('network', SENSOR_HEALTH_STATE.HEALTHY),
+          ],
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.FAILED);
+    });
+
+    it('5. FAILED → DEGRADED: recovery does not require every leaf to be clean', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.HEALTHY),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec('network', SENSOR_HEALTH_STATE.FAILED),
+          ],
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('6. HEALTHY → DEGRADED on identity degradation', () => {
+      const out = deriveAppHealth(
+        input({
+          identityDegraded: true,
+          capabilities: caps(SENSOR_HEALTH_STATE.HEALTHY, { identityQuality: 'unknown' }),
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+      expect(out.reasons).toContain(APP_HEALTH_REASON.IDENTITY_DEGRADED);
+    });
+
+    it('7. HEALTHY → DEGRADED on an unavailable watch root', () => {
+      const out = deriveAppHealth(
+        input({
+          watchPlan: plan(SENSOR_HEALTH_STATE.DEGRADED, {
+            unavailableGroups: [{ id: 'env-files', state: 'errored', reason: 'EPERM' }],
+            liveWatcherCount: 3,
+          }),
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('8. residual loss never reads as HEALTHY (no addLoss caller in src/ today)', () => {
+      const out = deriveAppHealth(
+        input({
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec('network', SENSOR_HEALTH_STATE.HEALTHY, { lossCount: 3 }),
+          ],
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+      expect(out.reasons).toContain(APP_HEALTH_REASON.RESIDUAL_LOSS);
+    });
+
+    it('9. zero coverage → FAILED (defensive invariant, no live route)', () => {
+      const out = deriveAppHealth(input({ records: [] }));
+      expect(out.effective.state).toBe(AGGREGATE_NONE);
+      expect(out.state).toBe(APP_HEALTH_STATE.FAILED);
+      expect(out.reasons).toContain(APP_HEALTH_REASON.ZERO_COVERAGE);
+    });
+  });
+
+  // populationReliable is `true` iff populationState === 'HEALTHY', so the boolean
+  // collapses STARTING, DEGRADED and FAILED into one `false`. A, B and C differ in
+  // exactly what it collapses — together they are the proof that the derivation reads
+  // the state and not the flag.
+  describe('population lifecycle — populationState, never populationReliable', () => {
+    it('A. normal startup is SENSORS_STARTING, never FAILED', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.STARTING),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.STARTING),
+            rec('network', SENSOR_HEALTH_STATE.STARTING),
+          ],
+          watchPlan: plan(SENSOR_HEALTH_STATE.STARTING),
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.SENSORS_STARTING);
+      expect(out.state).not.toBe(APP_HEALTH_STATE.FAILED);
+    });
+
+    it('B. a real population failure is FAILED even while another leaf is STARTING', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.FAILED),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.FAILED),
+            rec('network', SENSOR_HEALTH_STATE.STARTING),
+          ],
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.FAILED);
+    });
+
+    it('C. a partial population state is DEGRADED, not FAILED', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.DEGRADED),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.DEGRADED),
+            rec('network', SENSOR_HEALTH_STATE.HEALTHY),
+          ],
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('all three carry populationReliable false — the flag cannot tell them apart', () => {
+      for (const state of [
+        SENSOR_HEALTH_STATE.STARTING,
+        SENSOR_HEALTH_STATE.DEGRADED,
+        SENSOR_HEALTH_STATE.FAILED,
+      ]) {
+        expect(caps(state).populationReliable).toBe(false);
+      }
+    });
+  });
+
+  describe('accepted CIM fallback — the effective projection', () => {
+    it('D. birth-time fallback with everything else healthy is app HEALTHY', () => {
+      expect(deriveAppHealth(birthTimeFallback()).state).toBe(APP_HEALTH_STATE.HEALTHY);
+    });
+
+    it('E. the fallback does not mask a leaf that is still starting', () => {
+      const out = deriveAppHealth(
+        birthTimeFallback({
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec(PROJECTED_SENSOR_ID, SENSOR_HEALTH_STATE.DEGRADED, { detail: 'cim-fallback' }),
+            rec('network', SENSOR_HEALTH_STATE.STARTING),
+          ],
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.SENSORS_STARTING);
+    });
+
+    it('F. the fallback does not mask a real failure', () => {
+      const out = deriveAppHealth(
+        birthTimeFallback({
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec(PROJECTED_SENSOR_ID, SENSOR_HEALTH_STATE.DEGRADED, { detail: 'cim-fallback' }),
+            rec('network', SENSOR_HEALTH_STATE.FAILED),
+          ],
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('G. the projection is narrow: not while identity is degraded', () => {
+      const out = deriveAppHealth(
+        birthTimeFallback({
+          identityDegraded: true,
+          capabilities: caps(SENSOR_HEALTH_STATE.HEALTHY, { identityQuality: 'unknown' }),
+        }),
+      );
+      expect(out.projections).toEqual([]);
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('G. the projection is narrow: never lifts a FAILED snapshot leaf', () => {
+      const out = deriveAppHealth(
+        birthTimeFallback({
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec(PROJECTED_SENSOR_ID, SENSOR_HEALTH_STATE.FAILED),
+          ],
+        }),
+      );
+      expect(out.projections).toEqual([]);
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('G. the projection is narrow: never erases residual loss', () => {
+      const out = deriveAppHealth(
+        birthTimeFallback({
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec(PROJECTED_SENSOR_ID, SENSOR_HEALTH_STATE.DEGRADED, {
+              detail: 'cim-fallback',
+              lossCount: 1,
+            }),
+          ],
+        }),
+      );
+      expect(out.projections).toEqual([]);
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+      expect(out.reasons).toContain(APP_HEALTH_REASON.RESIDUAL_LOSS);
+    });
+
+    it('G. the projection is narrow: no other sensor id is ever lifted', () => {
+      const out = deriveAppHealth(
+        birthTimeFallback({
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec('fs-rm', SENSOR_HEALTH_STATE.DEGRADED),
+          ],
+        }),
+      );
+      expect(out.projections).toEqual([]);
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('H. the raw record stays DEGRADED and the rewrite is published', () => {
+      const out = deriveAppHealth(birthTimeFallback());
+      expect(out.raw.state).toBe(SENSOR_HEALTH_STATE.DEGRADED);
+      expect(out.raw.degradedSensorIds).toEqual([PROJECTED_SENSOR_ID]);
+      expect(out.effective.state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+      expect(out.effective.degradedSensorIds).toEqual([]);
+      expect(out.projections).toEqual([
+        {
+          sensorId: PROJECTED_SENSOR_ID,
+          from: SENSOR_HEALTH_STATE.DEGRADED,
+          to: SENSOR_HEALTH_STATE.HEALTHY,
+          reason: PROJECTION_REASON,
+        },
+      ]);
+    });
+
+    it('H. participation is unchanged — the record is rewritten, not dropped', () => {
+      const out = deriveAppHealth(birthTimeFallback());
+      expect(out.effective.participatingCount).toBe(out.raw.participatingCount);
+      expect(out.effective.totalCount).toBe(out.raw.totalCount);
+    });
+
+    it('projectEffectiveRecords does not mutate the caller’s records', () => {
+      const records = [
+        rec(PROJECTED_SENSOR_ID, SENSOR_HEALTH_STATE.DEGRADED, { detail: 'cim-fallback' }),
+      ];
+      const out = projectEffectiveRecords(records, { identityQuality: 'birth-time' }, false);
+      expect(records[0].state).toBe(SENSOR_HEALTH_STATE.DEGRADED);
+      expect(out.records[0].state).toBe(SENSOR_HEALTH_STATE.HEALTHY);
+      expect(out.records[0]).not.toBe(records[0]);
+    });
+  });
+
+  // These red if rules 2/3 are moved below rule 4 — a confirmed failure outranks a
+  // not-yet, exactly as deriveWatchPlaneState orders its own rules.
+  describe('rule order — failure outranks not-yet', () => {
+    it('I. a closed population gate is not masked by a starting plan', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.FAILED),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.FAILED),
+            rec('network', SENSOR_HEALTH_STATE.STARTING),
+          ],
+          watchPlan: plan(SENSOR_HEALTH_STATE.STARTING),
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.FAILED);
+    });
+
+    it('J. a degraded leaf is not masked by a starting plan', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.STARTING),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.STARTING),
+            rec('network', SENSOR_HEALTH_STATE.DEGRADED),
+          ],
+          watchPlan: plan(SENSOR_HEALTH_STATE.STARTING),
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+    });
+
+    it('K. a mixed startup does not fall through the rules', () => {
+      // ~9 s of every launch: the process tick lands at 3 s, the network one at 12 s.
+      const out = deriveAppHealth(
+        input({
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec('network', SENSOR_HEALTH_STATE.STARTING),
+            rec('fs-handle', SENSOR_HEALTH_STATE.STARTING),
+          ],
+        }),
+      );
+      expect(out.effective.state).toBe(SENSOR_HEALTH_STATE.STARTING);
+      expect(out.state).toBe(APP_HEALTH_STATE.SENSORS_STARTING);
+    });
+  });
+
+  // A single leaf in FAILED reaches DEGRADED, never FAILED. Replacing the derivation
+  // with `return effective.state` reds every case here.
+  describe('FAILED is a capability statement, not worst-of', () => {
+    for (const sensorId of ['network', 'fs-rm', PROJECTED_SENSOR_ID, 'fs-chokidar']) {
+      it(`a lone ${sensorId} FAILED is app DEGRADED`, () => {
+        const out = deriveAppHealth(
+          input({
+            records: [
+              rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+              rec(sensorId, SENSOR_HEALTH_STATE.FAILED),
+            ],
+          }),
+        );
+        expect(out.effective.state).toBe(SENSOR_HEALTH_STATE.FAILED);
+        expect(out.state).toBe(APP_HEALTH_STATE.DEGRADED);
+      });
+    }
+
+    it('only a lost population capability reaches FAILED', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.FAILED),
+          records: [rec('process', SENSOR_HEALTH_STATE.FAILED)],
+        }),
+      );
+      expect(out.state).toBe(APP_HEALTH_STATE.FAILED);
+    });
+  });
+
+  describe('reasons — the complete set of satisfied conditions', () => {
+    it('R1. normal startup', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.STARTING),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.STARTING),
+            rec('network', SENSOR_HEALTH_STATE.STARTING),
+          ],
+          watchPlan: plan(SENSOR_HEALTH_STATE.STARTING),
+        }),
+      );
+      expect(out.reasons).toEqual([
+        APP_HEALTH_REASON.POPULATION_STARTING,
+        APP_HEALTH_REASON.SENSOR_STARTING,
+        APP_HEALTH_REASON.WATCH_PLAN_STARTING,
+      ]);
+    });
+
+    it('R2. population failure keeps sensor-failed too — the process leaf is both', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.FAILED),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.FAILED),
+            rec('network', SENSOR_HEALTH_STATE.STARTING),
+          ],
+        }),
+      );
+      expect(out.reasons).toEqual([
+        APP_HEALTH_REASON.POPULATION_FAILED,
+        APP_HEALTH_REASON.SENSOR_FAILED,
+      ]);
+      expect(out.effective.failedSensorIds).toEqual(['process']);
+    });
+
+    it('R3. an accepted fallback leaves nothing to report', () => {
+      expect(deriveAppHealth(birthTimeFallback()).reasons).toEqual([]);
+    });
+
+    it('R4. the fallback plus a failed network reports only the failure', () => {
+      const out = deriveAppHealth(
+        birthTimeFallback({
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+            rec(PROJECTED_SENSOR_ID, SENSOR_HEALTH_STATE.DEGRADED, { detail: 'cim-fallback' }),
+            rec('network', SENSOR_HEALTH_STATE.FAILED),
+          ],
+        }),
+      );
+      expect(out.reasons).toEqual([APP_HEALTH_REASON.SENSOR_FAILED]);
+    });
+
+    it('R5. several causes at once, in declaration order', () => {
+      const out = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.DEGRADED, { identityQuality: 'unknown' }),
+          identityDegraded: true,
+          records: [rec('process', SENSOR_HEALTH_STATE.DEGRADED)],
+          watchPlan: plan(SENSOR_HEALTH_STATE.DEGRADED, {
+            unavailableGroups: [{ id: 'agent-config', state: 'errored', reason: 'ENOENT' }],
+            liveWatcherCount: 2,
+          }),
+        }),
+      );
+      expect(out.reasons).toEqual([
+        APP_HEALTH_REASON.POPULATION_DEGRADED,
+        APP_HEALTH_REASON.SENSOR_DEGRADED,
+        APP_HEALTH_REASON.IDENTITY_DEGRADED,
+        APP_HEALTH_REASON.WATCH_ROOTS_UNAVAILABLE,
+      ]);
+    });
+  });
+
+  describe('orthogonality — monitoringPaused is not an input', () => {
+    it('N1. an injected monitoringPaused changes nothing, in either position', () => {
+      const base = deriveAppHealth(input());
+      expect(deriveAppHealth(input({ monitoringPaused: true }))).toEqual(base);
+      expect(deriveAppHealth(input({ monitoringPaused: false }))).toEqual(base);
+    });
+
+    it('N1. it cannot rescue a degraded reading either', () => {
+      const degraded = input({
+        records: [
+          rec('process', SENSOR_HEALTH_STATE.HEALTHY),
+          rec('network', SENSOR_HEALTH_STATE.DEGRADED),
+        ],
+      });
+      expect(deriveAppHealth({ ...degraded, monitoringPaused: true }).state).toBe(
+        APP_HEALTH_STATE.DEGRADED,
+      );
+    });
+
+    it('N3. no age-based rule: a stale lastSuccessAt derives the same state', () => {
+      const fresh = deriveAppHealth(input());
+      const stale = deriveAppHealth(
+        input({
+          capabilities: caps(SENSOR_HEALTH_STATE.HEALTHY, { populationAsOf: 1 }),
+          records: [
+            rec('process', SENSOR_HEALTH_STATE.HEALTHY, { lastSuccessAt: 1, lastAttemptAt: 1 }),
+            rec('network', SENSOR_HEALTH_STATE.HEALTHY, { lastSuccessAt: 1, lastAttemptAt: 1 }),
+          ],
+        }),
+      );
+      expect(stale.state).toBe(fresh.state);
+      expect(stale.reasons).toEqual(fresh.reasons);
+    });
+  });
+
+  describe('totality and closed range', () => {
+    /**
+     * The three axes are fed as INDEPENDENT inputs on purpose, and some combinations
+     * are unconstructable from real records: `populationState` IS the `process`
+     * record's state and that record participates in the aggregate, so
+     * populationState FAILED alongside an effective aggregate of HEALTHY never occurs
+     * in life — and neither does watchPlan FAILED beside a healthy aggregate, which is
+     * why the watch-plan states are named in rule 3 at all.
+     *
+     * Totality is proven over the INPUT TYPE, not over reachable states: the
+     * impossible rows are exactly what catches a fall-through. Deleting them as
+     * "unrealistic" destroys the test.
+     *
+     * It proves termination in a valid state and a closed reason range. It does NOT
+     * prove precedence — that is what A/B/C, D/E/F and the mutation runs are for.
+     */
+    const POPULATION = [
+      SENSOR_HEALTH_STATE.STARTING,
+      SENSOR_HEALTH_STATE.HEALTHY,
+      SENSOR_HEALTH_STATE.DEGRADED,
+      SENSOR_HEALTH_STATE.FAILED,
+    ];
+    const AGGREGATES = [
+      [SENSOR_HEALTH_STATE.HEALTHY, [rec('x', SENSOR_HEALTH_STATE.HEALTHY)]],
+      [SENSOR_HEALTH_STATE.STARTING, [rec('x', SENSOR_HEALTH_STATE.STARTING)]],
+      [SENSOR_HEALTH_STATE.DEGRADED, [rec('x', SENSOR_HEALTH_STATE.DEGRADED)]],
+      [SENSOR_HEALTH_STATE.FAILED, [rec('x', SENSOR_HEALTH_STATE.FAILED)]],
+      [AGGREGATE_NONE, []],
+    ];
+    const PLANS = [
+      SENSOR_HEALTH_STATE.STARTING,
+      SENSOR_HEALTH_STATE.HEALTHY,
+      SENSOR_HEALTH_STATE.DEGRADED,
+      SENSOR_HEALTH_STATE.FAILED,
+    ];
+
+    it('20. every combination terminates in exactly one valid state', () => {
+      const states = Object.values(APP_HEALTH_STATE);
+      let combinations = 0;
+      for (const populationState of POPULATION) {
+        for (const [aggregateState, records] of AGGREGATES) {
+          for (const planState of PLANS) {
+            const out = deriveAppHealth(
+              input({ capabilities: caps(populationState), records, watchPlan: plan(planState) }),
+            );
+            combinations += 1;
+            expect(out.effective.state, `aggregate axis for ${aggregateState}`).toBe(
+              aggregateState,
+            );
+            expect(states, `${populationState} / ${aggregateState} / ${planState}`).toContain(
+              out.state,
+            );
+          }
+        }
+      }
+      expect(combinations).toBe(80);
+    });
+
+    it('R6. reasons stay inside the closed set, with no duplicates', () => {
+      const codes = Object.values(APP_HEALTH_REASON);
+      for (const populationState of POPULATION) {
+        for (const [, records] of AGGREGATES) {
+          for (const planState of PLANS) {
+            const out = deriveAppHealth(
+              input({ capabilities: caps(populationState), records, watchPlan: plan(planState) }),
+            );
+            for (const reason of out.reasons) expect(codes).toContain(reason);
+            expect(new Set(out.reasons).size).toBe(out.reasons.length);
+          }
+        }
+      }
+    });
+
+    it('the state set itself is closed and frozen', () => {
+      expect(Object.isFrozen(APP_HEALTH_STATE)).toBe(true);
+      expect(Object.isFrozen(APP_HEALTH_REASON)).toBe(true);
+      expect(Object.values(APP_HEALTH_STATE)).toHaveLength(5);
+      expect(Object.values(APP_HEALTH_REASON)).toHaveLength(11);
+    });
+  });
+
+  describe('input validation', () => {
+    it('rejects a missing bootPhase rather than guessing one', () => {
+      expect(() => deriveAppHealth({})).toThrow(/bootPhase/);
+    });
+
+    it('rejects a booted input with no capability contract', () => {
+      expect(() => deriveAppHealth({ bootPhase: true })).toThrow(/populationState/);
+    });
+
+    it('rejects a non-boolean identityDegraded — it must be read, never inferred', () => {
+      expect(() =>
+        deriveAppHealth(input({ identityDegraded: /** @type {never} */ ('unknown') })),
+      ).toThrow(/identityDegraded/);
+    });
+  });
+});


### PR DESCRIPTION
New pure module `src/main/app-health.js` plus its unit suite. **No consumer, no IPC,
no UI** — nothing in the app calls it yet. P3 wires it into `getStats()`.

## What it is

`deriveAppHealth(input) -> { state, reasons, raw, effective, projections }` over
`BOOTING | SENSORS_STARTING | HEALTHY | DEGRADED | FAILED`. A derivation, not a stored
machine: every "transition" is the edge between two derivations on consecutive ticks,
so each edge is a change in a named signal rather than a hidden field.

It writes **no** health record. A leaf is written only by the code that performed or
refused the observation it names (PR #225), and that boundary is not this module's to
cross.

## `populationState`, never `populationReliable`

```js
// process-scanner.getProcessCapabilities()
populationReliable: _processHealth.state === sensorHealth.SENSOR_HEALTH_STATE.HEALTHY,
```

`populationReliable` is `true` **iff** `populationState === 'HEALTHY'`. The boolean
collapses `STARTING`, `DEGRADED` and `FAILED` into one `false`, so a rule of the form
`!populationReliable -> FAILED` declares a **normal pre-first-observation startup** a
total observation failure: the process leaf sits at `STARTING` until the first tick,
which `population-scope-gate.test.js:67` already pins ("a never-scanned leaf is
STARTING, not reliable, and has no asOf").

The contract and the reason for reading the state instead are in the `deriveAppHealth`
JSDoc verbatim. `populationReliable` stays what it is — the capability **gate**
agent-scoped consumers read before they observe.

## FAILED is a capability statement, not worst-of

The only **live** route is `populationState === 'FAILED'`, because that single fact
closes the population gate and with it `doNetworkScan`, `doFileScan`, `doHotReadScan`
and owner inference — the claim "we can see which agents are running" becomes false.
`zero-coverage` is a defensive invariant that closes totality and is **not reachable
today**: every leaf but `fs-rm` is created participating on every platform, nothing
calls `markDisabled`, and the projection rewrites rather than drops. A lone leaf in
FAILED — `network`, `fs-rm`, `proc-snapshot`, `fs-chokidar` — reaches DEGRADED.

## The effective projection

`aggregateSensorHealth` stays the single implementation of worst-of; only the record
set it runs over changes. **One hardcoded row**, not a mechanism:

```
sensorId === 'proc-snapshot' && state === DEGRADED
  && identityQuality === 'birth-time' && !identityDegraded && lossCount === 0
```

- **Rewritten in a copy, never dropped.** Dropping would move `participatingCount` and
  open `AGGREGATE_NONE` where it must not be reachable.
- **`lossCount === 0` is a narrowing the plan did not name, and it is required.**
  `markHealthy` refuses to erase residual loss; a projection undoing that would be a
  second, weaker source of truth for the same rule. Vacuous today — nothing in `src/`
  calls `addLoss`, which `memory-bank/progress.md:39,45` already records — and written
  down anyway.
- **Not gated on `detail === 'cim-fallback'`.** "DEGRADED implies cim-fallback" is a
  property of `getIdentityQuality()`, not of this function. A second condition would
  diverge silently the day the string is renamed and would guard against a defect
  belonging next door (ai-mistakes #27).
- Raw records, the raw aggregate, and the list of rewrites are all published.

## State is derived FROM `reasons`

The conditions live once, in `collectReasons`; a frozen `TIERS` table partitions every
code onto a state. A reason and a state that disagree are therefore **not expressible**,
and HEALTHY is reachable only through an empty `reasons`. `reasons` is the complete set
of satisfied conditions, in declaration order — `population-failed` and `sensor-failed`
co-occur on purpose, because the `process` leaf is genuinely both.

## Mutation proofs — all run and reverted

| mutation | result |
|---|---|
| `return effective.state` (make it worst-of) | **16 failed** / 30 passed |
| raw aggregate substituted for effective | **5 failed** — incl. D (fallback is HEALTHY) and R3 (`reasons === []`) |
| `if (!populationReliable) return FAILED` | **6 failed** — incl. A (normal startup) and C (partial population) |

## Counts — derived from the index, not carried forward

`origin/master` had advanced past the reviewed base via #245, so every figure was
re-measured after fast-forwarding.

- `src/main` **51 → 52**, top-level **39 → 40**. Declared at **seven** sites, one more
  than the plan listed: `docs/current-state/CORRECTNESS-AUDIT.md:71` was the missed
  sibling — the very file ai-mistakes #24 names as having "audited the number and
  recorded match".
- `size.over300` **30 → 31**, declared at four more sites. `app-health.js` is 343 lines,
  over the 300-line target. Rule 3 calls 300 a target for new files and explicitly not
  an invariant; the length here is the mandated rationale (the `populationReliable`
  contract, the projection's basis, the FAILED semantics, the orthogonality clauses),
  and trimming it to hit a soft number would be optimising the metric against the
  content. Declared honestly instead.
- `.claude/rules/code-quality.md` needed `git add -f`: it is **tracked** but sits under
  an ignored path — the exact asymmetry ai-mistakes #28 documents.

## Not in this PR

No IPC, no renderer, no `getStats()` change, no `preload.js` change. `monitoringPaused`
is absent from the input type; there is no age-based rule anywhere; no production
consumer gates an observation on this value.

## Gates

`build:renderer`, `format:check` + `lint` (0 errors, 28 pre-existing warnings),
`typecheck` + `typecheck:svelte` (407 files, 0 errors), `test:coverage` (103 files,
1854 passed / 4 skipped), `verify:gate` (4/4 mutants killed), `counts:check` (19
counters, 131 declaration sites agree), `npm audit --audit-level=high --omit=dev`
(0 vulnerabilities) — all green locally.
