### PR TITLE
feat(ipc): bound and coalesce the file-access display lane, surface its counters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ regenerating a lockfile.
 8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` + `npm run typecheck:svelte` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths
-- src/main/ — 52 CommonJS modules (40 top-level + platform/ 10 + token-adapters/ 2)
+- src/main/ — 53 CommonJS modules (41 top-level + platform/ 10 + token-adapters/ 2)
 - src/renderer/ — Svelte 5 components + stores + utils + tokens.css/global.css
   (count: `git ls-files 'src/renderer/**/*.svelte' | wc -l`)
 - src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (9 TS files), constants.js (ignore patterns, config paths; SENSITIVE_RULES deprecated)

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **52** = 40 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **53** = 41 top-level + 10 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 52 CommonJS modules (40 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 53 CommonJS modules (41 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle

--- a/src/main/file-access-batching.js
+++ b/src/main/file-access-batching.js
@@ -1,0 +1,125 @@
+// @ts-check
+/**
+ * @file file-access-batching.js
+ * @module main/file-access-batching
+ * @description The DISPLAY-lane batching policy for the `file-access` IPC channel:
+ *   the merge key and the bounds main.js hands to {@link module:main/ipc-batcher}.
+ *   Pure — no I/O, no Electron, no timers, no module state — so main.js can load it
+ *   on the fast path to a visible window, ahead of `loadDeferredModules`.
+ * @since v0.13.0
+ */
+'use strict';
+
+/**
+ * Largest number of `file-access` entries one 150 ms flush window may hold. A window
+ * that accumulates a thousand display frames is already pathological: the renderer
+ * cannot paint them, and the durable lane — the activityLog ring and the audit-logger
+ * JSONL with its hash chain — owns completeness independently of this number.
+ *
+ * An eviction here is a frame the UI never saw. It is not a sensor `lossCount` and it
+ * is not an audit drop; see the ipc-batcher module header for that boundary.
+ * @type {number}
+ * @since v0.13.0
+ */
+const FILE_ACCESS_CAPACITY = 1000;
+
+/**
+ * Flush window for the `file-access` channel, unchanged since v0.5.0.
+ * @type {number}
+ */
+const FILE_ACCESS_INTERVAL_MS = 150;
+
+/**
+ * Field separator for {@link fileAccessCoalesceKey}, written as an escape so the source
+ * file stays plain text. NUL cannot occur in any of the three segments — `instanceId` is
+ * `<pid>:<epochMs>` / `0:<name>` / `<pid>:u` (process-identity.js), `file` is an OS path,
+ * `action` is a five-value closed set (shared/types/events.ts `FileAction`) — so the join
+ * is unambiguous. A printable delimiter would not be: a Windows path carries both `:`
+ * and `\`, and either could otherwise let two different field splits build one key.
+ * @type {string}
+ */
+const KEY_SEP = '\u0000';
+
+/**
+ * True when `v` is a usable key segment: a string with at least one character. A type
+ * predicate so the three segment checks below narrow the fields they guard, rather than
+ * leaving the template literal to stringify an `unknown`.
+ * @param {unknown} v
+ * @returns {v is string}
+ */
+function isSegment(v) {
+  return typeof v === 'string' && v.length > 0;
+}
+
+/**
+ * Merge key for a file event on the `file-access` display lane, or `null` when the
+ * event must never merge.
+ *
+ * THREE REFUSALS, and each one is a separate claim:
+ *
+ * 1. **A sensitive event never merges.** Checked first and independently of everything
+ *    below. Today `sensitive` is false whenever `selfAccess` is true by construction
+ *    (`sensitive: reason !== null && !selfAccess`, file-watcher.js), so this guard is
+ *    unreachable through the self-churn branch — it is here so the refusal does not
+ *    depend on that coupling surviving a future edit.
+ * 2. **Anything that is not the agent's own benign self-churn never merges.** The only
+ *    self-churn marker a file event carries is `selfAccess`, set at all three emission
+ *    sites (file-watcher.js `handleWatcherEvent`, `scanFileHandles`, `_scanRmHolders`)
+ *    and meaning exactly "this agent touched its OWN config directory". Note the bound
+ *    that comes with it: `selfAccess` is true only where the path ALSO matched a
+ *    sensitive rule and the owning agent's own exemption cleared it, so an ordinary
+ *    non-sensitive file event is not self-churn and is never merged. That is the marker
+ *    the event shape actually has; no proxy is invented for the wider case.
+ * 3. **An event with no process-instance key never merges.** `instanceId` is `null` for
+ *    an unattributed event and for an owner that was never stamped (process-identity.js
+ *    `readInstanceId`). Merging on a missing key would pool two different instances'
+ *    frames under one entry — the same collapse `dedupFileEvent` refuses for the same
+ *    reason (scan-loop.js, F-E03).
+ *
+ * WHERE THIS ACTUALLY FIRES. `scanLoop.dedupFileEvent` sits AHEAD of the batcher on
+ * every push path and suppresses a repeat of the same `instanceId|file` for 30 s, so in
+ * steady state the same pair cannot reach one 150 ms window twice and this key merges
+ * nothing. It earns its place under burst, where `eventDedupMap` passes 1000 entries and
+ * is cleared wholesale, and repeats start arriving: coalescing is the burst-mode
+ * backstop, {@link FILE_ACCESS_CAPACITY} is the primary bound.
+ *
+ * Pure and total: no throw for any input, which matters because ipc-batcher resolves
+ * this on the push path before any counter moves.
+ * @param {unknown} value - A file event as built by file-watcher.js, or anything else.
+ * @returns {string|null} A stable key for benign self-churn, else `null`.
+ * @since v0.13.0
+ */
+function fileAccessCoalesceKey(value) {
+  if (value === null || typeof value !== 'object') return null;
+  const ev = /** @type {Record<string, unknown>} */ (value);
+  if (ev.sensitive === true) return null;
+  if (ev.selfAccess !== true) return null;
+  if (!isSegment(ev.instanceId)) return null;
+  if (!isSegment(ev.file)) return null;
+  if (!isSegment(ev.action)) return null;
+  return `${ev.instanceId}${KEY_SEP}${ev.file}${KEY_SEP}${ev.action}`;
+}
+
+/**
+ * The exact options main.js passes to `createBatcher('file-access', …)`.
+ *
+ * Frozen and exported as ONE object rather than three loose constants so a test can
+ * exercise the production configuration itself instead of re-assembling something that
+ * merely looks like it — a re-assembled config proves the values, never the wiring.
+ * @type {Readonly<{intervalMs: number, capacity: number,
+ *   coalesceKey: (value: unknown) => string | null}>}
+ * @since v0.13.0
+ */
+const FILE_ACCESS_BATCHER_OPTIONS = Object.freeze({
+  intervalMs: FILE_ACCESS_INTERVAL_MS,
+  capacity: FILE_ACCESS_CAPACITY,
+  coalesceKey: fileAccessCoalesceKey,
+});
+
+module.exports = {
+  FILE_ACCESS_CAPACITY,
+  FILE_ACCESS_INTERVAL_MS,
+  FILE_ACCESS_BATCHER_OPTIONS,
+  KEY_SEP,
+  fileAccessCoalesceKey,
+};

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -43,9 +43,12 @@ const logger = require('./logger');
 const tray = require('./tray-icon');
 const ipc = require('./ipc-handlers');
 const { createBatcher } = require('./ipc-batcher');
-// Pure domain module — no I/O, no Electron, no timers — so it costs nothing to load
-// on the fast path to a visible window.
+// Pure domain modules — no I/O, no Electron, no timers — so they cost nothing to load
+// on the fast path to a visible window. `file-access-batching` must be here rather than
+// deferred: the file-access batcher is built at module scope below, long before
+// loadDeferredModules runs.
 const appHealth = require('./app-health');
+const { FILE_ACCESS_BATCHER_OPTIONS } = require('./file-access-batching');
 
 // ═══ DEFERRED (loaded after ready-to-show via loadDeferredModules) ═══
 // `network` is here rather than local to initDeferredSubsystems because getAppHealth()
@@ -232,12 +235,32 @@ function getResourceUsage() {
 }
 
 /**
+ * Per-channel IPC delivery accounting, for the DISPLAY lane only.
+ *
+ * A SIBLING of `appHealth`, never a field inside it, and the reason is the same
+ * boundary the ipc-batcher module header draws: an eviction or a merge here is a frame
+ * the renderer never painted. It is not a sensor `lossCount` — nothing went unobserved —
+ * and it is not an audit drop — nothing went unrecorded. The activityLog ring and the
+ * audit-logger JSONL account for their own loss on their own lane. Filing these counters
+ * under app health would let a UI-throughput number read as an observation failure.
+ *
+ * Total by construction: the batcher exists from module load, so this answers with real
+ * values on BOTH `getStats` branches — the scanner-absent branch is not a shaped stub.
+ * @returns {{fileAccess: import('./ipc-batcher').BatcherStats}}
+ * @since v0.13.0
+ */
+function getIpcStats() {
+  return { fileAccess: fileAccessBatcher.getStats() };
+}
+
+/**
  * Monitoring statistics.
  *
  * `appHealth` and `monitoringPaused` are SIBLINGS and must stay that way: one answers
  * "what can we still observe", the other "did the operator stop us". Folding the pause
  * into the health enum would make a deliberate silence indistinguishable from a broken
- * sensor, which is the false-clean this whole model exists to kill.
+ * sensor, which is the false-clean this whole model exists to kill. `ipc` is a third
+ * sibling on the same principle — see {@link getIpcStats}.
  * @returns {Object} Monitoring statistics @since v0.1.0
  */
 function getStats() {
@@ -256,6 +279,10 @@ function getStats() {
       permissionDeniedScans: 0,
       attribution: { confirmed: 0, inferred: 0, unattributed: 0, unattributedSensitive: 0 },
       appHealth: getAppHealth(),
+      // Same expression as the loaded branch, not a zeroed lookalike: the batcher is a
+      // module-scope const, so it has been counting since before this branch was
+      // reachable and its numbers are real here too.
+      ipc: getIpcStats(),
       monitoringPaused,
     };
   }
@@ -279,6 +306,7 @@ function getStats() {
       unattributedSensitive: attrUnattributedSensitive,
     },
     appHealth: getAppHealth(),
+    ipc: getIpcStats(),
     monitoringPaused,
   };
 }
@@ -293,7 +321,10 @@ function sendToRenderer(channel, data) {
   }
 }
 
-const fileAccessBatcher = createBatcher('file-access', sendToRenderer, { intervalMs: 150 });
+// Options passed VERBATIM from file-access-batching.js — the flush window, the capacity
+// bound and the coalesce key live there as one frozen object so a test can drive the
+// production configuration itself rather than a re-assembled lookalike.
+const fileAccessBatcher = createBatcher('file-access', sendToRenderer, FILE_ACCESS_BATCHER_OPTIONS);
 const statsUpdateBatcher = createBatcher('stats-update', sendToRenderer, {
   intervalMs: 1000,
   mode: 'latest',
@@ -653,6 +684,21 @@ function _setWatcherForTest(mod) {
   watcher = mod;
 }
 
+/**
+ * @internal Inject the process-scanner module, normally set by loadDeferredModules
+ * (for tests).
+ *
+ * `getStats` branches on `scanner` alone while {@link getAppHealth} branches on
+ * `scanner || watcher`, so injecting a scanner and leaving `watcher` undefined reaches
+ * the LOADED stats branch with app health still on its own booting path. That is what
+ * makes both stats branches executable in a test instead of merely readable: a payload
+ * contract proven by running the code, not by matching the source (ai-mistakes #21).
+ * @param {Object|undefined} mod
+ */
+function _setScannerForTest(mod) {
+  scanner = mod;
+}
+
 /** @internal Clear the one-shot guard and the registered watcher list (for tests). */
 function _resetWatchersForTest() {
   watchersStarted = false;
@@ -669,12 +715,13 @@ function _getWatchersForTest() {
 module.exports = {
   startWatchers,
   startWatchersWhenLoaded,
-  // Read-only. Exposed so a test can assert the payload SHAPE — that `appHealth` and
-  // `monitoringPaused` are siblings, and that the pre-`loadDeferredModules` branch
-  // answers BOOTING instead of throwing.
+  // Read-only. Exposed so a test can assert the payload SHAPE — that `appHealth`,
+  // `ipc` and `monitoringPaused` are siblings, and that the pre-`loadDeferredModules`
+  // branch answers BOOTING instead of throwing.
   getStats,
   getAppHealth,
   _setWatcherForTest,
+  _setScannerForTest,
   _resetWatchersForTest,
   _getWatchersForTest,
 };

--- a/tests/main/file-access-batching.test.js
+++ b/tests/main/file-access-batching.test.js
@@ -1,0 +1,327 @@
+/**
+ * The DISPLAY-lane batching policy for the `file-access` channel (file-access-batching.js):
+ * the coalesce key, and that key driving the REAL batcher under the REAL production
+ * options object.
+ *
+ * What the wiring block below does and does not prove. It drives
+ * `FILE_ACCESS_BATCHER_OPTIONS` — the very object main.js hands to `createBatcher` — so
+ * the capacity, the flush window and the key function are the production ones, not a
+ * lookalike reassembled here. It does NOT prove main.js passes that object: main.js
+ * exports no handle on its batcher, and the only remaining link is the single `require`
+ * at its module scope.
+ *
+ * One more bound worth stating, because it decides how this file has to be written:
+ * `scanLoop.dedupFileEvent` sits AHEAD of the batcher on every production push path and
+ * suppresses a repeat of the same `instanceId|file` for 30 s. In steady state the same
+ * pair therefore cannot reach one 150 ms window twice and the key merges nothing; it
+ * earns its place under burst, once `eventDedupMap` passes 1000 entries and is cleared
+ * wholesale. So these tests push straight into the batcher, BELOW that layer — which is
+ * exactly where the counters they assert on become reachable.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createBatcher } from '../../src/main/ipc-batcher.js';
+import {
+  FILE_ACCESS_CAPACITY,
+  FILE_ACCESS_INTERVAL_MS,
+  FILE_ACCESS_BATCHER_OPTIONS,
+  KEY_SEP,
+  fileAccessCoalesceKey,
+} from '../../src/main/file-access-batching.js';
+
+/**
+ * A benign self-churn event, shaped exactly as file-watcher.js builds one: an agent
+ * touching its OWN config dir, so the sensitive rule matched (`reason` non-empty) and
+ * the owner's own exemption cleared it (`selfAccess: true`, `sensitive: false`).
+ * @param {Object} [over] - field overrides.
+ */
+function selfChurn(over = {}) {
+  return {
+    agent: 'Claude Code',
+    pid: 4321,
+    instanceId: '4321:1699887000000',
+    parentEditor: null,
+    cwd: 'C:\\work\\proj',
+    file: 'C:\\Users\\me\\.claude\\settings.json',
+    sensitive: false,
+    selfAccess: true,
+    reason: 'AI agent config directory',
+    action: 'modified',
+    timestamp: 1,
+    category: 'ai',
+    attribution: { status: 'inferred', evidence: ['self-config-path'] },
+    repeatCount: 1,
+    ...over,
+  };
+}
+
+/**
+ * A sensitive event: a credential file read, attributed from a pid.
+ * @param {Object} [over] - field overrides.
+ */
+function sensitiveEvent(over = {}) {
+  return {
+    agent: 'Claude Code',
+    pid: 4321,
+    instanceId: '4321:1699887000000',
+    parentEditor: null,
+    cwd: 'C:\\work\\proj',
+    file: 'C:\\Users\\me\\.aws\\credentials',
+    sensitive: true,
+    selfAccess: false,
+    reason: 'Cloud provider credentials',
+    action: 'accessed',
+    timestamp: 2,
+    category: 'ai',
+    attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
+    repeatCount: 1,
+    ...over,
+  };
+}
+
+describe('fileAccessCoalesceKey', () => {
+  describe('refuses to merge', () => {
+    it('a sensitive event — null, whatever else it carries', () => {
+      expect(fileAccessCoalesceKey(sensitiveEvent())).toBeNull();
+    });
+
+    it('a sensitive event that also claims selfAccess', () => {
+      // Unreachable in production (`sensitive: reason !== null && !selfAccess`), and
+      // that is the point: the sensitive refusal must not be resting on that coupling.
+      // Strip the sensitive guard and this case starts returning a key.
+      expect(fileAccessCoalesceKey(selfChurn({ sensitive: true }))).toBeNull();
+    });
+
+    it('an event that is not the owning agent own benign self-churn', () => {
+      expect(fileAccessCoalesceKey(selfChurn({ selfAccess: false, reason: '' }))).toBeNull();
+    });
+
+    it('an event whose selfAccess is merely truthy, not true', () => {
+      expect(fileAccessCoalesceKey(selfChurn({ selfAccess: 1 }))).toBeNull();
+      expect(fileAccessCoalesceKey(selfChurn({ selfAccess: 'yes' }))).toBeNull();
+    });
+
+    it('an unattributed event — instanceId null', () => {
+      // Two unattributed events must not pool under one shared key: that is the same
+      // collapse dedupFileEvent refuses (scan-loop.js, F-E03).
+      expect(fileAccessCoalesceKey(selfChurn({ instanceId: null }))).toBeNull();
+    });
+
+    it('an event whose instanceId is an empty string', () => {
+      expect(fileAccessCoalesceKey(selfChurn({ instanceId: '' }))).toBeNull();
+    });
+
+    it('an event missing file or action', () => {
+      expect(fileAccessCoalesceKey(selfChurn({ file: '' }))).toBeNull();
+      expect(fileAccessCoalesceKey(selfChurn({ file: undefined }))).toBeNull();
+      expect(fileAccessCoalesceKey(selfChurn({ action: '' }))).toBeNull();
+      expect(fileAccessCoalesceKey(selfChurn({ action: undefined }))).toBeNull();
+    });
+
+    it('anything that is not an object', () => {
+      // Total, never throwing: ipc-batcher resolves this on the push path before any
+      // counter moves, so a throw would leave the batcher mid-update.
+      for (const v of [null, undefined, 0, 1, '', 'x', true, false, Symbol('s'), () => {}]) {
+        expect(fileAccessCoalesceKey(v)).toBeNull();
+      }
+      expect(() => fileAccessCoalesceKey(undefined)).not.toThrow();
+    });
+  });
+
+  describe('merges benign self-churn', () => {
+    it('returns a key built from instance identity + path + action', () => {
+      const ev = selfChurn();
+      expect(fileAccessCoalesceKey(ev)).toBe(
+        `4321:1699887000000${KEY_SEP}C:\\Users\\me\\.claude\\settings.json${KEY_SEP}modified`,
+      );
+    });
+
+    it('is stable — the same event pushed twice yields the same key', () => {
+      const ev = selfChurn();
+      expect(fileAccessCoalesceKey(ev)).toBe(fileAccessCoalesceKey(ev));
+    });
+
+    it('is stable across two separately built but equal events', () => {
+      expect(fileAccessCoalesceKey(selfChurn())).toBe(fileAccessCoalesceKey(selfChurn()));
+    });
+
+    it('ignores the fields that are not part of the key', () => {
+      // timestamp and repeatCount move on every repeat; the key must not.
+      const a = fileAccessCoalesceKey(selfChurn({ timestamp: 1, repeatCount: 1 }));
+      const b = fileAccessCoalesceKey(selfChurn({ timestamp: 999, repeatCount: 42 }));
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('separates what must stay separate', () => {
+    // Each of these three is a discriminating negative: drop a segment from the key and
+    // exactly one of them starts merging two events that are not the same frame. A
+    // "the key is stable" test alone passes against a function returning a constant.
+    it('a different instanceId is a different key', () => {
+      const a = fileAccessCoalesceKey(selfChurn({ instanceId: '4321:1699887000000' }));
+      const b = fileAccessCoalesceKey(selfChurn({ instanceId: '4321:1699887000001' }));
+      expect(a).not.toBe(b);
+    });
+
+    it('a different file is a different key', () => {
+      const a = fileAccessCoalesceKey(selfChurn({ file: 'C:\\Users\\me\\.claude\\a.json' }));
+      const b = fileAccessCoalesceKey(selfChurn({ file: 'C:\\Users\\me\\.claude\\b.json' }));
+      expect(a).not.toBe(b);
+    });
+
+    it('a different action is a different key', () => {
+      const a = fileAccessCoalesceKey(selfChurn({ action: 'modified' }));
+      const b = fileAccessCoalesceKey(selfChurn({ action: 'created' }));
+      expect(a).not.toBe(b);
+    });
+
+    it('the separator cannot occur inside a segment, so no two field splits collide', () => {
+      // A printable delimiter would let `<id>|<file>` and `<id>|<file2>` build one key
+      // when a path happens to contain it. NUL is unavailable to every segment.
+      const key = fileAccessCoalesceKey(selfChurn());
+      expect(KEY_SEP).toBe(String.fromCharCode(0));
+      expect(key.split(KEY_SEP)).toEqual([
+        '4321:1699887000000',
+        'C:\\Users\\me\\.claude\\settings.json',
+        'modified',
+      ]);
+    });
+  });
+});
+
+describe('FILE_ACCESS_BATCHER_OPTIONS', () => {
+  it('carries the documented bounds and is frozen', () => {
+    expect(FILE_ACCESS_CAPACITY).toBe(1000);
+    expect(FILE_ACCESS_INTERVAL_MS).toBe(150);
+    expect(FILE_ACCESS_BATCHER_OPTIONS).toEqual({
+      intervalMs: 150,
+      capacity: 1000,
+      coalesceKey: fileAccessCoalesceKey,
+    });
+    expect(Object.isFrozen(FILE_ACCESS_BATCHER_OPTIONS)).toBe(true);
+  });
+});
+
+describe('file-access batcher under the production options', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** @returns {{send: import('vitest').Mock, batcher: ReturnType<typeof createBatcher>}} */
+  function makeProductionBatcher() {
+    const send = vi.fn();
+    return { send, batcher: createBatcher('file-access', send, FILE_ACCESS_BATCHER_OPTIONS) };
+  }
+
+  it('a burst of identical self-churn becomes ONE entry, and a sensitive event in the same burst survives un-merged', () => {
+    const { send, batcher } = makeProductionBatcher();
+    const sensitive = sensitiveEvent();
+
+    for (let i = 1; i <= 25; i += 1) batcher.push(selfChurn({ timestamp: i, repeatCount: i }));
+    batcher.push(sensitive);
+    for (let i = 26; i <= 50; i += 1) batcher.push(selfChurn({ timestamp: i, repeatCount: i }));
+
+    const before = batcher.getStats();
+    expect(before.pushed).toBe(51);
+    expect(before.coalesced).toBe(49);
+    expect(before.evicted).toBe(0);
+    expect(before.buffered).toBe(2);
+    expect(before.highWater).toBe(2);
+
+    vi.advanceTimersByTime(FILE_ACCESS_INTERVAL_MS);
+    expect(send).toHaveBeenCalledOnce();
+    const [channel, payload] = send.mock.calls[0];
+    expect(channel).toBe('file-access');
+    expect(payload).toHaveLength(2);
+
+    // One displayed entry for 50 identical frames, and it is the LAST one: a merge
+    // replaces the buffered entry where it stands, so position is kept and the newest
+    // value wins.
+    expect(payload[0].file).toBe('C:\\Users\\me\\.claude\\settings.json');
+    expect(payload[0].timestamp).toBe(50);
+    expect(payload[0].repeatCount).toBe(50);
+
+    // Delivered untouched — same object, every field intact, in its own slot.
+    expect(payload[1]).toBe(sensitive);
+    expect(payload[1]).toEqual(sensitiveEvent());
+
+    const after = batcher.getStats();
+    expect(after.coalesced).toBe(49);
+    expect(after.buffered).toBe(0);
+    expect(after.evictedSinceFlush).toBe(0);
+    batcher.destroy();
+  });
+
+  it('two sensitive events in one burst each keep their own slot', () => {
+    const { send, batcher } = makeProductionBatcher();
+    batcher.push(sensitiveEvent({ file: 'C:\\a\\credentials' }));
+    batcher.push(sensitiveEvent({ file: 'C:\\a\\credentials' }));
+    vi.advanceTimersByTime(FILE_ACCESS_INTERVAL_MS);
+    expect(send.mock.calls[0][1]).toHaveLength(2);
+    expect(batcher.getStats().coalesced).toBe(0);
+    batcher.destroy();
+  });
+
+  it('self-churn from two different instances does not collapse onto one entry', () => {
+    const { send, batcher } = makeProductionBatcher();
+    for (let i = 0; i < 10; i += 1) {
+      batcher.push(selfChurn({ instanceId: '4321:1699887000000' }));
+      batcher.push(selfChurn({ instanceId: '9876:1699887000000' }));
+    }
+    vi.advanceTimersByTime(FILE_ACCESS_INTERVAL_MS);
+    const payload = send.mock.calls[0][1];
+    expect(payload).toHaveLength(2);
+    expect(payload.map((e) => e.instanceId)).toEqual([
+      '4321:1699887000000',
+      '9876:1699887000000',
+    ]);
+    expect(batcher.getStats().coalesced).toBe(18);
+    batcher.destroy();
+  });
+
+  it('unattributed self-churn never merges — each observation keeps its own slot', () => {
+    const { send, batcher } = makeProductionBatcher();
+    for (let i = 0; i < 5; i += 1) batcher.push(selfChurn({ instanceId: null }));
+    vi.advanceTimersByTime(FILE_ACCESS_INTERVAL_MS);
+    expect(send.mock.calls[0][1]).toHaveLength(5);
+    expect(batcher.getStats().coalesced).toBe(0);
+    batcher.destroy();
+  });
+
+  it('bounds the window at FILE_ACCESS_CAPACITY, dropping the oldest frame first', () => {
+    const { send, batcher } = makeProductionBatcher();
+    // Distinct files → distinct keys → nothing merges, so capacity is what answers.
+    for (let i = 0; i < FILE_ACCESS_CAPACITY + 1; i += 1) {
+      batcher.push(selfChurn({ file: `C:\\Users\\me\\.claude\\f${i}.json` }));
+    }
+    const stats = batcher.getStats();
+    expect(stats.pushed).toBe(FILE_ACCESS_CAPACITY + 1);
+    expect(stats.evicted).toBe(1);
+    expect(stats.evictedSinceFlush).toBe(1);
+    expect(stats.buffered).toBe(FILE_ACCESS_CAPACITY);
+    expect(stats.highWater).toBe(FILE_ACCESS_CAPACITY);
+
+    vi.advanceTimersByTime(FILE_ACCESS_INTERVAL_MS);
+    const payload = send.mock.calls[0][1];
+    expect(payload).toHaveLength(FILE_ACCESS_CAPACITY);
+    // The oldest frame is the one the renderer never sees; the newest always enters.
+    expect(payload[0].file).toBe('C:\\Users\\me\\.claude\\f1.json');
+    expect(payload[FILE_ACCESS_CAPACITY - 1].file).toBe(
+      `C:\\Users\\me\\.claude\\f${FILE_ACCESS_CAPACITY}.json`,
+    );
+    expect(batcher.getStats().evictedSinceFlush).toBe(0);
+    batcher.destroy();
+  });
+
+  it('coalescing keeps a sustained self-churn burst from ever reaching capacity', () => {
+    const { batcher } = makeProductionBatcher();
+    for (let i = 0; i < FILE_ACCESS_CAPACITY * 3; i += 1) batcher.push(selfChurn({ timestamp: i }));
+    const stats = batcher.getStats();
+    expect(stats.evicted).toBe(0);
+    expect(stats.buffered).toBe(1);
+    expect(stats.coalesced).toBe(FILE_ACCESS_CAPACITY * 3 - 1);
+    batcher.destroy();
+  });
+});

--- a/tests/main/main-ipc-stats.test.js
+++ b/tests/main/main-ipc-stats.test.js
@@ -1,0 +1,164 @@
+/**
+ * The `ipc` block of the stats payload (main.js `getStats`).
+ *
+ * `getStats` has TWO branches — a pre-`loadDeferredModules` literal and a loaded one —
+ * and they are separate object literals, so one can grow a field the other never gets.
+ * Both are exercised here by EXECUTION, not by matching the source: `getStats` branches
+ * on `scanner` alone while `getAppHealth` branches on `scanner || watcher`, so injecting
+ * a scanner stub and leaving `watcher` undefined reaches the loaded stats branch with
+ * app health still on its own booting path (ai-mistakes #21 — a gate that does not
+ * inspect the change is decoration).
+ *
+ * `app.whenReady()` never resolves in this harness, so no real deferred module ever
+ * loads and the injected stub is the only scanner that exists.
+ */
+import { describe, it, expect, afterAll, afterEach } from 'vitest';
+import Module from 'module';
+import os from 'os';
+import { createRequire } from 'module';
+
+const fakeElectron = {
+  app: {
+    name: 'Aegis',
+    getPath: () => os.tmpdir(),
+    getVersion: () => '0.0.0-test',
+    setName: () => {},
+    disableHardwareAcceleration: () => {},
+    requestSingleInstanceLock: () => true,
+    whenReady: () => new Promise(() => {}),
+    on: () => {},
+    quit: () => {},
+  },
+  BrowserWindow: class {},
+  globalShortcut: { register: () => {}, unregisterAll: () => {} },
+  shell: { openExternal: () => {} },
+  ipcMain: { handle: () => {}, on: () => {} },
+  dialog: {},
+  Notification: class {},
+  Tray: class {},
+  Menu: { buildFromTemplate: (t) => t },
+  nativeImage: { createFromBuffer: (b) => b },
+  safeStorage: { isEncryptionAvailable: () => false },
+};
+
+const originalLoad = Module._load;
+Module._load = function (request, _parent, _isMain) {
+  if (request === 'electron') return fakeElectron;
+  return originalLoad.apply(this, arguments);
+};
+
+const originalArgv = process.argv;
+// main.js exits early via a module-scope `return` when argv carries a CLI flag —
+// vitest's own argv must not trip that branch and blank out module.exports.
+process.argv = ['node', 'main.js'];
+
+// createRequire, not `import`: main.js is CommonJS with a module-scope `return`, which
+// is a syntax error under an ESM transform but legal for the CJS loader.
+const require_ = createRequire(import.meta.url);
+const main = require_('../../src/main/main.js');
+
+/** The six fields ipc-batcher's getStats() publishes, sorted. */
+const BATCHER_STATS_KEYS = [
+  'buffered',
+  'coalesced',
+  'evicted',
+  'evictedSinceFlush',
+  'highWater',
+  'pushed',
+];
+
+/** Only what the loaded `getStats` branch reads off the scanner. */
+function scannerStub() {
+  return {
+    activityLog: [],
+    monitoringStarted: 1_700_000_000_000,
+    peakAgents: 3,
+    uniqueAgentNames: new Set(['Claude Code']),
+    permissionDeniedScans: 0,
+  };
+}
+
+afterEach(() => {
+  // Module-level state in main.js: leave the booting branch as the default so test
+  // order cannot decide which branch a later case sees.
+  main._setScannerForTest(undefined);
+});
+
+afterAll(() => {
+  Module._load = originalLoad;
+  process.argv = originalArgv;
+});
+
+describe('getStats().ipc — display-lane delivery accounting', () => {
+  it('the scanner-absent branch carries the full six-field batcher shape', () => {
+    const stats = main.getStats();
+    expect(stats).toHaveProperty('ipc');
+    expect(Object.keys(stats.ipc)).toEqual(['fileAccess']);
+    expect(Object.keys(stats.ipc.fileAccess).sort()).toEqual(BATCHER_STATS_KEYS);
+    for (const key of BATCHER_STATS_KEYS) {
+      expect(typeof stats.ipc.fileAccess[key], `${key} must be a number`).toBe('number');
+    }
+  });
+
+  it('the loaded branch carries the same shape', () => {
+    main._setScannerForTest(scannerStub());
+    const stats = main.getStats();
+    // Proof the branch actually changed: the booting literal hardcodes 0 here, the
+    // loaded one reads the stub. Without this the next assertion would pass on either.
+    expect(stats.peakAgents).toBe(3);
+    expect(Object.keys(stats.ipc)).toEqual(['fileAccess']);
+    expect(Object.keys(stats.ipc.fileAccess).sort()).toEqual(BATCHER_STATS_KEYS);
+  });
+
+  it('both branches produce the identical ipc key set', () => {
+    const booting = main.getStats().ipc;
+    main._setScannerForTest(scannerStub());
+    const loaded = main.getStats().ipc;
+    expect(Object.keys(loaded.fileAccess).sort()).toEqual(Object.keys(booting.fileAccess).sort());
+  });
+
+  it('the scanner-absent branch reports the REAL batcher, not a zeroed stub', () => {
+    // The batcher is a module-scope const created at load, so it has been counting
+    // since before this branch was reachable. A hand-written zero literal here would
+    // start lying the moment anything pushed before the first scan.
+    const stats = main.getStats();
+    const direct = main.getStats();
+    expect(stats.ipc.fileAccess).toEqual(direct.ipc.fileAccess);
+    // A fresh object per call — never a shared mutable reference handed to the renderer.
+    expect(stats.ipc.fileAccess).not.toBe(direct.ipc.fileAccess);
+  });
+
+  it('ipc is a SIBLING of appHealth, never inside it', () => {
+    // Display loss is not app health: an eviction here is a frame the UI never painted,
+    // not a sensor lossCount and not an audit drop. Folding it into the health block
+    // would let a UI-throughput number read as an observation failure.
+    const stats = main.getStats();
+    expect(stats.appHealth).not.toHaveProperty('ipc');
+    expect(stats.ipc).not.toHaveProperty('appHealth');
+    expect(stats.ipc).not.toHaveProperty('state');
+    expect(stats.ipc.fileAccess).not.toHaveProperty('lossCount');
+    expect(stats).toHaveProperty('monitoringPaused');
+  });
+
+  it('leaves every legacy stats field in place', () => {
+    const stats = main.getStats();
+    for (const key of [
+      'totalFiles',
+      'totalSensitive',
+      'aiSensitive',
+      'uptimeMs',
+      'monitoringStarted',
+      'peakAgents',
+      'currentAgents',
+      'aiAgentCount',
+      'otherAgentCount',
+      'uniqueAgents',
+      'permissionDeniedScans',
+      'attribution',
+      'appHealth',
+      'monitoringPaused',
+    ]) {
+      expect(stats, `missing legacy field ${key}`).toHaveProperty(key);
+    }
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -44,6 +44,8 @@ export default defineConfig({
         'src/main/process-utils.js',
         'src/main/process-scanner.js',
         'src/main/file-watcher.js',
+        'src/main/ipc-batcher.js',
+        'src/main/file-access-batching.js',
         'src/main/network-monitor.js',
         'src/main/platform/posix-shared.js',
         'src/main/platform/proc-snapshot-protocol.js',


### PR DESCRIPTION
PR #264 gave `src/main/ipc-batcher.js` opt-in `capacity`, `coalesceKey` and `getStats()`. Nothing used them: the `file-access` batcher still ran unbounded, no batcher counter reached the renderer, and the module was absent from `coverage.include`, so `test:coverage` never measured it.

## The coalesce key

`src/main/file-access-batching.js` — new, pure, no I/O and no module state, so `main.js` can load it on the fast path to a visible window (the batcher is built at module scope, long before `loadDeferredModules`).

`fileAccessCoalesceKey(event)` merges **only** an agent's own benign self-churn, and each refusal is a separate claim:

| input | result |
|---|---|
| `sensitive === true` | `null` — checked first and independently |
| `selfAccess !== true` | `null` — not the agent's own self-churn |
| `instanceId` null / empty | `null` — an unattributed event has no identity to merge on |
| otherwise | `instanceId` + `file` + `action`, joined on NUL |

The self-churn marker is `selfAccess`, verified against the real event shape rather than guessed: it is declared in `src/shared/types/events.ts` and set at all three emission sites in `file-watcher.js` (`handleWatcherEvent`, `scanFileHandles`, `_scanRmHolders`), meaning exactly "this agent touched its OWN config directory".

The `sensitive` guard is unreachable through the self-churn branch today (`sensitive: reason !== null && !selfAccess`), and it is there anyway so the refusal does not depend on that coupling surviving a future edit — a test pins it by feeding an event that claims both.

Bound worth stating: `selfAccess` is true only where the path ALSO matched a sensitive rule and the owner's own exemption cleared it. An ordinary non-sensitive file event is therefore not self-churn and never merges. That is the marker the event shape actually carries; no proxy was invented for the wider case.

NUL as the separator because it is the one byte no segment can hold — a Windows path carries both `:` and `\`, so a printable delimiter would let two different field splits build one key.

## Where the key actually fires

`scanLoop.dedupFileEvent` sits **ahead** of the batcher on every production push path and suppresses a repeat of the same `instanceId|file` for 30 s. In steady state the same pair cannot reach one 150 ms window twice, so the key merges nothing. It earns its place under burst, once `eventDedupMap` passes 1000 entries and is cleared wholesale and repeats start arriving.

**Coalescing is the burst-mode backstop; `capacity: 1000` is the primary bound.** The tests push straight into the batcher, below the dedup layer, which is exactly where these counters become reachable.

## Stats payload

`getStats()` gains `ipc: { fileAccess: … }` as a **sibling** of `appHealth`, on the same principle that keeps `monitoringPaused` outside the health enum. Display loss is not app health: a merge or an eviction here is a frame the renderer never painted — never a sensor `lossCount`, never an audit drop. The activityLog ring and the audit-logger JSONL account for their own loss on their own lane.

Both `getStats` branches use the **same expression**, not merely the same shape: the batcher is a module-scope const, so the scanner-absent branch reports real counters rather than a zeroed lookalike.

## Coverage

`src/main/ipc-batcher.js` and `src/main/file-access-batching.js` join `coverage.include`. Measured in isolation both report 100 % statements / branches / functions / lines. In the whole-suite run the reported figures are lower (73 % and 70 %) because `main-app-health-stats.test.js` and `main-ipc-stats.test.js` must load `main.js` through `createRequire` — `main.js` has a module-scope `return`, so Vite cannot transform it — and that uninstrumented second load dilutes the v8 merge. Pre-existing harness behaviour, newly visible now that the file is measured; no threshold is configured, so `test:coverage` is unaffected either way.

## Verification

All 9 CI gate commands green locally: `build:renderer`, `format:check`, `lint` (0 errors), `typecheck`, `typecheck:svelte`, `test:coverage` (2136 passed / 4 skipped, 122 files), `verify:gate` (4/4 mutants killed), `counts:check`, `npm audit --audit-level=high --omit=dev`.

Mutation-checked rather than assumed (ai-mistakes #21): removing the `sensitive` guard and dropping the `action` segment from the key each turned the suite red — 4 failing tests across both mutations — and the tests went green again on revert.

Smoke-launched with an isolated `--user-data-dir` (the installed instance holds the single-instance lock, so a plain `npm start` would exit 0 without a window and prove nothing): app opened, 4 watch roots registered, snapshot sidecar ready, process/network/file scans all ran, console clean.

`src/main` module count updated 52 → 53 / 40 → 41 top-level in `CLAUDE.md`, `memory-bank/architecture.md` and `docs/current-state/CORRECTNESS-AUDIT.md` — the three tracked declaration sites `counts:check` checks.
