### PR TITLE
fix(rules): let a digit bound the secrets keywords, and name the password stores

### DIFF
--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -182,5 +182,38 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     it survives every reader who does not open the definition. Grep the definition, not the name
     (cf. #27 — write the guarantee, not the impression).
 
+30. **Narrows a pattern without an adversarial list of what the OLD one matched and the new
+    one does not — and then pins the narrowing with a must-match list that protects only what
+    someone happened to write down.** PR #249 rewrote SC003/SC005/SC006 to bound each keyword
+    with `[._-]` separator classes and to scope loose compounds to an extension allowlist. It
+    shipped with a table of what must stop firing and what must keep firing, an "accepted
+    residuals" section, and per-rule tests — and every one of those lists was built from the
+    false positives that had prompted the work, never from the far larger set of names the old
+    pattern used to match. `[\\/][^\\/]*password[^\\/]*$` matched any basename containing the
+    word at any extension; the replacement matched a bounded word at 17 listed extensions.
+    Everything in that difference left the ruleset silently, and nothing anywhere went red.
+    A reviewer found it later: `passwords.kdbx`, `password.db`, `passwords.xlsx`,
+    `1password_backup.csv` and `1password-export.1pux` — five ordinary password stores, all
+    critical-risk hits before #249, all unclassified after it.
+    **Two independent causes, and the report named only one.** (a) SEPARATOR BOUNDARY —
+    `(?:[^\\/]*[._-])?` can only end on `.`, `_` or `-`, so a digit adjacent to the keyword has
+    nothing to match and the whole prefix group is forced empty: reproduced in node against
+    master, `password_backup.csv` matched and `1password_backup.csv` did not. (b) EXTENSION
+    ALLOWLIST — the list held no password-manager format, so `.kdbx`, `.db`, `.xlsx` and
+    `.1pux` dropped out with their separators perfectly intact. Three of the five reported
+    misses never involved a digit at all, so the one-line diagnosis in the report covered two
+    of five and a fix that only widened the separator class would have left the other three
+    broken while reading as done.
+    **Three things follow.** (a) Before narrowing, build the adversarial list FIRST — sample
+    what the old pattern matched and the new one does not, and decide each entry in or out on
+    purpose. A residual you enumerated is a decision; a residual you never enumerated is a
+    regression waiting for someone else to report it. (b) A must-match list is not a sample,
+    it is the entire protected set: write every case into the test, spell out both path
+    separators, and read "not on the list" as "not protected" (cf. #21 — a passing gate proves
+    the command ran, not that it inspected your change). (c) Reproduce the report before
+    trusting its diagnosis. Running the five names through the real loader is what separated
+    the two causes; the summary sentence would have sent the fix at one of them (cf. #27 —
+    write the guarantee, not the impression).
+
 ## Rule
 NEVER change what was not asked. Do ONLY what the prompt says.

--- a/rules/secrets.yaml
+++ b/rules/secrets.yaml
@@ -21,7 +21,7 @@ rules:
 
   - id: "SC003"
     name: "Password file"
-    pattern: '[\\\/](?:[^\\\/]*[._-])?passwords?(?:[._-][^\\\/]*)?\.(?:txt|csv|json|ya?ml|xml|ini|conf|cfg|toml|properties|key|pem|bak|old|gpg|enc)$|[\\\/](?:[^\\\/]*[._-])?passwords?$'
+    pattern: '[\\\/](?:[^\\\/]*[._\d-])?passwords?(?:[._-][^\\\/]*)?\.(?:txt|csv|json|ya?ml|xml|ini|conf|cfg|toml|properties|key|pem|bak|old|gpg|enc|kdbx|db|xlsx|1pux)$|[\\\/](?:[^\\\/]*[._\d-])?passwords?$'
     reason: "Password file"
     category: "secrets"
     risk: critical
@@ -37,7 +37,7 @@ rules:
 
   - id: "SC005"
     name: "Secret file"
-    pattern: '[\\\/]\.?secrets?[\\\/]|[\\\/](?:[^\\\/]*[._-])?secrets?(?:[._-][^\\\/]*)?\.(?:json|ya?ml|env|txt|xml|ini|conf|cfg|toml|properties|key|pem)$|[\\\/](?:[^\\\/]*[._-])?secrets?$'
+    pattern: '[\\\/]\.?secrets?[\\\/]|[\\\/](?:[^\\\/]*[._\d-])?secrets?(?:[._-][^\\\/]*)?\.(?:json|ya?ml|env|txt|xml|ini|conf|cfg|toml|properties|key|pem)$|[\\\/](?:[^\\\/]*[._\d-])?secrets?$'
     reason: "Secret file"
     category: "secrets"
     risk: critical
@@ -45,7 +45,7 @@ rules:
 
   - id: "SC006"
     name: "API token"
-    pattern: '[\\\/](?:[^\\\/]*[._-])?tokens?(?:[._-][^\\\/]*)?\.(?:txt|json|ya?ml|env|ini|conf|cfg)$|[\\\/](?:[^\\\/]*[._-])?tokens?$'
+    pattern: '[\\\/](?:[^\\\/]*[._\d-])?tokens?(?:[._-][^\\\/]*)?\.(?:txt|json|ya?ml|env|ini|conf|cfg)$|[\\\/](?:[^\\\/]*[._\d-])?tokens?$'
     reason: "API token"
     category: "secrets"
     risk: critical

--- a/tests/main/rule-loader.test.js
+++ b/tests/main/rule-loader.test.js
@@ -328,4 +328,174 @@ describe('rule-loader', () => {
       expect(re.test('/home/user/github-token')).toBe(true);
     });
   });
