### PR TITLE
feat(renderer): name the degraded and failed sensors in the footer

### DIFF
--- a/.agents/skills/aegis-context/SKILL.md
+++ b/.agents/skills/aegis-context/SKILL.md
@@ -23,7 +23,7 @@ Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs
 
 ## Architecture
 - Main process (Node.js): src/main/ — 52 CJS modules (40 top-level + 10 platform/ + 2 token-adapters/)
-- Renderer (Svelte 5): src/renderer/ — 47 components + 13 stores + 21 utils via IPC bridge
+- Renderer (Svelte 5): src/renderer/ — 48 components + 14 stores + 21 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 40 invoke + 9 push = 49 channels
 - Data: src/shared/agent-database.json (110 agents / 262 name signatures)
 - Rules: rules/*.yaml — 73 active rules across 8 categories, validated against rules/_schema.json

--- a/.claude/skills/aegis-context/SKILL.md
+++ b/.claude/skills/aegis-context/SKILL.md
@@ -23,7 +23,7 @@ Electron 33, Svelte 5, Vite 7, chokidar. TypeScript: `allowJs: true`, **`checkJs
 
 ## Architecture
 - Main process (Node.js): src/main/ — 52 CJS modules (40 top-level + 10 platform/ + 2 token-adapters/)
-- Renderer (Svelte 5): src/renderer/ — 47 components + 13 stores + 21 utils via IPC bridge
+- Renderer (Svelte 5): src/renderer/ — 48 components + 14 stores + 21 utils via IPC bridge
 - Bridge: src/main/preload.js — contextBridge, 40 invoke + 9 push = 49 channels
 - Data: src/shared/agent-database.json (110 agents / 262 name signatures)
 - Rules: rules/*.yaml — 73 active rules across 8 categories, validated against rules/_schema.json

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -26,7 +26,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (src/renderer/) — Svelte 5 + Vite 7
-47 Svelte components, 13 stores, 21 utils, scoped CSS + tokens.css/global.css
+48 Svelte components, 14 stores, 21 utils, scoped CSS + tokens.css/global.css
 
 ### Components (src/renderer/lib/components/)
 - App.svelte — root layout, tab routing, settings modal

--- a/src/renderer/lib/components/Footer.svelte
+++ b/src/renderer/lib/components/Footer.svelte
@@ -2,6 +2,7 @@
   import { monitorResourceUsage, stats, tokenCosts } from '../stores/ipc.js';
   import { t } from '../i18n/index.js';
   import FooterMiniCharts from './FooterMiniCharts.svelte';
+  import SensorHealthChip from './SensorHealthChip.svelte';
   import { tick, startTick } from '../stores/tick.ts';
 
   let permDenied = $derived($stats.permissionDeniedScans || 0);
@@ -12,7 +13,17 @@
 
   let heapMB = $state('--');
   let scanInterval = $state('--');
-  let appVersion = $state('v0.8.0-alpha');
+  /**
+   * Empty until `getAppVersion()` answers, and NO literal default — not even a
+   * plausible one. A version string written here is a claim about the running build
+   * that this file cannot keep true: the default it replaces outlived three minor
+   * bumps and was still naming a long-dead alpha to any window whose bridge had not
+   * answered. Absent is honest; a stale number is not, and it never goes red.
+   * Deliberately not a placeholder either — the brand name renders alone until the
+   * real version lands, so nothing on screen is ever a version that is not this one.
+   */
+  let appVersion = $state('');
+  let versionLabel = $derived(appVersion ? `${$t('brand.name')} ${appVersion}` : $t('brand.name'));
 
   const appStart = Date.now();
   let uptimeMs = $derived($tick ? Date.now() - appStart : 0);
@@ -48,7 +59,7 @@
 </script>
 
 <footer class="footer">
-  <span class="footer-version">{$t('brand.name')} {appVersion}</span>
+  <span class="footer-version">{versionLabel}</span>
 
   <div class="footer-stats">
     <FooterMiniCharts />
