### PR TITLE
feat(renderer): gate empty agent states on populationState FAILED

### DIFF
--- a/src/renderer/lib/components/AgentPanel.svelte
+++ b/src/renderer/lib/components/AgentPanel.svelte
@@ -1,6 +1,7 @@
 <script>
   import { enrichedAgents } from '../stores/risk.js';
   import { selectedAgentInstanceId } from '../stores/ipc.js';
+  import { populationUnknown } from '../stores/app-health.js';
   import AgentCard from './AgentCard.svelte';
   import { t } from '../i18n/index.js';
   import { groupAgentsForPanel } from '../utils/agent-panel-utils.ts';
@@ -23,7 +24,11 @@
 <section class="agent-panel">
   {#if grouped.length === 0}
     <div class="empty-state">
-      <span>{$t('agents.no_agents')}</span>
+      {#if $populationUnknown}
+        <span>{$t('agents.population_unknown')}</span>
+      {:else}
+        <span>{$t('agents.no_agents')}</span>
+      {/if}
     </div>
   {:else}
     <div class="agent-list">

--- a/src/renderer/lib/components/AgentStatsPanel.svelte
+++ b/src/renderer/lib/components/AgentStatsPanel.svelte
@@ -15,6 +15,7 @@
   } from '../utils/agent-stats-utils.ts';
   import { focusInstanceId } from '../utils/agent-selection.ts';
   import { tick, startTick } from '../stores/tick.ts';
+  import { populationUnknown } from '../stores/app-health.js';
 
   /** @type {{ active?: boolean }} */
   let { active = true } = $props();
@@ -132,7 +133,9 @@
         </tr>
       {:else}
         <tr>
-          <td colspan="6" class="empty-state">No agents detected</td>
+          <td colspan="6" class="empty-state">
+            {#if $populationUnknown}Agent population unknown{:else}No agents detected{/if}
+          </td>
         </tr>
       {/each}
     </tbody>

--- a/src/renderer/lib/components/ShieldTab.svelte
+++ b/src/renderer/lib/components/ShieldTab.svelte
@@ -1,6 +1,7 @@
 <script>
   import { fade } from 'svelte/transition';
   import { agents, firstScanDone } from '../stores/ipc.js';
+  import { populationUnknown } from '../stores/app-health.js';
   import { t } from '../i18n/index.js';
   import Radar from './Radar.svelte';
   import AgentPanel from './AgentPanel.svelte';
@@ -45,8 +46,13 @@
   {:else if empty}
     <div class="bento-empty panel" transition:fade={{ duration: 300 }}>
       <div class="empty-card">
-        <h2 class="empty-title">{$t('agents.no_agents')}</h2>
-        <p class="empty-hint">{$t('agents.no_agents_hint')}</p>
+        {#if $populationUnknown}
+          <h2 class="empty-title">{$t('agents.population_unknown')}</h2>
+          <p class="empty-hint">{$t('agents.population_unknown_hint')}</p>
+        {:else}
+          <h2 class="empty-title">{$t('agents.no_agents')}</h2>
+          <p class="empty-hint">{$t('agents.no_agents_hint')}</p>
+        {/if}
       </div>
     </div>
   {:else}

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -120,6 +120,8 @@
   "agents": {
     "no_agents": "No AI agents detected",
     "no_agents_hint": "AEGIS is monitoring your system — detected AI agents will appear here automatically.",
+    "population_unknown": "Agent population unknown",
+    "population_unknown_hint": "The process sensor cannot currently enumerate running processes, so AEGIS cannot tell which AI agents are active. This is a sensor failure, not an empty system.",
     "pid": "PID {pid}",
     "last_file": "Last: {file}",
     "session_hours": "{h}h {m}m",

--- a/src/renderer/lib/stores/app-health.ts
+++ b/src/renderer/lib/stores/app-health.ts
@@ -1,10 +1,14 @@
 /**
  * @file app-health.ts — the app-health block of the stats payload, narrowed for the UI
  * @module renderer/stores/app-health
- * @description The renderer's ONLY reader of `stats.appHealth`. It answers one
- *   question — which sensors are degraded and which have failed — and it answers it
- *   from `appHealth.sensors.effective`, the id lists the main process publishes for
- *   exactly this purpose.
+ * @description The renderer's ONLY reader of `stats.appHealth`. It answers two
+ *   questions. Which sensors are degraded and which have failed — answered from
+ *   `appHealth.sensors.effective`, the id lists the main process publishes for
+ *   exactly this purpose. And whether the agent population is currently unknown —
+ *   answered from `appHealth.populationState`, the enum, being `'FAILED'`; never
+ *   from `populationReliable`, which collapses STARTING, DEGRADED and FAILED into
+ *   one `false` (ai-mistakes #29), and never from `appHealth.state`, whose FAILED
+ *   also has a defensive zero-coverage route.
  *
  *   `appHealth.reasons` is NOT a source of sensor names and must never be parsed for
  *   them. It is the aggregate-level explanation, a closed set of reason CODES
@@ -103,3 +107,32 @@ export function readUnhealthySensors(
  * @since 0.12.0
  */
 export const unhealthySensors: Readable<UnhealthySensors> = derived(stats, readUnhealthySensors);
+
+/**
+ * Whether the process-population sensor has FAILED, so an empty agent list is the
+ * absence of an observation rather than an observation of zero agents.
+ *
+ * Reads `appHealth.populationState` — the enum — and nothing else. `'STARTING'` and
+ * the BOOTING `null` are NOT unknown: boot is already covered by the skeleton /
+ * `firstScanDone` paths, and a starting scanner must not be painted as a failure.
+ * `populationReliable` would collapse STARTING, DEGRADED and FAILED into one `false`
+ * (ai-mistakes #29), and `appHealth.state === 'FAILED'` also has a defensive
+ * zero-coverage route — neither is read here.
+ * @param payload The `stats` store value, or any prefix of it.
+ * @returns True iff `appHealth.populationState` is `'FAILED'`.
+ * @since 0.12.0
+ */
+export function readPopulationUnknown(
+  payload: Record<string, unknown> | null | undefined,
+): boolean {
+  return pick(pick(payload, 'appHealth'), 'populationState') === 'FAILED';
+}
+
+/**
+ * Live population-unknown flag, refreshed with every stats payload.
+ *
+ * Derived from {@link stats} like {@link unhealthySensors} — the app-health block
+ * rides the stats surfaces and has no channel of its own.
+ * @since 0.12.0
+ */
+export const populationUnknown: Readable<boolean> = derived(stats, readPopulationUnknown);

--- a/tests/renderer/app-health-population.test.ts
+++ b/tests/renderer/app-health-population.test.ts
@@ -1,0 +1,113 @@
+/**
+ * app-health-population.test.ts — the population-unknown gate reads the enum, and
+ * nothing but the enum.
+ *
+ * `populationState` is the lifecycle classifier; `populationReliable` collapses
+ * STARTING, DEGRADED and FAILED into one `false` (ai-mistakes #29), and
+ * `appHealth.state === 'FAILED'` also has a defensive zero-coverage route. The
+ * load-bearing cases here are the ones that separate those collapsed members: a
+ * reimplementation of `readPopulationUnknown` via `!populationReliable` or via
+ * `appHealth.state` must go red on them.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+// stores/ipc.ts reads `window.aegis` at module load (and would start demo-mode
+// timers in a browserless env), so its `stats` input is replaced with a plain
+// writable. The factory is self-contained — it must not close over module-scope
+// bindings, because vi.mock is hoisted above the imports below.
+vi.mock('../../src/renderer/lib/stores/ipc.js', async () => {
+  const { writable } = await import('svelte/store');
+  return { stats: writable({}) };
+});
+
+import {
+  readPopulationUnknown,
+  populationUnknown,
+} from '../../src/renderer/lib/stores/app-health.js';
+import * as ipc from '../../src/renderer/lib/stores/ipc.js';
+
+const stats = (ipc as unknown as { stats: { set: (v: Record<string, unknown>) => void } }).stats;
+
+/** A stats payload whose `appHealth` block carries the given population fields. */
+function payload(appHealth: Record<string, unknown>): Record<string, unknown> {
+  return { currentAgents: 0, permissionDeniedScans: 0, appHealth };
+}
+
+beforeEach(() => {
+  stats.set({});
+});
+
+describe('readPopulationUnknown — FAILED and only FAILED', () => {
+  it('is true when populationState is FAILED', () => {
+    expect(
+      readPopulationUnknown(
+        payload({ populationState: 'FAILED', populationReliable: false, populationAsOf: null }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false for HEALTHY', () => {
+    expect(
+      readPopulationUnknown(payload({ populationState: 'HEALTHY', populationReliable: true })),
+    ).toBe(false);
+  });
+
+  it('is false for DEGRADED', () => {
+    expect(
+      readPopulationUnknown(payload({ populationState: 'DEGRADED', populationReliable: false })),
+    ).toBe(false);
+  });
+
+  it('is false for an observed STARTING, whose populationReliable is already false', () => {
+    // The ai-mistakes #29 case: a never-scanned leaf is STARTING with the flag
+    // false on every launch. An implementation reading `!populationReliable`
+    // instead of the enum paints that normal startup as a failure — and goes red here.
+    expect(
+      readPopulationUnknown(payload({ populationState: 'STARTING', populationReliable: false })),
+    ).toBe(false);
+  });
+
+  it('is false for the BOOTING null, where no leaf record exists yet', () => {
+    expect(
+      readPopulationUnknown(payload({ populationState: null, populationReliable: false })),
+    ).toBe(false);
+  });
+
+  it('is false when appHealth.state is FAILED but the population leaf is not', () => {
+    // `state === 'FAILED'` also has a defensive zero-coverage route, so it is not
+    // evidence of a failed population. Only the leaf's own enum is.
+    expect(
+      readPopulationUnknown(
+        payload({
+          state: 'FAILED',
+          reasons: ['zero-coverage'],
+          populationState: 'HEALTHY',
+          populationReliable: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is total: null, undefined and malformed payloads all yield false', () => {
+    expect(readPopulationUnknown(null)).toBe(false);
+    expect(readPopulationUnknown(undefined)).toBe(false);
+    expect(readPopulationUnknown({})).toBe(false);
+    expect(readPopulationUnknown({ appHealth: 'broken' })).toBe(false);
+    expect(readPopulationUnknown({ appHealth: { populationState: 42 } })).toBe(false);
+  });
+});
+
+describe('populationUnknown — tracks the stats store', () => {
+  it('flips with the payload and back', () => {
+    stats.set(payload({ populationState: 'FAILED', populationReliable: false }));
+    expect(get(populationUnknown)).toBe(true);
+
+    stats.set(payload({ populationState: 'HEALTHY', populationReliable: true }));
+    expect(get(populationUnknown)).toBe(false);
+  });
+
+  it('is false on the empty boot payload', () => {
+    expect(get(populationUnknown)).toBe(false);
+  });
+});

--- a/tests/renderer/components/AgentPanel.test.ts
+++ b/tests/renderer/components/AgentPanel.test.ts
@@ -1,0 +1,60 @@
+/**
+ * AgentPanel.test.ts — the panel's empty state distinguishes "no agents observed"
+ * from "the population could not be observed".
+ *
+ * An empty agent list from a FAILED process-population sensor is the absence of an
+ * observation, not an observation of zero agents. The gate is
+ * `appHealth.populationState === 'FAILED'` — driven end to end here: a real stats
+ * payload goes into the store the IPC bridge writes, and the assertions are made
+ * against the DOM.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { agents, stats } from '../../../src/renderer/lib/stores/ipc.js';
+import AgentPanel from '../../../src/renderer/lib/components/AgentPanel.svelte';
+
+/** A stats payload whose population leaf sits at the given state. */
+function statsPayload(populationState: string): Record<string, unknown> {
+  const failed = populationState === 'FAILED';
+  return {
+    currentAgents: 0,
+    permissionDeniedScans: 0,
+    monitoringPaused: false,
+    appHealth: {
+      state: failed ? 'FAILED' : 'HEALTHY',
+      reasons: failed ? ['population-failed', 'sensor-failed'] : [],
+      populationState,
+      populationReliable: populationState === 'HEALTHY',
+      populationAsOf: failed ? null : 1_700_000_000_000,
+      identityQuality: 'witnessed',
+      identityDegraded: false,
+      sensors: { byId: {}, raw: null, effective: null, projections: [] },
+      watchPlan: { state: 'HEALTHY', liveWatcherCount: 4, unavailableGroups: [] },
+    },
+  };
+}
+
+beforeEach(() => {
+  agents.set([]);
+  stats.set({});
+});
+
+describe('AgentPanel — empty list under a FAILED population', () => {
+  it('says the population is unknown, not that there are no agents', () => {
+    stats.set(statsPayload('FAILED'));
+    const { container } = render(AgentPanel);
+
+    expect(container.textContent).toContain('Agent population unknown');
+    expect(container.textContent).not.toContain('No AI agents detected');
+  });
+});
+
+describe('AgentPanel — empty list under a HEALTHY population', () => {
+  it('keeps the current no-agents empty state, without the unknown text', () => {
+    stats.set(statsPayload('HEALTHY'));
+    const { container } = render(AgentPanel);
+
+    expect(container.textContent).toContain('No AI agents detected');
+    expect(container.textContent).not.toContain('Agent population unknown');
+  });
+});

--- a/tests/renderer/components/AgentStatsPanel.test.ts
+++ b/tests/renderer/components/AgentStatsPanel.test.ts
@@ -1,0 +1,62 @@
+/**
+ * AgentStatsPanel.test.ts — the table's empty row distinguishes "no agents
+ * observed" from "the population could not be observed".
+ *
+ * The gate is `appHealth.populationState === 'FAILED'`, read through the
+ * app-health store; the existing hardcoded "No agents detected" branch stays
+ * byte-identical for every other population state.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { agents, stats } from '../../../src/renderer/lib/stores/ipc.js';
+import AgentStatsPanel from '../../../src/renderer/lib/components/AgentStatsPanel.svelte';
+
+/** A stats payload whose population leaf sits at the given state. */
+function statsPayload(populationState: string): Record<string, unknown> {
+  const failed = populationState === 'FAILED';
+  return {
+    currentAgents: 0,
+    permissionDeniedScans: 0,
+    monitoringPaused: false,
+    appHealth: {
+      state: failed ? 'FAILED' : 'HEALTHY',
+      reasons: failed ? ['population-failed', 'sensor-failed'] : [],
+      populationState,
+      populationReliable: populationState === 'HEALTHY',
+      populationAsOf: failed ? null : 1_700_000_000_000,
+      identityQuality: 'witnessed',
+      identityDegraded: false,
+      sensors: { byId: {}, raw: null, effective: null, projections: [] },
+      watchPlan: { state: 'HEALTHY', liveWatcherCount: 4, unavailableGroups: [] },
+    },
+  };
+}
+
+beforeEach(() => {
+  agents.set([]);
+  stats.set({});
+});
+
+describe('AgentStatsPanel — empty table under a FAILED population', () => {
+  it('says the population is unknown, not that there are no agents', () => {
+    stats.set(statsPayload('FAILED'));
+    const { container } = render(AgentStatsPanel);
+
+    const cell = container.querySelector('.empty-state');
+    expect(cell).toBeInTheDocument();
+    expect(cell).toHaveTextContent('Agent population unknown');
+    expect(container.textContent).not.toContain('No agents detected');
+  });
+});
+
+describe('AgentStatsPanel — empty table under a HEALTHY population', () => {
+  it('keeps the current no-agents empty state, without the unknown text', () => {
+    stats.set(statsPayload('HEALTHY'));
+    const { container } = render(AgentStatsPanel);
+
+    const cell = container.querySelector('.empty-state');
+    expect(cell).toBeInTheDocument();
+    expect(cell).toHaveTextContent('No agents detected');
+    expect(container.textContent).not.toContain('Agent population unknown');
+  });
+});

--- a/tests/renderer/components/ShieldTab.test.ts
+++ b/tests/renderer/components/ShieldTab.test.ts
@@ -1,0 +1,66 @@
+/**
+ * ShieldTab.test.ts — the bento empty state distinguishes "no agents observed"
+ * from "the population could not be observed".
+ *
+ * Both directions run with `firstScanDone` true: the skeleton path already covers
+ * boot, and this file does not touch it. The gate is
+ * `appHealth.populationState === 'FAILED'`, read through the app-health store —
+ * never `appHealth.state`, whose FAILED also has a defensive zero-coverage route.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { agents, firstScanDone, stats } from '../../../src/renderer/lib/stores/ipc.js';
+import ShieldTab from '../../../src/renderer/lib/components/ShieldTab.svelte';
+
+/** A stats payload whose population leaf sits at the given state. */
+function statsPayload(populationState: string): Record<string, unknown> {
+  const failed = populationState === 'FAILED';
+  return {
+    currentAgents: 0,
+    permissionDeniedScans: 0,
+    monitoringPaused: false,
+    appHealth: {
+      state: failed ? 'FAILED' : 'HEALTHY',
+      reasons: failed ? ['population-failed', 'sensor-failed'] : [],
+      populationState,
+      populationReliable: populationState === 'HEALTHY',
+      populationAsOf: failed ? null : 1_700_000_000_000,
+      identityQuality: 'witnessed',
+      identityDegraded: false,
+      sensors: { byId: {}, raw: null, effective: null, projections: [] },
+      watchPlan: { state: 'HEALTHY', liveWatcherCount: 4, unavailableGroups: [] },
+    },
+  };
+}
+
+beforeEach(() => {
+  agents.set([]);
+  firstScanDone.set(true);
+  stats.set({});
+});
+
+describe('ShieldTab — empty state under a FAILED population', () => {
+  it('says the population is unknown, not that there are no agents', () => {
+    stats.set(statsPayload('FAILED'));
+    const { container } = render(ShieldTab);
+
+    expect(container.querySelector('.empty-title')).toHaveTextContent('Agent population unknown');
+    expect(container.querySelector('.empty-hint')).toHaveTextContent(
+      'cannot currently enumerate running processes',
+    );
+    expect(container.textContent).not.toContain('No AI agents detected');
+  });
+});
+
+describe('ShieldTab — empty state under a HEALTHY population', () => {
+  it('keeps the current no-agents empty state, without the unknown text', () => {
+    stats.set(statsPayload('HEALTHY'));
+    const { container } = render(ShieldTab);
+
+    expect(container.querySelector('.empty-title')).toHaveTextContent('No AI agents detected');
+    expect(container.querySelector('.empty-hint')).toHaveTextContent(
+      'detected AI agents will appear here automatically',
+    );
+    expect(container.textContent).not.toContain('Agent population unknown');
+  });
+});


### PR DESCRIPTION
## What

When `appHealth.populationState === 'FAILED'`, the three empty-state surfaces (AgentPanel, AgentStatsPanel, ShieldTab) say the agent population is unknown instead of claiming there are no agents. For every other population state (HEALTHY, DEGRADED, STARTING, BOOTING null) the empty states are byte-identical to before.

## Why

An empty agent list from a FAILED process-population sensor is the absence of an observation, not an observation of zero agents. The main process already publishes the contract for exactly this (`stats.appHealth.populationState`); the renderer just never read it.

## How

- `stores/app-health.ts` (the renderer's only reader of `stats.appHealth`) gains `readPopulationUnknown` + a `populationUnknown` derived — true iff the enum is `'FAILED'`. Never `populationReliable`, which collapses STARTING/DEGRADED/FAILED into one `false` (ai-mistakes #29), and never `appHealth.state`, whose FAILED also has a defensive zero-coverage route.
- Each component branches only inside its existing empty state; populated branches and ShieldTab's `firstScanDone` logic untouched.
- i18n: `agents.population_unknown` / `agents.population_unknown_hint` (English only). AgentStatsPanel keeps its hardcoded style — plain text in both branches.

## Tests

- `tests/renderer/app-health-population.test.ts` — discriminating kill-list: FAILED → true; HEALTHY/DEGRADED/STARTING/null → false; `appHealth.state === 'FAILED'` with a HEALTHY leaf → false; malformed payloads → false. A `!populationReliable` mutant was injected locally and killed by exactly the DEGRADED/STARTING/null cases, then reverted.
- Component tests for all three surfaces, both gate directions each, DOM-asserted through the real stats store.

All 9 local gate commands green (format:check, build:renderer, lint, typecheck, typecheck:svelte, test:coverage 2042 passed / 4 skipped, verify:gate 4/4 killed, counts:check, audit). Dev app boots with a clean console.