### PR TITLE
feat(ipc): bound the append buffer with capacity, coalescing and honest counters

### DIFF
--- a/src/main/ipc-batcher.js
+++ b/src/main/ipc-batcher.js
@@ -12,6 +12,21 @@
  * @typedef {Object} BatcherOptions
  * @property {number} [intervalMs] - Flush interval in milliseconds (default 150)
  * @property {'append' | 'latest'} [mode] - Batching strategy (default 'append')
+ * @property {number} [capacity] - 'append' only. Largest number of entries the buffer
+ *   may hold between two flushes; a push beyond it evicts the oldest entry. Absent =
+ *   unbounded, which is exactly the behaviour every caller had before v0.13.0.
+ * @property {(value: unknown) => string | null} [coalesceKey] - 'append' only. Merge key
+ *   for a pushed value, or null when the value must never merge.
+ */
+
+/**
+ * @typedef {Object} BatcherStats
+ * @property {number} pushed - Accepted `push` calls, lifetime.
+ * @property {number} coalesced - Pushes that replaced a same-key entry, lifetime.
+ * @property {number} evicted - Entries dropped to honour `capacity`, lifetime.
+ * @property {number} evictedSinceFlush - Evictions since the last flush that SENT.
+ * @property {number} highWater - Largest buffered length ever observed.
+ * @property {number} buffered - Entries the next flush would send, right now.
  */
 
 /**
@@ -20,6 +35,7 @@
  * @property {(producer: () => unknown) => void} pushLazy - Queue a producer, resolved once at flush ('latest' only)
  * @property {() => void} flush - Send buffered data immediately
  * @property {() => void} destroy - Flush and prevent further pushes
+ * @property {() => BatcherStats} getStats - Snapshot of this batcher's own accounting
  */
 
 /**
@@ -28,18 +44,56 @@
  * - **append** mode: accumulates events in an array, flushes as flat array.
  * - **latest** mode: keeps only the most recent value, flushes that.
  *
+ * ## What an eviction here is, and what it is not
+ *
+ * This batcher is the DISPLAY lane. Everything it drops is a frame the renderer never
+ * paints, and nothing else: an eviction is not a sensor `lossCount`, and it is not an
+ * audit drop. The durable record — the activityLog ring and the audit-logger JSONL with
+ * its hash chain and buffer-overflow-drop markers — is a separate lane that accounts for
+ * its own loss. A number from {@link BatcherStats} answers "what did the UI not see",
+ * never "what was not observed" or "what was not recorded".
+ *
  * @param {string} channel - IPC channel name (e.g. 'file-access').
  * @param {(channel: string, data: unknown) => void} sendFn - Function that sends data to renderer.
  * @param {BatcherOptions} [options]
  * @returns {Batcher}
+ * @throws {Error} when `capacity` is not a positive integer, when `coalesceKey` is not a
+ *   function, or when either is passed in 'latest' mode, where a one-slot buffer can
+ *   neither overflow nor merge.
  * @since v0.5.0
  */
 function createBatcher(channel, sendFn, options = {}) {
   const intervalMs = options.intervalMs || 150;
   const mode = options.mode || 'append';
+  const capacity = options.capacity;
+  const coalesceKey = options.coalesceKey;
+
+  if (capacity !== undefined) {
+    if (mode !== 'append') {
+      throw new Error("ipc-batcher: capacity requires mode 'append'");
+    }
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new Error('ipc-batcher: capacity must be a positive integer');
+    }
+  }
+  if (coalesceKey !== undefined) {
+    if (mode !== 'append') {
+      throw new Error("ipc-batcher: coalesceKey requires mode 'append'");
+    }
+    if (typeof coalesceKey !== 'function') {
+      throw new Error('ipc-batcher: coalesceKey must be a function');
+    }
+  }
 
   /** @type {unknown} */
   let buffer = mode === 'append' ? [] : undefined;