@@ -76,6 +87,8 @@
         >
       </div>
     {/if}
+
+    <SensorHealthChip />
 
     {#if permDenied > 5}
       <div

--- a/src/renderer/lib/components/SensorHealthChip.svelte
+++ b/src/renderer/lib/components/SensorHealthChip.svelte
@@ -1,0 +1,76 @@
+<!--
+  SensorHealthChip.svelte — names the sensors behind a degraded or failed app health.
+
+  Before this, `stats.appHealth` reached the renderer and nothing read it: the health
+  state was carried the whole way and then dropped, so a dead file-handle scanner and a
+  quiet machine looked identical in the UI. This chip is the minimum that fixes it — it
+  says WHICH sensors, by id, and nothing else.
+
+  The names come from `appHealth.sensors.effective.degradedSensorIds` /
+  `failedSensorIds` via the app-health store, never from `appHealth.reasons`: reasons
+  are aggregate reason codes, and parsing prose for identifiers breaks silently the
+  first time the wording changes.
+
+  Both lists empty renders NOTHING — no wrapper, no empty section, no placeholder. A
+  chip that is always present has to say "all clear" on every tick, and "all clear" is
+  the one claim a health surface must not make on its own.
+-->
+<script lang="ts">
+  import { unhealthySensors } from '../stores/app-health.js';
+  import { t } from '../i18n/index.js';
+
+  let degraded = $derived($unhealthySensors.degraded);
+  let failed = $derived($unhealthySensors.failed);
+</script>
+
+{#if failed.length > 0}
+  <div
+    class="sensor-health"
+    title="These sensors have failed and are producing no usable observation: {failed.join(
+      ', ',
+    )}. Their evidence is missing, not empty."
+  >
+    <span class="sensor-health__label">{$t('footer.sensors_failed')}</span>
+    <span class="sensor-health__value sensor-health__value--failed">{failed.join(', ')}</span>
+  </div>
+{/if}
+
+{#if degraded.length > 0}
+  <div
+    class="sensor-health"
+    title="These sensors are running with incomplete observation: {degraded.join(
+      ', ',
+    )}. What they report is partial."
+  >
+    <span class="sensor-health__label">{$t('footer.sensors_degraded')}</span>
+    <span class="sensor-health__value sensor-health__value--degraded">{degraded.join(', ')}</span>
+  </div>
+{/if}
+
+<style>
+  .sensor-health {
+    display: flex;
+    align-items: center;
+    gap: var(--aegis-space-3);
+  }
+
+  .sensor-health__label {
+    font: var(--md-sys-typescale-label-medium);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .sensor-health__value {
+    font: var(--md-sys-typescale-label-medium);
+    font-family: var(--fancy-font-mono);
+  }
+
+  /* Failed and degraded are different severities, so they are different colours —
+     both themed roles, not the dark-only --fancy-* pair. */
+  .sensor-health__value--failed {
+    color: var(--md-sys-color-error);
+  }
+
+  .sensor-health__value--degraded {
+    color: var(--md-sys-color-secondary);
+  }
+</style>

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -14,7 +14,9 @@
     "scan": "SCAN",
     "up": "UP",
     "perm_warn": "PERM",
-    "tokens": "TOK"
+    "tokens": "TOK",
+    "sensors_degraded": "DEGRADED",
+    "sensors_failed": "FAILED"
   },
   "process_action": {
     "stop_title": "Stop process?",

--- a/src/renderer/lib/stores/app-health.ts
+++ b/src/renderer/lib/stores/app-health.ts
@@ -1,0 +1,105 @@
+/**
+ * @file app-health.ts — the app-health block of the stats payload, narrowed for the UI
+ * @module renderer/stores/app-health
+ * @description The renderer's ONLY reader of `stats.appHealth`. It answers one
+ *   question — which sensors are degraded and which have failed — and it answers it
+ *   from `appHealth.sensors.effective`, the id lists the main process publishes for
+ *   exactly this purpose.
+ *
+ *   `appHealth.reasons` is NOT a source of sensor names and must never be parsed for
+ *   them. It is the aggregate-level explanation, a closed set of reason CODES
+ *   (`sensor-degraded`, `population-failed`, …) that says a sensor is degraded without
+ *   saying which one; the shared type says so at `AppHealthReason`. Deriving names by
+ *   matching substrings out of those codes would couple this surface to prose, and
+ *   prose changes silently — the wording would drift, the names would stop appearing,
+ *   and nothing would go red. `tests/renderer/components/SensorHealthChip.test.ts`
+ *   pins that: a payload whose reasons mention a sensor absent from the id lists must
+ *   not surface that name.
+ *
+ *   `effective` and not `raw`: the two differ by exactly the entries listed in
+ *   `sensors.projections` — today the accepted CIM birth-time fallback on
+ *   `proc-snapshot`, which is degradation of the SOURCE and not of the application.
+ *   `effective` is the set `appHealth.state` itself rests on, so naming its members is
+ *   naming the sensors that actually drove the state the user is being shown.
+ * @since 0.12.0
+ */
+
+import { derived } from 'svelte/store';
+import type { Readable } from 'svelte/store';
+import { stats } from './ipc.js';
+import type { SensorHealthAggregate } from '../../../shared/types';
+
+/**
+ * The two sensor-id lists of `appHealth.sensors.effective`, narrowed to strings.
+ *
+ * The element types are taken FROM the shared aggregate rather than restated as
+ * `string[]`, so a rename on either field of `SensorHealthAggregate` fails this file
+ * instead of silently leaving the UI reading a key that no longer exists.
+ */
+export interface UnhealthySensors {
+  /** `sensors.effective.degradedSensorIds`, in payload order. Empty when none. */
+  readonly degraded: SensorHealthAggregate['degradedSensorIds'];
+  /** `sensors.effective.failedSensorIds`, in payload order. Empty when none. */
+  readonly failed: SensorHealthAggregate['failedSensorIds'];
+}
+
+/**
+ * Read one property off a value that the renderer only knows as `unknown`.
+ *
+ * `stats` is a `Record<string, unknown>` off the wire, so every step down to the id
+ * lists is a value this process has not proven anything about. Walking it one guarded
+ * hop at a time keeps the reader total without a single `any` and without a cast that
+ * would assert a shape nobody checked.
+ * @param source Any value; a non-object yields `undefined`.
+ * @param key Property to read.
+ * @returns The property value, or `undefined`.
+ */
+function pick(source: unknown, key: string): unknown {
+  if (typeof source !== 'object' || source === null) return undefined;
+  return (source as Record<string, unknown>)[key];
+}
+
+/**
+ * Narrow a wire value to a list of sensor ids.
+ *
+ * Order is preserved exactly as delivered — the main process emits the records in a
+ * stable order so a reader diffing two ticks sees a real change, and re-sorting here
+ * would throw that away. Non-string and empty entries are dropped rather than rendered
+ * as a blank name.
+ * @param value The candidate list.
+ * @returns The sensor ids, or an empty array.
+ */
+function toSensorIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((id): id is string => typeof id === 'string' && id !== '');
+}
+
+/**
+ * Extract the degraded and failed sensor ids from a stats payload.
+ *
+ * Total by construction: a payload with no `appHealth`, the BOOTING payload whose
+ * `sensors.effective` is `null`, and a malformed list all yield two empty arrays. An
+ * empty result means "no sensor is named", which the UI renders as nothing at all —
+ * never as an empty section or a placeholder.
+ * @param payload The `stats` store value, or any prefix of it.
+ * @returns The two id lists.
+ * @since 0.12.0
+ */
+export function readUnhealthySensors(
+  payload: Record<string, unknown> | null | undefined,
+): UnhealthySensors {
+  const effective = pick(pick(pick(payload, 'appHealth'), 'sensors'), 'effective');
+  return {
+    degraded: toSensorIds(pick(effective, 'degradedSensorIds')),
+    failed: toSensorIds(pick(effective, 'failedSensorIds')),
+  };
+}
+
+/**
+ * Live degraded / failed sensor ids, refreshed with every stats payload.
+ *
+ * Derived from {@link stats}, which `get-stats`, `stats-update` and `scan-batch.stats`
+ * all write — the app-health block rides those surfaces and has no channel of its own.
+ * @since 0.12.0
+ */
+export const unhealthySensors: Readable<UnhealthySensors> = derived(stats, readUnhealthySensors);

