### PR TITLE
fix(renderer): correct GitHub org in demo banner link

### DIFF
--- a/src/renderer/lib/components/DemoBanner.svelte
+++ b/src/renderer/lib/components/DemoBanner.svelte
@@ -7,7 +7,7 @@
   </span>
   <a
     class="demo-link"
-    href="https://github.com/anthropos17/Aegis"
+    href="https://github.com/antropos17/Aegis"
     target="_blank"
     rel="noopener noreferrer"
   >


### PR DESCRIPTION
Fixes #276

`DemoBanner.svelte:10` linked to `https://github.com/anthropos17/Aegis`. The org name carries an extra `h`; the account does not exist, so the link returned HTTP 404. This repository is `antropos17/Aegis`, which every other reference in the tree already uses.

The banner ships in the demo build (`npm run build:demo`), so the broken link was reachable from the hosted demo.

## Change

```diff
-    href="https://github.com/anthropos17/Aegis"
+    href="https://github.com/antropos17/Aegis"
```

One line, one file. Nothing else in `DemoBanner.svelte` was touched.

## Verification

```
git grep -n anthropos       # no hits, exit 1
```

Local pre-merge set, all green on this branch:

| Command | Result |
|---|---|
| `npm run build:renderer` | exit 0 |
| `npm run format:check` | exit 0 — all matched files use Prettier code style |
| `npm run lint` | exit 0 — 0 errors, 37 pre-existing warnings |
| `npm run typecheck` | exit 0 |
| `npm run typecheck:svelte` | exit 0 — 415 files, 0 errors, 0 warnings |
| `npm run test:coverage` | exit 0 — 123 files, 2151 passed / 4 skipped |
| `npm run verify:gate` | exit 0 — all 4 mutants killed |
| `npm run counts:check` | exit 0 — 19 counters, 96 declaration sites agree |
| `npm audit --audit-level=high --omit=dev` | exit 0 — 0 vulnerabilities |
