### PR TITLE
feat(shared): project internal events onto an ECS view at the boundary

### DIFF
--- a/docs/ECS-MAPPING.md
+++ b/docs/ECS-MAPPING.md
@@ -1,0 +1,230 @@
+# ECS mapping — the AEGIS event boundary
+
+AEGIS keeps its internal event schema untouched and exposes an **Elastic Common Schema 8.11**
+view at the boundary. One module performs that projection:
+
+**`src/shared/ecs-normalizer.js` is the source of truth. The tables in this document must follow
+it, never the other way round.** If a row here and the module disagree, the module is right and
+this file is the bug. Any change to the mapping is made in the module first; the row is then
+updated to match.
+
+Nothing consumes the projection yet. It exists so the names are fixed before the consumers are
+built against them: sequence-rule-engine input, the bench trace format, and SIEM export.
+
+---
+
+## 1. Why ECS, and why at the boundary
+
+**The Sysmon oracle joins through a mapping somebody else maintains.** `bench/lib/oracles/sysmon.js`
+confirms what the sensor recorded against a kernel-backed independent source. Sysmon events reach
+an ECS index through Elastic's own maintained winlogbeat mapping, and every field name on that side
+is decided for us. Naming the AEGIS side anything else would mean writing — and then maintaining —
+a second, private translation between two things that already agree on a vocabulary. `process.pid`,
+`file.path`, `event.category` and `process.entity_id` on both sides is the whole point.
+
+**Sigma correlation rules group by a field name, and that name is `process.entity_id`.** A Sigma
+correlation (`group-by`) buckets events by field, so a sequence rule such as "this process read a
+credential file and then opened an outbound connection" is only expressible if both events carry
+the same process key under the same name. AEGIS already has the right value — `instanceId` binds a
+pid to the OS process-creation time, which is exactly what `process.entity_id` is for (Sysmon puts
+its `ProcessGuid` there). What was missing was the name.
+
+**The internal schema stays as it is.** The projection happens at the boundary and only there.
+Nothing inside AEGIS renames a field, and Event Schema v1 records on disk are unchanged.
+
+---
+
+## 2. How a record is recognised
+
+`normalizeToEcs(event)` takes any of four carriers and works out which by structure. First match
+wins; the order is part of the contract:
+
+| # | test | carrier | emitted by |
+|---|------|---------|-----------|
+| 1 | `type` is a non-empty string | `AuditRecordV1` / `AuditRecordV0` | `src/main/audit-logger.js` |
+| 2 | `file` is a string | `FileEvent` | `src/main/file-watcher.js` |
+| 3 | `remoteIp` is a string | `NetworkConnection` | `src/main/network-monitor.js` |
+| 4 | `firstSeen` is a number | session record | `src/main/session-tracker.js` `reconcile()` |
+
+`type` is tested first because an audit record is the only carrier that has one, while its
+`path`/`action` pair would otherwise be read as a live shape. A session record says which side it
+is by `lastSeen`: `reconcile()` puts that field on an exit and withholds it on an enter.
+
+**An unrecognised shape throws `TypeError`.** A normalizer that answered `{}` would drop the event
+and look like it had handled it (memory-bank/ai-mistakes.md #25).
+
+### Absence
+
+A value a record does not carry is **omitted from the output — never written as `null`**. This is
+the same convention `bench/lib/catalogue.js` states as B2.2, and it is load-bearing: `null` in an
+ECS document reads as a measured null. Empty containers are omitted too — there is no
+`process: {}` and no `aegis: {}`.
+
+---
+
+## 3. Categorization — `event.kind` / `event.category` / `event.type` / `event.action`
+
+`event.category` and `event.type` are arrays, as ECS requires; `event.action` is a string.
+
+| record | `kind` | `category` | `type` | `action` |
+|---|---|---|---|---|
+| `FileEvent` `created` | `event` | `[file]` | `[creation]` | `file-created` |
+| `FileEvent` `modified` | `event` | `[file]` | `[change]` | `file-modified` |
+| `FileEvent` `deleted` | `event` | `[file]` | `[deletion]` | `file-deleted` |
+| `FileEvent` `accessed` | `event` | `[file]` | `[access]` | `file-accessed` |
+| `FileEvent` `holding` | `event` | `[file]` | `[info]` | `file-handle-held` |
+| `NetworkConnection` | `event` | `[network]` | `[connection]` | `network-connection` |
+| session record, enter | `event` | `[process]` | `[start]` | `agent-enter` |
+| session record, exit | `event` | `[process]` | `[end]` | `agent-exit` |
+| audit `file-access` | `event` | `[file]` | by its `action`, as above | as above |
+| audit `config-access` | `event` | `[configuration, file]` | by its `action` | as above |
+| audit `network-connection` | `event` | `[network]` | `[connection]` | `network-connection` |
+| audit `agent-enter` | `event` | `[process]` | `[start]` | `agent-enter` |
+| audit `agent-exit` | `event` | `[process]` | `[end]` | `agent-exit` |
+| audit `anomaly-alert` | `alert` | `[intrusion_detection]` | `[info]` | `anomaly-alert` |
+| audit `permission-deny`, `buffer-overflow-drop`, any unknown type | `event` | *omitted* | *omitted* | the `type` string |
+| `FileEvent` with an action outside the closed union | `event` | `[file]` | *omitted* | *omitted* |
+
+Four of those rows are decisions rather than transcriptions:
+
+- **`holding` is `info`, not `access`.** `file-watcher.js` emits `holding` for a point-in-time
+  handle HOLD observed at the scan tick, and its own comment says it is explicitly not a read.
+  `access` would claim more than the observation supports (ai-mistakes.md #27).
+- **`agent-enter` / `agent-exit`, not `process-started` / `process-ended`.** An enter is AEGIS's
+  first *sighting* of an agent under eager-enter/lazy-exit reconciliation, which is not a process
+  start; and a synthetic agent (pid 0 — editor extension, WSL-inner, local runtime) has no process
+  to start at all. `event.category` and `event.type` still read `process` / `start`, and those,
+  with `process.entity_id`, are what a Sysmon join actually uses.
+- **`config-access` keeps its own category.** It is a file event *and* a settings access, and
+  `event.category` is an array precisely so both can be said. No custom field is spent on it.
+- **`permission-deny` and `buffer-overflow-drop` get no categorization.** Nothing in `src/` emits
+  the first, and `src/shared/types/events.ts` refuses to invent its field semantics for a code path
+  that never runs; inventing them here would be the same manufacture one layer down. The second is
+  the audit log stating that *other* records were lost, which is no categorization of the marker
+  itself — in particular it is not ECS `pipeline_error`, which describes a failure to ingest *this*
+  document. Both keep `event.action` equal to their type and claim nothing more.
+
+---
+
+## 4. Field mapping
+
+The mapping is field-driven: a field is mapped wherever it appears, so a carrier that lacks one
+simply produces a smaller document.
+
+| internal field | carrier | ECS field | rule |
+|---|---|---|---|
+| `timestamp` (epoch ms) | `FileEvent` | `@timestamp` | finite, `> 0`, within Date range → ISO 8601 UTC |
+| `timestamp` (ISO string) | audit record | `@timestamp` | verbatim |
+| `firstSeen` | session enter | `@timestamp` | epoch ms → ISO 8601 UTC |
+| `lastSeen` | session exit | `@timestamp` | epoch ms → ISO 8601 UTC |
+| `instanceId` | all | `process.entity_id` | non-empty string, **verbatim** — `pid:startTime`, `0:<name>` or `<pid>:u`, format unchanged |
+| `pid` | all | `process.pid` | only `Number.isSafeInteger(pid) && pid > 0` |
+| `process` | session record | `process.name` | non-empty string — the OS process name |
+| `cwd` | `FileEvent`, `NetworkConnection` | `process.working_directory` | non-empty string |
+| `file` | `FileEvent` | `file.path` | non-empty string |
+| `path` | audit `file-access` / `config-access` | `file.path` | non-empty string |
+| `remoteIp` | `NetworkConnection` | `destination.ip` | non-empty string |
+| `remotePort` | `NetworkConnection` | `destination.port` | safe integer `> 0` |
+| `domain` | `NetworkConnection` | `destination.domain` | non-empty string; the forward-confirmed name the classifier established, never a bare PTR answer |
+| — | `NetworkConnection` | `network.transport` | constant `tcp` |
+| `agent` | all | `aegis.agent.name` | non-empty string — the AEGIS display name |
+| `attribution.status` | `FileEvent`, audit record | `aegis.attribution.status` | non-empty string |
+| `attribution.evidence` | `FileEvent`, audit record | `aegis.attribution.evidence` | array, copied |
+| `schemaVersion` | audit record | `aegis.schema_version` | safe integer |
+| `_demo` | any | `aegis.demo` | only when strictly `true` |
+| `riskScore` | audit record | `event.risk_score` | any finite number, **including `0`** |
+| — | all | `ecs.version` | constant `8.11.0` |
+
+### Rows that are decisions
+
+**Two names, and they are not the same thing.** `process` is the OS process name (`node.exe`) and
+goes to `process.name`. `agent` is the AEGIS display name (`Claude Code`) and goes to
+`aegis.agent.name`. They are different strings about different things, and a join treating one as
+the other would manufacture matches out of a naming coincidence — the reason `bench/lib/join.js`
+refuses to join on a name at all. Root ECS `agent.*` is reserved for the collector, which here is
+AEGIS itself, and is never written.
+
+**`process.pid` only for a pid the OS handed out.** `pid: 0` is a real value in AEGIS meaning a
+synthetic, process-less agent, and `pid: null` means none was observed. Neither is an OS pid, and
+writing either invites a join on it — every synthetic in the fleet would land in one bucket. The
+synthetic stays identified: its `process.entity_id` is `0:<name>`. Same rule and same reason as
+`bench/lib/observed.js` `processIdentity()`.
+
+**`process.entity_id` is copied, never parsed.** The value carries its own three value spaces
+(`src/main/process-identity.js`); splitting the pid back out of it here would be a second identity
+resolution one step removed from the first (ai-mistakes.md #19).
+
+**`aegis.demo` is written only for `_demo === true`.** Absence is the observed case and presence is
+the claim: the main process has no way to set the flag, so an unmarked record must not be marked
+here — and a marked one must not reach a SIEM looking like a real observation.
+
+### `event.risk_score` is vestigial, and it is `0` on every record
+
+`AuditRecordV1.riskScore` is always `0` in v1. `src/shared/types/events.ts` says so and adds
+"derive nothing from it". It is mapped anyway, `0` included, because a value the record carries is
+not an absence — the omit-never-null rule is about fields that are *missing*.
+
+The consequence must be read before writing a rule against it: **`event.risk_score` is `0` on every
+ECS document AEGIS produces today.** A detection expressed as `risk_score > 50` will never fire,
+and will look like a rule that is evaluating a score. When a real score exists, it will map through
+this same row unchanged.
+
+---
+
+## 5. Requested mappings with no source
+
+These ECS fields are **never written**, because no internal record carries a value for them. None
+is a stub awaiting a value; each is a statement about what AEGIS observes today.
+
+| ECS field | why there is no source |
+|---|---|
+| `process.executable` | No full executable path exists anywhere in the internal shapes. `DetectedAgent` carries `process` (the image name) and nothing more; the snapshot sidecar frame is `{pid, ppid, name, ct, seq}`. |
+| `process.parent.pid` | `ppid` lives inside the process map `getParentProcessMap()` builds and is never carried onto an agent record or an event. |
+| `process.parent.name` | `parentEditor` is a display **label** (`'VS Code'`, from `EDITOR_LABELS`), not a process name; `parentChain` — which does hold real parent process names — lives on `DetectedAgent` only and is copied onto no event. |
+| `source.ip` | A `RawTcpConnection` is `{pid, ip, port, state}`. The local endpoint is not in the row. |
+| `source.port` | Same row, same absence. |
+| `@timestamp` on a `NetworkConnection` | The connection object carries no observation time at all — `network-monitor.js` uses its `now` only for sensor health. The audit record written for the same socket does carry one, and that is where a time for that event comes from. |
+| `destination.ip` / `destination.port` on an **audit** `network-connection` record | Its `path` is the display string `` `${remoteIp}:${remotePort}` ``. Splitting it back apart would rebuild an identity out of a rendering, and is ambiguous the moment the address is IPv6. `destination.*` comes from a live `NetworkConnection` only. |
+
+Wiring any of these means changing an emitter first, which is a separate piece of work. Until then,
+the honest answer is the empty one.
+
+---
+
+## 6. Carried by the internal schema, not mapped in this block
+
+Enumerated so each omission is a decision rather than an oversight (ai-mistakes.md #30):
+
+`verdict`, `verdictReason`, `severity`, `sensitive`, `selfAccess`, `reason`, `category`, `state`,
+`flagged`, `httpUnencrypted`, `userAgent`, `parentEditor`, `details`, `seq`, `hash`, `repeatCount`.
+
+Several have obvious ECS or `aegis.*` homes — `severity`, `verdict` and `state` in particular. They
+are left out because this block fixes the identity, time, path and network naming and nothing else.
+Adding one later is an additive change to the module and one more row above.
+
+---
+
+## 7. Relationship to `bench/lib`
+
+`bench/lib/catalogue.js` and `bench/lib/observed.js` already write a minimal ECS subset, and they
+are **not** refactored onto this module. Nothing under `bench/lib/` may import from `src/`: the
+bench is the oracle side, and an oracle that shares code with the sensor it confirms stops being
+independent. The duplication is deliberate and stays.
+
+What that costs, stated rather than hidden:
+
+| | `src/shared/ecs-normalizer.js` | `bench/lib/{catalogue,observed}.js` |
+|---|---|---|
+| custom namespace | `aegis.*` | `bench.*` |
+| instance key | `process.entity_id` | `bench.instanceId` |
+| attribution | `aegis.attribution` | `bench.attribution` |
+| action for an `agent-enter` record | `agent-enter` | `process-started` |
+| scope | every carrier and every audit type | four shapes; network and anomaly records are tallied, not written |
+| ECS version | `ECS_VERSION` | `ECS_VERSION` — same value, separate declaration |
+
+The two `ECS_VERSION` declarations are compared by a case in `tests/shared/ecs-normalizer.test.js`.
+That test is the only thing that goes red if they drift apart; there is no other gate on it.
+
+The shared conventions — omit rather than null, `event.category`/`event.type` as arrays,
+`@timestamp` at the root, `ecs.version` on every document — are the same on both sides, and a row
+that changes one should change the other.

--- a/src/shared/ecs-normalizer.js
+++ b/src/shared/ecs-normalizer.js
@@ -1,0 +1,300 @@
+// @ts-check
+/**
+ * @file ecs-normalizer.js
+ * @module shared/ecs-normalizer
+ * @description The ECS VIEW of an AEGIS internal event. AEGIS keeps its own event schema
+ *   untouched and exposes Elastic Common Schema 8.11 names at the boundary. This module is the
+ *   ONLY place that mapping is written down; `docs/ECS-MAPPING.md` follows it, never the other
+ *   way round, and carries the argument for every row.
+ *
+ *   Pure: no imports, no module state, no clock, no I/O, the input is never mutated, and no value
+ *   in the output shares a reference with it. Nothing in `src/` calls it yet — it fixes the naming
+ *   before the sequence rule engine, the bench trace format and any SIEM export are built on it.
+ *
+ *   FOUR CARRIERS, one field-driven mapping — a field is mapped wherever it appears, so a
+ *   carrier that lacks it just yields a smaller document. `AuditRecordV1`/`V0` (`type`) ·
+ *   `FileEvent` (`file`) · `NetworkConnection` (`remoteIp`) · a session record (`firstSeen`,
+ *   with `lastSeen` marking the exit side — `reconcile()` puts it there and withholds it on an
+ *   enter). `type` is tested FIRST: only an audit record holds one, and its `path`/`action`
+ *   pair would otherwise read as a live shape. An unrecognised shape THROWS, because a
+ *   normalizer answering `{}` drops an event silently (ai-mistakes.md #25).
+ *
+ *   ABSENCE IS WRITTEN AS ABSENCE — a value the record does not carry is OMITTED, never emitted
+ *   as `null` (the convention `bench/lib/catalogue.js` states as B2.2). Empty containers go the
+ *   same way: no `process: {}`, no `aegis: {}`.
+ *
+ *   TWO NAMES, not interchangeable: `process` is the OS process name (`node.exe`) →
+ *   `process.name`; `agent` is the AEGIS display name (`Claude Code`) → `aegis.agent.name`.
+ *   Root ECS `agent.*` belongs to the collector — AEGIS itself — and is never written here.
+ *
+ *   NEVER WRITTEN for want of a source, none a stub awaiting a value: `process.executable`,
+ *   `process.parent.{pid,name}`, `source.{ip,port}`, and a `NetworkConnection`'s `@timestamp`.
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ * @since v0.14.0
+ */
+
+'use strict';
+
+/**
+ * ECS version these field names are taken from. Duplicated deliberately: `bench/lib/catalogue.js`
+ * declares the same constant and may not import from `src/` (an oracle sharing code with the
+ * sensor stops being independent). The parity case in the test file is the only thing that goes
+ * red if the two drift.
+ * @type {string}
+ * @since v0.14.0
+ */
+const ECS_VERSION = '8.11.0';
+
+/**
+ * @typedef {Object} EcsShape
+ * @property {Record<string, unknown>} event - the assembled ECS `event` branch.
+ * @property {string|null} timestamp - ISO 8601, or null when the carrier holds none.
+ * @property {Record<string, unknown>} fields - carrier-specific ECS branches.
+ */
+
+/**
+ * The closed `FileAction` union (types/events.ts) mapped to ECS categorization. `holding` is
+ * `info`, NOT `access`: file-watcher.js emits it for a point-in-time handle HOLD at the scan
+ * tick, explicitly not a read.
+ * @type {ReadonlyMap<string, {type: string, action: string}>}
+ */
+const FILE_ACTIONS = new Map([
+  ['created', { type: 'creation', action: 'file-created' }],
+  ['modified', { type: 'change', action: 'file-modified' }],
+  ['deleted', { type: 'deletion', action: 'file-deleted' }],
+  ['accessed', { type: 'access', action: 'file-accessed' }],
+  ['holding', { type: 'info', action: 'file-handle-held' }],
+]);
+
+/**
+ * `AuditEventType` (types/events.ts) mapped to ECS categorization. `file: true` means the record's
+ * own `action` selects the pair out of {@link FILE_ACTIONS} and its `path` becomes `file.path`.
+ * `permission-deny` and `buffer-overflow-drop` are ABSENT on purpose: nothing emits the first and
+ * events.ts refuses to invent its fields, while the second reports that OTHER records were lost —
+ * no categorization of THIS one. Both fall to the unknown-type branch of {@link _auditEvent}.
+ * @type {ReadonlyMap<string, {kind: string, categories: string[], type?: string, action?: string, file?: boolean}>}
+ */
+const AUDIT_ROUTES = new Map([
+  ['file-access', { kind: 'event', categories: ['file'], file: true }],
+  ['config-access', { kind: 'event', categories: ['configuration', 'file'], file: true }],
+  [
+    'network-connection',
+    { kind: 'event', categories: ['network'], type: 'connection', action: 'network-connection' },
+  ],
+  ['agent-enter', { kind: 'event', categories: ['process'], type: 'start', action: 'agent-enter' }],
+  ['agent-exit', { kind: 'event', categories: ['process'], type: 'end', action: 'agent-exit' }],
+  [
+    'anomaly-alert',
+    { kind: 'alert', categories: ['intrusion_detection'], type: 'info', action: 'anomaly-alert' },
+  ],
+]);
+
+/**
+ * A usable string, or null. `''` means absent throughout the internal schema (`agent: ''` is
+ * the C-01 unattributed marker), so it maps to nothing.
+ * @param {unknown} v @returns {string|null}
+ */
+function _text(v) {
+  return typeof v === 'string' && v !== '' ? v : null;
+}
+
+/**
+ * An epoch-ms observation as ISO 8601 UTC, or null when it is not one. `8.64e15` is the largest
+ * epoch-ms a Date can hold; past it `toISOString()` throws instead of answering.
+ * @param {unknown} v @returns {string|null}
+ */
+function _iso(v) {
+  if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0 || v > 8.64e15) return null;
+  return new Date(v).toISOString();
+}
+
+/**
+ * The ECS `event` branch for a file-shaped record. An `action` outside the closed union yields the
+ * category alone: it IS about a file, but no type or action is invented for an unknown verb.
+ * @param {unknown} action @param {string[]} categories @returns {Record<string, unknown>}
+ */
+function _fileEvent(action, categories) {
+  /** @type {Record<string, unknown>} */
+  const out = { kind: 'event', category: categories.slice() };
+  const known = typeof action === 'string' ? FILE_ACTIONS.get(action) : undefined;
+  if (known) {
+    out.type = [known.type];
+    out.action = known.action;
+  }
+  return out;
+}
+
+/**
+ * The ECS `event` branch for an audit record, chosen by its `type`.
+ * @param {string} auditType @param {unknown} action @returns {Record<string, unknown>}
+ */
+function _auditEvent(auditType, action) {
+  const route = AUDIT_ROUTES.get(auditType);
+  if (!route) return { kind: 'event', action: auditType };
+  if (route.file) return _fileEvent(action, route.categories);
+  /** @type {Record<string, unknown>} */
+  const out = { kind: route.kind, category: route.categories.slice() };
+  if (route.type) out.type = [route.type];
+  if (route.action) out.action = route.action;
+  return out;
+}
+
+/**
+ * Attribution copied into `aegis`; the evidence array is COPIED, so no reference is shared.
+ * @param {unknown} value @returns {Record<string, unknown>|null}
+ */
+function _attribution(value) {
+  if (value === null || typeof value !== 'object') return null;
+  const src = /** @type {{status?: unknown, evidence?: unknown}} */ (value);
+  /** @type {Record<string, unknown>} */
+  const out = {};
+  const status = _text(src.status);
+  if (status !== null) out.status = status;
+  if (Array.isArray(src.evidence)) out.evidence = src.evidence.slice();
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * Categorize one record and lift the branches only its own carrier can fill.
+ * @param {Record<string, unknown>} event
+ * @param {string|null} auditType - the record's `type`, when it is an audit record.
+ * @returns {EcsShape}
+ * @throws {TypeError} When the record matches none of the four carriers.
+ */
+function _shape(event, auditType) {
+  /** @type {Record<string, unknown>} */
+  const fields = {};
+  if (auditType !== null) {
+    const route = AUDIT_ROUTES.get(auditType);
+    // A `network-connection` audit record yields NO `destination.*`: its `path` is the display
+    // string `${remoteIp}:${remotePort}`, and splitting that apart would rebuild an identity out
+    // of a rendering — ambiguous the moment the address is IPv6.
+    if (route && route.file) {
+      const path = _text(event.path);
+      if (path !== null) fields.file = { path };
+    }
+    return {
+      event: _auditEvent(auditType, event.action),
+      timestamp: _text(event.timestamp),
+      fields,
+    };
+  }
+
+  if (typeof event.file === 'string') {
+    const path = _text(event.file);
+    if (path !== null) fields.file = { path };
+    return { event: _fileEvent(event.action, ['file']), timestamp: _iso(event.timestamp), fields };
+  }
+
+  if (typeof event.remoteIp === 'string') {
+    /** @type {Record<string, unknown>} */
+    const destination = {};
+    const ip = _text(event.remoteIp);
+    if (ip !== null) destination.ip = ip;
+    const port = event.remotePort;
+    if (typeof port === 'number' && Number.isSafeInteger(port) && port > 0) destination.port = port;
+    const domain = _text(event.domain);
+    if (domain !== null) destination.domain = domain;
+    // `tcp` is a constant because the sole provider, `platform.getRawTcpConnections`, enumerates
+    // TCP and nothing else. `source.*` stays absent — a `RawTcpConnection` is `{pid, ip, port,
+    // state}` with no local endpoint — and the timestamp is null because the connection object
+    // carries no observation time at all; the audit record for the same socket does.
+    fields.network = { transport: 'tcp' };
+    if (Object.keys(destination).length > 0) fields.destination = destination;
+    const ev = { kind: 'event', category: ['network'], type: ['connection'] };
+    return { event: { ...ev, action: 'network-connection' }, timestamp: null, fields };
+  }
+
+  if (typeof event.firstSeen === 'number') {
+    // `agent-enter`/`agent-exit`, never `process-started`: an enter is AEGIS's first SIGHTING of
+    // an agent, which is not a process start, and a synthetic agent has no process to start.
+    // `category`/`type` still read `process`/`start`, which is what a Sysmon join uses.
+    // `firstSeen` is an AEGIS observation time, so it never becomes ECS `process.start`, which
+    // means the OS birth time.
+    const exited = typeof event.lastSeen === 'number';
+    const ev = {
+      kind: 'event',
+      category: ['process'],
+      type: [exited ? 'end' : 'start'],
+      action: exited ? 'agent-exit' : 'agent-enter',
+    };
+    return { event: ev, timestamp: _iso(exited ? event.lastSeen : event.firstSeen), fields };
+  }
+
+  throw new TypeError(
+    'normalizeToEcs: unrecognised event shape — expected an audit record (type), a FileEvent ' +
+      '(file), a NetworkConnection (remoteIp) or a session record (firstSeen)',
+  );
+}
+
+/**
+ * Project one AEGIS internal event onto its ECS view.
+ * @param {Record<string, unknown>} event - a `FileEvent`, a `NetworkConnection`, a session
+ *   record, or an audit record; see the file header for the discriminators.
+ * @returns {Record<string, unknown>} An ECS 8.11 document.
+ * @throws {TypeError} When the argument is not an object, or matches none of the four carriers
+ *   — an unrecognised event is refused, never silently emptied.
+ * @since v0.14.0
+ */
+function normalizeToEcs(event) {
+  if (event === null || typeof event !== 'object') {
+    throw new TypeError(`normalizeToEcs: expected an event object, received ${typeof event}`);
+  }
+  const shape = _shape(event, _text(event.type));
+
+  // Vestigial in Event Schema v1 — audit-logger writes 0 on every record. Mapped as it stands,
+  // 0 included, rather than filtered: a value the record carries is not an absence. Nothing may
+  // be derived from it; see docs/ECS-MAPPING.md.
+  const riskScore = event.riskScore;
+  if (typeof riskScore === 'number' && Number.isFinite(riskScore)) {
+    shape.event.risk_score = riskScore;
+  }
+
+  /** @type {Record<string, unknown>} */
+  const ecsProcess = {};
+  // Verbatim, format unchanged (`pid:startTime`, `0:<name>`, `<pid>:u`). Parsing it apart here
+  // would be a second identity resolution (ai-mistakes.md #19).
+  const entityId = _text(event.instanceId);
+  if (entityId !== null) ecsProcess.entity_id = entityId;
+  // Only a pid the OS handed out. 0 is a real value meaning a synthetic, process-less agent and
+  // `null` means none was observed; writing either would invite a join on it, and the synthetic
+  // stays identified by its `0:<name>` entity_id. Same rule as bench `processIdentity()`.
+  const pid = event.pid;
+  if (typeof pid === 'number' && Number.isSafeInteger(pid) && pid > 0) ecsProcess.pid = pid;
+  const processName = _text(event.process);
+  if (processName !== null) ecsProcess.name = processName;
+  const cwd = _text(event.cwd);
+  if (cwd !== null) ecsProcess.working_directory = cwd;
+
+  /** @type {Record<string, unknown>} */
+  const aegis = {};
+  const agentName = _text(event.agent);
+  if (agentName !== null) aegis.agent = { name: agentName };
+  const attribution = _attribution(event.attribution);
+  if (attribution !== null) aegis.attribution = attribution;
+  const schemaVersion = event.schemaVersion;
+  if (typeof schemaVersion === 'number' && Number.isSafeInteger(schemaVersion)) {
+    aegis.schema_version = schemaVersion;
+  }
+  // Strictly `true`, never truthiness: absence is the observed case and presence the claim
+  // (DetectedAgent._demo). An unmarked record must not be marked here, and a marked one must
+  // not reach a SIEM looking like a real observation.
+  if (event._demo === true) aegis.demo = true;
+
+  /** @type {Record<string, unknown>} */
+  const doc = {};
+  if (shape.timestamp !== null) doc['@timestamp'] = shape.timestamp;
+  doc.ecs = { version: ECS_VERSION };
+  doc.event = shape.event;
+  Object.assign(doc, shape.fields);
+  if (Object.keys(ecsProcess).length > 0) doc.process = ecsProcess;
+  if (Object.keys(aegis).length > 0) doc.aegis = aegis;
+  return doc;
+}
+
+module.exports = {
+  ECS_VERSION,
+  normalizeToEcs,
+};

--- a/tests/shared/ecs-normalizer.test.js
+++ b/tests/shared/ecs-normalizer.test.js
@@ -1,0 +1,378 @@
+/**
+ * The ECS view of an AEGIS internal event (src/shared/ecs-normalizer.js).
+ *
+ * Every fixture below is shaped from a LIVE emit site, not from a doc:
+ *   - FileEvent          — src/main/file-watcher.js, the three `const event = {…}` literals
+ *   - NetworkConnection  — src/main/network-monitor.js, the `deduped.map` return
+ *   - session record     — src/main/session-tracker.js, `reconcile()`'s entered/exited pushes
+ *   - AuditRecordV1      — src/main/audit-logger.js `log()`, fed by scan-loop.js
+ *
+ * The whole-document `toEqual` assertions are deliberate: they pin what is ABSENT as hard as
+ * what is present, which is the property the B2.2 omit-never-null convention actually needs.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { ECS_VERSION, normalizeToEcs } = require('../../src/shared/ecs-normalizer.js');
+const catalogue = require('../../bench/lib/catalogue.js');
+
+/** An instance key in space 1 — `pid:startTime`, the reuse-resistant case. */
+const INSTANCE_ID = '4242:1755950000000';
+const EVENT_MS = 1755950123456;
+const EVENT_ISO = new Date(EVENT_MS).toISOString();
+const AUDIT_ISO = '2026-08-23T10:00:00.000Z';
+
+/** @returns {Object} A `created` FileEvent with a confirmed owner. */
+function fileEvent(overrides = {}) {
+  return {
+    agent: 'Claude Code',
+    pid: 4242,
+    instanceId: INSTANCE_ID,
+    parentEditor: 'VS Code',
+    cwd: 'C:/proj/app',
+    file: 'C:/proj/app/.env',
+    sensitive: true,
+    selfAccess: false,
+    reason: 'Credentials file',
+    action: 'created',
+    timestamp: EVENT_MS,
+    category: 'coding',
+    attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
+    ...overrides,
+  };
+}
+
+/** @returns {Object} An enriched connection to an allowlisted endpoint. */
+function networkConnection(overrides = {}) {
+  return {
+    agent: 'Claude Code',
+    pid: 4242,
+    instanceId: INSTANCE_ID,
+    parentEditor: null,
+    cwd: 'C:/proj/app',
+    category: 'coding',
+    remoteIp: '160.79.104.10',
+    remotePort: 443,
+    domain: 'api.anthropic.com',
+    state: 'Established',
+    verdict: 'allowlisted',
+    verdictReason: 'ip-allowlist',
+    flagged: false,
+    httpUnencrypted: false,
+    userAgent: 'node.exe',
+    ...overrides,
+  };
+}
+
+/** @returns {Object} An `entered` session record; add `lastSeen` to make it an exit. */
+function sessionRecord(overrides = {}) {
+  return {
+    pid: 4242,
+    instanceId: INSTANCE_ID,
+    agent: 'Claude Code',
+    process: 'node.exe',
+    firstSeen: EVENT_MS,
+    ...overrides,
+  };
+}
+
+/** @returns {Object} A v1 audit record as `flush()` leaves it on disk. */
+function auditRecord(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    timestamp: AUDIT_ISO,
+    type: 'agent-enter',
+    agent: 'Claude Code',
+    pid: 4242,
+    instanceId: INSTANCE_ID,
+    action: 'started',
+    path: '',
+    severity: 'normal',
+    riskScore: 0,
+    attribution: null,
+    details: { startTime: 1755950000000 },
+    seq: 12,
+    hash: 'a'.repeat(64),
+    ...overrides,
+  };
+}
+
+/**
+ * Freeze an object graph so any write inside the module throws instead of being observed
+ * after the fact. The module is `'use strict'`, so a frozen-property assignment is a TypeError.
+ * @param {*} value @returns {*} the same value
+ */
+function deepFreeze(value) {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const key of Object.keys(value)) deepFreeze(value[key]);
+  return value;
+}
+
+describe('normalizeToEcs — file events', () => {
+  it('maps a created FileEvent onto the full ECS document', () => {
+    expect(normalizeToEcs(fileEvent())).toEqual({
+      '@timestamp': EVENT_ISO,
+      ecs: { version: ECS_VERSION },
+      event: { kind: 'event', category: ['file'], type: ['creation'], action: 'file-created' },
+      file: { path: 'C:/proj/app/.env' },
+      process: {
+        entity_id: INSTANCE_ID,
+        pid: 4242,
+        working_directory: 'C:/proj/app',
+      },
+      aegis: {
+        agent: { name: 'Claude Code' },
+        attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
+      },
+    });
+  });
+
+  it('categorizes every member of the closed FileAction union', () => {
+    const seen = ['created', 'modified', 'deleted', 'accessed', 'holding'].map(
+      (action) => normalizeToEcs(fileEvent({ action })).event,
+    );
+    expect(seen).toEqual([
+      { kind: 'event', category: ['file'], type: ['creation'], action: 'file-created' },
+      { kind: 'event', category: ['file'], type: ['change'], action: 'file-modified' },
+      { kind: 'event', category: ['file'], type: ['deletion'], action: 'file-deleted' },
+      { kind: 'event', category: ['file'], type: ['access'], action: 'file-accessed' },
+      // A point-in-time handle HOLD is not a read; `access` would claim more than was observed.
+      { kind: 'event', category: ['file'], type: ['info'], action: 'file-handle-held' },
+    ]);
+  });
+
+  it('keeps the file category but invents no type for an action outside the union', () => {
+    const ev = normalizeToEcs(fileEvent({ action: 'renamed' })).event;
+    expect(ev).toEqual({ kind: 'event', category: ['file'] });
+    expect('type' in ev).toBe(false);
+    expect('action' in ev).toBe(false);
+  });
+
+  it('omits @timestamp for a timestamp that is not a usable epoch-ms', () => {
+    for (const timestamp of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1e18, '2026-01-01']) {
+      expect('@timestamp' in normalizeToEcs(fileEvent({ timestamp }))).toBe(false);
+    }
+  });
+});
+
+describe('normalizeToEcs — network connections', () => {
+  it('maps a NetworkConnection, and carries no observation time because it has none', () => {
+    const doc = normalizeToEcs(networkConnection());
+    expect(doc).toEqual({
+      ecs: { version: ECS_VERSION },
+      event: {
+        kind: 'event',
+        category: ['network'],
+        type: ['connection'],
+        action: 'network-connection',
+      },
+      network: { transport: 'tcp' },
+      destination: { ip: '160.79.104.10', port: 443, domain: 'api.anthropic.com' },
+      process: { entity_id: INSTANCE_ID, pid: 4242, working_directory: 'C:/proj/app' },
+      aegis: { agent: { name: 'Claude Code' } },
+    });
+    // The connection object holds no time at all; its audit record is where one comes from.
+    expect('@timestamp' in doc).toBe(false);
+    // No local endpoint exists in a RawTcpConnection, so no source is invented for one.
+    expect('source' in doc).toBe(false);
+  });
+
+  it('omits destination.domain when no name was forward-confirmed', () => {
+    const doc = normalizeToEcs(networkConnection({ domain: '' }));
+    expect(doc.destination).toEqual({ ip: '160.79.104.10', port: 443 });
+  });
+
+  it('drops the whole destination branch when neither address nor port is usable', () => {
+    const doc = normalizeToEcs(networkConnection({ remoteIp: '', remotePort: 0, domain: '' }));
+    expect('destination' in doc).toBe(false);
+    expect(doc.network).toEqual({ transport: 'tcp' });
+  });
+});
+
+describe('normalizeToEcs — agent-scoped session records', () => {
+  it('maps an entered session to process/start and keeps the OS process name', () => {
+    expect(normalizeToEcs(sessionRecord())).toEqual({
+      '@timestamp': EVENT_ISO,
+      ecs: { version: ECS_VERSION },
+      event: { kind: 'event', category: ['process'], type: ['start'], action: 'agent-enter' },
+      process: { entity_id: INSTANCE_ID, pid: 4242, name: 'node.exe' },
+      aegis: { agent: { name: 'Claude Code' } },
+    });
+  });
+
+  it('maps an exited session to process/end and times it by lastSeen', () => {
+    const lastSeen = EVENT_MS + 60_000;
+    const doc = normalizeToEcs(sessionRecord({ lastSeen }));
+    expect(doc.event).toEqual({
+      kind: 'event',
+      category: ['process'],
+      type: ['end'],
+      action: 'agent-exit',
+    });
+    expect(doc['@timestamp']).toBe(new Date(lastSeen).toISOString());
+  });
+
+  it('never writes the AEGIS-observed firstSeen into ECS process.start', () => {
+    const doc = normalizeToEcs(sessionRecord());
+    expect('start' in doc.process).toBe(false);
+  });
+});
+
+describe('normalizeToEcs — audit records', () => {
+  it('maps an agent-enter record, risk_score included at its vestigial 0', () => {
+    expect(normalizeToEcs(auditRecord())).toEqual({
+      '@timestamp': AUDIT_ISO,
+      ecs: { version: ECS_VERSION },
+      event: {
+        kind: 'event',
+        category: ['process'],
+        type: ['start'],
+        action: 'agent-enter',
+        risk_score: 0,
+      },
+      process: { entity_id: INSTANCE_ID, pid: 4242 },
+      aegis: { agent: { name: 'Claude Code' }, schema_version: 1 },
+    });
+  });
+
+  it('separates config-access from file-access by category, not by a custom field', () => {
+    const record = auditRecord({
+      type: 'config-access',
+      action: 'modified',
+      path: 'C:/Users/u/.claude/settings.json',
+      severity: 'sensitive',
+    });
+    const doc = normalizeToEcs(record);
+    expect(doc.event.category).toEqual(['configuration', 'file']);
+    expect(doc.event.type).toEqual(['change']);
+    expect(doc.file).toEqual({ path: 'C:/Users/u/.claude/settings.json' });
+    expect(normalizeToEcs(auditRecord({ type: 'file-access', action: 'modified' })).event.category)
+      .toEqual(['file']);
+  });
+
+  it('raises an anomaly-alert to event.kind alert', () => {
+    const doc = normalizeToEcs(
+      auditRecord({ type: 'anomaly-alert', action: 'sensitive', pid: null, severity: 'high' }),
+    );
+    expect(doc.event).toEqual({
+      kind: 'alert',
+      category: ['intrusion_detection'],
+      type: ['info'],
+      action: 'anomaly-alert',
+      risk_score: 0,
+    });
+    expect(doc.process).toEqual({ entity_id: INSTANCE_ID });
+  });
+
+  it('never rebuilds destination.* out of a network audit record display path', () => {
+    const doc = normalizeToEcs(
+      auditRecord({ type: 'network-connection', action: 'Established', path: '160.79.104.10:443' }),
+    );
+    expect(doc.event.category).toEqual(['network']);
+    expect('destination' in doc).toBe(false);
+    expect('file' in doc).toBe(false);
+  });
+
+  it('states an uncategorizable type and claims nothing else about it', () => {
+    for (const type of ['permission-deny', 'buffer-overflow-drop', 'something-a-later-build-adds']) {
+      const ev = normalizeToEcs(auditRecord({ type })).event;
+      expect(ev).toEqual({ kind: 'event', action: type, risk_score: 0 });
+      expect('category' in ev).toBe(false);
+      expect('type' in ev).toBe(false);
+    }
+  });
+
+  it('carries a v0 record with no schemaVersion and writes no aegis.schema_version', () => {
+    const v0 = auditRecord();
+    delete v0.schemaVersion;
+    const doc = normalizeToEcs(v0);
+    expect('schema_version' in doc.aegis).toBe(false);
+    expect(doc['@timestamp']).toBe(AUDIT_ISO);
+  });
+});
+
+describe('normalizeToEcs — absence stays absent', () => {
+  it('omits process.entity_id for a null instanceId rather than writing null', () => {
+    const doc = normalizeToEcs(fileEvent({ instanceId: null }));
+    expect('entity_id' in doc.process).toBe(false);
+    expect(JSON.stringify(doc)).not.toContain('entity_id');
+  });
+
+  it('drops the whole process branch when nothing about the process was observed', () => {
+    // The C-01 unattributed file event: no owner, so no name, no pid, no key and no cwd.
+    const doc = normalizeToEcs(
+      fileEvent({
+        agent: '',
+        pid: null,
+        instanceId: null,
+        cwd: null,
+        attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+      }),
+    );
+    expect('process' in doc).toBe(false);
+    expect(doc.aegis).toEqual({
+      attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+    });
+  });
+
+  it('refuses pid 0 as a pid — a synthetic agent is identified by its entity_id', () => {
+    const doc = normalizeToEcs(sessionRecord({ pid: 0, instanceId: '0:lm-studio' }));
+    expect('pid' in doc.process).toBe(false);
+    expect(doc.process.entity_id).toBe('0:lm-studio');
+  });
+
+  it('writes aegis.demo only for a record that claims it, never by truthiness', () => {
+    expect('demo' in normalizeToEcs(fileEvent()).aegis).toBe(false);
+    expect('demo' in normalizeToEcs(fileEvent({ _demo: false })).aegis).toBe(false);
+    expect(normalizeToEcs(fileEvent({ _demo: 1 })).aegis.demo).toBeUndefined();
+    expect(normalizeToEcs(fileEvent({ _demo: true })).aegis.demo).toBe(true);
+  });
+});
+
+describe('normalizeToEcs — purity and refusal', () => {
+  it('does not mutate the input and shares no reference with it', () => {
+    const input = deepFreeze(fileEvent());
+    const doc = normalizeToEcs(input);
+    expect(doc.aegis.attribution.evidence).toEqual(['handle-scan-pid']);
+    expect(doc.aegis.attribution.evidence).not.toBe(input.attribution.evidence);
+    expect(doc.aegis.attribution).not.toBe(input.attribution);
+    // Writing through the output must not reach the input.
+    doc.aegis.attribution.evidence.push('rm-holder-pid');
+    expect(input.attribution.evidence).toEqual(['handle-scan-pid']);
+  });
+
+  it('mutates no carrier — every shape survives a deep-frozen input', () => {
+    for (const input of [fileEvent(), networkConnection(), sessionRecord(), auditRecord()]) {
+      expect(() => normalizeToEcs(deepFreeze(input))).not.toThrow();
+    }
+  });
+
+  it('refuses an unrecognised shape instead of answering an empty document', () => {
+    for (const bad of [{}, { agent: 'Claude Code', pid: 7 }, { instanceId: INSTANCE_ID }]) {
+      expect(() => normalizeToEcs(bad)).toThrow(TypeError);
+      expect(() => normalizeToEcs(bad)).toThrow(/unrecognised event shape/);
+    }
+  });
+
+  it('refuses a non-object argument', () => {
+    for (const bad of [null, undefined, 'file-access', 42]) {
+      expect(() => normalizeToEcs(bad)).toThrow(TypeError);
+    }
+  });
+});
+
+describe('ECS_VERSION', () => {
+  it('agrees with the independent declaration in bench/lib/catalogue.js', () => {
+    // bench may not import from src/ (an oracle sharing code with the sensor stops being
+    // independent), so the constant is duplicated on purpose. This case is the only gate on it.
+    expect(ECS_VERSION).toBe(catalogue.ECS_VERSION);
+  });
+
+  it('is written into every document', () => {
+    for (const input of [fileEvent(), networkConnection(), sessionRecord(), auditRecord()]) {
+      expect(normalizeToEcs(input).ecs).toEqual({ version: ECS_VERSION });
+    }
+  });
+});


### PR DESCRIPTION
AEGIS keeps its internal event schema untouched and exposes an **Elastic Common Schema 8.11** view where events leave the process. `normalizeToEcs()` is that projection and the single place the field names are decided. Nothing consumes it yet — it lands now so the naming is fixed before the sequence rule engine, the bench trace format and SIEM export are built against it. No emitter, IPC channel, renderer path or Event Schema v1 record is touched.

## Why ECS at the boundary

- **The Sysmon oracle joins through a mapping somebody else maintains.** Sysmon events reach an ECS index through Elastic's own winlogbeat mapping, so every field name on the oracle side is already decided. Naming the AEGIS side differently would mean writing and then maintaining a second private translation between two things that already agree on a vocabulary.
- **Sigma correlation rules group by a field name, and that name is `process.entity_id`.** AEGIS already had the right value — `instanceId` binds a pid to the OS process-creation time, exactly what `process.entity_id` is for. What was missing was the name.

## Shape

Four carriers, one field-driven mapping, discriminated by structure — an audit record (`type`), a `FileEvent` (`file`), a `NetworkConnection` (`remoteIp`), a session record (`firstSeen`, with `lastSeen` marking the exit side). An unrecognised shape **throws** rather than answering an empty document.

Load-bearing decisions, each argued in `docs/ECS-MAPPING.md`:

- **Absence is written as absence.** A value a record does not carry is omitted, never emitted as `null`; an empty container goes with it. The same B2.2 convention `bench/lib/catalogue.js` already states.
- **`instanceId` → `process.entity_id` verbatim**, format unchanged. Parsing the pid back out of it would be a second identity resolution (ai-mistakes #19).
- **`process.pid` only for a pid the OS handed out.** `0` means a synthetic, process-less agent and `null` means none was observed; the synthetic stays identified by its `0:<name>` entity_id. Same rule as bench `observed.js` `processIdentity()`.
- **Two names stay apart.** `process` (OS image name) → `process.name`; `agent` (AEGIS display name) → `aegis.agent.name`. Root ECS `agent.*` belongs to the collector and is never written.
- **`holding` categorizes as `info`, not `access`** — a point-in-time handle hold at the scan tick, explicitly not a read.
- **`permission-deny`, `buffer-overflow-drop` and any unknown type get no categorization.** The type is stated; nothing else is claimed. `events.ts` already refuses to invent `permission-deny`'s semantics, and a drop marker reports that *other* records were lost, which is no categorization of itself.

## Requested fields with no source — documented, not stubbed

`process.executable`, `process.parent.pid`, `process.parent.name`, `source.ip`, `source.port`, and `@timestamp` on a `NetworkConnection` are **never written**, because no internal record carries a value for them. `parentEditor` is a display label, not a process name; `parentChain` lives on `DetectedAgent` and reaches no event; a `RawTcpConnection` is `{pid, ip, port, state}` with no local endpoint. Each absence is argued in the document rather than stubbed in the module (ai-mistakes #20, #14).

A `network-connection` **audit** record also yields no `destination.*`: its `path` is the display string `` `${remoteIp}:${remotePort}` ``, and splitting that apart would rebuild an identity out of a rendering, ambiguous on IPv6.

`event.risk_score` maps `riskScore` as it stands, `0` included — it is vestigial in v1, so the document says loudly that a `risk_score > 50` rule will never fire today.

## bench/lib is deliberately not refactored onto this

Nothing under `bench/` may import from `src/`, or the oracle stops being independent of the sensor it confirms. The duplication stays, and the divergences (`aegis.*` vs `bench.*`, `process.entity_id` vs `bench.instanceId`, `agent-enter` vs `process-started`) are tabulated in the document. The two `ECS_VERSION` declarations are compared by a test case — the only gate on that duplication.

## Tests — 26 cases

One per carrier and per member of the closed `FileAction` union, `config-access` vs `file-access` categorization, the `alert` kind for anomalies, uncategorizable audit types, a v0 record with no `schemaVersion`, null-`instanceId` omission, the whole `process` branch dropping for an unattributed event, pid-0 refusal, `aegis.demo` only on a literal `true`, refusal of an unrecognised shape and of a non-object, and the bench parity case.

Purity is pinned by construction: every carrier is normalized against a **deep-frozen** input, so any write would throw under the module's `'use strict'`, and the attribution evidence array is asserted to be a copy.

**Mutation-checked** (ai-mistakes #21, #34d) — three mutants, each went red and was restored byte-identically:

| mutant | result |
|---|---|
| `pid > 0` → `pid >= 0` | RED (1 failed) |
| `holding` type `info` → `access` | RED (1 failed) |
| `out.evidence = src.evidence.slice()` → no copy | RED (1 failed) |

## Local gates — all nine green

`build:renderer` · `format:check` · `lint` (0 errors) · `typecheck` · `typecheck:svelte` (416 files, 0 errors) · `test:coverage` (124 files, 2175 passed, 4 skipped) · `verify:gate` (4/4 mutants killed) · `counts:check` (19 counters, 96 declaration sites agree) · `npm audit --audit-level=high --omit=dev` (0 vulnerabilities)

The module is 300 lines exactly, so `size.over300` stays at 30 and no declaration site moves.

One flake seen and not reproduced: `tests/shared/bench-scenarios/actor-secret-hold.test.js` timed out at 5000 ms on the first whole-suite run (2.86 s in isolation, green on two subsequent whole-suite runs). It spawns a real binary and is load-sensitive; it does not load any file in this diff.