+  /**
+   * Merge keys, parallel to the append buffer — index i holds the key of entry i, or
+   * null for an entry that must never merge. Stays null while coalescing is off, so a
+   * batcher without `coalesceKey` allocates and walks nothing extra.
+   * @type {(string | null)[] | null}
+   */
+  let keys = coalesceKey ? [] : null;
   /**
    * A pending {@link pushLazy} producer, or null. Held in its own slot rather than in
    * `buffer` so a payload that happens to be a function is still a payload.
@@ -50,6 +104,12 @@ function createBatcher(channel, sendFn, options = {}) {
   let timer = null;
   let destroyed = false;
 
+  let pushed = 0;
+  let coalesced = 0;
+  let evicted = 0;
+  let evictedSinceFlush = 0;
+  let highWater = 0;
+
   /** Schedule a flush if one isn't already pending. */
   function scheduleFlush() {
     if (timer === null && !destroyed) {
@@ -58,17 +118,59 @@ function createBatcher(channel, sendFn, options = {}) {
   }
 
   /**
+   * How many entries the next flush would send. One flat array in 'append' mode, one
+   * value or nothing in 'latest'.
+   * @returns {number}
+   */
+  function bufferedCount() {
+    if (mode === 'append') return /** @type {unknown[]} */ (buffer).length;
+    return buffer === undefined ? 0 : 1;
+  }
+
+  /**
    * Add an event to the batch buffer.
+   *
+   * In 'append' mode with `coalesceKey`, a value whose key already sits in the buffer
+   * REPLACES that entry where it stands — position preserved, last value wins — instead
+   * of extending the buffer. A merge adds no entry, so it can never trigger an eviction.
+   *
+   * With `capacity` set, a push that would exceed it drops the OLDEST buffered entry
+   * first and the pushed value always enters. Eviction is oldest-first regardless of what
+   * an entry holds: selective retention is the caller's job via `coalesceKey`, and the
+   * durable lane owns completeness.
    * @param {unknown} value - Event object (append) or full replacement value (latest).
    */
   function push(value) {
     if (destroyed) return;
     if (mode === 'append') {
-      /** @type {unknown[]} */ (buffer).push(value);
+      const buf = /** @type {unknown[]} */ (buffer);
+      // Resolved before any counter moves: a throwing coalesceKey must leave the
+      // batcher exactly as it found it.
+      const key = coalesceKey ? coalesceKey(value) : null;
+      pushed++;
+      // Only a string merges. null, undefined, or anything else means this value must
+      // never merge, and two such values both occupy their own slot.
+      const at = typeof key === 'string' && keys !== null ? keys.indexOf(key) : -1;
+      if (at !== -1) {
+        buf[at] = value;
+        coalesced++;
+      } else {
+        if (capacity !== undefined && buf.length >= capacity) {
+          buf.shift();
+          if (keys !== null) keys.shift();
+          evicted++;
+          evictedSinceFlush++;
+        }
+        buf.push(value);
+        if (keys !== null) keys.push(typeof key === 'string' ? key : null);
+      }
     } else {
       buffer = value;
       producer = null;
+      pushed++;
     }
+    const now = bufferedCount();
+    if (now > highWater) highWater = now;
     scheduleFlush();
   }
 
@@ -119,6 +221,8 @@ function createBatcher(channel, sendFn, options = {}) {
       const buf = /** @type {unknown[]} */ (buffer);
       if (buf.length === 0) return;
       buffer = [];
+      if (keys !== null) keys = [];
+      evictedSinceFlush = 0;
       sendFn(channel, buf);
     } else {
       // A pending producer is resolved HERE, once, and dropped before the send so a
@@ -145,7 +249,37 @@ function createBatcher(channel, sendFn, options = {}) {
     destroyed = true;
   }
 
-  return { push, pushLazy, flush, destroy };
+  /**
+   * Snapshot of this batcher's own accounting, as a fresh object per call.
+   *
+   * `pushed`, `coalesced` and `evicted` are lifetime totals; `evictedSinceFlush` returns
+   * to 0 on every flush that actually sent; `highWater` is a lifetime maximum and never
+   * returns to 0. Still readable after {@link destroy}, which leaves the totals standing
+   * and `buffered` at 0.
+   *
+   * Two exclusions, stated rather than implied. A push refused because the batcher was
+   * destroyed is not counted anywhere — it never entered. And {@link pushLazy} is outside
+   * this accounting entirely: a queued producer moves no counter and a pending one reads
+   * `buffered: 0`, because what it will build does not exist yet.
+   *
+   * In 'latest' mode only the counters that can apply do: `buffered` is 0 or 1, and
+   * `coalesced`, `evicted` and `evictedSinceFlush` stay 0 — a one-slot buffer can neither
+   * overflow nor merge.
+   * @returns {BatcherStats}
+   * @since v0.13.0
+   */
+  function getStats() {
+    return {
+      pushed,
+      coalesced,
+      evicted,
+      evictedSinceFlush,
+      highWater,
+      buffered: bufferedCount(),
+    };
+  }
+
+  return { push, pushLazy, flush, destroy, getStats };
 }
 
 module.exports = { createBatcher };

--- a/tests/main/ipc-batcher.test.js
+++ b/tests/main/ipc-batcher.test.js
@@ -288,6 +288,555 @@ describe('ipc-batcher', () => {
     });
   });
 
