### PR TITLE
chore: remove deprecated SENSITIVE_RULES from constants.js

### DIFF
--- a/.codex/agents/consistency-reviewer.toml
+++ b/.codex/agents/consistency-reviewer.toml
@@ -20,8 +20,6 @@ When invoked:\r
 3. Verify each against code:\r
    - Agent signatures: count entries in agent-database.json; compare to the\r
      "107" (or whatever the docs say) claim.\r
-   - Sensitive rules: count SENSITIVE_RULES / patterns in constants.js; compare\r
-     to the "68" (or whatever the docs claim) figure.\r
    - "<2s boot": is there any benchmark/evidence, or is it unsubstantiated?\r
    - "CSP hardened": find the actual CSP and judge whether the claim holds.\r
    - JS vs TS: AGENTS.md says JS + JSDoc, other context says TS — determine\r

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Key modules:
 - `src/main/platform/` — OS abstraction (win32.js, darwin.js, linux.js)
 - `src/shared/agent-database.json` — 110 known agents; their `names` arrays hold 262 process-name signatures in total
 - `src/main/rule-loader.js` — loads `rules/*.yaml` (73 rules, 8 categories) against `rules/_schema.json`, hot-reload
-- `src/shared/constants.js` — ignore patterns, editor lists, AGENT_CONFIG_PATHS. `SENSITIVE_RULES` (68) is deprecated and unread at runtime — editing it changes nothing
+- `src/shared/constants.js` — ignore patterns, editor lists, AGENT_CONFIG_PATHS
 
 ## Build & test
 
@@ -62,7 +62,7 @@ coverage thresholds are configured in `vitest.config.js`, so coverage cannot fai
 
 ## Code conventions
 
-- 300 lines/file is a target for NEW files, not an invariant — 31 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 30 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - **Main process:** CommonJS (`require`/`module.exports`). Never use `import` in `src/main/`.
 - **Renderer:** ES modules (`import`/`export`). Never use `require()` in `src/renderer/`.
 - **Svelte 5 runes:** `$state`, `$derived`, `$effect`, `$props`. No legacy `let` reactivity.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,7 +276,7 @@ Rules live in `rules/*.yaml` (one file per category), validated against `rules/_
     risk: critical
     enabled: true
 ```
-`category` must be one of the 8 values allowed by `_schema.json` (ai-config, secrets, ssh, certificates, cloud, browser, devtools, crypto). `SENSITIVE_RULES` in `src/shared/constants.js` is deprecated and not read at runtime — editing it has no effect.
+`category` must be one of the 8 values allowed by `_schema.json` (ai-config, secrets, ssh, certificates, cloud, browser, devtools, crypto).
 
 ### Adding a New Monitoring Module
 1. Create `src/main/new-module.js` with `init(state)` pattern

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ regenerating a lockfile.
 ## Critical Rules
 1. Read memory-bank/ai-mistakes.md before ANY code change
 2. Do ONLY what the prompt says — no extra features, no unrequested changes
-3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 31 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 30 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
@@ -81,7 +81,7 @@ regenerating a lockfile.
 - src/main/ — 53 CommonJS modules (41 top-level + platform/ 10 + token-adapters/ 2)
 - src/renderer/ — Svelte 5 components + stores + utils + tokens.css/global.css
   (count: `git ls-files 'src/renderer/**/*.svelte' | wc -l`)
-- src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (9 TS files), constants.js (ignore patterns, config paths; SENSITIVE_RULES deprecated)
+- src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (9 TS files), constants.js (ignore patterns, config paths)
 - rules/ — 73 active detection rules in 8 YAML files, validated by rules/_schema.json
 - memory-bank/ — ai-mistakes.md (READ FIRST), progress.md, architecture.md
 - .claude/skills/ — 11 skills: aegis-context, design-system, electron-main, svelte-patterns, testing, ship, pr-monitor, ci-monitor, prompt-craft, audit-check, commit-and-track

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,8 +174,6 @@ Rules live in `rules/*.yaml` — one ruleset file per category, validated agains
 - `risk` — `critical`, `high`, `medium`, or `low`
 - `enabled` — Set `false` to ship a rule disabled by default
 