--- a/tests/renderer/components/SensorHealthChip.test.ts
+++ b/tests/renderer/components/SensorHealthChip.test.ts
@@ -1,0 +1,275 @@
+/**
+ * SensorHealthChip.test.ts — the renderer names degraded and failed sensors, and it
+ * names them from the id lists.
+ *
+ * The chip is driven end to end here: a real `stats` payload goes into the store the
+ * IPC bridge writes, and the assertions are made against the DOM. Nothing is stubbed
+ * between the two, so these also pin the store's narrowing of an `unknown` payload.
+ *
+ * The load-bearing test in this file is the anti-parsing pin. `appHealth.reasons` is a
+ * closed set of aggregate reason codes and is NOT a source of sensor names; a surface
+ * that scraped identifiers out of it would look right today and go quietly blank the
+ * first time a reason's wording changed. So a payload whose reasons and whose raw
+ * `byId` records both mention a sensor that is absent from
+ * `sensors.effective.{degraded,failed}SensorIds` must not put that name on screen.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { stats } from '../../../src/renderer/lib/stores/ipc.js';
+import {
+  readUnhealthySensors,
+  unhealthySensors,
+} from '../../../src/renderer/lib/stores/app-health.js';
+import SensorHealthChip from '../../../src/renderer/lib/components/SensorHealthChip.svelte';
+
+/** A leaf record shaped like the ones `sensors.byId` carries. */
+function record(sensorId: string, state: string): Record<string, unknown> {
+  return {
+    sensorId,
+    state,
+    lastAttemptAt: 1_700_000_000_000,
+    lastSuccessAt: state === 'FAILED' ? null : 1_699_999_990_000,
+    lastError: state === 'FAILED' ? 'access is denied' : null,
+    consecutiveFailures: state === 'FAILED' ? 3 : 0,
+    lossCount: state === 'DEGRADED' ? 2 : 0,
+    detail: null,
+  };
+}
+
+/**
+ * A stats payload carrying an `appHealth` block, with the two effective id lists and
+ * the aggregate reasons under the caller's control.
+ */
+function statsPayload(options: {
+  degraded?: string[];
+  failed?: string[];
+  reasons?: string[];
+  byId?: Record<string, unknown>;
+}): Record<string, unknown> {
+  const degraded = options.degraded ?? [];
+  const failed = options.failed ?? [];
+  return {
+    currentAgents: 3,
+    permissionDeniedScans: 0,
+    monitoringPaused: false,
+    appHealth: {
+      state: failed.length > 0 || degraded.length > 0 ? 'DEGRADED' : 'HEALTHY',
+      reasons: options.reasons ?? [],
+      populationState: 'HEALTHY',
+      populationReliable: true,
+      populationAsOf: 1_700_000_000_000,
+      identityQuality: 'witnessed',
+      identityDegraded: false,
+      sensors: {
+        byId: options.byId ?? {},
+        raw: {
+          state: 'HEALTHY',
+          participatingCount: 5,
+          totalCount: 6,
+          failedSensorIds: [],
+          degradedSensorIds: [],
+        },
+        effective: {
+          state: failed.length > 0 ? 'FAILED' : degraded.length > 0 ? 'DEGRADED' : 'HEALTHY',
+          participatingCount: 5,
+          totalCount: 6,
+          failedSensorIds: failed,
+          degradedSensorIds: degraded,
+        },
+        projections: [],
+      },
+      watchPlan: { state: 'HEALTHY', liveWatcherCount: 4, unavailableGroups: [] },
+    },
+  };
+}
+
+beforeEach(() => {
+  stats.set({});
+});
+
+describe('SensorHealthChip — nothing to report', () => {
+  it('renders nothing when both id lists are empty', () => {
+    stats.set(statsPayload({ degraded: [], failed: [] }));
+    const { container } = render(SensorHealthChip);
+
+    expect(container.querySelector('.sensor-health')).toBeNull();
+    expect(container.textContent?.trim()).toBe('');
+  });
+
+  it('renders nothing when the payload carries no appHealth at all', () => {
+    stats.set({ currentAgents: 0, permissionDeniedScans: 0 });
+    const { container } = render(SensorHealthChip);
+
+    expect(container.querySelector('.sensor-health')).toBeNull();
+  });
+
+  it('renders nothing on the BOOTING payload, whose effective aggregate is null', () => {
+    stats.set({
+      appHealth: {
+        state: 'BOOTING',
+        reasons: [],
+        populationState: null,
+        populationReliable: false,
+        sensors: { byId: {}, raw: null, effective: null, projections: [] },
+        watchPlan: null,
+      },
+    });
+    const { container } = render(SensorHealthChip);
+
+    expect(container.querySelector('.sensor-health')).toBeNull();
+  });
+
+  it('renders no placeholder text — an empty list is absence, not an empty section', () => {
+    stats.set(statsPayload({}));
+    const { container } = render(SensorHealthChip);
+
+    expect(container.textContent).not.toContain('DEGRADED');
+    expect(container.textContent).not.toContain('FAILED');
+    expect(container.textContent).not.toContain('None');
+  });
+});
+
+describe('SensorHealthChip — naming the sensors', () => {
+  it('names every degraded sensor from degradedSensorIds', () => {
+    stats.set(statsPayload({ degraded: ['fs-handle', 'network'] }));
+    const { container } = render(SensorHealthChip);
+
+    const value = container.querySelector('.sensor-health__value--degraded');
+    expect(value).toBeInTheDocument();
+    expect(value).toHaveTextContent('fs-handle, network');
+  });
+
+  it('names every failed sensor from failedSensorIds', () => {
+    stats.set(statsPayload({ failed: ['process', 'fs-rm'] }));
+    const { container } = render(SensorHealthChip);
+
+    const value = container.querySelector('.sensor-health__value--failed');
+    expect(value).toBeInTheDocument();
+    expect(value).toHaveTextContent('process, fs-rm');
+  });
+
+  it('keeps degraded and failed visually distinct, each under its own label', () => {
+    stats.set(statsPayload({ degraded: ['fs-chokidar'], failed: ['process'] }));
+    const { container } = render(SensorHealthChip);
+
+    const chips = container.querySelectorAll('.sensor-health');
+    expect(chips).toHaveLength(2);
+
+    const failed = container.querySelector('.sensor-health__value--failed');
+    const degraded = container.querySelector('.sensor-health__value--degraded');
+    expect(failed).toHaveTextContent('process');
+    expect(degraded).toHaveTextContent('fs-chokidar');
+    // Different elements, different modifier classes — the two severities never share
+    // a node, so they can never render as one undifferentiated list.
+    expect(failed).not.toBe(degraded);
+    expect(failed).not.toHaveClass('sensor-health__value--degraded');
+    expect(degraded).not.toHaveClass('sensor-health__value--failed');
+
+    const labels = Array.from(container.querySelectorAll('.sensor-health__label')).map(
+      (el) => el.textContent,
+    );
+    expect(labels).toEqual(['FAILED', 'DEGRADED']);
+  });
+
+  it('preserves payload order rather than re-sorting the ids', () => {
+    stats.set(statsPayload({ degraded: ['network', 'fs-chokidar', 'fs-handle'] }));
+    const { container } = render(SensorHealthChip);
+
+    expect(container.querySelector('.sensor-health__value--degraded')).toHaveTextContent(
+      'network, fs-chokidar, fs-handle',
+    );
+  });
+});
+
+describe('SensorHealthChip — the names come from the id lists, nowhere else', () => {
+  it('does not surface a sensor that only the reasons mention (anti-parsing pin)', () => {
+    // `reasons` is the aggregate explanation. Here it is written the way a future
+    // wording change might write it — with a sensor id inside the string — while the
+    // id lists name a different sensor. Only the lists may reach the DOM.
+    stats.set(
+      statsPayload({
+        degraded: ['network'],
+        failed: [],
+        reasons: ['sensor-degraded: fs-handle', 'identity-degraded', 'population-degraded'],
+      }),
+    );
+    const { container } = render(SensorHealthChip);
+
+    expect(container.querySelector('.sensor-health__value--degraded')).toHaveTextContent('network');
+    expect(container.textContent).not.toContain('fs-handle');
+    expect(container.textContent).not.toContain('identity-degraded');
+    expect(container.textContent).not.toContain('population');
+  });
+
+  it('renders nothing when the reasons report a degradation the id lists do not', () => {
+    stats.set(
+      statsPayload({
+        degraded: [],
+        failed: [],
+        reasons: ['sensor-degraded', 'sensor-failed', 'watch-roots-unavailable'],
+      }),
+    );
+    const { container } = render(SensorHealthChip);
+
+    expect(container.querySelector('.sensor-health')).toBeNull();
+    expect(container.textContent?.trim()).toBe('');
+  });
+
+  it('does not surface a raw byId record that the effective aggregate leaves out', () => {
+    // `proc-snapshot` is DEGRADED in the raw records and absent from `effective` —
+    // exactly the accepted birth-time fallback the projection rewrites. `effective` is
+    // the set the app-health state rests on, so it is the set the UI names.
+    stats.set(
+      statsPayload({
+        degraded: ['network'],
+        byId: {
+          'proc-snapshot': record('proc-snapshot', 'DEGRADED'),
+          network: record('network', 'DEGRADED'),
+          process: record('process', 'HEALTHY'),
+        },
+      }),
+    );
+    const { container } = render(SensorHealthChip);
+
+    expect(container.textContent).toContain('network');
+    expect(container.textContent).not.toContain('proc-snapshot');
+  });
+});
+
+describe('readUnhealthySensors — the store narrowing behind the chip', () => {
+  it('reads both lists off sensors.effective', () => {
+    expect(
+      readUnhealthySensors(statsPayload({ degraded: ['network'], failed: ['process'] })),
+    ).toEqual({ degraded: ['network'], failed: ['process'] });
+  });
+
+  it('is total: null, undefined and a malformed payload all yield empty lists', () => {
+    const empty = { degraded: [], failed: [] };
+    expect(readUnhealthySensors(null)).toEqual(empty);
+    expect(readUnhealthySensors(undefined)).toEqual(empty);
+    expect(readUnhealthySensors({})).toEqual(empty);
+    expect(readUnhealthySensors({ appHealth: 'broken' })).toEqual(empty);
+    expect(readUnhealthySensors({ appHealth: { sensors: { effective: 7 } } })).toEqual(empty);
+  });
+
+  it('drops non-string and empty entries instead of rendering a blank name', () => {
+    expect(
+      readUnhealthySensors({
+        appHealth: {
+          sensors: {
+            effective: { degradedSensorIds: ['network', '', 42, null], failedSensorIds: 'process' },
+          },
+        },
+      }),
+    ).toEqual({ degraded: ['network'], failed: [] });
+  });
+
+  it('tracks the stats store', () => {
+    stats.set(statsPayload({ failed: ['fs-rm'] }));
+    expect(get(unhealthySensors)).toEqual({ degraded: [], failed: ['fs-rm'] });
+
+    stats.set(statsPayload({}));
+    expect(get(unhealthySensors)).toEqual({ degraded: [], failed: [] });
+  });
+});