+
+  describe('secrets rules — the narrowing pin, both directions (SC003 / SC005 / SC006)', () => {
+    const PROD_RULES_DIR = path.resolve(__dirname, '../../rules');
+
+    // PR #249 bound each keyword with [._-] separator classes and scoped the loose
+    // compounds to an extension allowlist. Two limits of that narrowing were never
+    // written down, so nothing went red when real password stores stopped matching:
+    //
+    //   1. SEPARATOR BOUNDARY — a digit next to the keyword is not a word
+    //      continuation, but `(?:[^\\/]*[._-])?` could only end on . _ or -, so the
+    //      leading "1" of `1password_backup.csv` had nothing to match and the whole
+    //      prefix group had to go empty. `password_backup.csv` matched; the same
+    //      name behind a digit did not.
+    //   2. EXTENSION ALLOWLIST — the list held no password-manager format, so
+    //      `passwords.kdbx`, `password.db` and `passwords.xlsx` dropped out with
+    //      their separators perfectly intact. Three of the five reported misses
+    //      never involved a digit at all.
+    //
+    // The two lists below ARE the contract. A pin protects only what it records, so
+    // they are written out in full — every pre-existing fixture from the block above,
+    // every path the audit reported, and both separators for each, because the rules
+    // are anchored on `[\\/]` and a Windows path is the ordinary case. Anything not
+    // on a list is not protected: add to the list, never assume by resemblance.
+
+    /**
+     * Every path a secrets rule MUST classify, with the rule that has to fire.
+     * @type {Array<{ id: string, path: string, note: string }>}
+     */
+    const MUST_MATCH = [
+      // The audit's five, posix and Windows — the regression this pin exists for.
+      { id: 'SC003', path: '/home/user/passwords.kdbx', note: 'KeePass store' },
+      { id: 'SC003', path: 'C:\\Users\\me\\passwords.kdbx', note: 'KeePass store' },
+      { id: 'SC003', path: '/home/user/password.db', note: 'password database' },
+      { id: 'SC003', path: 'C:\\Users\\me\\password.db', note: 'password database' },
+      { id: 'SC003', path: '/home/user/passwords.xlsx', note: 'spreadsheet of passwords' },
+      { id: 'SC003', path: 'C:\\Users\\me\\passwords.xlsx', note: 'spreadsheet of passwords' },
+      { id: 'SC003', path: '/home/user/1password_backup.csv', note: 'digit before the keyword' },
+      {
+        id: 'SC003',
+        path: 'C:\\Users\\me\\1password_backup.csv',
+        note: 'digit before the keyword',
+      },
+      {
+        id: 'SC003',
+        path: '/home/user/1password-export.1pux',
+        note: 'digit before the keyword AND a 1Password export extension',
+      },
+      {
+        id: 'SC003',
+        path: 'C:\\Users\\me\\1password-export.1pux',
+        note: 'digit before the keyword AND a 1Password export extension',
+      },
+      // The same boundary on the two rules widened alongside SC003.
+      { id: 'SC005', path: '/home/user/1secret.json', note: 'digit before the keyword' },
+      { id: 'SC006', path: '/home/user/oauth2token.json', note: 'digit before the keyword' },
+      // Everything #249 already had to keep firing.
+      { id: 'SC003', path: '/home/user/passwords.txt', note: 'pre-existing positive' },
+      {
+        id: 'SC003',
+        path: 'C:\\Users\\me\\Documents\\wifi-password.txt',
+        note: 'pre-existing positive',
+      },
+      { id: 'SC003', path: '/home/user/.password', note: 'pre-existing positive' },
+      { id: 'SC003', path: 'C:\\Users\\me\\db_password', note: 'pre-existing positive' },
+      { id: 'SC003', path: '/home/user/password.key', note: 'pre-existing positive' },
+      {
+        id: 'SC003',
+        path: 'C:\\Users\\me\\app\\password.properties',
+        note: 'pre-existing positive',
+      },
+      { id: 'SC005', path: '/run/secrets/db_password', note: 'pre-existing positive' },
+      { id: 'SC005', path: 'C:\\Users\\me\\.secrets\\api', note: 'pre-existing positive' },
+      { id: 'SC005', path: '/app/config/secrets.yaml', note: 'pre-existing positive' },
+      { id: 'SC005', path: '/home/user/.env.secret', note: 'pre-existing positive' },
+      {
+        id: 'SC005',
+        path: 'C:\\Users\\me\\AppData\\client_secret.json',
+        note: 'pre-existing positive',
+      },
+      { id: 'SC006', path: '/home/user/.npm_token', note: 'pre-existing positive' },
+      { id: 'SC006', path: '/home/user/api-token.txt', note: 'pre-existing positive' },
+      {
+        id: 'SC006',
+        path: 'C:\\Users\\me\\.config\\gh\\access_token.json',
+        note: 'pre-existing positive',
+      },
+      { id: 'SC006', path: '/home/user/github-token', note: 'pre-existing positive' },
+    ];
+
+    /**
+     * Every path that NO secrets rule may classify. `owner` is the rule whose word
+     * appears in the path — the whole ruleset is swept as well, so a widening that
+     * merely moves a false positive to a neighbouring rule still goes red.
+     * @type {Array<{ owner: string, path: string, note: string }>}
+     */
+    const MUST_NOT_MATCH = [
+      {
+        owner: 'SC006',
+        path: 'X:\\proj\\src\\renderer\\lib\\styles\\tokens.css',
+        note: "this repo's own design tokens — the file #249 was written for",
+      },
+      { owner: 'SC003', path: '/app/src/components/PasswordInput.svelte', note: 'UI component' },
+      { owner: 'SC003', path: 'C:\\proj\\src\\pages\\forgot-password.html', note: 'page' },
+      { owner: 'SC003', path: '/app/src/auth/password-reset.js', note: 'source file' },
+      { owner: 'SC003', path: '/docs/reset-password.md', note: 'documentation' },
+      { owner: 'SC005', path: '/app/src/pages/SecretSanta.tsx', note: 'English word, not a store' },
+      { owner: 'SC005', path: '/home/user/docs/secretary-notes.md', note: 'word prefix only' },
+      { owner: 'SC005', path: 'C:\\proj\\src\\SecretsManagerClient.ts', note: 'SDK client' },
+      { owner: 'SC006', path: '/app/src/nlp/tokenizer.py', note: 'word prefix only' },
+      {
+        owner: 'SC006',
+        path: '/app/src/main/token-adapters/usage.js',
+        note: 'word in a directory',
+      },
+      // C-05 basename anchoring, pinned in tests/main/file-watcher.test.js through
+      // classifySensitive(); recorded here too so the rules keep their half of it.
+      { owner: 'SC003', path: '/home/user/projects/password-manager/README.md', note: 'C-05 dir' },
+      { owner: 'SC004', path: '/home/user/code/credential-helper/index.js', note: 'C-05 dir' },
+      { owner: 'SC007', path: '/home/user/src/api_key_validator/test.js', note: 'C-05 dir' },
+    ];
+
+    /** Every rule ID in rules/secrets.yaml, for the whole-ruleset sweep. */
+    const SECRETS_IDS = ['SC001', 'SC002', 'SC003', 'SC004', 'SC005', 'SC006', 'SC007', 'SC008'];
+
+    it('every must-match path is classified by the rule that owns it', () => {
+      const rules = ruleLoader.reloadRules(PROD_RULES_DIR);
+      for (const { id, path: candidate, note } of MUST_MATCH) {
+        const rule = rules.get(id);
+        expect(rule, `${id} missing from the production ruleset`).toBeDefined();
+        expect(rule.pattern.test(candidate), `${id} must match ${candidate} (${note})`).toBe(true);
+      }
+    });
+
+    it('every must-not-match path is clear on the rule whose word it carries', () => {
+      const rules = ruleLoader.reloadRules(PROD_RULES_DIR);
+      for (const { owner, path: candidate, note } of MUST_NOT_MATCH) {
+        const rule = rules.get(owner);
+        expect(rule, `${owner} missing from the production ruleset`).toBeDefined();
+        expect(rule.pattern.test(candidate), `${owner} must NOT match ${candidate} (${note})`).toBe(
+          false,
+        );
+      }
+    });
+
+    it('no rule in the secrets ruleset fires on any must-not-match path', () => {
+      const rules = ruleLoader.reloadRules(PROD_RULES_DIR);
+      for (const { path: candidate, note } of MUST_NOT_MATCH) {
+        const fired = SECRETS_IDS.filter((id) => rules.get(id).pattern.test(candidate));
+        expect(fired, `${candidate} (${note}) fired: ${fired.join(', ')}`).toEqual([]);
+      }
+    });
+
+    it('the rewritten patterns stay polynomial on adversarial segments', () => {
+      const rules = ruleLoader.reloadRules(PROD_RULES_DIR);
+      // Only the prefix `[^\\/]*[._\d-]` and the suffix `[._-][^\\/]*` are quantified,
+      // and a required literal separates them — so a long run of separator/digit
+      // characters with no valid extension backtracks linearly, not exponentially.
+      // The budget is ~4 orders of magnitude above the measured cost (<0.1 ms each):
+      // it is here to catch a catastrophic rewrite, not to benchmark the machine.
+      const words = { SC003: 'password', SC005: 'secret', SC006: 'token' };
+      const started = Date.now();
+      for (const [id, word] of Object.entries(words)) {
+        const { pattern: re } = rules.get(id);
+        re.test('/home/user/' + '1._-'.repeat(8000) + '!');
+        re.test('/home/user/' + '1._-'.repeat(4000) + word + '.a'.repeat(4000));
+        re.test('/home/user/' + 'a._-'.repeat(4000) + word + '-' + '.z'.repeat(4000));
+      }
+      expect(Date.now() - started).toBeLessThan(2000);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

A reviewer audit found that five ordinary password stores stopped being classified after the narrowing in PR #249. Reproduced in node against `master` through the real loader, all five miss on both path separators:

```
MISS    passwords.kdbx           posix=[-] win=[-]
MISS    password.db              posix=[-] win=[-]
MISS    passwords.xlsx           posix=[-] win=[-]
MISS    1password_backup.csv     posix=[-] win=[-]
MISS    1password-export.1pux    posix=[-] win=[-]
```

**The report's one-line diagnosis covers two of the five.** There are two independent causes, and a fix aimed only at the reported one would have left three of the five broken while reading as done:

| cause | which of the five | evidence |
|---|---|---|
| **Separator boundary** — `(?:[^\\/]*[._-])?` can only end on `.`, `_` or `-`, so a digit adjacent to the keyword has nothing to match and the prefix group is forced empty | `1password_backup.csv`, and `1password-export.1pux` (both causes) | `password_backup.csv` matches, `1password_backup.csv` does not — same name, one digit apart |
| **Extension allowlist** — it held no password-manager format, so the name dropped out with its separators perfectly intact | `passwords.kdbx`, `password.db`, `passwords.xlsx`, and `1password-export.1pux` | `passwords.txt` matches, `passwords.kdbx` does not — no digit anywhere |

## The fix

`rules/secrets.yaml`, patterns only — ids, names, reasons, risk levels and `rules.total` are untouched.

1. `[._-]` → `[._\d-]` in the prefix group of **SC003, SC005 and SC006** — the three rules that carry the construct #249 introduced. A digit is a boundary, not a word continuation.
2. SC003's extension allowlist gains exactly four entries: `kdbx`, `db`, `xlsx`, `1pux`. No others — an extension nobody pinned is an extension nobody protects.

A digit boundary is not a return to the pre-#249 noise: the old `[\\/][^\\/]*password[^\\/]*$` matched any basename containing the word at any extension, while the keyword here stays bound on both sides and the compounds stay scoped to the allowlist.

### After — the same probe, same lists

```
MATCH   passwords.kdbx           posix=[SC003] win=[SC003]
MATCH   password.db              posix=[SC003] win=[SC003]
MATCH   passwords.xlsx           posix=[SC003] win=[SC003]
MATCH   1password_backup.csv     posix=[SC003] win=[SC003]
MATCH   1password-export.1pux    posix=[SC003] win=[SC003]
```

Every pre-existing negative is still clear, per-rule **and** against the whole secrets ruleset — including this repo's own `tokens.css`, `SecretSanta.tsx`, `secretary-notes.md`, `tokenizer.py`, `PasswordInput.svelte`, and the three C-05 directory-name fixtures from `file-watcher.test.js`. Every pre-existing positive still fires. `TOTAL FAILURES: 0` after, `7` before.

## Tests

`tests/main/rule-loader.test.js` gains a two-direction pin. The lists are written out in full, not sampled, because a pin protects only what it records:

- **MUST_MATCH** — the five reported names on both path separators (10 entries), one digit-adjacent case for each rule widened alongside SC003 (`1secret.json`, `oauth2token.json`), and all 15 pre-existing positives.
- **MUST_NOT_MATCH** — `tokens.css` and all 9 other pre-existing negatives, plus the three C-05 directory-name fixtures. Checked twice: on the rule whose word the path carries, and across all 8 secrets rules, so a widening cannot merely move a false positive to a neighbour.
- A fourth case bounds the rewritten patterns on adversarial segments (separator runs, keyword-plus-dots, both loaded at once).

Revert-check: with `rules/secrets.yaml` reverted and the tests kept, the pin goes red on the first blocker entry — `AssertionError: SC003 must match /home/user/passwords.kdbx (KeePass store)`.

## Invariants

- `rules.total` = **73**, `npm run counts:check` green (19 counters derived, 96 declaration sites agree).
- Every `/` in every ruleset still sits inside a character class — verified by a walker over all 8 files, and byte-for-byte by the existing `RegExp.source` vs raw-YAML parity test.
- No nested quantifiers. Measured on adversarial segments up to 32k characters: **under 0.1 ms**, doubling with length, for all three rewritten rules.

All 9 local gate commands green: `build:renderer`, `format:check`, `lint`, `typecheck`, `typecheck:svelte`, `test:coverage` (113 files, 2019 passed / 4 skipped), `verify:gate` (4/4 mutants killed), `counts:check`, `npm audit`.

## Accepted residual, stated rather than hidden

Only a **leading** digit is treated as a boundary. A trailing one (`password2.txt`, `token3.json`) behaves exactly as it did after #249 — it was not in the report, it is not on the pin, and widening it is a separate decision with its own adversarial list.

## Lesson recorded

`memory-bank/ai-mistakes.md` #30 — narrowing a pattern requires an adversarial list of what the old pattern matched and the new one does not; a must-match pin protects only what is written down.
