### PR TITLE
docs: link release verification from README, unpin progress.md Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ AI agents run with deep access to files, credentials, and shell commands. The ri
 
 ### Windows installer
 
-Starting with v0.11.0-alpha, releases ship a Windows NSIS installer — download the `.exe` from the [latest release](https://github.com/antropos17/Aegis/releases/latest).
+Starting with v0.11.0-alpha, releases ship a Windows NSIS installer — download the `.exe` from the [latest release](https://github.com/antropos17/Aegis/releases/latest). Each release also ships a signed manifest, so a download can be verified offline against the public key committed in this repository — see [Verifying an AEGIS release](docs/RELEASE-VERIFICATION.md).
 
 ### From source (all platforms)
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,7 +1,9 @@
 # AEGIS Progress
 
 ## Status
-Version 0.10.0-alpha. 110 agents / 262 signatures in database. 73 rules across 8 YAML. build:renderer clean. 46 CJS modules in src/main. **Phase 1 P0 CLOSED — C-01…C-05 all DONE. instanceId rollout COMPLETE (PR #180–182). Identity migration: C1, C2 (main + renderer), C6, C7 closed. tsconfig debt CLOSED (#184), docs truth-synced (#185), audit buffer bounded (#186).**
+The current version lives in `package.json` (`node -p "require('./package.json').version"`).
+Agent, signature, rule and module counts are derived from the tree by `scripts/counts.js` (`npm run counts:check`), not pinned here.
+Entries in this file are appended chronologically, newest at the bottom.
 
 ## feat/identity-main — identity migration (branch `feat/identity-main`)
 **Steps 1–5 + 7 of `docs/current-state/IDENTITY-RECON.md` §6 (main stamp/carry + renderer correlation including anomaly).** Every identity value the main process emits is an OS-grounded instance key, or an honest `null`.


### PR DESCRIPTION
Two docs edits, no source changes.

## README.md — release verification is discoverable

`docs/RELEASE-VERIFICATION.md` shipped with the signed release manifests but was
reachable only by browsing `docs/`. The Windows installer paragraph now ends with one
sentence linking it, so someone following the download instructions learns that the
download can be checked offline. No new section, no badge.

## memory-bank/progress.md — Status block no longer pins live figures

The Status block still read as it did several releases ago: a version, an agent count, a
signature count, a rule count and a module count, all inline, while entries were appended
below it and the header was never revisited. That is exactly the failure `ai-mistakes.md`
records under Documentation — a hand-maintained counter that is true only until the next
merge, with nothing going red when it stops being true.

The block now points at `package.json` for the version and at `scripts/counts.js` /
`npm run counts:check` for the counts, and states that entries are appended
chronologically, newest at the bottom. No number, version or PR reference remains in it.

Every entry below the Status block is byte-identical; the diff is a single hunk at the top
of the file.

## Verification

- `npx prettier --check README.md memory-bank/progress.md` — clean
- `npm run counts:check` — OK, 19 counters derived, 96 declaration sites agree
- `git diff --stat` — 2 files, 4 insertions, 2 deletions
