### PR TITLE
feat(bench): trace recorder — input tap over published seams, offline derivation

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -949,6 +949,13 @@ trace the reader refuses, and must not quietly drop what it could not record. Th
 inert the only way it can be: the same scripted session, with the tap and without, must write
 byte-identical audit logs (`tests/shared/bench-trace/recorder-roundtrip.test.js`).
 
+A recording can only observe what its platform can produce. The hot Restart Manager source
+exists on win32 and nowhere else, and `file-watcher.js` holds the RM sensor at UNSUPPORTED on
+the other platforms — `scanViaRestartManager` refuses to tick it there (sensor-health allows
+neither HEALTHY nor FAILED from UNSUPPORTED), so an `rm.hot.tick` can be recorded on win32 only.
+That is the product's own rule, not the recorder's: a POSIX session scripting hot holders anyway
+would be recording an observation its platform never makes.
+
 One consequence of neutralization is worth stating: a trace may be committed, so the writer
 rewrites the clone root and the OS account name in every record. A recording whose observed paths
 live under either of those therefore replays to a verdict naming the RECORDED tree, which is

--- a/bench/README.md
+++ b/bench/README.md
@@ -673,7 +673,9 @@ loaded and is not named here is a change to this table:
 |---|---|---|---|
 | `src/main/audit-hashchain.js` | `trace/schema.js`, `trace/environment.js` | `canonical`, `computeHash` | one hashing algorithm rather than a third implementation of it |
 | `src/main/attribution.js` | `trace/environment.js` | `EVIDENCE_CODES` | the closed list is pinned into a trace, so a change to it is a refusal on READ instead of a silent diff |
