### PR TITLE
chore: drop the dangling SENSITIVE_RULES reference from rule-loader's header

### DIFF
--- a/src/main/rule-loader.js
+++ b/src/main/rule-loader.js
@@ -5,8 +5,8 @@
  * @file rule-loader.js
  * @module main/rule-loader
  * @description Loads YAML ruleset files from rules/, validates against JSON Schema,
- *   and compiles pattern strings into RegExp objects. Provides the same contract
- *   as SENSITIVE_RULES in constants.js: { pattern: RegExp, reason: string }.
+ *   and compiles pattern strings into RegExp objects. Every loaded rule carries
+ *   at least { pattern: RegExp, reason: string } — full shape in LoadedRule.
  */
 
 const fs = require('fs');


### PR DESCRIPTION
Third and last follow-up to #289 / #291.

#289 deleted `SENSITIVE_RULES` from `src/shared/constants.js`; #291 dropped the
count from the consistency-reviewer definition. One mention survived under `src/`:
the `@file` block of `rule-loader.js` — the module that *replaced* the array —
still pointed back at it.

```
- *   and compiles pattern strings into RegExp objects. Provides the same contract
- *   as SENSITIVE_RULES in constants.js: { pattern: RegExp, reason: string }.
+ *   and compiles pattern strings into RegExp objects. Every loaded rule carries
+ *   at least { pattern: RegExp, reason: string } — full shape in LoadedRule.
```

### Why this wording

The old line described the loader by what it used to be compatible with. The new
one states what it guarantees (ai-mistakes #27): every loaded rule carries
`pattern` and `reason` — `classifySensitive()` in `file-watcher.js:307-308` reads
exactly those two off `getAllRules()` — and `at least` plus the pointer to
`LoadedRule` keeps the other seven fields (`id`, `name`, `category`, `risk`,
`tags`, `enabled`, `platform`) from being implied away by an exhaustive-looking
literal.

### Scope

Comment-only. Two `*`-prefixed lines; no code line moves. The file stays at 229
lines, so no size counter shifts and `counts:check` is unaffected.

### Sweep

`git ls-files -z | xargs -0 grep -n SENSITIVE_RULES` — an index sweep, not
`git grep --untracked` (ai-mistakes #28) — now returns only `CHANGELOG.md`,
`docs/current-state/STATE-RECON.md`, `memory-bank/AEGIS-MASTER-PLAN.md` and
`memory-bank/progress.md`. All four are dated records and stay, matching #289's
own policy.

### Verification

`format:check`, `lint`, `typecheck` (both projects), `counts:check` and
`build:renderer` green locally.
