### PR TITLE
docs: replace machine-specific repository paths (#269)

### DIFF
--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -24,15 +24,17 @@
 
 ## For AI agents (Claude Code)
 
+Replace `<repo-root>` with the path to your local Aegis checkout before running these commands.
+
 ```powershell
 # Create branch
-powershell.exe -NoProfile -Command "cd 'X:\dev\project\AEGIS'; git checkout -b feat/feature-name"
+powershell.exe -NoProfile -Command "cd '<repo-root>'; git checkout -b feat/feature-name"
 
 # Make changes, commit
-powershell.exe -NoProfile -Command "cd 'X:\dev\project\AEGIS'; git add file1 file2; git commit -m 'feat(scope): description'"
+powershell.exe -NoProfile -Command "cd '<repo-root>'; git add file1 file2; git commit -m 'feat(scope): description'"
 
 # Push branch
-powershell.exe -NoProfile -Command "cd 'X:\dev\project\AEGIS'; git push origin feat/feature-name"
+powershell.exe -NoProfile -Command "cd '<repo-root>'; git push origin feat/feature-name"
 
 # Create PR
 gh pr create --title 'feat(scope): description' --base master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ regenerating a lockfile.
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
-7. Git: powershell.exe -NoProfile -Command "cd 'X:\dev\project\AEGIS'; git ..."
+7. Git: powershell.exe -NoProfile -Command "cd '<repo-root>'; git ..."
 8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` + `npm run typecheck:svelte` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths


### PR DESCRIPTION
## Description

Replaces the machine-specific `X:\dev\project\AEGIS` path in the contributor Git examples with a `<repo-root>` placeholder, and tells contributors to substitute their local checkout path. This keeps the documented commands usable outside the original development machine.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `git grep -n -F 'X:\\dev\\project\\AEGIS' -- CLAUDE.md BRANCHING.md` — no matches
- Verified all three branch commands use `<repo-root>`
- `git diff --check` — passed

## Checklist
- [x] Follows code style guidelines
- [x] No console.log in production code
- [x] Files under 300 lines
- [ ] I have tested this locally with `npm start` (documentation-only change)
- [ ] This code has been reviewed by a human (not solely AI-generated)

Fixes #269