### PR TITLE
fix: localize agent stats panel

### DIFF
--- a/src/renderer/lib/components/AgentStatsPanel.svelte
+++ b/src/renderer/lib/components/AgentStatsPanel.svelte
@@ -16,6 +16,7 @@
   import { focusInstanceId } from '../utils/agent-selection.ts';
   import { tick, startTick } from '../stores/tick.ts';
   import { populationUnknown } from '../stores/app-health.js';
+  import { t } from '../i18n/index.js';
 
   /** @type {{ active?: boolean }} */
   let { active = true } = $props();
@@ -82,19 +83,19 @@
     <thead>
       <tr>
         <th class="col-agent" onclick={() => toggleSort('agent')}>
-          Agent{sortArrow('agent')}
+          {$t('stats.columns.agent')}{sortArrow('agent')}
         </th>
-        <th class="col-status">Status</th>
+        <th class="col-status">{$t('stats.columns.status')}</th>
         <th class="col-risk" onclick={() => toggleSort('risk')}>
-          Risk{sortArrow('risk')}
+          {$t('stats.columns.risk')}{sortArrow('risk')}
         </th>
         <th class="col-files" onclick={() => toggleSort('files')}>
-          File Act{sortArrow('files')}
+          {$t('stats.columns.file_activity')}{sortArrow('files')}
         </th>
         <th class="col-net" onclick={() => toggleSort('network')}>
-          Network{sortArrow('network')}
+          {$t('stats.columns.network')}{sortArrow('network')}
         </th>
-        <th class="col-seen">Last Seen</th>
+        <th class="col-seen">{$t('stats.columns.last_seen')}</th>
       </tr>
     </thead>
     <tbody>
@@ -104,8 +105,8 @@
             <span class="agent-name">{row.name}</span>
           </td>
           <td class="col-status">
-            <span class="status-dot active" aria-label="active"></span>
-            active
+            <span class="status-dot active" aria-label={$t('stats.status_active')}></span>
+            {$t('stats.status_active')}
           </td>
           <td class="col-risk">
             <div class="risk-cell">
@@ -122,10 +123,10 @@
             </div>
           </td>
           <td class="col-files">
-            {row.fileCount} events
+            {$t('stats.events', { count: row.fileCount })}
           </td>
           <td class="col-net">
-            {row.networkCount} conn
+            {$t('stats.connections', { count: row.networkCount })}
           </td>
           <td class="col-seen">
             {formatRelativeTime(now - row.lastSeen)}
@@ -134,7 +135,11 @@
       {:else}
         <tr>
           <td colspan="6" class="empty-state">
-            {#if $populationUnknown}Agent population unknown{:else}No agents detected{/if}
+            {#if $populationUnknown}
+              {$t('agents.population_unknown')}
+            {:else}
+              {$t('stats.no_agents')}
+            {/if}
           </td>
         </tr>
       {/each}

--- a/src/renderer/lib/i18n/translations/en.json
+++ b/src/renderer/lib/i18n/translations/en.json
@@ -31,6 +31,20 @@
     "reports": "Reports",
     "stats": "Stats"
   },
+  "stats": {
+    "columns": {
+      "agent": "Agent",
+      "status": "Status",
+      "risk": "Risk",
+      "file_activity": "File Act",
+      "network": "Network",
+      "last_seen": "Last Seen"
+    },
+    "status_active": "active",
+    "events": "{count} events",
+    "connections": "{count} conn",
+    "no_agents": "No agents detected"
+  },
   "demo": {
     "badge": "DEMO MODE",
     "description": "Simulated data only. No real agents are being monitored.",

--- a/tests/renderer/components/AgentStatsPanel.test.ts
+++ b/tests/renderer/components/AgentStatsPanel.test.ts
@@ -60,3 +60,27 @@ describe('AgentStatsPanel — empty table under a HEALTHY population', () => {
     expect(container.textContent).not.toContain('Agent population unknown');
   });
 });
+
+describe('AgentStatsPanel — translated table labels', () => {
+  it('renders column, status, and count strings through the English catalogue', () => {
+    agents.set([
+      {
+        agent: 'Claude Code',
+        pid: 100,
+        process: 'claude.exe',
+        status: 'running',
+        instanceId: '100:1754380000000',
+        category: 'coding-assistant',
+      },
+    ]);
+
+    const { container } = render(AgentStatsPanel);
+
+    expect(container.querySelector('.col-agent')).toHaveTextContent('Agent');
+    expect(container.querySelector('.col-status')).toHaveTextContent('Status');
+    expect(container.querySelector('.status-dot')).toHaveAttribute('aria-label', 'active');
+    expect(container.querySelector('tbody .col-status')).toHaveTextContent('active');
+    expect(container.querySelector('tbody .col-files')).toHaveTextContent('0 events');
+    expect(container.querySelector('tbody .col-net')).toHaveTextContent('0 conn');
+  });
+});


### PR DESCRIPTION
## Description

Routes the Agent Stats panel’s user-visible strings through the existing i18n store instead of rendering English literals directly.

- adds translation keys for column labels, active status, event and connection counts, and the healthy empty state
- reuses the existing agents.population_unknown translation for the failed-population state
- applies translated text to the active-status aria-label as well as visible content
- preserves the current English wording and count formatting
- adds a focused component test covering translated headers, status text, accessibility text, and counts

Closes #271

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Passed locally:

- npm run build:renderer
- npm run format:check
- npm run lint (0 errors; existing warnings only)
- npm run typecheck
- npm run typecheck:svelte
- npm run test -- tests/renderer/components/AgentStatsPanel.test.ts (3 tests)
- npm run verify:gate
- npm run counts:check
- npm audit --audit-level=high --omit=dev

The full coverage command was also run. The changed AgentStatsPanel suite passed, while unrelated Electron/bootstrap and scan-loop suites failed in the local macOS environment. CI remains the authoritative full-suite result.

## Checklist
- [x] Follows code style guidelines (CommonJS main, Svelte 5 renderer)
- [x] No console.log in production code
- [x] Files under 300 lines
- [ ] I have tested this locally with npm start
- [x] This code has been reviewed by a human