-`SENSITIVE_RULES` in `src/shared/constants.js` is deprecated and not read at runtime — editing it has no effect on detection.
-
 ## Issue Labels
 
 When filing issues, use these labels:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -295,7 +295,7 @@ Key token namespaces:
 
 ## Conventions
 
-- **300-line soft limit** per file — a target for NEW files, not an invariant; 31 existing `src/` files already exceed it. Not enforced by the linter
+- **300-line soft limit** per file — a target for NEW files, not an invariant; 30 existing `src/` files already exceed it. Not enforced by the linter
 - **JSDoc on all exported functions**: `@param`, `@returns`, `@since`
 - **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `security:`
 - **IPC channel names**: `kebab-case`

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -64,7 +64,7 @@ Core modules:
 - global.css — base styles, scrollbar, body gradients
 
 ## Shared (src/shared/)
-- constants.js — ignore patterns, editor lists, AGENT_CONFIG_PATHS. SENSITIVE_RULES (68) deprecated, unused at runtime
+- constants.js — ignore patterns, editor lists, AGENT_CONFIG_PATHS
 - rules/*.yaml (repo root, NOT src/shared) — 73 active detection rules across 8 categories, the real source of truth
 - src/main/rule-loader.js exports: getAllRules(), getRulesByCategory(category), getRuleById(id), reloadRules(), and loadRules aliased as _loadRules (test seam — not a public API)
 - agent-database.json — 110 agents / 262 name signatures

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -3,7 +3,7 @@
  * @file constants.js
  * @module shared/constants
  * @description Shared constant arrays used across AEGIS main-process modules:
- *   process ignore patterns, file ignore patterns, sensitive file rules,
+ *   process ignore patterns, file ignore patterns, agent config paths,
  *   and permission categories.
  * @author AEGIS Contributors
  * @license MIT
@@ -15,7 +15,6 @@
 /**
  * @typedef {import('./types/config').PermissionCategory} PermissionCategory
  * @typedef {{ readonly names: string[]; readonly label: string }} EditorDef
- * @typedef {import('./types/config').SensitiveRule & { readonly category?: string; readonly severity?: string }} BuiltinSensitiveRule
  */
 
 /** @type {readonly string[]} Hardware/driver process name fragments to never flag as AI agents */
@@ -161,248 +160,6 @@ const AGENT_SELF_CONFIG = {
   jan: /[\\\/]\.jan[\\\/]/i,
 };
 