### PR DESCRIPTION
## What

`stats.appHealth` has been reaching the renderer since #253 and nothing read it — the health state was carried the whole way and then dropped, so a dead file-handle scanner and a quiet machine looked identical on screen. This is roadmap B7, minimum scope: **which** sensors, by id, and nothing else.

- `src/renderer/lib/stores/app-health.ts` (new) — the renderer's only reader of `stats.appHealth`. Narrows an `unknown` wire payload down to the two id lists, total by construction (no `appHealth`, the BOOTING payload whose `effective` is `null`, a malformed list → two empty arrays). Zero `any`.
- `src/renderer/lib/components/SensorHealthChip.svelte` (new) — two footer chips, failed first, each with its own label and its own themed colour role (`--md-sys-color-error` / `--md-sys-color-secondary`).
- `Footer.svelte` — mounts the chip; `appVersion` fallback fixed (below).
- `en.json` — `footer.sensors_degraded` / `footer.sensors_failed`.

## The names come from the id lists

`appHealth.sensors.effective.degradedSensorIds` / `failedSensorIds`, never `appHealth.reasons`. Reasons are a closed set of aggregate reason CODES: they say a sensor is degraded without saying which one, and the shared type says so at `AppHealthReason`. Scraping identifiers out of that prose would look right today and go quietly blank the first time a wording changed — nothing would go red.

