### PR TITLE
docs: purge cut approaches from roadmap and blind-spot table

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,17 +102,17 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 
 ### What's NOT Covered Yet (Blind Spots → Future Work)
 
-| Blind Spot | Description | Planned Approach |
+| Blind Spot | Description | Planned Approach / Status |
 |---|---|---|
 | **UI Awareness** | Cannot see what AI agents display or interact with in UI | Accessibility API monitoring (no screen capture) |
 | **Container/VM Detection** | Detected — 7 container/VM agents added (Docker, WSL, Ollama, LM Studio, LocalAI, GPT4All, Jan) | Process pattern matching for containers + GPU monitoring |
-| **Sandbox Containment** | Monitor-only — cannot isolate or restrict agents | Job Objects (Windows), AppContainer, Linux namespaces |
+| **Sandbox Containment** | Monitor-only — cannot isolate or restrict agents | Non-goal: OS containment (Job Objects, AppContainer) is deliberately out of scope; pair AEGIS with external sandboxing |
 | **GPU Monitoring** | Cannot detect local inference processes | GPU utilization APIs, process GPU memory tracking |
-| **Deep Packet Inspection** | Sees TCP endpoints but not encrypted payloads | TLS interception proxy with user consent |
-| **Syscall Monitoring** | No kernel-level visibility into system calls | Windows Minifilter, macOS Endpoint Security, Linux eBPF |
-| **Memory Inspection** | Cannot inspect agent process memory | ReadProcessMemory API, `/proc/[pid]/mem` |
+| **Deep Packet Inspection** | Sees TCP endpoints but not encrypted payloads | Non-goal: TLS interception is deliberately out of scope; endpoints-only is the contract |
+| **Syscall Monitoring** | No kernel-level visibility into system calls | Kernel drivers (Minifilter/Endpoint Security/eBPF) are a non-goal; user-mode ETW telemetry is under evaluation |
+| **Memory Inspection** | Cannot inspect agent process memory | Non-goal: process-memory reading is deliberately out of scope |
 | **Cross-device Correlation** | Single-machine visibility only | Local network discovery + shared audit format |
-| **Mac/Linux parity** | Narrower than it looks: `platform/darwin.js` and `platform/linux.js` both implement `listProcesses()` (via `ps`) and `suspendProcess()`/`resumeProcess()` (via `posix-shared.js`), so process scanning and stop/resume are cross-platform. What is Windows-only is open-handle detection via the Restart Manager (`rstrtmgr.dll`); POSIX falls back to `lsof` / `/proc` | `fanotify` (Linux) and Endpoint Security (macOS) for richer file-access attribution |
+| **Mac/Linux parity** | Narrower than it looks: `platform/darwin.js` and `platform/linux.js` both implement `listProcesses()` (via `ps`) and `suspendProcess()`/`resumeProcess()` (via `posix-shared.js`), so process scanning and stop/resume are cross-platform. What is Windows-only is open-handle detection via the Restart Manager (`rstrtmgr.dll`); POSIX falls back to `lsof` / `/proc` | `fanotify` (Linux) for richer file-access attribution |
 
 ## Module Dependency Diagram
 

--- a/README.md
+++ b/README.md
@@ -230,12 +230,10 @@ Add custom agents via the UI or edit the JSON. See [AGENTS.md](AGENTS.md).
 
 Everything below is **planned**, not shipped. AEGIS today is monitor-only (see [Monitor-first](#monitor-first)).
 
-- [ ] Active blocking — enforce rules on violation (today: observe & log only)
-- [ ] OS-level enforcement / kernel hooks (Windows Minifilter, macOS Endpoint Security, Linux eBPF)
+- [ ] Active blocking — enforce rules on violation (userspace, pre-execution; kernel drivers are a non-goal) (today: observe & log only)
 - [ ] Surface per-sensor health in the UI — main-process records exist ([design](docs/roadmap/sensor-health-degraded.md))
 - [ ] MITRE ATT&CK mapping for detection rules
 - [ ] ML-based anomaly detection (today: hard-coded heuristic weights)
-- [ ] TLS / encrypted-traffic visibility, with user consent (today: TCP endpoints only)
 - [ ] First-class macOS & Linux support (currently experimental — [#37](https://github.com/antropos17/Aegis/issues/37))
 - [ ] GPU monitoring for local inference detection
 - [ ] Per-process file attribution (ETW, fanotify) — static recon: [docs/recon/kernel-file-etw.md](docs/recon/kernel-file-etw.md)


### PR DESCRIPTION
## Why

PR #288 declared kernel-driver enforcement and TLS interception deliberate non-goals in SECURITY.md. Two docs still listed those permanently-cut approaches as planned work, so the repo promised what it had just ruled out.

## What changed

**README.md — Roadmap**
- Removed `OS-level enforcement / kernel hooks (Windows Minifilter, macOS Endpoint Security, Linux eBPF)`.
- Removed `TLS / encrypted-traffic visibility, with user consent (today: TCP endpoints only)`.
- `Active blocking` stays planned and now reads `(userspace, pre-execution; kernel drivers are a non-goal)`.

**ARCHITECTURE.md — "What's NOT Covered Yet"**

Every row kept — the blind spots themselves are honest. Only the approach column changed, and the header is now `Planned Approach / Status` because four cells state a non-goal rather than a plan.

| Row | New approach/status |
|---|---|
| Sandbox Containment | Non-goal: OS containment (Job Objects, AppContainer) is deliberately out of scope; pair AEGIS with external sandboxing |
| Deep Packet Inspection | Non-goal: TLS interception is deliberately out of scope; endpoints-only is the contract |
| Syscall Monitoring | Kernel drivers (Minifilter/Endpoint Security/eBPF) are a non-goal; user-mode ETW telemetry is under evaluation |
| Memory Inspection | Non-goal: process-memory reading is deliberately out of scope |
| Mac/Linux parity | `fanotify` (Linux) for richer file-access attribution — Endpoint Security dropped, fanotify is not a kernel driver |

## Not touched

SECURITY.md (the authority for this wording), `src/`, `memory-bank/`. `docs/recon/EXTERNAL-TECHNIQUES.md` already marks minifilters and TLS interception out of scope; `memory-bank/` hits are dated audit records.

Docs only — no code paths affected.
