### PR TITLE
chore: drop the dead sensitive-rule count from consistency-reviewer

### DIFF
--- a/.codex/agents/consistency-reviewer.toml
+++ b/.codex/agents/consistency-reviewer.toml
@@ -1,5 +1,5 @@
 name = "consistency-reviewer"
-description = 'Read-only docs-vs-reality auditor for AEGIS. Use before any public release, README update, or grant/investor material to catch drift between the docs (README, AGENTS.md, llms.txt, AGENTS.md) and the actual code. Verifies every factual claim against source: agent-signature count (e.g. "107"), sensitive- rule count (e.g. "68"), "<2s boot", "CSP hardened", the JS vs TS story, IPC channel counts, and feature lists. Trigger explicitly with "use the consistency-reviewer subagent". Read-only: produces a claim -> reality -> verdict report, never edits docs or code.'
+description = 'Read-only docs-vs-reality auditor for AEGIS. Use before any public release, README update, or grant/investor material to catch drift between the docs (README, AGENTS.md, llms.txt, AGENTS.md) and the actual code. Verifies every factual claim against source: agent-signature count (e.g. "107"), "<2s boot", "CSP hardened", the JS vs TS story, IPC channel counts, and feature lists. Trigger explicitly with "use the consistency-reviewer subagent". Read-only: produces a claim -> reality -> verdict report, never edits docs or code.'
 developer_instructions = """
 You are a meticulous technical auditor checking whether AEGIS's documentation\r
 tells the truth. Marketing-grade claims in a security tool's README are a\r


### PR DESCRIPTION
Follow-up to #289.

#289 removed the body instruction telling the agent to `count SENSITIVE_RULES / patterns in constants.js; compare to the "68" ... figure`. The same claim survived in the `description` field one screen up, where it carries the number **without the identifier** — so the `SENSITIVE_RULES` sweep that found every other hit walked straight past it (ai-mistakes #24: grep the claim, not the name; assume siblings).

Found by re-sweeping on the number instead of the identifier:

```
git ls-files -z '*.md' '*.toml' ... | xargs -0 grep -n "68" | grep -i "rule\|sensitive\|pattern"
```

Two hits. This one is fixed; `README.md:130` stays — it is the v0.7.0-alpha row of the release-history table, which `scripts/counts.js` exempts by name as archival ("a release-history table row: it describes v0.7.0-alpha, not the tree").

Left as it stood, the agent's own trigger text still asked a reviewer to verify a count against an array that no longer exists.

Verified locally: `counts:check` and `format:check` green; the diff is one line in a `.toml` that no gate reads, so the 5 CI contexts are unaffected by construction and still have to pass.