The anti-parsing pin is the load-bearing test: a payload whose `reasons` carry `'sensor-degraded: fs-handle'` and whose raw `byId` carries a DEGRADED `proc-snapshot`, while `effective.degradedSensorIds` is `['network']`, must render `network` and neither of the other two.

**Verified non-vacuous** (ai-mistakes #21): a mutant that appends reason-parsed names to the degraded list turns that pin — and only that pin — red (1 of 15). A mutant that drops the `{#if}` guard turns the five empty-render tests red.

`effective` and not `raw`: the two differ by exactly the entries in `sensors.projections`, and `effective` is the set `appHealth.state` itself rests on.

## Empty renders nothing

Both lists empty → no wrapper, no empty section, no placeholder text. A chip that is always present has to say "all clear" on every tick, and that is the one claim a health surface must not make on its own.

## Footer version fallback

`Footer.svelte:15` held the literal `'v0.8.0-alpha'` — three minor bumps stale, and shown to any window whose bridge had not answered. Now `$state('')`, with the brand name rendering alone until `getAppVersion()` resolves. No version literal that can rot; `git ls-files -z src/renderer | xargs -0 grep -n '0\.8\.0'` returns only `format-bytes.ts`'s `@since` provenance tag, which is a true historical fact and not a fallback.

## Escaping

Every id reaches the DOM through Svelte text interpolation and attribute binding, which escape by construction. No `{@html}` anywhere in the new component.

## Verification (all 9 local commands)

| command | result |
|---|---|
| `build:renderer` | ✓ built in 1.25s |
| `format:check` | ✓ all matched files |
| `lint` | ✓ 0 errors (29 pre-existing warnings) |
| `typecheck` | ✓ both projects |
| `typecheck:svelte` | ✓ 411 files, 0 errors, 0 warnings |
| `test:coverage` | ✓ 113 files, 2015 passed, 4 skipped |
| `verify:gate` | ✓ 4/4 mutants killed |
| `counts:check` | ✓ 19 counters, 141 declaration sites agree |
| `npm audit --audit-level=high --omit=dev` | ✓ 0 vulnerabilities |

Counts moved 47→48 components and 13→14 stores; all three declaration sites updated (`.claude/` and `.agents/` aegis-context SKILL.md, `memory-bank/architecture.md`).
