### PR TITLE
docs: fix manifest scope, supported versions, and non-goal wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ AI agents run with deep access to files, credentials, and shell commands. The ri
 
 ### Windows installer
 
-Starting with v0.11.0-alpha, releases ship a Windows NSIS installer — download the `.exe` from the [latest release](https://github.com/antropos17/Aegis/releases/latest). Each release also ships a signed manifest, so a download can be verified offline against the public key committed in this repository — see [Verifying an AEGIS release](docs/RELEASE-VERIFICATION.md).
+Starting with v0.11.0-alpha, releases ship a Windows NSIS installer — download the `.exe` from the [latest release](https://github.com/antropos17/Aegis/releases/latest). Releases from v0.13.0-alpha onward also ship a signed manifest, so a download can be verified offline against the public key committed in this repository — see [Verifying an AEGIS release](docs/RELEASE-VERIFICATION.md). Earlier releases ship no manifest and cannot be verified this way.
 
 ### From source (all platforms)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,18 +83,14 @@ AEGIS follows Electron security best practices:
 
 ### Known Limitations
 
-- **Monitor-only:** AEGIS currently observes but does not enforce at the OS level. Permission states (allow/monitor/block) affect UI display and alerting. True OS-level enforcement via kernel hooks is planned.
+- **Monitor-only:** AEGIS observes and does not enforce at the OS level. Permission states (allow/monitor/block) affect UI display and alerting. OS-level blocking by kernel driver is a deliberate non-goal.
 - **Audit logs are plaintext:** JSONL files in `userData/audit-logs/` are unencrypted. They contain file paths and agent names but not file contents.
 - **Process attribution:** chokidar file watchers cannot attribute events to specific processes. Handle-based scanning provides per-process attribution but runs on a timer, not in real-time.
-- **No TLS inspection:** Network monitoring sees connection endpoints but cannot inspect encrypted traffic. Deep packet inspection is planned for future versions.
+- **No TLS inspection:** Network monitoring sees connection endpoints only and cannot inspect encrypted traffic. TLS interception is a deliberate non-goal, not a pending feature.
 
 ## Supported Versions
 
-| Version     | Supported                          |
-|-------------|------------------------------------|
-| 0.10.x      | Current release — actively supported |
-| 0.7.x–0.9.x | Security fixes only                |
-| < 0.7.x     | End of life                        |
+Only the latest release on the [GitHub Releases page](https://github.com/antropos17/Aegis/releases) is supported. AEGIS is alpha software: older releases receive no security fixes. Always run the latest release.
 
 ## Credit
 


### PR DESCRIPTION
Three factual inaccuracies in public-facing docs. Docs only — no source, no CHANGELOG, no memory-bank.

## README.md — manifest scope

"Each release also ships a signed manifest" was true of exactly one release. Release assets verified with `gh release view`: `manifest.json` + `manifest.json.sig` exist on `v0.13.0-alpha` only; `v0.11.0-alpha` and `v0.12.0-alpha` ship the installer alone. The sentence now names the version the capability started at and says earlier releases have no manifest.

## SECURITY.md — Supported Versions

The table pinned `0.10.x` as "Current release" while the latest release is three minors ahead. A pinned live version number goes stale on the next release and nothing goes red (ai-mistakes #24), so the table is replaced with prose that carries no version numbers: only the latest release is supported, older alpha releases receive no fixes.

## SECURITY.md — Known Limitations

Two bullets promised features that are deliberate non-goals, not pending work: "True OS-level enforcement via kernel hooks is planned" and "Deep packet inspection is planned for future versions". Both now state the limitation and name the non-goal (ai-mistakes #20 — do not document a mechanism that will not be built). The other two bullets are untouched.

## Known follow-up, out of scope here

The new SECURITY.md wording contradicts two spots this PR does not touch: `README.md:234` lists "OS-level enforcement / kernel hooks" under Roadmap, and `ARCHITECTURE.md:111` gives "TLS interception proxy with user consent" as the planned approach for deep packet inspection. If kernel drivers and TLS interception are non-goals, those two entries need the same treatment in a separate PR.

## Verification

- `npm run build:renderer` green (2.34s).
- Diff is 2 files, 4 insertions, 8 deletions; CRLF and UTF-8 preserved, no NUL bytes.
