### PR TITLE
fix(tooling): scope lint-staged to the file set format:check gates

### DIFF
--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -251,5 +251,44 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     instances. They collide too only under the CIM emergency fallback, where
     `_witnessOf` derives the witness from that same stored millisecond.
 
+## Tooling
+32. **Two overlapping tool scopes that disagree silently corrupt whichever files only one of
+    them sees; align the scopes, and after any merge commit diff the file list against what
+    was intended.** The pre-commit hook (`.husky/pre-commit` runs `npx lint-staged`) and the
+    `lint` job's `format:check` step drive the same prettier with the same `.prettierrc`, so
+    they read as one mechanism. They were not one: `format:check` globs `src/**`, `bench/**`
+    and root-level `*.{js,ts,json}` and CHECKS, while lint-staged's `*.{js,ts,json}` was
+    matched with micromatch's `matchBase` — lint-staged turns it on for every pattern that
+    contains no slash (node_modules/lint-staged/README.md lines 334-340) — so the hook WROTE
+    every staged `.js`/`.ts`/`.json` at any depth. Measured against master `24912ed`: the hook
+    could rewrite 315 files where `format:check` gated 187. Of the 128 it saw alone, 117 were
+    under `tests/`, six were `scripts/*.js`, plus `rules/_schema.json`, `.codex/hooks.json`,
+    `.codex/hooks/branch-guard.js`, and two `.json` files under `src/` —
+    `src/shared/agent-database.json` and `src/renderer/lib/i18n/translations/en.json` — which
+    the `src/**/*.{js,ts,svelte,css,html}` extension list does not cover.
+    **The write side being wider than the check side IS the failure mode.** A gate narrower
+    than the writer cannot object to the writer's output: the reformat is valid Prettier, so
+    nothing goes red, and the only file at risk is the one no gate ever reads. It landed
+    twice. First on `tests/fixtures/bench` — byte-exact replay recordings that the hook
+    reflowed out of matching their rebuild, so `tests/main/bench/replay.test.js` compared a
+    rebuild against a file the formatter had edited. That was repaired with a
+    `.prettierignore` line, which fixes one directory and leaves the scope mismatch standing.
+    Second during the PR #207 merge commit, on two master-side files under
+    `tests/shared/bench-trace/` — files that merge was not changing at all, staged only
+    because a merge stages what it resolves. The workaround was restoring the bytes and
+    committing with `--no-verify`.
+    **Three things follow.** (a) When two tools share a job, make their scopes the SAME SET,
+    not merely similar ones: the fix was `./*.{js,ts,json}` (the documented root-only,
+    matchBase-free form, README line 339) plus the `bench/**/*.{js,json}` the hook had never
+    had — proven by running `git ls-files` through micromatch with lint-staged's own options
+    and diffing that against the set prettier resolves from the `format:check` globs. 187
+    files each, empty diff in both directions. (b) A per-file ignore entry is a symptom fix.
+    It buys the current directory and hides the next occurrence, which arrives somewhere else
+    (cf. #24 — derive the fact, do not restate it in one more place). (c) A merge commit
+    stages files you did not write. After every merge, diff the changed-file list against
+    what the merge was supposed to touch: this corruption lands on files absent from your own
+    diff, exactly where nobody is looking (cf. #22 — a side edit nobody asked for destroys a
+    file).
+
 ## Rule
 NEVER change what was not asked. Do ONLY what the prompt says.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "lint-staged": {
     "src/**/*.{js,ts,svelte,css,html}": "prettier --write",
-    "*.{js,ts,json}": "prettier --write"
+    "bench/**/*.{js,json}": "prettier --write",
+    "./*.{js,ts,json}": "prettier --write"
   },
   "build": {
     "appId": "com.aegis.oversight",


### PR DESCRIPTION
## What was wrong

lint-staged enables micromatch's `matchBase` for any pattern that contains no slash
(`node_modules/lint-staged/README.md` lines 334-340). The hook's root pattern was
`*.{js,ts,json}`, so it matched **every** staged `.js`/`.ts`/`.json` at any depth, while
`npm run format:check` only globs `src/**`, `bench/**` and root-level files.

The pre-commit hook therefore **wrote** files no gate ever **read**. Measured against master
`24912ed`:

| | files |
|---|---|
| hook could rewrite | 315 |
| `format:check` gates | 187 |
| **written but never gated** | **128** |

Those 128: 117 under `tests/`, six `scripts/*.js`, `rules/_schema.json`, `.codex/hooks.json`,
`.codex/hooks/branch-guard.js`, and two `.json` files under `src/` that the `src/**` extension
list does not cover — `src/shared/agent-database.json` and
`src/renderer/lib/i18n/translations/en.json`.

A reformat there is valid Prettier output, so nothing goes red. It has bitten twice: the
byte-exact replay recordings under `tests/fixtures/bench` (papered over with a
`.prettierignore` line), and two master-side files under `tests/shared/bench-trace/` during the
PR #207 merge commit, which needed a byte restore and a `--no-verify` commit.

## The change

```diff
 "lint-staged": {
   "src/**/*.{js,ts,svelte,css,html}": "prettier --write",
-  "*.{js,ts,json}": "prettier --write"
+  "bench/**/*.{js,json}": "prettier --write",
+  "./*.{js,ts,json}": "prettier --write"
 }
```

`./*.{js,ts,json}` is the form lint-staged documents as repo-root-only (README line 339).
All three patterns now contain a slash, so matchBase is off for every one of them.
`bench/**/*.{js,json}` is a deliberate widening: `format:check` already gates `bench/`, and set
equality requires the hook to cover it too.

`format:check`'s globs are untouched — widening them onto `tests/` was rejected (CRLF minefield),
so the hook was narrowed to meet them.

## Proof of set equality

`git ls-files` through micromatch with lint-staged's own options (`dot: true`, matchBase only
for slashless patterns), diffed against the set prettier resolves from the `format:check` globs.
`.prettierignore` applies to both sides — prettier honours it for explicitly-passed paths
(`prettier --file-info package-lock.json` → `{"ignored": true}`).

```
lint-staged patterns  : ["src/**/*.{js,ts,svelte,css,html}","bench/**/*.{js,json}","./*.{js,ts,json}"]
hook glob hits        : 188
  of which .prettierignore-skipped: [ 'package-lock.json' ]
hook would REWRITE    : 187 files
format:check GATES    : 187 files
REWRITTEN, NOT GATED  : (none)
GATED, NOT REWRITTEN  : (none)
SCOPES IDENTICAL
```

## Dry run

One `npx lint-staged` run, both files staged, same whitespace perturbation (leading blank lines
+ trailing spaces), differential outcome:

```
[STARTED] package.json — 2 files
[STARTED] src/**/*.{js,ts,svelte,css,html} — 1 file
[SKIPPED] bench/**/*.{js,json} — no files
[SKIPPED] ./*.{js,ts,json} — no files
```

| file | original | perturbed | after hook | |
|---|---|---|---|---|
| `tests/shared/bench-trace/clock.test.js` | `1e917b8` | `c108332` | `c108332` | **untouched** |
| `src/main/logger.js` | `5e807e1` | `873f5a8` | `5e807e1` | **formatted** |

Control on the same branch with the old patterns: `*.{js,ts,json}` reported **2 files** and
prettier rewrote `clock.test.js` back to `1e917b8` — the bug, reproduced.

## Gates

All 9 green: `build:renderer` ✓ · `format:check` ✓ · `lint` 0 errors / 29 pre-existing warnings ·
`typecheck` ✓ · `typecheck:svelte` 411 files 0 errors · `test:coverage` 2027 pass / 4 skip
(114 files) · `verify:gate` 4/4 mutants killed · `counts:check` OK · `npm audit` 0 vulnerabilities.

## Known residual, not fixed here

The `.prettierignore` comment above `tests/fixtures/bench` explains that entry as load-bearing
*because* lint-staged runs `*.{js,ts,json}` with matchBase. After this change that rationale no
longer holds. `.prettierignore` was explicitly out of scope for this task; the entry is now
belt-and-braces rather than load-bearing, and the comment is stale.

Records `memory-bank/ai-mistakes.md` entry 32.