+  // ── capacity (append mode) ──
+
+  describe('capacity (append mode)', () => {
+    it('bounds the buffer under a burst and counts exactly what it dropped', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 150, capacity: 3 });
+
+      for (let i = 1; i <= 10; i++) b.push(i);
+
+      expect(b.getStats()).toEqual({
+        pushed: 10,
+        coalesced: 0,
+        evicted: 7,
+        evictedSinceFlush: 7,
+        highWater: 3,
+        buffered: 3,
+      });
+
+      vi.advanceTimersByTime(150);
+      expect(send).toHaveBeenCalledOnce();
+      expect(send).toHaveBeenCalledWith('ch', [8, 9, 10]);
+      b.destroy();
+    });
+
+    it('evicts oldest-first: the pushed value always enters', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, capacity: 1 });
+      b.push('a');
+      b.push('b');
+      b.push('c');
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', ['c']);
+      expect(b.getStats()).toMatchObject({ pushed: 3, evicted: 2, highWater: 1 });
+      b.destroy();
+    });
+
+    it('the flushed payload stays a FLAT array — the wire format is unchanged', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 50, capacity: 2 });
+      b.push('ev1');
+      b.push('ev2');
+      b.push('ev3');
+      vi.advanceTimersByTime(50);
+      expect(send.mock.calls[0][1]).toEqual(['ev2', 'ev3']);
+      expect(Array.isArray(send.mock.calls[0][1])).toBe(true);
+      b.destroy();
+    });
+
+    it('absent capacity is UNBOUNDED — today’s behaviour, pinned', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 150 });
+
+      for (let i = 0; i < 5000; i++) b.push(i);
+
+      expect(b.getStats()).toMatchObject({ pushed: 5000, evicted: 0, buffered: 5000 });
+      vi.advanceTimersByTime(150);
+      expect(send.mock.calls[0][1]).toHaveLength(5000);
+      b.destroy();
+    });
+
+    it('highWater is a LIFETIME maximum and does not fall back on flush', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100 });
+
+      for (let i = 0; i < 5; i++) b.push(i);
+      vi.advanceTimersByTime(100);
+      expect(b.getStats()).toMatchObject({ highWater: 5, buffered: 0 });
+
+      b.push('x');
+      b.push('y');
+      vi.advanceTimersByTime(100);
+      expect(b.getStats()).toMatchObject({ highWater: 5, buffered: 0 });
+      b.destroy();
+    });
+
+    it('highWater never exceeds capacity when one is set', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, capacity: 4 });
+      for (let i = 0; i < 200; i++) b.push(i);
+      expect(b.getStats().highWater).toBe(4);
+      b.destroy();
+    });
+
+    it('evictedSinceFlush resets on a flush that SENT; evicted keeps counting', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, capacity: 2 });
+
+      b.push(1);
+      b.push(2);
+      b.push(3); // 1 eviction
+      expect(b.getStats()).toMatchObject({ evicted: 1, evictedSinceFlush: 1 });
+
+      vi.advanceTimersByTime(100);
+      expect(b.getStats()).toMatchObject({ evicted: 1, evictedSinceFlush: 0 });
+
+      b.push(4);
+      b.push(5);
+      b.push(6);
+      b.push(7); // 2 more evictions
+      expect(b.getStats()).toMatchObject({ evicted: 3, evictedSinceFlush: 2 });
+
+      vi.advanceTimersByTime(100);
+      expect(b.getStats()).toMatchObject({ evicted: 3, evictedSinceFlush: 0 });
+      expect(send).toHaveBeenCalledTimes(2);
+      expect(send.mock.calls[0][1]).toEqual([2, 3]);
+      expect(send.mock.calls[1][1]).toEqual([6, 7]);
+      b.destroy();
+    });
+
+    it('a manual flush resets evictedSinceFlush exactly as the timer does', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, capacity: 2 });
+      b.push(1);
+      b.push(2);
+      b.push(3);
+      b.flush();
+      expect(send).toHaveBeenCalledWith('ch', [2, 3]);
+      expect(b.getStats()).toMatchObject({ evicted: 1, evictedSinceFlush: 0 });
+
+      // A second flush finds an empty buffer, sends nothing, and moves no counter.
+      b.flush();
+      expect(send).toHaveBeenCalledOnce();
+      expect(b.getStats()).toMatchObject({ pushed: 3, evicted: 1, evictedSinceFlush: 0 });
+      b.destroy();
+    });
+
+    it('counters survive many flush cycles', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, capacity: 2 });
+      for (let cycle = 0; cycle < 4; cycle++) {
+        b.push('a');
+        b.push('b');
+        b.push('c'); // 1 eviction per cycle
+        vi.advanceTimersByTime(100);
+      }
+      expect(send).toHaveBeenCalledTimes(4);
+      expect(b.getStats()).toEqual({
+        pushed: 12,
+        coalesced: 0,
+        evicted: 4,
+        evictedSinceFlush: 0,
+        highWater: 2,
+        buffered: 0,
+      });
+      b.destroy();
+    });
+  });
+
+  // ── coalescing (append mode) ──
+
+  describe('coalesceKey (append mode)', () => {
+    it('replaces the same-key entry IN PLACE — position preserved, last value wins', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, coalesceKey: (v) => v.path });
+
+      b.push({ path: 'a.txt', n: 1 });
+      b.push({ path: 'b.txt', n: 2 });
+      b.push({ path: 'a.txt', n: 3 });
+
+      expect(b.getStats()).toMatchObject({ pushed: 3, coalesced: 1, buffered: 2, highWater: 2 });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { path: 'a.txt', n: 3 },
+        { path: 'b.txt', n: 2 },
+      ]);
+      b.destroy();
+    });
+
+    it('a coalesced push is still a push: coalesced is a SUBSET of pushed', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, coalesceKey: () => 'same' });
+      b.push(1);
+      b.push(2);
+      b.push(3);
+      expect(b.getStats()).toMatchObject({ pushed: 3, coalesced: 2, buffered: 1, highWater: 1 });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [3]);
+      b.destroy();
+    });
+
+    it('a null key NEVER merges — two of them both travel', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, coalesceKey: () => null });
+      b.push('x');
+      b.push('x');
+      b.push('x');
+      expect(b.getStats()).toMatchObject({ pushed: 3, coalesced: 0, buffered: 3 });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', ['x', 'x', 'x']);
+      b.destroy();
+    });
+
+    it('mixes merging and non-merging values in one window', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        coalesceKey: (v) => (v.merge ? v.id : null),
+      });
+
+      b.push({ id: 'k', merge: true, n: 1 });
+      b.push({ id: 'k', merge: false, n: 2 });
+      b.push({ id: 'k', merge: true, n: 3 });
+
+      expect(b.getStats()).toMatchObject({ pushed: 3, coalesced: 1, buffered: 2 });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { id: 'k', merge: true, n: 3 },
+        { id: 'k', merge: false, n: 2 },
+      ]);
+      b.destroy();
+    });
+
+    it('a non-string key never merges either — undefined and a number both stay apart', () => {
+      const send = vi.fn();
+      const undef = createBatcher('ch', send, { intervalMs: 100, coalesceKey: () => undefined });
+      undef.push('a');
+      undef.push('a');
+      expect(undef.getStats()).toMatchObject({ coalesced: 0, buffered: 2 });
+      undef.destroy();
+
+      const numeric = createBatcher('ch', send, { intervalMs: 100, coalesceKey: () => 7 });
+      numeric.push('a');
+      numeric.push('a');
+      expect(numeric.getStats()).toMatchObject({ coalesced: 0, buffered: 2 });
+      numeric.destroy();
+    });
+
+    it('the key table resets with the buffer — a key from the last batch does not merge', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, coalesceKey: (v) => v.path });
+      b.push({ path: 'a', n: 1 });
+      vi.advanceTimersByTime(100);
+      b.push({ path: 'a', n: 2 });
+      vi.advanceTimersByTime(100);
+
+      expect(send).toHaveBeenCalledTimes(2);
+      expect(send.mock.calls[0][1]).toEqual([{ path: 'a', n: 1 }]);
+      expect(send.mock.calls[1][1]).toEqual([{ path: 'a', n: 2 }]);
+      expect(b.getStats()).toMatchObject({ pushed: 2, coalesced: 0 });
+      b.destroy();
+    });
+
+    it('a throwing coalesceKey leaves the batcher exactly as it found it', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        coalesceKey: (v) => {
+          if (v === 'boom') throw new Error('key exploded');
+          return String(v);
+        },
+      });
+
+      b.push('ok');
+      expect(() => b.push('boom')).toThrow(/key exploded/);
+      expect(b.getStats()).toMatchObject({ pushed: 1, coalesced: 0, evicted: 0, buffered: 1 });
+
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', ['ok']);
+      b.destroy();
+    });
+  });
+
+  // ── coalescing × capacity ──
+
+  describe('coalescing and capacity together', () => {
+    it('a coalesced push does NOT evict, even at full capacity', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        capacity: 2,
+        coalesceKey: (v) => v.k,
+      });
+
+      b.push({ k: 'a', n: 1 });
+      b.push({ k: 'b', n: 2 }); // buffer is now full
+      b.push({ k: 'a', n: 3 }); // merges instead of overflowing
+
+      expect(b.getStats()).toEqual({
+        pushed: 3,
+        coalesced: 1,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 2,
+        buffered: 2,
+      });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { k: 'a', n: 3 },
+        { k: 'b', n: 2 },
+      ]);
+      b.destroy();
+    });
+
+    it('an eviction shifts the key table in step with the buffer', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        capacity: 2,
+        coalesceKey: (v) => v.k,
+      });
+
+      b.push({ k: 'a', n: 1 });
+      b.push({ k: 'b', n: 2 });
+      b.push({ k: 'c', n: 3 }); // evicts a → [b, c]
+      b.push({ k: 'b', n: 4 }); // must land on slot 0, not slot 1
+
+      expect(b.getStats()).toMatchObject({ pushed: 4, coalesced: 1, evicted: 1, buffered: 2 });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { k: 'b', n: 4 },
+        { k: 'c', n: 3 },
+      ]);
+      b.destroy();
+    });
+
+    it('an evicted key frees its slot: the same key returns as a NEW entry', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        capacity: 2,
+        coalesceKey: (v) => v.k,
+      });
+
+      b.push({ k: 'a', n: 1 });
+      b.push({ k: 'b', n: 2 });
+      b.push({ k: 'c', n: 3 }); // evicts a → [b, c]
+      b.push({ k: 'a', n: 4 }); // a is gone, so this appends and evicts b → [c, a]
+
+      expect(b.getStats()).toMatchObject({ pushed: 4, coalesced: 0, evicted: 2, buffered: 2 });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { k: 'c', n: 3 },
+        { k: 'a', n: 4 },
+      ]);
+      b.destroy();
+    });
+
+    it('coalescing keeps a bounded buffer inside its bound under a keyed burst', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 150,
+        capacity: 4,
+        coalesceKey: (v) => `k${v % 3}`,
+      });
+
+      for (let i = 0; i < 300; i++) b.push(i);
+
+      // Three distinct keys, so the buffer never reaches capacity and nothing is evicted.
+      expect(b.getStats()).toEqual({
+        pushed: 300,
+        coalesced: 297,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 3,
+        buffered: 3,
+      });
+      vi.advanceTimersByTime(150);
+      expect(send).toHaveBeenCalledWith('ch', [297, 298, 299]);
+      b.destroy();
+    });
+  });
+
+  // ── getStats ──
+
+  describe('getStats', () => {
+    it('exposes exactly the six documented fields', () => {
+      const b = createBatcher('ch', vi.fn(), { intervalMs: 100 });
+      expect(Object.keys(b.getStats()).sort()).toEqual([
+        'buffered',
+        'coalesced',
+        'evicted',
+        'evictedSinceFlush',
+        'highWater',
+        'pushed',
+      ]);
+      b.destroy();
+    });
+
+    it('a fresh batcher reports all zeros', () => {
+      const b = createBatcher('ch', vi.fn(), { intervalMs: 100 });
+      expect(b.getStats()).toEqual({
+        pushed: 0,
+        coalesced: 0,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 0,
+        buffered: 0,
+      });
+      b.destroy();
+    });
+
+    it('counts pushes and highWater even with no new options passed', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100 });
+      b.push('a');
+      b.push('b');
+      expect(b.getStats()).toEqual({
+        pushed: 2,
+        coalesced: 0,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 2,
+        buffered: 2,
+      });
+      b.destroy();
+    });
+
+    it('stays readable after destroy, with the lifetime totals standing', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, capacity: 2 });
+      b.push(1);
+      b.push(2);
+      b.push(3);
+      b.destroy();
+
+      expect(send).toHaveBeenCalledWith('ch', [2, 3]);
+      expect(b.getStats()).toEqual({
+        pushed: 3,
+        coalesced: 0,
+        evicted: 1,
+        evictedSinceFlush: 0,
+        highWater: 2,
+        buffered: 0,
+      });
+    });
+
+    it('a push refused because the batcher is destroyed is counted nowhere', () => {
+      const b = createBatcher('ch', vi.fn(), { intervalMs: 100, capacity: 1 });
+      b.destroy();
+      b.push('late');
+      expect(b.getStats()).toEqual({
+        pushed: 0,
+        coalesced: 0,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 0,
+        buffered: 0,
+      });
+    });
+
+    it('returns a snapshot, not a live view', () => {
+      const b = createBatcher('ch', vi.fn(), { intervalMs: 100 });
+      const before = b.getStats();
+      b.push('x');
+      expect(before).toMatchObject({ pushed: 0, buffered: 0 });
+      expect(b.getStats()).toMatchObject({ pushed: 1, buffered: 1 });
+      b.destroy();
+    });
+  });
+
+  // ── latest mode stats ──
+
+  describe('getStats (latest mode)', () => {
+    it('reports the same six fields with only the counters that can apply', () => {
+      const send = vi.fn();
+      const b = createBatcher('stats', send, { intervalMs: 100, mode: 'latest' });
+
+      expect(b.getStats()).toEqual({
+        pushed: 0,
+        coalesced: 0,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 0,
+        buffered: 0,
+      });
+
+      b.push({ n: 1 });
+      b.push({ n: 2 });
+      expect(b.getStats()).toEqual({
+        pushed: 2,
+        coalesced: 0,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 1,
+        buffered: 1,
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledOnce();
+      expect(send).toHaveBeenCalledWith('stats', { n: 2 });
+      expect(b.getStats()).toEqual({
+        pushed: 2,
+        coalesced: 0,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 1,
+        buffered: 0,
+      });
+      b.destroy();
+    });
+
+    it('a pending pushLazy producer moves no counter and reads buffered 0', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, mode: 'latest' });
+      b.pushLazy(() => 'built');
+      expect(b.getStats()).toEqual({
+        pushed: 0,
+        coalesced: 0,
+        evicted: 0,
+        evictedSinceFlush: 0,
+        highWater: 0,
+        buffered: 0,
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', 'built');
+      expect(b.getStats().pushed).toBe(0);
+      b.destroy();
+    });
+  });
+
+  // ── option validation ──
+
+  describe('option validation', () => {
+    it('refuses a capacity that is not a positive integer', () => {
+      for (const bad of [0, -1, 1.5, '5', NaN, Infinity, null]) {
+        expect(() => createBatcher('ch', vi.fn(), { capacity: bad })).toThrow(
+          /capacity must be a positive integer/,
+        );
+      }
+    });
+
+    it('accepts capacity 1 — the smallest useful bound', () => {
+      const b = createBatcher('ch', vi.fn(), { intervalMs: 100, capacity: 1 });
+      expect(b.getStats().buffered).toBe(0);
+      b.destroy();
+    });
+
+    it('refuses a coalesceKey that is not a function', () => {
+      for (const bad of ['path', 42, {}, null]) {
+        expect(() => createBatcher('ch', vi.fn(), { coalesceKey: bad })).toThrow(
+          /coalesceKey must be a function/,
+        );
+      }
+    });
+
+    it('refuses capacity in latest mode: a one-slot buffer cannot overflow', () => {
+      expect(() => createBatcher('ch', vi.fn(), { mode: 'latest', capacity: 5 })).toThrow(
+        /capacity requires mode 'append'/,
+      );
+    });
+
+    it('refuses coalesceKey in latest mode: a one-slot buffer cannot merge', () => {
+      expect(() =>
+        createBatcher('ch', vi.fn(), { mode: 'latest', coalesceKey: () => 'k' }),
+      ).toThrow(/coalesceKey requires mode 'append'/);
+    });
+  });
+
   // ── defaults ──
 
   describe('defaults', () => {


### PR DESCRIPTION
## What

`ipc-batcher` in `'append'` mode held an unbounded array: a burst between two 150 ms flushes grew it without limit, and nothing counted what a bound would have dropped. This gives append mode a capacity bound, optional coalescing, and counters that say what the display lane lost.

Pure module + tests. **No wiring, no caller changes.** `main.js` and `scan-loop.js` are untouched, and the flushed payload is still a flat array.

## Which lane this is

This batcher is the **DISPLAY** lane. Everything it drops is a frame the renderer never paints, and nothing else — an eviction is **not** a sensor `lossCount` and **not** an audit drop. The durable record (activityLog ring + audit-logger JSONL with its hash chain and buffer-overflow-drop markers) is a separate lane that already accounts for its own loss honestly. The module header now states this rather than leaving it to be inferred, so a future reader cannot borrow a display number as an observation number.

## API — all three additions are opt-in

| option / member | behaviour |
|---|---|
| `capacity` | Positive integer, `'append'` only. A push beyond the bound evicts the **oldest** entry; the pushed value always enters. Absent = unbounded, byte-identical to today. |
| `coalesceKey` | `(value) => string \| null`, `'append'` only. Applied **before** the capacity check. A string key already in the buffer replaces that entry **in place** — position preserved, last value wins. `null` (or any non-string) never merges. A merge adds no entry, so it can never evict one. |
| `getStats()` | `{ pushed, coalesced, evicted, evictedSinceFlush, highWater, buffered }` — exactly six fields. |

Eviction is oldest-first **regardless of content**: selective retention is the caller's job via `coalesceKey`, and the durable lane owns completeness.

`pushed`/`coalesced`/`evicted` are lifetime totals; `evictedSinceFlush` returns to 0 on every flush that actually **sent**; `highWater` is a lifetime maximum and never falls back. `getStats()` stays readable after `destroy()`.

Two exclusions, stated in the JSDoc rather than implied: a push refused because the batcher was destroyed is counted nowhere, and `pushLazy` is outside the accounting entirely — it moves no counter and a pending producer reads `buffered: 0`.

Invalid options are refused at construction — `capacity` not a positive integer, `coalesceKey` not a function, either one in `'latest'` mode — on the existing `pushLazy` refusal precedent. `'latest'` mode and `pushLazy` are otherwise untouched.

## Evidence

**Existing behaviour pinned, not edited.** The test diff is `549 insertions(+), 0 deletions(-)` — every one of the 26 pre-existing tests passes unmodified. 32 new tests: capacity under burst, oldest-first eviction, unbounded-when-absent (5000 pushes), `highWater` as a lifetime maximum, `evictedSinceFlush` reset across ≥2 flush cycles, in-place coalescing, `null`/non-string keys never merging, key-table/buffer sync across an eviction, coalesce-at-full-capacity not evicting, the exact six-field shape, post-`destroy()` readability, and option validation.

**A passing suite proves the command ran, not that it inspected the change** (ai-mistakes #21), so seven mutants were hand-injected against the new tests. Every one goes red:

| mutant | failing tests |
|---|---|
| eviction removed | 10 |
| `keys.shift()` removed (key table desyncs from buffer) | 2 |
| `null` key allowed to merge | 1 |
| coalesce appends instead of replacing in place | 6 |
| `evictedSinceFlush` never reset | 4 |
| `highWater` assigned instead of maximised | 1 |
| eviction takes the newest instead of the oldest | 6 |

**Gates.** All 9 local CI commands green: `build:renderer`, `format:check`, `lint`, `typecheck`, `typecheck:svelte`, `test:coverage` (120 files, 2107 pass / 4 skip), `verify:gate` (4/4 mutants red), `counts:check` (19 counters, 96 declaration sites agree), `npm audit --audit-level=high --omit=dev` (0 vulnerabilities).

## One thing a reviewer should know

`vitest.config.js` `coverage.include` is an explicit 24-file allowlist and `src/main/ipc-batcher.js` is **not** on it — so `test:coverage` being green says nothing about this file's coverage. Measured out-of-band with `--coverage.include='src/main/ipc-batcher.js'`: **100% statements / branches / functions / lines.** Adding the file to that allowlist is a config change outside this PR's stated scope and is deliberately left out; worth a follow-up.

`src/main/ipc-batcher.js` is now 285 lines, so `size.over300` stays at 31 and `counts:check` is unaffected.