-// @deprecated — use rule-loader.js instead. Will be removed in v0.7.0-alpha.
-// Kept for backward compatibility during migration.
-/** @type {readonly BuiltinSensitiveRule[]} Rules that classify a file path as sensitive */
-const SENSITIVE_RULES = [
-  // ── AI Agent Config Files — critical targets (Hudson Rock, Feb 2026) ──
-  {
-    pattern: /[\\\/]\.claude[\\\/]/i,
-    reason: 'AI agent config — Claude Code',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.claude\.json$/i,
-    reason: 'AI agent config — Claude Code',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.copilot[\\\/]/i,
-    reason: 'AI agent config — GitHub Copilot',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.cursor[\\\/]/i,
-    reason: 'AI agent config — Cursor',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.cursorrules$/i,
-    reason: 'AI agent config — Cursor',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.codeium[\\\/]/i,
-    reason: 'AI agent config — Codeium',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.continue[\\\/]/i,
-    reason: 'AI agent config — Continue',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.tabnine[\\\/]/i,
-    reason: 'AI agent config — Tabnine',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]TabNine[\\\/]/i,
-    reason: 'AI agent config — Tabnine',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]github-copilot[\\\/]/i,
-    reason: 'AI agent config — GitHub Copilot',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]aider[\\\/]/i,
-    reason: 'AI agent config — Aider',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.aider\.conf\.yml$/i,
-    reason: 'AI agent config — Aider',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.openclaw[\\\/]/i,
-    reason: 'AI agent config — OpenClaw',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.supermaven[\\\/]/i,
-    reason: 'AI agent config — Supermaven',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]JetBrains[\\\/]/i,
-    reason: 'AI agent config — JetBrains AI',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.codex[\\\/]/i,
-    reason: 'AI agent config — OpenAI Codex',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]goose[\\\/]/i,
-    reason: 'AI agent config — Goose',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.warp[\\\/]/i,
-    reason: 'AI agent config — Warp',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.gemini[\\\/]/i,
-    reason: 'AI agent config — Gemini',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]shell_gpt[\\\/]/i,
-    reason: 'AI agent config — ShellGPT',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.aish[\\\/]/i,
-    reason: 'AI agent config — AIsh',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.mentat[\\\/]/i,
-    reason: 'AI agent config — Mentat',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.tabby-client[\\\/]/i,
-    reason: 'AI agent config — Tabby',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.metagpt[\\\/]/i,
-    reason: 'AI agent config — MetaGPT',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]Claude[\\\/]/i,
-    reason: 'AI agent config — Claude Desktop',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.composio[\\\/]/i,
-    reason: 'AI agent config — Composio',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.semgrep[\\\/]/i,
-    reason: 'AI agent config — Semgrep',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]zed[\\\/]/i,
-    reason: 'AI agent config — Zed',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.config[\\\/]configstore[\\\/]/i,
-    reason: 'AI agent config — Config Store',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  // ── Container / VM / Local LLM configs ──
-  {
-    pattern: /[\\\/]\.ollama[\\\/]/i,
-    reason: 'Local LLM config — Ollama',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.jan[\\\/]/i,
-    reason: 'Local LLM config — Jan',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]lm-studio[\\\/]/i,
-    reason: 'Local LLM config — LM Studio',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  {
-    pattern: /[\\\/]\.cache[\\\/]gpt4all[\\\/]/i,
-    reason: 'Local LLM config — GPT4All',
-    category: 'agent-config',
-    severity: 'critical',
-  },
-  // ── Environment variables ──
-  { pattern: /[\\\/]\.env$/i, reason: 'Environment variables' },
-  { pattern: /[\\\/]\.env\.[^\\\/]+$/i, reason: 'Environment variables' },
-  { pattern: /[\\\/]\.ssh[\\\/]/i, reason: 'SSH keys/config' },
-  { pattern: /id_rsa/i, reason: 'SSH private key' },
-  { pattern: /id_ed25519/i, reason: 'SSH private key' },
-  { pattern: /id_ecdsa/i, reason: 'SSH private key' },
-  { pattern: /known_hosts/i, reason: 'SSH known hosts' },
-  { pattern: /authorized_keys/i, reason: 'SSH authorized keys' },
-  { pattern: /password/i, reason: 'Password file' },
-  { pattern: /credential/i, reason: 'Credentials' },
-  { pattern: /[\\\/]secret/i, reason: 'Secret file' },
-  { pattern: /[\\\/][^\\\/]*token[^\\\/]*$/i, reason: 'API token' },
-  { pattern: /api_key/i, reason: 'API key file' },
-  { pattern: /[\\\/]\.git-credentials$/i, reason: 'Git credentials' },
-  { pattern: /\.pem$/i, reason: 'Private key (PEM)' },
-  { pattern: /\.key$/i, reason: 'Private key' },
-  { pattern: /\.pfx$/i, reason: 'Certificate (PFX)' },
-  { pattern: /\.p12$/i, reason: 'Certificate (P12)' },
-  { pattern: /[\\\/]\.aws[\\\/]/i, reason: 'AWS credentials' },
-  { pattern: /[\\\/]\.azure[\\\/]/i, reason: 'Azure credentials' },
-  { pattern: /[\\\/]\.gcloud[\\\/]/i, reason: 'GCloud credentials' },
-  { pattern: /[\\\/]\.gnupg[\\\/]/i, reason: 'GPG keys' },
-  { pattern: /Chrome[\\\/]User Data[\\\/].*Login Data/i, reason: 'Chrome passwords' },
-  { pattern: /Chrome[\\\/]User Data[\\\/].*Cookies/i, reason: 'Chrome cookies' },
-  { pattern: /Chrome[\\\/]User Data[\\\/].*Web Data/i, reason: 'Chrome autofill data' },
-  { pattern: /Chrome[\\\/]User Data[\\\/].*History/i, reason: 'Chrome browsing history' },
-  { pattern: /Firefox[\\\/]Profiles[\\\/].*logins\.json/i, reason: 'Firefox passwords' },
-  { pattern: /Firefox[\\\/]Profiles[\\\/].*cookies\.sqlite/i, reason: 'Firefox cookies' },
-  { pattern: /Firefox[\\\/]Profiles[\\\/].*key[34]\.db/i, reason: 'Firefox key database' },
-  { pattern: /Edge[\\\/]User Data[\\\/].*Login Data/i, reason: 'Edge passwords' },
-  { pattern: /Edge[\\\/]User Data[\\\/].*Cookies/i, reason: 'Edge cookies' },
-  { pattern: /[\\\/]\.npmrc$/i, reason: 'NPM config (may contain tokens)' },
-  { pattern: /[\\\/]\.pypirc$/i, reason: 'PyPI config (may contain tokens)' },
-  { pattern: /[\\\/]\.docker[\\\/]config\.json/i, reason: 'Docker credentials' },
-  { pattern: /[\\\/]\.kube[\\\/]/i, reason: 'Kubernetes config' },
-];
-
 /**
  * @type {readonly string[]} Endpoint hosts Anthropic publishes as required for Claude Code.
  * Source: https://code.claude.com/docs/en/network-config (retrieved 2026-08-04).
@@ -469,7 +226,6 @@ module.exports = {
   AGENT_CONFIG_PATHS,
   SENSITIVE_AGENT_DIRS,
   AGENT_SELF_CONFIG,
-  SENSITIVE_RULES,
   PERMISSION_CATEGORIES,
   ALLOWLIST_DOMAINS,
   ALLOWLIST_IP_RANGES,

--- a/tests/shared/constants.test.js
+++ b/tests/shared/constants.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-  SENSITIVE_RULES,
   AGENT_SELF_CONFIG,
   AGENT_CONFIG_PATHS,
   PERMISSION_CATEGORIES,
@@ -9,29 +8,6 @@ import {
 } from '../../src/shared/constants.js';
 
 describe('constants', () => {
-  describe('SENSITIVE_RULES', () => {
-    it('all patterns are valid RegExp', () => {
-      for (const rule of SENSITIVE_RULES) {
-        expect(rule.pattern).toBeInstanceOf(RegExp);
-        expect(typeof rule.reason).toBe('string');
-        expect(rule.reason.length).toBeGreaterThan(0);
-      }
-    });
-
-    it('agent config rules match expected paths', () => {
-      const agentConfigRules = SENSITIVE_RULES.filter((r) => r.category === 'agent-config');
-      expect(agentConfigRules.length).toBeGreaterThan(0);
-
-      const claudeRule = agentConfigRules.find((r) => r.reason.includes('Claude Code'));
-      expect(claudeRule).toBeDefined();
-      expect(claudeRule.pattern.test('/home/user/.claude/config.json')).toBe(true);
-
-      const cursorRule = agentConfigRules.find((r) => r.reason.includes('Cursor'));
-      expect(cursorRule).toBeDefined();
-      expect(cursorRule.pattern.test('/home/user/.cursor/settings.json')).toBe(true);
-    });
-  });
-
   describe('AGENT_SELF_CONFIG', () => {
     it('each matches its own config path', () => {
       expect(AGENT_SELF_CONFIG.claude.test('/home/.claude/config')).toBe(true);


### PR DESCRIPTION
## What

Removes `SENSITIVE_RULES` (68 entries) from `src/shared/constants.js`. It was marked
`@deprecated — use rule-loader.js instead. Will be removed in v0.7.0-alpha.` when
`rule-loader.js` took over classification (`74500dd`). The tree is at `0.13.0-alpha`,
so the removal deadline is long past.

## Deadness re-proven, not assumed

Sweep run against the index, not a working-tree walk (`git grep --untracked` narrows
the search and would have silently skipped `.claude/rules/` — ai-mistakes #28):

```
git ls-files -z | xargs -0 grep -n "SENSITIVE_RULES"
```

| Hit | Class |
|---|---|
| `src/shared/constants.js:167` definition, `:472` export | definition |
| `tests/shared/constants.test.js:3,12,14,22` | dead test |
| `src/main/rule-loader.js:9` | doc comment, not a consumer |
| `.codex/agents/consistency-reviewer.toml:23` | agent instruction to count it |
| `AGENTS.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `memory-bank/architecture.md` | docs, present tense |
| `CHANGELOG.md`, `docs/current-state/STATE-RECON.md`, `memory-bank/progress.md`, `memory-bank/AEGIS-MASTER-PLAN.md` | dated records |

**Zero live consumers.** Grep-by-name alone would not prove that, so every requirer of
`src/shared/constants.js` was enumerated (`config-manager`, `file-watcher`,
`network-monitor`, `platform/restart-manager`, `process-scanner`, `process-utils`) and
each destructures named exports — no `import * as`, no `Object.keys`, no computed
access. The name sweep is therefore complete for this module.

## Removed

- `src/shared/constants.js` — the array, its `module.exports` entry, and the
  `BuiltinSensitiveRule` typedef, which had no other user. 476 → 232 lines.
  `SensitiveRule` in `src/shared/types/config.ts` stays: `rule-loader.js` and
  `config-manager.js` use it.
- `tests/shared/constants.test.js` — the two `describe('SENSITIVE_RULES')` cases only.
  The file's other blocks exercise live exports and are untouched.

## Docs

Only claims that assert the export exists *now* were rewritten. `size.over300` falls
31 → 30 because `constants.js` drops under the line limit, so its three declaration
sites move with it and `counts:check` stays green on the derived figure.

Deliberately left alone: `CHANGELOG.md` (release-please history of the migration
commits), `docs/current-state/STATE-RECON.md`, `memory-bank/progress.md` and
`memory-bank/AEGIS-MASTER-PLAN.md` — dated records whose numbers are the finding being
reported (ai-mistakes #22, #24). `src/main/rule-loader.js:9` also stays: it is a
one-clause doc comment inside the module that serves detection at runtime, and this PR
does not touch that module.

## Verification — all 9 CI commands, local, on this branch

| command | result |
|---|---|
| `npm run build:renderer` | ✅ built in 2.11s |
| `npm run format:check` | ✅ all matched files use Prettier code style |
| `npm run lint` | ✅ 0 errors (37 pre-existing warnings, same as master) |
| `npm run typecheck` | ✅ both tsc projects |
| `npm run typecheck:svelte` | ✅ 415 files, 0 errors |
| `npm run test:coverage` | ✅ 123 files, 2149 passed / 4 skipped (master: 2151 — exactly the 2 deleted cases) |
| `npm run verify:gate` | ✅ 4/4 mutants killed |
| `npm run counts:check` | ✅ 19 counters, 96 declaration sites agree |
| `npm audit --audit-level=high --omit=dev` | ✅ 0 vulnerabilities |

Every command was also run on the clean tree first, so each result above is a
before/after comparison rather than a bare green.