-| `src/main/rule-loader.js` | `trace/environment.js` | `_loadRules` | the rules are digested AS THE PRODUCT COMPILES THEM; `_loadRules` is the entry point that does not populate the module cache, so observing an environment does not change it |
+| `src/main/rule-loader.js` | `trace/environment.js`; reloaded by `trace/wiring.js` | `_loadRules`; `reloadRules` | the rules are digested AS THE PRODUCT COMPILES THEM; `_loadRules` is the entry point that does not populate the module cache, so observing an environment does not change it. `reloadRules` is the product's own public reload |
+| `src/main/audit-logger.js`, `src/main/baselines.js`, `src/main/config-manager.js`, `src/main/file-watcher.js`, `src/main/network-monitor.js`, `src/main/scan-loop.js` | `trace/wiring.js` (lazily, inside `wireGraph` — replay AND recording) | the published seams: `init(state)`, `_setDepsForTest`, `_resetForTest`, `_setSettingsPathForTest`, `_setBaselinesPathForTest`, `audit.init`/`shutdown`, `dedupFileEvent`, `logAuditForFile`, `doNetworkScan` | this IS the system under test — there is nothing to replay or record without the detection code itself. Loaded lazily so requiring the orchestration declaration does not pull the product |
+| `src/main/platform/index.js` (transitively the platform module `pinnedSourceFiles` names — `win32.js` / `darwin.js` / `linux.js` — and that module's OWN dependency graph: on win32 `restart-manager.js`, `process-snapshot.js` and what they require; `posix-shared.js` elsewhere) | `trace/recorder.js` (lazily, only when a recording takes the default real providers) | `getFileHandles`, `getHotSensitiveHolders`, `getRawTcpConnections` | a recording wraps the REAL providers record-and-pass-through, and these are literally the un-injected defaults `file-watcher.js` and `network-monitor.js` hold. The two DNS defaults live in module-private closures and are MIRRORED in `recorder.js` instead — a named drift point, see "Recording a trace" |
 
 Deriving a trace from a recorded run is the one place that does NOT move: an audit file the
 product wrote is still verified with `lib/observed.js`'s own re-implementation, because that
@@ -845,6 +847,11 @@ decides what the local-time getters answer, which is what `audit-logger.js` buil
 AEGIS_TRACE_CLOCK_EPOCH_MS=<header.clock.epochMs> AEGIS_TRACE_TZ=<header.tz.name>   node --require bench/trace/preload.js bench/trace/replay-trace.js <trace dir> [--out <dir>]
 ```
 
+`npm run bench:replay -- <trace dir> [--out <dir>]` runs exactly that: the wrapper
+(`bench/trace/bench-replay.js`) reads the two values out of the trace's own header, sets the
+environment, and spawns the entrypoint under the preload. Every decision about the trace —
+validation, refusals, the verdict — stays in `replay-trace.js`.
+
 Both variables come out of the trace's own header, and the zone is passed back **verbatim**:
 the runtime canonicalizes zone names, so `TZ=Etc/UTC` makes `Intl` report `UTC`, and a header
 naming the alias would be refused for a difference that is not one. A header always carries what
@@ -901,11 +908,60 @@ The guard is one-sided, and that is worth stating: it lives under `tests/`, so a
 `scan-loop.js` learns about the harness when CI goes red rather than while typing. A comment at
 each product site pointing back here would close that half; it is two lines in `src/`.
 
+### Recording a trace
+
+Nothing else in this repository can produce a trace's records: an arm-A run writes only the
+product's DECISIONS — the audit log `lib/observed.js` reads back — never the sensors' INPUTS, so
+a trace cannot be derived from `observed.ndjson` or `observed.meta.json`; the information is
+simply not there. `trace/recorder.js` is the missing input tap. It wires the SAME product graph
+through the SAME published seams the replay uses (`wiring.wireGraph` is one function serving both
+postures), in the mirror posture: the providers are REAL, and every answer a sensor consumes is
+also written down, record-and-pass-through, bytes unchanged — the wrapper hands the product the
+provider's own return value and buffers a JSON snapshot of it.
+
+**What a recording is, and is not.** A recording is the system under test observing itself. It
+proves REPLAYABILITY — that the same bytes in produce the same verdicts out, checked by replaying
+the derived trace against the audit bytes the recording run itself wrote — and it proves nothing
+about accuracy: no independent oracle confirms that the sensors saw what a machine did, which is
+the measurement column's job and stays on the other side of the `src/` boundary. The committed
+suites drive the recorder over SCRIPTED providers (determinism is the point); the real-provider
+default (`src/main/platform`, plus a DNS mirror of `network-monitor.js`'s own module-private
+defaults — the one named drift point in this subtree) is exercised only by a live local recording.
+
+**A recording runs on the virtual clock**, under the same preload as a replay, and
+`setUpRecording` refuses without it. The product stamps `new Date().toISOString()` on every audit
+record, so a recording on the wall clock could never replay to its own verdicts byte for byte.
+Cadence therefore comes from the scripted session — `advanceClock` is recorded as
+`clock.advance`, exactly the record a replay moves its clock by — not from the machine's timers.
+
+**The tap appends; the writer derives.** During the run every observation is appended raw to
+`observations.ndjson`, one validated JSON line at a time, beside `recording.meta.json` (the clock
+epoch, the settings, and the environment OBSERVED AT RECORDING TIME — so the derived header pins
+the tree the recording actually ran against, and a tree edited between record and derive becomes
+a digest mismatch at replay, not a silently re-pinned header). `trace.ndjson` and
+`trace.header.json` are then derived OFFLINE by `deriveTrace` through the existing `writer.js` —
+chained, neutralized, validated — never streamed live. No new record kinds exist for recording:
+everything the recorder can observe is one of the six kinds `schema.js` already declares, every
+observation is validated against its kind BEFORE it is appended, and an answer the format cannot
+express (a handle scan that threw, a forward answer with no recorded reverse to hang it on) is
+marked unrecordable and fails `deriveTrace` by name — a recorder must not be able to produce a
+trace the reader refuses, and must not quietly drop what it could not record. The tap is proven
+inert the only way it can be: the same scripted session, with the tap and without, must write
+byte-identical audit logs (`tests/shared/bench-trace/recorder-roundtrip.test.js`).
+
+One consequence of neutralization is worth stating: a trace may be committed, so the writer
+rewrites the clone root and the OS account name in every record. A recording whose observed paths
+live under either of those therefore replays to a verdict naming the RECORDED tree, which is
+byte-identical to the recording's own audit log only when the session's paths sit outside both
+rewrites — the round-trip suite stages its session that way on purpose.
+
 ### Arriving later
 
 `trace/fingerprint.js` and `trace/verdict.js` (the run report and the byte comparison against a
-committed golden), and `trace/record-trace.js` (deriving a trace from a recorded run). Nothing in
-that list exists yet; it is here so the subtree's shape is legible, not so it reads as built.
+committed golden). Nothing in that list exists yet; it is here so the subtree's shape is legible,
+not so it reads as built. (`trace/record-trace.js` used to be listed here as "deriving a trace
+from a recorded run" — that derivation is impossible, see "Recording a trace" above, and the
+recorder that replaced it exists.)
 
 ## Replaying a recorded run
 

--- a/bench/lib/actor.js
+++ b/bench/lib/actor.js
@@ -347,6 +347,31 @@ function awaitExit(child, timeoutMs) {
 }
 
 /**
+ * Whether a resolved path sits INSIDE a resolved stage directory, by the path
+ * rules of the platform the comparison is for.
+ *
+ * win32 paths are case-insensitive, so the two operands are lowercased before the
+ * prefix check — a path that names a file inside the stage directory must not be
+ * rejected for disagreeing about the casing of a drive letter or a segment.
+ * Everywhere else the filesystem's own rule is case-sensitive and the comparison
+ * stays exact. One helper for both call sites, so the two guards cannot drift.
+ *
+ * Note the containment guard's operands both derive from the same `ctx.stageDir`
+ * today, so `execute()` cannot currently produce a case-variant pair — this fixes
+ * the guard's CONTRACT on win32, where the false rejection was latent.
+ * @param {string} resolvedPath - An absolute path, already through `path.resolve`.
+ * @param {string} resolvedStageDir - The stage directory, already through `path.resolve`.
+ * @param {string} [platform] - A `process.platform` value. Defaults to this one.
+ * @returns {boolean}
+ */
+function isInsideStageDir(resolvedPath, resolvedStageDir, platform = process.platform) {
+  const sep = platform === 'win32' ? '\\' : '/';
+  const child = platform === 'win32' ? resolvedPath.toLowerCase() : resolvedPath;
+  const parent = platform === 'win32' ? resolvedStageDir.toLowerCase() : resolvedStageDir;
+  return child.startsWith(parent + sep);
+}
+
+/**
  * The step kinds themselves. Each returns `{observed, result}`: `observed` is
  * what the catalogue writes, `result` is what later steps refer back to.
  * @type {Readonly<Object<string, function(Object, Object): Promise<Object>>>}
@@ -382,7 +407,7 @@ const KIND_IMPL = Object.freeze({
     const args = step.with.args ?? [];
     const resolvedExec = path.resolve(source.path);
     const resolvedStageDir = path.resolve(ctx.stageDir);
-    if (!resolvedExec.startsWith(resolvedStageDir + path.sep)) {
+    if (!isInsideStageDir(resolvedExec, resolvedStageDir)) {
       throw new Error(`executable path is outside the stage directory`);
     }
     const child = spawn(resolvedExec, args, { stdio: 'ignore', windowsHide: true });
@@ -510,7 +535,7 @@ const KIND_IMPL = Object.freeze({
     }
     const resolvedExec = path.resolve(source.path);
     const resolvedStageDir = path.resolve(ctx.stageDir);
-    if (!resolvedExec.startsWith(resolvedStageDir + path.sep)) {
+    if (!isInsideStageDir(resolvedExec, resolvedStageDir)) {
       throw new Error(`executable path is outside the stage directory`);
     }
     const holdMs = step.with.ms;
@@ -650,6 +675,7 @@ module.exports = {
   assertAgentName,
   execute,
   expandEnv,
+  isInsideStageDir,
   loadScenario,
   sha256File,
   validateScenario,

--- a/bench/trace/bench-replay.js
+++ b/bench/trace/bench-replay.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * @file bench/trace/bench-replay.js
+ * @module bench/trace/bench-replay
+ * @description What `npm run bench:replay` executes: reads the trace's own header,
+ *   supplies the environment the replay needs — `AEGIS_TRACE_CLOCK_EPOCH_MS`,
+ *   `AEGIS_TRACE_TZ`, and the `--require bench/trace/preload.js` flag — and runs
+ *   `replay-trace.js` in a child process.
+ *
+ *   ```
+ *   npm run bench:replay -- <trace dir> [--out <dir>]
+ *   ```
+ *
+ *   A WRAPPER, NOT A SECOND ENTRYPOINT. The clock has to be installed before any
+ *   product module is compiled, which is strictly earlier than anything an already
+ *   running process can do — so the child is spawned with the preload, and every
+ *   decision about the trace (validation, refusals, the verdict) stays in
+ *   `replay-trace.js`. The header is read here ONLY for the two values the
+ *   environment must carry, and both are passed back verbatim: the zone because the
+ *   runtime canonicalizes zone names, the epoch because `readEpochMs` accepts only a
+ *   string of digits.
+ *
+ *   Exit codes follow `replay-trace.js`: **2** the invocation was wrong and nothing
+ *   ran · **1** the header could not be read, the trace was refused, or the replay
+ *   could not complete · **0** the replay completed and the verdict was written.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const clockEnv = require('./clock-env');
+const schema = require('./schema');
+const { parseArgs } = require('./replay-trace');
+
+/**
+ * Read the two environment values out of a trace's header.
+ * @param {string} traceDir - The trace directory.
+ * @returns {{epochMs: number, tz: string}|{error: string}}
+ */
+function readClockFromHeader(traceDir) {
+  const headerPath = path.join(traceDir, schema.HEADER_FILENAME);
+  let header;
+  try {
+    header = JSON.parse(fs.readFileSync(headerPath, 'utf8'));
+  } catch (err) {
+    return { error: `the trace header could not be read at ${headerPath}: ${err.message}` };
+  }
+  const epochMs = header && header.clock ? header.clock.epochMs : undefined;
+  const tz = header && header.tz ? header.tz.name : undefined;
+  if (!Number.isSafeInteger(epochMs) || typeof tz !== 'string' || tz.length === 0) {
+    return {
+      error:
+        `${headerPath} does not carry clock.epochMs and tz.name — without them no clock can ` +
+        'be installed, and the replay itself would refuse the header anyway',
+    };
+  }
+  return { epochMs, tz };
+}
+
+/**
+ * Spawn the replay under the preload, with the header's own environment.
+ * @param {string[]} argv - `process.argv.slice(2)`.
+ * @returns {number} The process exit code.
+ */
+function main(argv) {
+  const args = parseArgs(argv);
+  if (args.error) {
+    console.error(`bench:replay: ${args.error}`);
+    console.error('usage: npm run bench:replay -- <trace dir> [--out <dir>]');
+    return 2;
+  }
+  const clock = readClockFromHeader(args.traceDir);
+  if (clock.error) {
+    console.error(`bench:replay: ${clock.error}`);
+    return 1;
+  }
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--require',
+      path.join(__dirname, 'preload.js'),
+      path.join(__dirname, 'replay-trace.js'),
+      ...argv,
+    ],
+    {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        [clockEnv.EPOCH_ENV]: String(clock.epochMs),
+        [clockEnv.TZ_ENV]: clock.tz,
+      },
+    },
+  );
+  // A spawn failure (no status at all) is the wrapper's own fault, not the trace's.
+  return result.status === null || result.status === undefined ? 1 : result.status;
+}
+
+/* c8 ignore start — the process boundary; every decision above is reachable directly. */
+if (require.main === module) {
+  process.exit(main(process.argv.slice(2)));
+}
+/* c8 ignore stop */
+
+module.exports = { main, readClockFromHeader };

--- a/bench/trace/recorder.js
+++ b/bench/trace/recorder.js
@@ -1,0 +1,796 @@
+/**
+ * @file bench/trace/recorder.js
+ * @module bench/trace/recorder
+ * @description Records a trace: the same product graph a replay drives, wired through
+ *   the same published seams, in the mirror posture — the providers are REAL, and
+ *   every answer a sensor consumes is also written down, record-and-pass-through,
+ *   bytes unchanged.
+ *
+ *   WHY THIS EXISTS. An arm-A run writes only the product's DECISIONS — the audit log
+ *   `bench/lib/observed.js` reads back — never the sensors' INPUTS, so a trace cannot
+ *   be derived from `observed.ndjson` or `observed.meta.json`: the information is
+ *   simply not there. The missing piece is this input tap.
+ *
+ *   WHAT A RECORDING IS NOT. It is not an oracle. It is the system under test
+ *   observing itself, so what a recording proves is REPLAYABILITY — the same bytes in
+ *   produce the same verdicts out — never accuracy. Nothing here confirms that a
+ *   sensor saw what the machine did; that is the measurement column's job, and the
+ *   recorder deliberately lives on the other side of the `src/` boundary
+ *   (`bench/README.md`, "Trace replay and the src/ boundary").
+ *
+ *   A RECORDING RUNS ON THE VIRTUAL CLOCK, and that is load-bearing. The product
+ *   stamps `new Date().toISOString()` on every audit record it writes, so a recording
+ *   on the wall clock could never replay to its own verdicts byte for byte — the
+ *   replay's clock would move exactly as recorded while the wall clock had drifted
+ *   between an observation and its audit write. Cadence therefore comes from the
+ *   session ({@link Recording#advanceClock}), exactly as it comes from the trace in a
+ *   replay, and {@link setUpRecording} refuses without the preload.
+ *
+ *   THE TAP APPENDS, THE WRITER DERIVES. During the run every observation is appended
+ *   raw to `observations.ndjson`, one JSON line at a time. `trace.ndjson` and
+ *   `trace.header.json` are then derived OFFLINE by {@link deriveTrace} through
+ *   `./writer.js` — chained, neutralized, validated — never streamed live. The
+ *   environment is observed at RECORDING time and carried through `recording.meta.json`,
+ *   so the header pins the tree the recording actually ran against; a tree edited
+ *   between record and derive becomes a digest mismatch at replay, not a silently
+ *   re-pinned header.
+ *
+ *   NO NEW RECORD KINDS. Everything the recorder can observe is one of the six kinds
+ *   `./schema.js` already declares, and every observation is validated against its
+ *   kind BEFORE it is appended — a recorder must not be able to produce a trace the
+ *   reader refuses. A provider answer the format cannot express (a handle scan that
+ *   THREW, say) is marked unrecordable and fails {@link deriveTrace} by name instead
+ *   of being dropped or invented.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @since v0.12.0
+ */
+
+'use strict';
+
+const dns = require('dns');
+const fs = require('fs');
+const path = require('path');
+
+const clockModule = require('./clock');
+const environment = require('./environment');
+const harness = require('./harness');
+const schema = require('./schema');
+const wiring = require('./wiring');
+const writer = require('./writer');
+
+/** @type {string} Raw observations, appended one JSON line at a time during the run. */
+const OBSERVATIONS_FILENAME = 'observations.ndjson';
+
+/** @type {string} What the recording pinned at setup: clock epoch, settings, environment. */
+const META_FILENAME = 'recording.meta.json';
+
+/** @type {string} Written by {@link Recording#finish}; its absence means the run never stopped cleanly. */
+const DONE_FILENAME = 'recording.done.json';
+
+/** @type {number} The raw recording layout's version, checked by {@link deriveTrace}. */
+const RECORDING_SCHEMA_VERSION = 1;
+
+/**
+ * The scope every recorder-made trace declares. Same answers, same reasons as the
+ * replay suites give: the recorder drives exactly the phase-1 surface the harness
+ * replays, so what a replay cannot reach, a recording cannot record.
+ * @returns {Object} A fresh scope object in the `{value, unavailable}` convention.
+ */
+function recorderScope() {
+  return {
+    processTicks: { value: null, unavailable: 'scan-loop.doProcessScan is not exported' },
+    anomalyAlerts: { value: null, unavailable: 'out-of-scope-phase-1' },
+    rmFullPath: { value: null, unavailable: 'the getSensitiveHolders injection is one-way' },
+  };
+}
+
+/**
+ * A JSON snapshot of a provider answer, taken at the instant it passed through.
+ * `undefined` survives as `undefined` so an absent value stays absent.
+ * @param {*} value
+ * @returns {*}
+ */
+function snapshot(value) {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * The REAL providers a production recording wraps — the same functions the product
+ * modules hold as their own un-injected defaults.
+ *
+ * Required lazily so that requiring THIS module does not pull the platform into a
+ * process that only wanted {@link deriveTrace}. `getFileHandles`,
+ * `getHotSensitiveHolders` and `getRawTcpConnections` are literally the defaults of
+ * `src/main/file-watcher.js` and `src/main/network-monitor.js` (their module-level
+ * `_platform.*` bindings). The two DNS functions cannot be reached that way — the
+ * product wraps them in module-private closures — so they are MIRRORED here from
+ * `network-monitor.js` (`_dnsReverse`, `_dnsResolve`): resolve4/resolve6 over
+ * authoritative DNS, never `dns.lookup`, because a hosts file an attacker on the box
+ * can write is not evidence about a remote endpoint. That mirror is a named drift
+ * point — see bench/README.md, "Recording a trace".
+ * @returns {Object} `{getFileHandles, getHotSensitiveHolders, getRawTcpConnections,
+ *   dnsReverse, dnsResolve}` — `getHotSensitiveHolders` is `undefined` off win32.
+ */
+function realProviders() {
+  const platform = require('../../src/main/platform');
+  return {
+    getFileHandles: platform.getFileHandles,
+    getHotSensitiveHolders: platform.getHotSensitiveHolders,
+    getRawTcpConnections: platform.getRawTcpConnections,
+    dnsReverse: (ip) => dns.promises.reverse(ip),
+    dnsResolve: async (hostname) => {
+      const settled = await Promise.allSettled([
+        dns.promises.resolve4(hostname),
+        dns.promises.resolve6(hostname),
+      ]);
+      const out = [];
+      for (const r of settled) if (r.status === 'fulfilled') out.push(...r.value);
+      return out;
+    },
+  };
+}
+
+/**
+ * The record-and-pass-through wrappers around one set of providers.
+ *
+ * Every wrapper returns EXACTLY what the wrapped provider returned — the same object,
+ * the same rejection — and writes a {@link snapshot} into the buffer of the tick that
+ * is currently open. An answer arriving with no tick open, or a non-DNS provider that
+ * THREW, is an observation the trace format cannot express: it is recorded as
+ * unrecordable and fails {@link deriveTrace} by name, because a recorder that dropped
+ * it would produce a trace claiming the run consumed less than it did.
+ */
+class Tap {
+  /** @param {Object} given - The providers to wrap. */
+  constructor(given) {
+    /** @type {Array<{provider: string, why: string}>} What the trace format could not hold. */
+    this.unrecordable = [];
+    /** @type {string|null} Which tick is collecting: 'handles' | 'rm' | 'net' | null. */
+    this.active = null;
+    /** @type {Object<string, string[]>} Per-pid answers of the open handles tick. */
+    this.byPid = {};
+    /** @type {Object[]} Holder answers of the open rm tick. */
+    this.holders = [];
+    /** @type {Object[]} The TCP answer of the open net tick. */
+    this.tcp = [];
+    /** @type {Object<string, {reverse: string[]|null, forward: string[]|null}>} */
+    this.dns = {};
+    /** @type {boolean} Whether the open net tick saw a TCP read at all. */
+    this.tcpObserved = false;
+
+    this.wrapped = this._wrap(given);
+  }
+
+  /**
+   * Open one tick's buffer.
+   * @param {string} what - 'handles' | 'rm' | 'net'.
+   * @returns {void}
+   */
+  begin(what) {
+    this.active = what;
+    this.byPid = {};
+    this.holders = [];
+    this.tcp = [];
+    this.dns = {};
+    this.tcpObserved = false;
+  }
+
+  /**
+   * Close the open tick's buffer and hand back what it collected.
+   * @returns {{byPid: Object, holders: Object[], tcp: Object[], dns: Object,
+   *   tcpObserved: boolean}}
+   */
+  end() {
+    const collected = {
+      byPid: this.byPid,
+      holders: this.holders,
+      tcp: this.tcp,
+      dns: this.dns,
+      tcpObserved: this.tcpObserved,
+    };
+    this.active = null;
+    return collected;
+  }
+
+  /**
+   * Note an answer the trace format cannot carry. The recording keeps running —
+   * the product's behaviour is not changed — but {@link deriveTrace} will refuse.
+   * @param {string} provider - Which provider produced it.
+   * @param {string} why - What could not be recorded.
+   * @returns {void}
+   */
+  markUnrecordable(provider, why) {
+    this.unrecordable.push({ provider, why });
+  }
+
+  /**
+   * Attribute one forward answer to the first recorded ip whose reverse answer
+   * includes the hostname — the SAME rule the replay's `dnsResolve` applies
+   * (`./wiring.js`), in the same insertion order, so a recording and its replay
+   * agree about which entry a forward answer lives on.
+   * @param {string} hostname
+   * @param {string[]|null} forward - The answer, or `null` for "the lookup threw".
+   * @returns {void}
+   */
+  _attributeForward(hostname, forward) {
+    for (const answer of Object.values(this.dns)) {
+      if (answer.reverse && answer.reverse.includes(hostname)) {
+        answer.forward = forward;
+        return;
+      }
+    }
+    // A real answer with no recorded reverse to hang it on cannot be replayed —
+    // wiring's dnsResolve would reject where the recording resolved. A THROWN one
+    // needs no record at all: the replay rejects an unknown hostname by itself.
+    if (forward !== null) {
+      this.markUnrecordable(
+        'dnsResolve',
+        `a forward answer for ${JSON.stringify(hostname)} arrived with no recorded reverse ` +
+          'answer naming that hostname, so no net.tick entry can carry it',
+      );
+    }
+  }
+
+  /**
+   * Build the wrappers.
+   * @param {Object} given - The providers to wrap.
+   * @returns {Object} The wrapped set, shaped for `wiring.wireGraph`.
+   */
+  _wrap(given) {
+    const tap = this;
+    return {
+      getFileHandles: async (pid) => {
+        let files;
+        try {
+          files = await given.getFileHandles(pid);
+        } catch (err) {
+          tap.markUnrecordable(
+            'getFileHandles',
+            `threw for pid ${pid} (${err.message}) — the trace format records answers, ` +
+              'and a handle scan that failed is not one',
+          );
+          throw err;
+        }
+        if (tap.active === 'handles') tap.byPid[String(pid)] = snapshot(files) || [];
+        else tap.markUnrecordable('getFileHandles', `answered pid ${pid} outside a handles tick`);
+        return files;
+      },
+      getHotSensitiveHolders:
+        typeof given.getHotSensitiveHolders === 'function'
+          ? async () => {
+              let holders;
+              try {
+                holders = await given.getHotSensitiveHolders();
+              } catch (err) {
+                tap.markUnrecordable(
+                  'getHotSensitiveHolders',
+                  `threw (${err.message}) — the trace format records answers, and a hot ` +
+                    'cycle that failed is not one',
+                );
+                throw err;
+              }
+              if (tap.active === 'rm') tap.holders = snapshot(holders) || [];
+              else tap.markUnrecordable('getHotSensitiveHolders', 'answered outside an rm tick');
+              return holders;
+            }
+          : undefined,
+      getRawTcpConnections: async (pids) => {
+        let raw;
+        try {
+          raw = await given.getRawTcpConnections(pids);
+        } catch (err) {
+          tap.markUnrecordable(
+            'getRawTcpConnections',
+            `threw (${err.message}) — the trace format records answers, and a TCP read ` +
+              'that failed is not one',
+          );
+          throw err;
+        }
+        if (tap.active === 'net') {
+          tap.tcp = snapshot(raw) || [];
+          tap.tcpObserved = true;
+        } else {
+          tap.markUnrecordable('getRawTcpConnections', 'answered outside a net tick');
+        }
+        return raw;
+      },
+      dnsReverse: async (ip) => {
+        // A throw IS a recordable observation here: the format's `null` means
+        // exactly "the lookup threw", so the rejection is written down and
+        // re-thrown unchanged.
+        try {
+          const answer = await given.dnsReverse(ip);
+          if (tap.active === 'net') tap.dns[ip] = { reverse: snapshot(answer), forward: null };
+          else tap.markUnrecordable('dnsReverse', `answered ${ip} outside a net tick`);
+          return answer;
+        } catch (err) {
+          if (tap.active === 'net') tap.dns[ip] = { reverse: null, forward: null };
+          else tap.markUnrecordable('dnsReverse', `threw for ${ip} outside a net tick`);
+          throw err;
+        }
+      },
+      dnsResolve: async (hostname) => {
+        try {
+          const answer = await given.dnsResolve(hostname);
+          if (tap.active === 'net') tap._attributeForward(hostname, snapshot(answer));
+          else tap.markUnrecordable('dnsResolve', `answered ${hostname} outside a net tick`);
+          return answer;
+        } catch (err) {
+          if (tap.active === 'net') tap._attributeForward(hostname, null);
+          else tap.markUnrecordable('dnsResolve', `threw for ${hostname} outside a net tick`);
+          throw err;
+        }
+      },
+    };
+  }
+}
+
+/**
+ * One live recording: the driver's handle onto the wired, tapped product.
+ *
+ * The methods ARE the session — a scripted recording calls them in whatever order
+ * the session it stages requires, and each one both drives the product (through the
+ * same calls the replay harness makes) and appends what was observed.
+ */
+class Recording {
+  /**
+   * @param {Object} opts - Assembled by {@link setUpRecording}; not for direct use.
+   */
+  constructor(opts) {
+    /** @type {string} */
+    this.runDir = opts.runDir;
+    /** @type {string} */
+    this.observationsPath = opts.observationsPath;
+    /** @type {Tap} */
+    this.tap = opts.tap;
+    /** @type {Object} What `wiring.wireGraph` returned. */
+    this.wired = opts.wired;
+    /** @type {Object} The orchestration steps, the same set `harness.replay` builds. */
+    this.calls = opts.calls;
+    /** @type {Object} The installed virtual clock. */
+    this.clock = opts.clock;
+    /** @type {boolean} */
+    this._finished = false;
+  }
+
+  /**
+   * Append one raw observation line. Validated against its kind FIRST, so a line
+   * that reaches the file is one the writer will accept and the reader will read.
+   * @param {string} kind - One of `schema.KIND_NAMES`.
+   * @param {Object} input - The observation, in the kind's declared shape.
+   * @param {number} [epochMs] - The instant to stamp. Defaults to now (virtual).
+   * @returns {void}
+   */
+  _append(kind, input, epochMs) {
+    if (this._finished) {
+      schema.refuse(
+        schema.REFUSAL.RECORD_MALFORMED,
+        'this recording has finished — the audit log is flushed and the raw file is closed, ' +
+          'so a later observation would describe a product that is no longer running',
+      );
+    }
+    schema.validateInput(kind, input, 'recording: ');
+    const observation = { kind, epochMs: epochMs != null ? epochMs : Date.now(), input };
+    if (schema.RECORD_KINDS[kind].observation) {
+      observation.ambient = {
+        populationReliable: this.wired.ambient.populationReliable,
+        isOtherPanelExpanded: this.wired.ambient.isOtherPanelExpanded,
+      };
+    }
+    fs.appendFileSync(this.observationsPath, `${JSON.stringify(observation)}\n`, 'utf8');
+  }
+
+  /**
+   * Hand the sensors a new agent population, and record that it was handed.
+   * @param {Object[]} agents - In the shape `population.set` declares.
+   * @returns {void}
+   */
+  setPopulation(agents) {
+    this._append('population.set', { agents: snapshot(agents) });
+    this.wired.ambient.agents = agents;
+  }
+
+  /**
+   * Set the ambient facts that ride each observation record. Not an observation
+   * itself — the snapshot is written per record, exactly where a replay reads it.
+   * @param {Object} partial - `{populationReliable?, isOtherPanelExpanded?}`.
+   * @returns {void}
+   */
+  setAmbient(partial) {
+    if (typeof partial.populationReliable === 'boolean') {
+      this.wired.ambient.populationReliable = partial.populationReliable;
+    }
+    if (typeof partial.isOtherPanelExpanded === 'boolean') {
+      this.wired.ambient.isOtherPanelExpanded = partial.isOtherPanelExpanded;
+    }
+  }
+
+  /**
+   * Move the virtual clock forward, and record the move.
+   *
+   * Advanced FIRST, appended second: `advanceTo` refuses a backwards or invalid
+   * instant, and a refused move must leave no record claiming it happened. The
+   * appended `epochMs` is captured before the move, the same instant convention the
+   * replay suites' fixtures use.
+   * @param {number} toEpochMs
+   * @returns {void}
+   */
+  advanceClock(toEpochMs) {
+    const before = Date.now();
+    this.clock.advanceTo(toEpochMs);
+    this._append('clock.advance', { toEpochMs }, before);
+  }
+
+  /**
+   * Deliver one filesystem event, exactly as the watcher would deliver it, and
+   * close the pipeline the way `main.js` closes it (dedup → audit, via the hook
+   * `harness.installFileEventHook` installed).
+   * @param {string} action - `created` | `modified` | `deleted`.
+   * @param {string} filePath - The path, exactly as observed.
+   * @returns {{written: number}} How many events survived dedup and reached the audit log.
+   */
+  fsEvent(action, filePath) {
+    this._append('fs.event', { action, path: filePath });
+    this.wired.fsWritten = 0;
+    this.wired.modules.fileWatcher.handleWatcherEvent(action, filePath);
+    return { written: this.wired.fsWritten };
+  }
+
+  /**
+   * Run one full handle scan — `scan-loop.js doFileScan`'s orchestration — and
+   * record the per-pid answers the real provider gave.
+   *
+   * An empty population records an empty `byPid`: the scan ran and consulted
+   * nobody, which is exactly what a replay of that record reproduces.
+   * @returns {Promise<{written: number}>}
+   */
+  async handlesTick() {
+    this.tap.begin('handles');
+    let events;
+    let collected;
+    try {
+      events = await this.calls.scanAllFileHandles(this.wired.ambient.all());
+    } finally {
+      collected = this.tap.end();
+    }
+    this._append('handles.tick', { byPid: collected.byPid });
+    return { written: harness.pipeFileEvents(events, this.calls) };
+  }
+
+  /**
+   * Run one Restart Manager hot cycle — `scan-loop.js doHotReadScan`'s
+   * orchestration — and record the holders the real provider reported.
+   * @returns {Promise<{written: number}>}
+   */
+  async rmHotTick() {
+    if (typeof this.tap.wrapped.getHotSensitiveHolders !== 'function') {
+      schema.refuse(
+        schema.REFUSAL.RECORD_MALFORMED,
+        'this recording has no getHotSensitiveHolders provider (the platform default exists ' +
+          'on win32 only), so an rm.hot.tick cannot be observed — there is nothing to record',
+      );
+    }
+    this.tap.begin('rm');
+    let events;
+    let collected;
+    try {
+      events = await this.calls.scanHotFileHolders(this.wired.ambient.all());
+    } finally {
+      collected = this.tap.end();
+    }
+    this._append('rm.hot.tick', { holders: collected.holders });
+    return { written: harness.pipeFileEvents(events, this.calls) };
+  }
+
+  /**
+   * Run one network scan — the product's own fire-and-forget `doNetworkScan`,
+   * drained the way the replay harness drains it — and record the TCP table and
+   * the DNS answers it consumed.
+   * @returns {Promise<void>}
+   */
+  async netTick() {
+    this.tap.begin('net');
+    let collected;
+    try {
+      this.wired.modules.scanLoop.doNetworkScan();
+      await harness.drainUntil(
+        () => !this.wired.modules.networkMonitor.isNetworkScanRunning(),
+        'doNetworkScan',
+      );
+    } finally {
+      collected = this.tap.end();
+    }
+    if (!collected.tcpObserved) {
+      schema.refuse(
+        schema.REFUSAL.RECORD_MALFORMED,
+        'doNetworkScan consulted no provider on this tick — an empty population makes the ' +
+          'scan a no-op, and recording an observation nobody made would invent one',
+      );
+    }
+    this._append('net.tick', { tcp: collected.tcp, dns: collected.dns });
+  }
+
+  /**
+   * Stop the product cleanly (its own `audit.shutdown`), and seal the recording.
+   *
+   * Writes `recording.done.json` — {@link deriveTrace} refuses a recording without
+   * it, because an unfinished recording's audit log is missing its buffered tail.
+   * @returns {{auditDir: string, auditFiles: string[], observationsPath: string,
+   *   unrecordable: Array<{provider: string, why: string}>}}
+   */
+  finish() {
+    const stopped = wiring.tearDown(this.wired);
+    this._finished = true;
+    const done = {
+      auditFiles: stopped.auditFiles,
+      unrecordable: this.tap.unrecordable,
+    };
+    fs.writeFileSync(path.join(this.runDir, DONE_FILENAME), `${JSON.stringify(done, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+    return { ...stopped, observationsPath: this.observationsPath, unrecordable: done.unrecordable };
+  }
+}
+
+/**
+ * Wire the product for one recording.
+ *
+ * @param {Object} opts
+ * @param {string} opts.runDir - Directory this recording writes into. Created here.
+ * @param {Object} [opts.providers] - The providers to wrap. Defaults to
+ *   {@link realProviders}; a test injects scripted ones through the same door.
+ * @param {Object} [opts.settings] - Settings the sensors run under. Defaults to `{}`.
+ * @returns {Recording}
+ * @throws {import('./schema').TraceError} When no virtual clock is installed, the
+ *   clock has already been moved, the directory already holds a recording, or a
+ *   graph was already wired in this process.
+ */
+function setUpRecording(opts) {
+  // BEFORE the product is loaded, for the same reason `wiring.setUp` gives: the
+  // preload has to have run before any product module was compiled, and a recording
+  // on the wall clock cannot replay to its own verdicts byte for byte.
+  if (!clockModule.isInstalled()) {
+    schema.refuse(
+      schema.REFUSAL.RECORD_MALFORMED,
+      'no virtual clock is installed. Run the recording entrypoint with ' +
+        '`node --require bench/trace/preload.js` — a recording on the wall clock produces a ' +
+        'trace that can never replay to the verdicts its own run wrote',
+    );
+  }
+  const clockEpochMs = clockModule.installedEpochMs();
+  if (Date.now() !== clockEpochMs) {
+    schema.refuse(
+      schema.REFUSAL.RECORD_MALFORMED,
+      `Date.now() reads ${Date.now()} where the installed clock was seeded at ${clockEpochMs} — ` +
+        'something moved the clock before the recording started, so its first observation ' +
+        'would not sit at the epoch the derived header declares',
+    );
+  }
+
+  const settings = opts.settings || {};
+  const tap = new Tap(opts.providers || realProviders());
+  // Wired BEFORE the meta file is written, so a refused wiring — above all the
+  // one-graph-per-process latch — leaves no recording directory behind it.
+  const wired = wiring.wireGraph({
+    runDir: opts.runDir,
+    settings,
+    fileWatcherDeps: {
+      getFileHandles: tap.wrapped.getFileHandles,
+      getHotSensitiveHolders: tap.wrapped.getHotSensitiveHolders,
+    },
+    networkMonitorDeps: {
+      getRawTcpConnections: tap.wrapped.getRawTcpConnections,
+      dnsReverse: tap.wrapped.dnsReverse,
+      dnsResolve: tap.wrapped.dnsResolve,
+    },
+  });
+
+  // The environment is observed NOW and pinned into the meta file: the header a
+  // derivation builds must describe the tree the recording ran against, not the
+  // tree that happens to be on disk when someone derives. (Reading the tree, not
+  // the wired modules — the order against `wireGraph` carries no information.)
+  const env = environment.observeEnvironment({ clockEpochMs });
+
+  const metaPath = path.join(opts.runDir, META_FILENAME);
+  const meta = {
+    recordingSchemaVersion: RECORDING_SCHEMA_VERSION,
+    clockEpochMs,
+    settings,
+    env,
+  };
+  try {
+    fs.writeFileSync(metaPath, `${JSON.stringify(meta, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+  } catch (err) {
+    schema.refuse(
+      schema.REFUSAL.FILE_UNREADABLE,
+      `${metaPath} could not be created (${err.message}) — a recording directory is written ` +
+        'once, and one that already holds a recording is never overwritten',
+    );
+  }
+
+  // The same orchestration steps `harness.replay` builds, closing the same
+  // dedup → audit pipeline through the same hook. One definition of the product's
+  // wiring, two postures — see `harness.ORCHESTRATION` for the drift guard.
+  const calls = {
+    dedupFileEvent: wired.modules.scanLoop.dedupFileEvent,
+    logAuditForFile: wired.modules.scanLoop.logAuditForFile,
+    scanAllFileHandles: (agents) => wired.modules.fileWatcher.scanAllFileHandles(agents),
+    scanHotFileHolders: (agents) => wired.modules.fileWatcher.scanHotFileHolders(agents),
+  };
+  harness.installFileEventHook(wired, calls);
+
+  return new Recording({
+    runDir: opts.runDir,
+    observationsPath: path.join(opts.runDir, OBSERVATIONS_FILENAME),
+    tap,
+    wired,
+    calls,
+    clock: clockModule.currentClock(),
+  });
+}
+
+/**
+ * Derive a replayable trace directory from a finished recording. OFFLINE: no clock,
+ * no product — this reads three files and drives `./writer.js`.
+ *
+ * @param {Object} opts
+ * @param {string} opts.runDir - The recording directory.
+ * @param {string} opts.traceDir - Where the trace is written. Refused if it holds one.
+ * @param {string} opts.id - The trace id; also the name a replay knows it by.
+ * @returns {{headerPath: string, tracePath: string, records: number}}
+ * @throws {import('./schema').TraceError} When the recording is absent, unfinished,
+ *   unreadable, empty, holds unrecordable observations, or an observation does not
+ *   fit its kind.
+ */
+function deriveTrace(opts) {
+  const metaPath = path.join(opts.runDir, META_FILENAME);
+  const donePath = path.join(opts.runDir, DONE_FILENAME);
+  const observationsPath = path.join(opts.runDir, OBSERVATIONS_FILENAME);
+
+  const meta = readJson(metaPath, 'the recording meta file');
+  if (meta.recordingSchemaVersion !== RECORDING_SCHEMA_VERSION) {
+    schema.refuse(
+      schema.REFUSAL.SCHEMA_VERSION,
+      `the recording declares recordingSchemaVersion ${JSON.stringify(meta.recordingSchemaVersion)} ` +
+        `and this deriver speaks version ${RECORDING_SCHEMA_VERSION}`,
+    );
+  }
+  // Both refusals guard the same property: the header is built from what the
+  // RECORDING pinned, never from what happens to be observable at derive time.
+  // `writer.buildHeader` would observe the current tree when `env` is absent —
+  // exactly the silent re-pin the meta file exists to prevent — and a clockless
+  // meta would build a header the reader refuses, which a recorder must not produce.
+  if (!Number.isSafeInteger(meta.clockEpochMs)) {
+    schema.refuse(
+      schema.REFUSAL.RECORD_MALFORMED,
+      `${metaPath} does not carry clockEpochMs as a safe integer — a trace whose clock nobody ` +
+        'recorded cannot declare where a replay starts',
+    );
+  }
+  if (!schema.isObject(meta.env)) {
+    schema.refuse(
+      schema.REFUSAL.RECORD_MALFORMED,
+      `${metaPath} does not carry the environment observed at recording time — deriving against ` +
+        'the tree on disk today would silently re-pin the header to a tree the recording ' +
+        'never ran against',
+    );
+  }
+  let done;
+  try {
+    done = readJson(donePath, 'the recording done file');
+  } catch (err) {
+    schema.refuse(
+      schema.REFUSAL.FILE_UNREADABLE,
+      `${donePath}: ${err.message}. A recording without its done file never finished — its ` +
+        'audit log is missing the buffered tail, so a trace derived from it would replay to ' +
+        'verdicts the recording itself does not hold',
+    );
+  }
+  if (Array.isArray(done.unrecordable) && done.unrecordable.length > 0) {
+    const listed = done.unrecordable.map((u) => `${u.provider}: ${u.why}`).join('; ');
+    schema.refuse(
+      schema.REFUSAL.RECORD_MALFORMED,
+      `the recording holds ${done.unrecordable.length} observation(s) the trace format cannot ` +
+        `express (${listed}) — a trace that silently dropped them would claim the run consumed ` +
+        'less than it did',
+    );
+  }
+
+  let text;
+  try {
+    text = fs.readFileSync(observationsPath, 'utf8');
+  } catch (err) {
+    return schema.refuse(
+      schema.REFUSAL.FILE_UNREADABLE,
+      `the raw observations could not be read at ${observationsPath}: ${err.message}`,
+    );
+  }
+  const lines = text.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length === 0) {
+    schema.refuse(
+      schema.REFUSAL.EMPTY_TRACE,
+      `${observationsPath} holds no observations — a recording that captured nothing derives ` +
+        'to an empty trace, and the reader refuses one of those by the same name',
+    );
+  }
+
+  const unchained = lines.map((line, i) => {
+    let observation;
+    try {
+      observation = JSON.parse(line);
+    } catch (err) {
+      return schema.refuse(
+        schema.REFUSAL.RECORD_MALFORMED,
+        `${OBSERVATIONS_FILENAME} line ${i} does not parse: ${err.message}`,
+      );
+    }
+    return writer.buildRecord({
+      trace: opts.id,
+      seq: i,
+      kind: observation.kind,
+      epochMs: observation.epochMs,
+      input: observation.input,
+      ambient: observation.ambient,
+    });
+  });
+
+  const header = writer.buildHeader({
+    id: opts.id,
+    clockEpochMs: meta.clockEpochMs,
+    env: meta.env,
+    settings: meta.settings,
+    scope: recorderScope(),
+    provenance: {
+      source: 'bench/trace/recorder.js',
+      derivedFrom: opts.runDir,
+      observations: OBSERVATIONS_FILENAME,
+    },
+  });
+  const written = writer.writeTrace(opts.traceDir, header, writer.chainRecords(unchained));
+  return { ...written, records: unchained.length };
+}
+
+/**
+ * Read and parse one JSON file, refusing rather than throwing a bare error.
+ * @param {string} filePath
+ * @param {string} label
+ * @returns {*}
+ * @throws {import('./schema').TraceError} `file-unreadable`.
+ */
+function readJson(filePath, label) {
+  let text;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    return schema.refuse(
+      schema.REFUSAL.FILE_UNREADABLE,
+      `${label} could not be read at ${filePath}: ${err.message}`,
+    );
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    return schema.refuse(
+      schema.REFUSAL.FILE_UNREADABLE,
+      `${label} at ${filePath} does not parse: ${err.message}`,
+    );
+  }
+}
+
+module.exports = {
+  DONE_FILENAME,
+  META_FILENAME,
+  OBSERVATIONS_FILENAME,
+  RECORDING_SCHEMA_VERSION,
+  Recording,
+  Tap,
+  deriveTrace,
+  realProviders,
+  recorderScope,
+  setUpRecording,
+};

--- a/bench/trace/wiring.js
+++ b/bench/trace/wiring.js
@@ -179,6 +179,109 @@ class Providers {
 }
 
 /**
+ * Wire the product's module graph, whatever the posture — replay or recording.
+ *
+ * The two postures differ ONLY in where the file and network providers point:
+ * a replay serves them from the trace ({@link setUp}), a recording serves the real
+ * ones wrapped record-and-pass-through (`./recorder.js`). Everything else — the
+ * settings path, the rules reload, the baselines path, the audit profile, the
+ * resets, the `state` object and the scan-loop wiring — must be the SAME lines,
+ * or the two postures would drive two subtly different products and the
+ * round-trip claim (a recording replays to its own verdicts) would compare
+ * nothing.
+ * @param {Object} opts
+ * @param {string} opts.runDir - Directory this graph writes into. Created here.
+ * @param {Object} [opts.settings] - Settings the sensors run under.
+ * @param {string} [opts.rulesDir] - Rules to load. Defaults to this checkout's.
+ * @param {Object} opts.fileWatcherDeps - `{getFileHandles, getHotSensitiveHolders}`.
+ * @param {Object} opts.networkMonitorDeps - `{getRawTcpConnections, dnsReverse, dnsResolve}`.
+ * @returns {Object} The wired graph: modules, ambient, and paths.
+ * @throws {import('./schema').TraceError} When a graph was already wired in this process.
+ */
+function wireGraph(opts) {
+  if (_wired) {
+    schema.refuse(
+      schema.REFUSAL.RECORD_MALFORMED,
+      'the product has already been wired in this process. `watcherDebounce`, `eventDedupMap`, ' +
+        '`dnsCache` and `activeSessions` are module state and not all of them have an external ' +
+        'reset, so a second pass would inherit the first one’s memory. Run one trace — replay ' +
+        'or recording — per process',
+    );
+  }
+
+  const profileDir = path.join(opts.runDir, 'profile');
+  fs.mkdirSync(profileDir, { recursive: true });
+
+  const modules = loadProductModules();
+  const ambient = new Ambient();
+
+  // Settings the sensors run under come from the caller, written where the product
+  // reads them. Never the developer's own settings file: `scanIntervalSec`, the
+  // ignore lists and the custom patterns all change what a sensor does.
+  modules.config._setSettingsPathForTest(path.join(opts.runDir, 'settings.json'));
+  modules.config.saveSettings(opts.settings || {});
+
+  // Rules from this checkout (whose digest the header pins). `reloadRules` is the
+  // product's own public reload, not a cache poke.
+  modules.ruleLoader.reloadRules(opts.rulesDir || path.join(schema.REPO_ROOT, 'rules'));
+
+  modules.baselines._setBaselinesPathForTest(path.join(opts.runDir, 'baselines.json'));
+  modules.audit.init({ userDataPath: profileDir });
+
+  modules.fileWatcher._resetForTest();
+  modules.networkMonitor._resetForTest();
+
+  modules.fileWatcher._setDepsForTest({
+    getFileHandles: opts.fileWatcherDeps.getFileHandles,
+    getHotSensitiveHolders: opts.fileWatcherDeps.getHotSensitiveHolders,
+    getProcessCapabilities: () => ambient.capabilities(),
+    // win32 probes the platform for this; both postures answer `true` instead, so
+    // the pool path is reached on every platform — and, just as load-bearing, a
+    // recording and its replay take the SAME branch.
+    isReadDetectionAvailable: true,
+  });
+
+  modules.networkMonitor._setDepsForTest(opts.networkMonitorDeps);
+
+  const state = {
+    getCustomRules: modules.config.getCustomSensitiveRules,
+    getLatestAgents: () => ambient.all(),
+    getLatestAiAgents: () => ambient.ai(),
+    isMonitoringPaused: () => false,
+    activityLog: [],
+    knownHandles: new Map(),
+    watchers: [],
+    recordFileAccess: modules.baselines.recordFileAccess,
+    onActivityPush: () => {},
+    onActivityEvict: () => {},
+    // Left unset on purpose. `main.js` wires the dedup → audit pipeline here, and the
+    // harness reproduces those lines explicitly so they are visible and can be held
+    // against the original. See `./harness.js` `ORCHESTRATION`.
+    onFileEvent: null,
+    isOtherPanelExpanded: () => ambient.isOtherPanelExpanded,
+  };
+  modules.fileWatcher.init(state);
+
+  modules.scanLoop.init({
+    scanner: { getProcessCapabilities: () => ambient.capabilities() },
+    network: modules.networkMonitor,
+    baselines: modules.baselines,
+    audit: modules.audit,
+    logger: silentLogger(),
+    tray: silentTray(),
+    fileAccessBatcher: silentBatcher(),
+    statsUpdateBatcher: silentBatcher(),
+    getStats: () => ({}),
+    getLatestAgents: () => ambient.all(),
+    setLatestNetConnections: () => {},
+    sendToRenderer: () => {},
+  });
+
+  _wired = true;
+  return { ambient, modules, profileDir, state };
+}
+
+/**
  * Wire the product for one replay.
  *
  * @param {Object} opts
@@ -227,98 +330,45 @@ function setUp(opts) {
     );
   }
 
-  const profileDir = path.join(opts.runDir, 'profile');
-  fs.mkdirSync(profileDir, { recursive: true });
-
-  const modules = loadProductModules();
-  const ambient = new Ambient();
   const providers = new Providers();
 
-  // Settings the sensors run under come from the header, written where the product
-  // reads them. Never the developer's own settings file: `scanIntervalSec`, the
-  // ignore lists and the custom patterns all change what a sensor does.
-  modules.config._setSettingsPathForTest(path.join(opts.runDir, 'settings.json'));
-  modules.config.saveSettings(opts.header.settings || {});
-
-  // Rules from the directory whose digest the header already matched. `reloadRules`
-  // is the product's own public reload, not a cache poke.
-  modules.ruleLoader.reloadRules(opts.rulesDir || path.join(schema.REPO_ROOT, 'rules'));
-
-  modules.baselines._setBaselinesPathForTest(path.join(opts.runDir, 'baselines.json'));
-  modules.audit.init({ userDataPath: profileDir });
-
-  modules.fileWatcher._resetForTest();
-  modules.networkMonitor._resetForTest();
-
-  modules.fileWatcher._setDepsForTest({
-    getFileHandles: (pid) =>
-      Promise.resolve(Providers.require('file handle', providers.handlesByPid)[String(pid)] || []),
-    getHotSensitiveHolders: () =>
-      Promise.resolve(Providers.require('Restart Manager holder', providers.rmHolders)),
-    getProcessCapabilities: () => ambient.capabilities(),
-    // win32 probes the platform for this; a replay answers from the trace instead, so
-    // the pool path is reached on every platform the recording was made on.
-    isReadDetectionAvailable: true,
-  });
-
-  modules.networkMonitor._setDepsForTest({
-    getRawTcpConnections: () => Promise.resolve(Providers.require('TCP table', providers.tcp)),
-    dnsReverse: (ip) => {
-      const answer = Providers.require('DNS', providers.dns)[ip];
-      // A recorded `null` means the lookup THREW, and the product distinguishes that
-      // from an empty answer. Replaying it as `[]` would turn "we never learned" into
-      // "the resolver said nothing", which is a different observation.
-      if (!answer || answer.reverse === null) return Promise.reject(new Error('recorded-failure'));
-      return Promise.resolve(answer.reverse);
+  const wired = wireGraph({
+    runDir: opts.runDir,
+    settings: opts.header.settings || {},
+    rulesDir: opts.rulesDir,
+    fileWatcherDeps: {
+      getFileHandles: (pid) =>
+        Promise.resolve(
+          Providers.require('file handle', providers.handlesByPid)[String(pid)] || [],
+        ),
+      getHotSensitiveHolders: () =>
+        Promise.resolve(Providers.require('Restart Manager holder', providers.rmHolders)),
     },
-    dnsResolve: (hostname) => {
-      const dns = Providers.require('DNS', providers.dns);
-      for (const answer of Object.values(dns)) {
-        if (answer.reverse && answer.reverse.includes(hostname)) {
-          if (answer.forward === null) return Promise.reject(new Error('recorded-failure'));
-          return Promise.resolve(answer.forward);
+    networkMonitorDeps: {
+      getRawTcpConnections: () => Promise.resolve(Providers.require('TCP table', providers.tcp)),
+      dnsReverse: (ip) => {
+        const answer = Providers.require('DNS', providers.dns)[ip];
+        // A recorded `null` means the lookup THREW, and the product distinguishes that
+        // from an empty answer. Replaying it as `[]` would turn "we never learned" into
+        // "the resolver said nothing", which is a different observation.
+        if (!answer || answer.reverse === null)
+          return Promise.reject(new Error('recorded-failure'));
+        return Promise.resolve(answer.reverse);
+      },
+      dnsResolve: (hostname) => {
+        const dns = Providers.require('DNS', providers.dns);
+        for (const answer of Object.values(dns)) {
+          if (answer.reverse && answer.reverse.includes(hostname)) {
+            if (answer.forward === null) return Promise.reject(new Error('recorded-failure'));
+            return Promise.resolve(answer.forward);
+          }
         }
-      }
-      return Promise.reject(new Error('recorded-failure'));
+        return Promise.reject(new Error('recorded-failure'));
+      },
     },
   });
 
-  const state = {
-    getCustomRules: modules.config.getCustomSensitiveRules,
-    getLatestAgents: () => ambient.all(),
-    getLatestAiAgents: () => ambient.ai(),
-    isMonitoringPaused: () => false,
-    activityLog: [],
-    knownHandles: new Map(),
-    watchers: [],
-    recordFileAccess: modules.baselines.recordFileAccess,
-    onActivityPush: () => {},
-    onActivityEvict: () => {},
-    // Left unset on purpose. `main.js` wires the dedup → audit pipeline here, and the
-    // harness reproduces those lines explicitly so they are visible and can be held
-    // against the original. See `./harness.js` `ORCHESTRATION`.
-    onFileEvent: null,
-    isOtherPanelExpanded: () => ambient.isOtherPanelExpanded,
-  };
-  modules.fileWatcher.init(state);
-
-  modules.scanLoop.init({
-    scanner: { getProcessCapabilities: () => ambient.capabilities() },
-    network: modules.networkMonitor,
-    baselines: modules.baselines,
-    audit: modules.audit,
-    logger: silentLogger(),
-    tray: silentTray(),
-    fileAccessBatcher: silentBatcher(),
-    statsUpdateBatcher: silentBatcher(),
-    getStats: () => ({}),
-    getLatestAgents: () => ambient.all(),
-    setLatestNetConnections: () => {},
-    sendToRenderer: () => {},
-  });
-
-  _wired = true;
-  return { ambient, modules, profileDir, providers, state };
+  return { ...wired, providers };
 }
 
 /**
@@ -357,4 +407,5 @@ module.exports = {
   silentLogger,
   silentTray,
   tearDown,
+  wireGraph,
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bench:generation": "node scripts/bench-generation.js",
     "bench:run": "node bench/run.js",
     "bench:s1": "node bench/run.js --scenario S1-agent-lifecycle --arm A",
+    "bench:replay": "node bench/trace/bench-replay.js",
     "prepare": "husky"
   },
   "engines": {

--- a/tests/main/bench/actor.test.js
+++ b/tests/main/bench/actor.test.js
@@ -236,6 +236,45 @@ describe('bench actor — stimulus is drawn from the agent database', () => {
   });
 });
 
+describe('bench actor — stage-directory containment respects the platform’s casing rule', () => {
+  it('accepts a case-variant path INSIDE the stage directory on win32', () => {
+    // The regression this suite pins: win32 paths are case-insensitive, so a staged
+    // path differing only in casing (drive letter, any component) is still inside.
+    expect(actor.isInsideStageDir('x:\\run\\stage\\claude.exe', 'X:\\Run\\Stage', 'win32')).toBe(
+      true,
+    );
+    expect(actor.isInsideStageDir('X:\\RUN\\STAGE\\CLAUDE.EXE', 'x:\\run\\stage', 'win32')).toBe(
+      true,
+    );
+  });
+
+  it('is what the raw prefix check both call sites used to be got wrong', () => {
+    // The exact comparison spawn-process and hold-secret-file performed before the
+    // helper existed — kept here so the fixed behaviour above cannot be mistaken
+    // for the old one agreeing by accident.
+    expect('x:\\run\\stage\\claude.exe'.startsWith('X:\\Run\\Stage' + '\\')).toBe(false);
+  });
+
+  it('stays case-SENSITIVE off win32, where the filesystem’s own rule is', () => {
+    expect(actor.isInsideStageDir('/run/Stage/claude', '/run/stage', 'linux')).toBe(false);
+    expect(actor.isInsideStageDir('/run/stage/claude', '/run/stage', 'linux')).toBe(true);
+    expect(actor.isInsideStageDir('/run/stage/claude', '/run/stage', 'darwin')).toBe(true);
+  });
+
+  it('rejects a path outside the stage directory on every platform', () => {
+    expect(
+      actor.isInsideStageDir('X:\\run\\elsewhere\\claude.exe', 'X:\\run\\stage', 'win32'),
+    ).toBe(false);
+    expect(actor.isInsideStageDir('/run/elsewhere/claude', '/run/stage', 'linux')).toBe(false);
+    // Prefix-shaped but not contained: `stage2` begins with `stage` and must not pass.
+    expect(actor.isInsideStageDir('X:\\run\\stage2\\claude.exe', 'X:\\run\\stage', 'win32')).toBe(
+      false,
+    );
+    // The stage directory itself is not INSIDE the stage directory.
+    expect(actor.isInsideStageDir('X:\\run\\stage', 'X:\\run\\stage', 'win32')).toBe(false);
+  });
+});
+
 describe('bench actor — environment expansion and loading', () => {
   it('expands a variable that is set', () => {
     process.env.AEGIS_BENCH_FIXTURE = 'C:\\fixture';

--- a/tests/shared/bench-trace/_record-session.js
+++ b/tests/shared/bench-trace/_record-session.js
@@ -1,0 +1,229 @@
+/**
+ * @file tests/shared/bench-trace/_record-session.js
+ * @description One scripted recording session, runnable in two postures.
+ *
+ *   ```
+ *   node --require bench/trace/preload.js tests/shared/bench-trace/_record-session.js \
+ *     <tap|no-tap> <runDir> [traceDir]
+ *   ```
+ *
+ *   - `tap`    — the session runs through `bench/trace/recorder.js`: providers wrapped
+ *                record-and-pass-through, observations appended, and the trace derived
+ *                offline into `traceDir`.
+ *   - `no-tap` — the SAME session, the SAME scripted providers, wired straight through
+ *                `wiring.wireGraph` with no tap anywhere. What this posture exists to
+ *                prove is that the tap does not change what the sensor observes or
+ *                decides: the two postures' audit bytes must be identical.
+ *
+ *   One session definition drives both postures through one driver interface, so the
+ *   equality claim compares the tap and nothing else.
+ *
+ *   THE PROVIDERS ARE SCRIPTED, AND THE PATHS ARE SYNTHETIC, on purpose. A committed
+ *   suite cannot depend on what this machine's handle tables and DNS answer today —
+ *   determinism is the point of the whole subtree. And every staged path lives under a
+ *   root that `bench/lib/paths.js` does not rewrite, so the recording's own audit
+ *   bytes and the derived trace's replay verdict can be compared byte for byte
+ *   (neutralization is the identity on them).
+ *
+ *   Not named `*.test.js`, so vitest does not collect it; it is spawned by
+ *   `recorder-roundtrip.test.js` exactly the way `harness-replay.test.js` spawns the
+ *   replay — the clock has to be installed before any product module is compiled.
+ *   Prints one JSON line: `{auditFile, observationsPath, traceDir?}`.
+ * @author AEGIS Contributors
+ * @license MIT
+ */
+
+'use strict';
+
+const path = require('path');
+
+const harness = require('../../../bench/trace/harness');
+const recorder = require('../../../bench/trace/recorder');
+const wiring = require('../../../bench/trace/wiring');
+const clockModule = require('../../../bench/trace/clock');
+
+/** @type {string} A root neither the repo-root nor the `\Users\<name>\` rewrite touches. */
+const BASE = process.platform === 'win32' ? 'X:\\bench-rt' : '/bench-rt';
+
+/** @type {string} The staged agent's cwd. */
+const PROJ = path.join(BASE, 'proj');
+
+/**
+ * The scripted providers — deterministic, machine-independent.
+ * @returns {Object} The provider set, in the shape `recorder.setUpRecording` wraps.
+ */
+function scriptedProviders() {
+  return {
+    getFileHandles: async (pid) => (pid === 4812 ? [path.join(PROJ, 'secrets', 'id_rsa')] : []),
+    getHotSensitiveHolders: async () => [
+      { pid: 4812, group: path.join(PROJ, 'creds'), reason: 'scripted-credential-store' },
+    ],
+    getRawTcpConnections: async () => [
+      { pid: 4812, ip: '203.0.113.10', port: 443, state: 'Established' },
+    ],
+    dnsReverse: async () => {
+      throw new Error('scripted-failure');
+    },
+    dnsResolve: async () => {
+      throw new Error('scripted-failure');
+    },
+  };
+}
+
+/**
+ * The one agent the session stages.
+ * @param {number} epochMs
+ * @returns {Object}
+ */
+function agent(epochMs) {
+  return {
+    agent: 'Claude Code',
+    pid: 4812,
+    process: 'claude.exe',
+    instanceId: `4812:${epochMs}`,
+    cwd: PROJ,
+    category: 'ai',
+    parentEditor: null,
+  };
+}
+
+/**
+ * The session itself, written once and driven through either posture.
+ * @param {Object} driver - `{setPopulation, fsEvent, advanceClock, handlesTick,
+ *   rmHotTick, netTick, finish}`.
+ * @param {number} epochMs
+ * @returns {Promise<Object>} What `finish()` returned.
+ */
+async function runSession(driver, epochMs) {
+  driver.setPopulation([agent(epochMs)]);
+  // Its own config dir (self-config-path), then a secret beside it (cwd-containment).
+  driver.fsEvent('created', path.join(PROJ, '.claude', 'settings.json'));
+  driver.fsEvent('created', path.join(PROJ, '.env'));
+  // Past the scan loop's 30 s dedup window, exactly as a real cadence would be.
+  driver.advanceClock(epochMs + 31_000);
+  await driver.handlesTick();
+  await driver.rmHotTick();
+  driver.advanceClock(epochMs + 31_010);
+  await driver.netTick();
+  return driver.finish();
+}
+
+/**
+ * The no-tap posture: the same graph, the same scripted providers, no recorder.
+ * @param {Object} providers - The scripted set, unwrapped.
+ * @param {string} runDir
+ * @returns {Object} A driver with the same interface `recorder.Recording` has.
+ */
+function noTapDriver(providers, runDir) {
+  const wired = wiring.wireGraph({
+    runDir,
+    settings: {},
+    fileWatcherDeps: {
+      getFileHandles: providers.getFileHandles,
+      getHotSensitiveHolders: providers.getHotSensitiveHolders,
+    },
+    networkMonitorDeps: {
+      getRawTcpConnections: providers.getRawTcpConnections,
+      dnsReverse: providers.dnsReverse,
+      dnsResolve: providers.dnsResolve,
+    },
+  });
+  const calls = {
+    dedupFileEvent: wired.modules.scanLoop.dedupFileEvent,
+    logAuditForFile: wired.modules.scanLoop.logAuditForFile,
+    scanAllFileHandles: (agents) => wired.modules.fileWatcher.scanAllFileHandles(agents),
+    scanHotFileHolders: (agents) => wired.modules.fileWatcher.scanHotFileHolders(agents),
+  };
+  harness.installFileEventHook(wired, calls);
+  const clock = clockModule.currentClock();
+  return {
+    setPopulation(agents) {
+      wired.ambient.agents = agents;
+    },
+    fsEvent(action, filePath) {
+      wired.modules.fileWatcher.handleWatcherEvent(action, filePath);
+    },
+    advanceClock(toEpochMs) {
+      clock.advanceTo(toEpochMs);
+    },
+    async handlesTick() {
+      const events = await calls.scanAllFileHandles(wired.ambient.all());
+      harness.pipeFileEvents(events, calls);
+    },
+    async rmHotTick() {
+      const events = await calls.scanHotFileHolders(wired.ambient.all());
+      harness.pipeFileEvents(events, calls);
+    },
+    async netTick() {
+      wired.modules.scanLoop.doNetworkScan();
+      await harness.drainUntil(
+        () => !wired.modules.networkMonitor.isNetworkScanRunning(),
+        'doNetworkScan',
+      );
+    },
+    finish() {
+      return wiring.tearDown(wired);
+    },
+  };
+}
+
+/**
+ * @param {string[]} argv - `process.argv.slice(2)`.
+ * @returns {Promise<number>} The process exit code.
+ */
+async function main(argv) {
+  const [mode, runDir, traceDir] = argv;
+  if ((mode !== 'tap' && mode !== 'no-tap') || !runDir || (mode === 'tap' && !traceDir)) {
+    console.error('usage: _record-session.js <tap|no-tap> <runDir> [traceDir]');
+    return 2;
+  }
+  const epochMs = clockModule.installedEpochMs();
+  const providers = scriptedProviders();
+
+  if (mode === 'tap') {
+    const recording = recorder.setUpRecording({ runDir, providers, settings: {} });
+    // The one-graph-per-process latch, exercised where it can actually fire: the
+    // clock guard still passes here (nothing has advanced it yet), so what refuses
+    // a second wiring is the latch and nothing earlier.
+    try {
+      recorder.setUpRecording({ runDir: path.join(runDir, 'second'), providers, settings: {} });
+      console.error('a second setUpRecording in one process was NOT refused');
+      return 1;
+    } catch (err) {
+      if (err.reason !== 'record-malformed' || !/already been wired/.test(err.message)) {
+        console.error(`the second setUpRecording refused for the wrong reason: ${err.message}`);
+        return 1;
+      }
+    }
+    const finished = await runSession(recording, epochMs);
+    if (finished.auditFiles.length !== 1) {
+      console.error(`expected exactly one daily audit file, got ${finished.auditFiles.length}`);
+      return 1;
+    }
+    recorder.deriveTrace({ runDir, traceDir, id: 'T1-recorded-session' });
+    console.log(
+      JSON.stringify({
+        auditFile: path.join(finished.auditDir, finished.auditFiles[0]),
+        observationsPath: finished.observationsPath,
+        traceDir,
+      }),
+    );
+    return 0;
+  }
+
+  const finished = await runSession(noTapDriver(providers, runDir), epochMs);
+  if (finished.auditFiles.length !== 1) {
+    console.error(`expected exactly one daily audit file, got ${finished.auditFiles.length}`);
+    return 1;
+  }
+  console.log(JSON.stringify({ auditFile: path.join(finished.auditDir, finished.auditFiles[0]) }));
+  return 0;
+}
+
+main(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(err && err.stack ? err.stack : err);
+    process.exit(1);
+  },
+);

--- a/tests/shared/bench-trace/_record-session.js
+++ b/tests/shared/bench-trace/_record-session.js
@@ -55,9 +55,18 @@ const PROJ = path.join(BASE, 'proj');
 function scriptedProviders() {
   return {
     getFileHandles: async (pid) => (pid === 4812 ? [path.join(PROJ, 'secrets', 'id_rsa')] : []),
-    getHotSensitiveHolders: async () => [
-      { pid: 4812, group: path.join(PROJ, 'creds'), reason: 'scripted-credential-store' },
-    ],
+    // Shaped like the platform: the hot Restart Manager source exists on win32 and
+    // NOWHERE else, and `file-watcher.js` holds the RM sensor at UNSUPPORTED on the
+    // other platforms — `scanViaRestartManager` cannot tick it there, by design
+    // (sensor-health refuses FAILED/HEALTHY from UNSUPPORTED). A POSIX session that
+    // scripted one anyway would be recording an observation its platform never
+    // makes, and the product rightly throws it out.
+    getHotSensitiveHolders:
+      process.platform === 'win32'
+        ? async () => [
+            { pid: 4812, group: path.join(PROJ, 'creds'), reason: 'scripted-credential-store' },
+          ]
+        : undefined,
     getRawTcpConnections: async () => [
       { pid: 4812, ip: '203.0.113.10', port: 443, state: 'Established' },
     ],
@@ -102,7 +111,8 @@ async function runSession(driver, epochMs) {
   // Past the scan loop's 30 s dedup window, exactly as a real cadence would be.
   driver.advanceClock(epochMs + 31_000);
   await driver.handlesTick();
-  await driver.rmHotTick();
+  // Only where the platform's own hot source exists — see scriptedProviders.
+  if (process.platform === 'win32') await driver.rmHotTick();
   driver.advanceClock(epochMs + 31_010);
   await driver.netTick();
   return driver.finish();

--- a/tests/shared/bench-trace/recorder-refusals.test.js
+++ b/tests/shared/bench-trace/recorder-refusals.test.js
@@ -1,0 +1,368 @@
+/**
+ * @file tests/shared/bench-trace/recorder-refusals.test.js
+ * @description What the recorder REFUSES, by name — the property all of it serves:
+ *   a recorder must not be able to produce a trace the reader refuses, and it must
+ *   not quietly drop what the format cannot hold.
+ *
+ *   The recording directories here are SYNTHETIC, laid down by hand, for the same
+ *   reason `trace-reader-refusals.test.js` builds synthetic headers: a refusal suite
+ *   that recorded through the real graph would pass for a different reason on every
+ *   machine. The one positive case (a valid synthetic recording derives to a trace
+ *   the reader accepts) closes the loop against `_make-trace`'s synthetic
+ *   environment; the real-tree positive lives in `recorder-roundtrip.test.js`.
+ *
+ *   `setUpRecording`'s clock refusal is safe to check in-process precisely because
+ *   it fires BEFORE any product module is loaded — the same ordering `wiring.setUp`
+ *   documents. Everything needing a wired product stays in the spawned round-trip
+ *   suite.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, it, expect, afterAll } from 'vitest';
+
+import recorder from '../../../bench/trace/recorder.js';
+import reader from '../../../bench/trace/reader.js';
+import schema from '../../../bench/trace/schema.js';
+import { CLOCK_EPOCH_MS, makeAgent, makeAmbient, makeEnv } from './_make-trace.js';
+
+/** @type {string[]} Every directory a test created, removed at the end. */
+const scratchDirs = [];
+
+/** @returns {string} A fresh scratch directory. */
+function scratch() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-recorder-refusals-'));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+/** @returns {Object[]} A small, valid observation list in the raw file's shape. */
+function makeObservations() {
+  return [
+    {
+      kind: 'population.set',
+      epochMs: CLOCK_EPOCH_MS,
+      input: { agents: [makeAgent()] },
+    },
+    {
+      kind: 'fs.event',
+      epochMs: CLOCK_EPOCH_MS + 10,
+      input: { action: 'created', path: 'X:\\dev\\project\\AEGIS\\.env' },
+      ambient: makeAmbient(),
+    },
+  ];
+}
+
+/**
+ * Lay down one synthetic recording directory.
+ * @param {Object} [opts]
+ * @param {Object|null} [opts.meta] - The meta object; `null` omits the file.
+ * @param {Object|null} [opts.done] - The done object; `null` omits the file.
+ * @param {Object[]|null} [opts.observations] - Raw observations; `null` omits the file.
+ * @param {string} [opts.observationsText] - Raw bytes, overriding `observations`.
+ * @returns {string} The recording directory.
+ */
+function makeRecordingDir(opts = {}) {
+  const dir = scratch();
+  const meta =
+    opts.meta !== undefined
+      ? opts.meta
+      : {
+          recordingSchemaVersion: recorder.RECORDING_SCHEMA_VERSION,
+          clockEpochMs: CLOCK_EPOCH_MS,
+          settings: {},
+          env: makeEnv(),
+        };
+  if (meta !== null) {
+    fs.writeFileSync(path.join(dir, recorder.META_FILENAME), JSON.stringify(meta, null, 2));
+  }
+  const done =
+    opts.done !== undefined
+      ? opts.done
+      : { auditFiles: ['aegis-audit-2026-08-21.json'], unrecordable: [] };
+  if (done !== null) {
+    fs.writeFileSync(path.join(dir, recorder.DONE_FILENAME), JSON.stringify(done, null, 2));
+  }
+  const observations = opts.observations !== undefined ? opts.observations : makeObservations();
+  if (opts.observationsText !== undefined) {
+    fs.writeFileSync(path.join(dir, recorder.OBSERVATIONS_FILENAME), opts.observationsText);
+  } else if (observations !== null) {
+    fs.writeFileSync(
+      path.join(dir, recorder.OBSERVATIONS_FILENAME),
+      observations.map((o) => JSON.stringify(o)).join('\n') + '\n',
+    );
+  }
+  return dir;
+}
+
+/**
+ * Run `deriveTrace` and hand back what it threw.
+ * @param {string} runDir
+ * @returns {Error|null}
+ */
+function deriveError(runDir) {
+  try {
+    recorder.deriveTrace({ runDir, traceDir: path.join(scratch(), 'trace'), id: 'T9-refusals' });
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+afterAll(() => {
+  for (const dir of scratchDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('setUpRecording — the clock guard', () => {
+  it('refuses without a virtual clock, before any product module is loaded', () => {
+    // This worker has no preload, which is exactly the point: the guard fires first.
+    let err = null;
+    try {
+      recorder.setUpRecording({ runDir: path.join(scratch(), 'rec') });
+    } catch (e) {
+      err = e;
+    }
+    expect(err && err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(err.message).toContain('no virtual clock is installed');
+  });
+});
+
+describe('deriveTrace — the positive case the refusals give meaning to', () => {
+  it('derives a valid recording to a trace the READER accepts', () => {
+    const runDir = makeRecordingDir();
+    const traceDir = path.join(scratch(), 'trace');
+    const result = recorder.deriveTrace({ runDir, traceDir, id: 'T9-valid' });
+    expect(result.records).toBe(2);
+
+    // The loop this suite exists to close: reader.readTrace, not a hand check.
+    const trace = reader.readTrace(traceDir, { env: makeEnv() });
+    expect(trace.header.id).toBe('T9-valid');
+    expect(trace.header.clock.epochMs).toBe(CLOCK_EPOCH_MS);
+    expect(trace.records.map((r) => r.bench.kind)).toEqual(['population.set', 'fs.event']);
+  });
+});
+
+describe('deriveTrace — refusals, by name', () => {
+  it('refuses a recording with no meta file', () => {
+    const err = deriveError(makeRecordingDir({ meta: null }));
+    expect(err.reason).toBe(schema.REFUSAL.FILE_UNREADABLE);
+    expect(err.message).toContain(recorder.META_FILENAME);
+  });
+
+  it('refuses a meta file of another version', () => {
+    const err = deriveError(
+      makeRecordingDir({
+        meta: { recordingSchemaVersion: 99, clockEpochMs: CLOCK_EPOCH_MS, env: makeEnv() },
+      }),
+    );
+    expect(err.reason).toBe(schema.REFUSAL.SCHEMA_VERSION);
+  });
+
+  it('refuses a meta file with no recorded environment, rather than re-pinning the tree', () => {
+    const err = deriveError(
+      makeRecordingDir({
+        meta: {
+          recordingSchemaVersion: recorder.RECORDING_SCHEMA_VERSION,
+          clockEpochMs: CLOCK_EPOCH_MS,
+          settings: {},
+        },
+      }),
+    );
+    expect(err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(err.message).toContain('environment observed at recording time');
+  });
+
+  it('refuses a meta file with no clock epoch', () => {
+    const err = deriveError(
+      makeRecordingDir({
+        meta: {
+          recordingSchemaVersion: recorder.RECORDING_SCHEMA_VERSION,
+          settings: {},
+          env: makeEnv(),
+        },
+      }),
+    );
+    expect(err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(err.message).toContain('clockEpochMs');
+  });
+
+  it('refuses a recording that never finished — the done file is absent', () => {
+    const err = deriveError(makeRecordingDir({ done: null }));
+    expect(err.reason).toBe(schema.REFUSAL.FILE_UNREADABLE);
+    expect(err.message).toContain('never finished');
+  });
+
+  it('refuses a recording holding observations the format could not express', () => {
+    const err = deriveError(
+      makeRecordingDir({
+        done: {
+          auditFiles: ['aegis-audit-2026-08-21.json'],
+          unrecordable: [{ provider: 'getFileHandles', why: 'threw for pid 4812' }],
+        },
+      }),
+    );
+    expect(err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(err.message).toContain('getFileHandles');
+    expect(err.message).toContain('cannot express');
+  });
+
+  it('refuses an empty observations file, by the reader’s own name for it', () => {
+    const err = deriveError(makeRecordingDir({ observationsText: '' }));
+    expect(err.reason).toBe(schema.REFUSAL.EMPTY_TRACE);
+  });
+
+  it('refuses a missing observations file', () => {
+    const err = deriveError(makeRecordingDir({ observations: null }));
+    expect(err.reason).toBe(schema.REFUSAL.FILE_UNREADABLE);
+  });
+
+  it('refuses an observation line that does not parse', () => {
+    const err = deriveError(makeRecordingDir({ observationsText: '{"kind": "fs.eve\n' }));
+    expect(err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(err.message).toContain('line 0');
+  });
+
+  it('refuses an observation of a kind outside the closed list', () => {
+    const err = deriveError(
+      makeRecordingDir({
+        observations: [{ kind: 'fs.renamed', epochMs: CLOCK_EPOCH_MS, input: {} }],
+      }),
+    );
+    expect(err.reason).toBe(schema.REFUSAL.UNKNOWN_KIND);
+  });
+
+  it('refuses an observation whose kind demands an ambient scope it does not carry', () => {
+    const observations = makeObservations();
+    delete observations[1].ambient;
+    const err = deriveError(makeRecordingDir({ observations }));
+    expect(err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(err.message).toContain('ambient');
+  });
+});
+
+describe('the Recording validates before it appends', () => {
+  /**
+   * A Recording over stubs — enough shape for `_append`, nothing real behind it.
+   * @param {string} runDir
+   * @returns {Object}
+   */
+  function bareRecording(runDir) {
+    return new recorder.Recording({
+      runDir,
+      observationsPath: path.join(runDir, recorder.OBSERVATIONS_FILENAME),
+      tap: new recorder.Tap({}),
+      wired: { ambient: { populationReliable: true, isOtherPanelExpanded: false } },
+      calls: {},
+      clock: {},
+    });
+  }
+
+  it('refuses a malformed observation and leaves NO line behind', () => {
+    const runDir = scratch();
+    const recording = bareRecording(runDir);
+    let err = null;
+    try {
+      recording._append('fs.event', { action: 'exploded', path: 'X:\\x' });
+    } catch (e) {
+      err = e;
+    }
+    expect(err && err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(fs.existsSync(path.join(runDir, recorder.OBSERVATIONS_FILENAME))).toBe(false);
+  });
+
+  it('appends a valid observation with the ambient snapshot its kind demands', () => {
+    const runDir = scratch();
+    const recording = bareRecording(runDir);
+    recording._append('fs.event', { action: 'created', path: 'X:\\x\\.env' });
+    const lines = fs
+      .readFileSync(path.join(runDir, recorder.OBSERVATIONS_FILENAME), 'utf8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    expect(lines.length).toBe(1);
+    const observation = JSON.parse(lines[0]);
+    expect(observation.kind).toBe('fs.event');
+    expect(observation.ambient).toEqual({ populationReliable: true, isOtherPanelExpanded: false });
+  });
+
+  it('refuses an observation after finish() sealed the recording', () => {
+    const runDir = scratch();
+    const recording = bareRecording(runDir);
+    recording._finished = true;
+    let err = null;
+    try {
+      recording._append('clock.advance', { toEpochMs: CLOCK_EPOCH_MS + 1 });
+    } catch (e) {
+      err = e;
+    }
+    expect(err && err.reason).toBe(schema.REFUSAL.RECORD_MALFORMED);
+    expect(err.message).toContain('finished');
+  });
+});
+
+describe('the Tap — record-and-pass-through, bytes unchanged', () => {
+  it('hands back the provider’s OWN answer and buffers a copy of it', async () => {
+    const answer = [path.join('X:', 'p', 'id_rsa')];
+    const tap = new recorder.Tap({ getFileHandles: async () => answer });
+    tap.begin('handles');
+    const returned = await tap.wrapped.getFileHandles(4812);
+    expect(returned).toBe(answer);
+    const collected = tap.end();
+    expect(collected.byPid['4812']).toEqual(answer);
+    expect(collected.byPid['4812']).not.toBe(answer);
+    expect(tap.unrecordable).toEqual([]);
+  });
+
+  it('records a DNS throw as null — the format’s word for "the lookup threw"', async () => {
+    const tap = new recorder.Tap({
+      dnsReverse: async () => {
+        throw new Error('scripted-failure');
+      },
+    });
+    tap.begin('net');
+    await expect(tap.wrapped.dnsReverse('203.0.113.10')).rejects.toThrow('scripted-failure');
+    expect(tap.end().dns['203.0.113.10']).toEqual({ reverse: null, forward: null });
+    expect(tap.unrecordable).toEqual([]);
+  });
+
+  it('attributes a forward answer by the replay’s own rule — first recorded reverse', async () => {
+    const tap = new recorder.Tap({
+      dnsReverse: async () => ['api.example.com'],
+      dnsResolve: async () => ['203.0.113.99'],
+    });
+    tap.begin('net');
+    await tap.wrapped.dnsReverse('203.0.113.10');
+    await tap.wrapped.dnsResolve('api.example.com');
+    expect(tap.end().dns['203.0.113.10']).toEqual({
+      reverse: ['api.example.com'],
+      forward: ['203.0.113.99'],
+    });
+    expect(tap.unrecordable).toEqual([]);
+  });
+
+  it('marks a REAL forward answer with no reverse to hang it on as unrecordable', async () => {
+    const tap = new recorder.Tap({ dnsResolve: async () => ['203.0.113.99'] });
+    tap.begin('net');
+    await tap.wrapped.dnsResolve('orphan.example.com');
+    expect(tap.unrecordable.length).toBe(1);
+    expect(tap.unrecordable[0].provider).toBe('dnsResolve');
+  });
+
+  it('marks a provider THROW as unrecordable — the format records answers only', async () => {
+    const tap = new recorder.Tap({
+      getFileHandles: async () => {
+        throw new Error('handle scan failed');
+      },
+    });
+    tap.begin('handles');
+    await expect(tap.wrapped.getFileHandles(4812)).rejects.toThrow('handle scan failed');
+    expect(tap.unrecordable.length).toBe(1);
+    expect(tap.unrecordable[0].provider).toBe('getFileHandles');
+  });
+
+  it('marks an answer arriving with no tick open as unrecordable', async () => {
+    const tap = new recorder.Tap({ getFileHandles: async () => [] });
+    await tap.wrapped.getFileHandles(4812);
+    expect(tap.unrecordable.length).toBe(1);
+    expect(tap.unrecordable[0].why).toContain('outside a handles tick');
+  });
+});

--- a/tests/shared/bench-trace/recorder-roundtrip.test.js
+++ b/tests/shared/bench-trace/recorder-roundtrip.test.js
@@ -1,0 +1,168 @@
+/**
+ * @file tests/shared/bench-trace/recorder-roundtrip.test.js
+ * @description The recorder's whole claim, checked end to end: a recorded session
+ *   derives to a trace that replays to the very bytes the recording run wrote, and
+ *   the tap that recorded it changed nothing about what the sensor decided.
+ *
+ *   THREE CHILD PROCESSES, ONE SESSION. `_record-session.js` defines one scripted
+ *   session and runs it in two postures — `tap` (through the recorder) and `no-tap`
+ *   (the same graph, the same scripted providers, no tap anywhere) — and the replay
+ *   runs through `bench/trace/bench-replay.js`, the same command `npm run
+ *   bench:replay` executes. Spawning rather than calling is not a style choice: the
+ *   clock has to be installed before any product module is compiled, and the
+ *   one-graph-per-process rule then holds naturally (the reasons
+ *   `harness-replay.test.js` already states).
+ *
+ *   EVERY ASSERTION HERE IS AN EQUALITY OF BYTES, not of evidence codes, so the suite
+ *   is portable to whatever platform runs it — the session's synthetic paths follow
+ *   the platform, and what is compared is one run's output against another's.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import clockEnv from '../../../bench/trace/clock-env.js';
+import reader from '../../../bench/trace/reader.js';
+import recorder from '../../../bench/trace/recorder.js';
+import replayTrace from '../../../bench/trace/replay-trace.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+const PRELOAD = path.join(REPO_ROOT, 'bench', 'trace', 'preload.js');
+const DRIVER = path.join(HERE, '_record-session.js');
+const WRAPPER = path.join(REPO_ROOT, 'bench', 'trace', 'bench-replay.js');
+
+/** @type {number} 2026-08-21T09:13:52.000Z — the instant `harness-replay` also pins. */
+const EPOCH_MS = 1_787_303_632_000;
+
+/** @type {string} Scratch root for this suite. */
+let scratch;
+/** @type {{auditFile: string, observationsPath: string, traceDir: string}} */
+let tap;
+
+/**
+ * Run the scripted session in a child, in one posture.
+ * @param {string} mode - `tap` | `no-tap`.
+ * @param {string} runDir
+ * @param {string} [traceDir]
+ * @returns {{status: number, stdout: string, stderr: string}}
+ */
+function runSession(mode, runDir, traceDir) {
+  const args = ['--require', PRELOAD, DRIVER, mode, runDir];
+  if (traceDir) args.push(traceDir);
+  // The zone is deliberately NOT set: the recording observes the machine's own zone
+  // into its header, and the replay wrapper hands that observation back — the same
+  // round-trip a real recording relies on.
+  const env = { ...process.env, [clockEnv.EPOCH_ENV]: String(EPOCH_MS) };
+  const result = spawnSync(process.execPath, args, { encoding: 'utf8', cwd: REPO_ROOT, env });
+  return { status: result.status, stdout: result.stdout || '', stderr: result.stderr || '' };
+}
+
+beforeAll(() => {
+  scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-recorder-test-'));
+  const result = runSession('tap', path.join(scratch, 'rec-tap'), path.join(scratch, 'trace'));
+  expect(result.status, result.stderr).toBe(0);
+  tap = JSON.parse(result.stdout);
+});
+
+afterAll(() => {
+  fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+describe('recording — what the run leaves behind', () => {
+  it('appends the raw observations during the run, one line per observation', () => {
+    const lines = fs
+      .readFileSync(tap.observationsPath, 'utf8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    // The session's own shape: population, two fs events, a clock advance, a handles
+    // tick, an rm tick, a second advance, a net tick.
+    expect(lines.length).toBe(8);
+    const kinds = lines.map((l) => JSON.parse(l).kind);
+    expect(kinds).toEqual([
+      'population.set',
+      'fs.event',
+      'fs.event',
+      'clock.advance',
+      'handles.tick',
+      'rm.hot.tick',
+      'clock.advance',
+      'net.tick',
+    ]);
+  });
+
+  it('writes the product’s own audit records — the recording’s verdict', () => {
+    const text = fs.readFileSync(tap.auditFile, 'utf8');
+    const records = text
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l));
+    expect(records.length).toBeGreaterThan(0);
+    records.forEach((record, i) => {
+      expect(record.schemaVersion).toBe(1);
+      expect(record.seq).toBe(i);
+    });
+  });
+});
+
+describe('recording — the derived trace', () => {
+  it('is one the reader ACCEPTS: same header shape, same chain, same kinds', () => {
+    // "A recorder must not be able to produce a trace the reader refuses" — checked
+    // against the real tree, which is exactly what a replay of this trace will do.
+    const trace = reader.readTrace(tap.traceDir);
+    expect(trace.header.id).toBe('T1-recorded-session');
+    expect(trace.header.clock.epochMs).toBe(EPOCH_MS);
+    expect(trace.header.provenance.source).toBe('bench/trace/recorder.js');
+    expect(trace.records.length).toBe(8);
+  });
+
+  it('derives offline from the raw file, refusing a second write of the same trace', () => {
+    let err = null;
+    try {
+      recorder.deriveTrace({
+        runDir: path.dirname(tap.observationsPath),
+        traceDir: tap.traceDir,
+        id: 'T1-recorded-session',
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err && err.reason).toBe('file-unreadable');
+    expect(err.message).toContain('never written twice');
+  });
+});
+
+describe('round-trip — record, derive, replay', () => {
+  it('replays through the bench:replay wrapper to the EXACT bytes the recording wrote', () => {
+    const outDir = path.join(scratch, 'replay-out');
+    // The same command `npm run bench:replay -- <trace> --out <dir>` runs; the
+    // wrapper reads the clock and the zone out of the trace's own header.
+    const result = spawnSync(process.execPath, [WRAPPER, tap.traceDir, '--out', outDir], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+      env: { ...process.env },
+    });
+    expect(result.status, result.stderr).toBe(0);
+
+    const recorded = fs.readFileSync(tap.auditFile);
+    const replayed = fs.readFileSync(path.join(outDir, replayTrace.VERDICT_FILENAME));
+    expect(recorded.length).toBeGreaterThan(0);
+    expect(replayed.equals(recorded)).toBe(true);
+  });
+});
+
+describe('the tap changes nothing', () => {
+  it('tap-on and tap-off verdicts are byte-identical on the same scripted inputs', () => {
+    const result = runSession('no-tap', path.join(scratch, 'rec-no-tap'));
+    expect(result.status, result.stderr).toBe(0);
+    const noTap = JSON.parse(result.stdout);
+
+    const withTap = fs.readFileSync(tap.auditFile);
+    const withoutTap = fs.readFileSync(noTap.auditFile);
+    expect(withTap.length).toBeGreaterThan(0);
+    expect(withoutTap.equals(withTap)).toBe(true);
+  });
+});

--- a/tests/shared/bench-trace/recorder-roundtrip.test.js
+++ b/tests/shared/bench-trace/recorder-roundtrip.test.js
@@ -79,19 +79,22 @@ describe('recording — what the run leaves behind', () => {
       .split('\n')
       .filter((l) => l.trim().length > 0);
     // The session's own shape: population, two fs events, a clock advance, a handles
-    // tick, an rm tick, a second advance, a net tick.
-    expect(lines.length).toBe(8);
+    // tick, an rm tick (win32 only — the hot Restart Manager source exists nowhere
+    // else, and the product refuses to tick an UNSUPPORTED sensor), a second
+    // advance, a net tick.
     const kinds = lines.map((l) => JSON.parse(l).kind);
-    expect(kinds).toEqual([
-      'population.set',
-      'fs.event',
-      'fs.event',
-      'clock.advance',
-      'handles.tick',
-      'rm.hot.tick',
-      'clock.advance',
-      'net.tick',
-    ]);
+    expect(kinds).toEqual(
+      [
+        'population.set',
+        'fs.event',
+        'fs.event',
+        'clock.advance',
+        'handles.tick',
+        process.platform === 'win32' ? 'rm.hot.tick' : null,
+        'clock.advance',
+        'net.tick',
+      ].filter(Boolean),
+    );
   });
 
   it('writes the product’s own audit records — the recording’s verdict', () => {
@@ -116,7 +119,7 @@ describe('recording — the derived trace', () => {
     expect(trace.header.id).toBe('T1-recorded-session');
     expect(trace.header.clock.epochMs).toBe(EPOCH_MS);
     expect(trace.header.provenance.source).toBe('bench/trace/recorder.js');
-    expect(trace.records.length).toBe(8);
+    expect(trace.records.length).toBe(process.platform === 'win32' ? 8 : 7);
   });
 
   it('derives offline from the raw file, refusing a second write of the same trace', () => {


### PR DESCRIPTION
## What

`bench/trace/` could REPLAY a recorded stream of observations but nothing could RECORD one — an arm-A run writes only the product's decisions (the audit log), never the sensors' inputs, so a trace cannot be derived from `observed.ndjson` (P5a). This PR adds the missing input tap, plus the unrelated win32 casing fix riding in the block (docs-debt #9).

### Trace recorder (`bench/trace/recorder.js`)

- The SAME product graph the replay drives, wired through the SAME published seams — `wiring.wireGraph` is extracted from `wiring.setUp` and now serves both postures, so the two cannot drift. Nothing in `src/` is patched.
- Providers stay REAL, wrapped record-and-pass-through: the wrapper hands the product the provider's own return value and buffers a JSON snapshot. The production default is `src/main/platform`'s own un-injected provider functions plus a mirror of `network-monitor.js`'s module-private DNS defaults (a named drift point, documented in the README).
- Raw observations are APPENDED during the run (`observations.ndjson`); `trace.ndjson` + `trace.header.json` are derived OFFLINE by `deriveTrace` through the existing `writer.js`. The environment is observed at RECORDING time and carried through `recording.meta.json`, so the header pins the tree the recording ran against.
- NO new record kinds: the six in `schema.js` express everything the recorder can observe. Every observation is validated before it is appended; an answer the format cannot express (a thrown handle scan, an orphan forward DNS answer) is marked unrecordable and fails `deriveTrace` by name — a recorder cannot produce a trace the reader refuses, and cannot silently drop what it could not record.
- A recording runs on the virtual clock (refused without the preload): the product stamps `new Date().toISOString()` on every audit record, so a wall-clock recording could never replay to its own verdicts byte for byte.
- `bench/trace/bench-replay.js` + `npm run bench:replay` — the wrapper the README already promised but `package.json` never had: reads the header, sets `AEGIS_TRACE_CLOCK_EPOCH_MS`/`AEGIS_TRACE_TZ`, spawns the preload.

### Evidence (all local, Windows)

- **Round-trip**: a scripted session recorded through the tap derives to a trace that `npm run bench:replay` replays with exit 0, and `verdict.ndjson` is byte-identical to the audit file the recording run itself wrote (2060 bytes, `SequenceEqual = True`).
- **Tap-on/tap-off**: the same session with the tap removed (same scripted providers, wired directly through `wireGraph`) writes byte-identical audit bytes.
- Both equalities are also pinned as tests (`tests/shared/bench-trace/recorder-roundtrip.test.js`, portable — the fixture's synthetic paths follow the platform and every assertion is bytes-vs-bytes).

### actor.js casing fix

The stage-directory containment guard (`spawn-process`, `hold-secret-file`) compared resolved paths with case-sensitive `startsWith`; win32 paths are case-insensitive. Both call sites now share `isInsideStageDir`, case-insensitive on win32 only. Note: the false rejection is LATENT — both operands derive from the same `ctx.stageDir` in one `execute()` call, so no current caller can produce a case-variant pair; the fix pins the guard's contract. Verified against master's copy of `actor.js`: the 3 new unit tests fail there (`isInsideStageDir` absent), the 29 existing pass; all 32 pass after.

### README

- New "Recording a trace" section: what a recording is and is not (it is not an oracle; it is the system under test observing itself — it proves replayability, never accuracy).
- The "What trace/ loads today" table now names everything, including the seven product modules `wiring.js` was already loading lazily (a pre-existing omission) and the recorder's platform default.
- `trace/record-trace.js` removed from "Arriving later" — that derivation is impossible, the recorder replaces it.

### Gates

All 9 local pre-merge commands green: build:renderer, format:check, lint, typecheck, typecheck:svelte, test:coverage (120 files, 2074 passed | 4 skipped), verify:gate (4/4 mutants killed), counts:check, npm audit.
