### PR TITLE
feat(rules): load rules/sequences/ correlations with the full refusal matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ coverage thresholds are configured in `vitest.config.js`, so coverage cannot fai
 
 ## Code conventions
 
-- 300 lines/file is a target for NEW files, not an invariant — 31 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 32 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - **Main process:** CommonJS (`require`/`module.exports`). Never use `import` in `src/main/`.
 - **Renderer:** ES modules (`import`/`export`). Never use `require()` in `src/renderer/`.
 - **Svelte 5 runes:** `$state`, `$derived`, `$effect`, `$props`. No legacy `let` reactivity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ regenerating a lockfile.
 ## Critical Rules
 1. Read memory-bank/ai-mistakes.md before ANY code change
 2. Do ONLY what the prompt says — no extra features, no unrequested changes
-3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 31 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 32 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
@@ -78,7 +78,7 @@ regenerating a lockfile.
 8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` + `npm run typecheck:svelte` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths
-- src/main/ — 53 CommonJS modules (41 top-level + platform/ 10 + token-adapters/ 2)
+- src/main/ — 54 CommonJS modules (42 top-level + platform/ 10 + token-adapters/ 2)
 - src/renderer/ — Svelte 5 components + stores + utils + tokens.css/global.css
   (count: `git ls-files 'src/renderer/**/*.svelte' | wc -l`)
 - src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (9 TS files), constants.js (ignore patterns, config paths)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -295,7 +295,7 @@ Key token namespaces:
 
 ## Conventions
 
-- **300-line soft limit** per file — a target for NEW files, not an invariant; 31 existing `src/` files already exceed it. Not enforced by the linter
+- **300-line soft limit** per file — a target for NEW files, not an invariant; 32 existing `src/` files already exceed it. Not enforced by the linter
 - **JSDoc on all exported functions**: `@param`, `@returns`, `@since`
 - **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `security:`
 - **IPC channel names**: `kebab-case`

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **53** = 41 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **54** = 42 top-level + 10 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/docs/roadmap/sequence-rules.md
+++ b/docs/roadmap/sequence-rules.md
@@ -1,10 +1,12 @@
 # Sequence rules — `temporal_ordered` correlations keyed on `process.entity_id`
 
-**Status (as of 2026-08-24):** design document, NOT an implementation. Nothing named below under
-`src/`, `rules/sequences/`, `tests/` or `scripts/` exists yet; every file path in §2–§7 is a target,
-not a claim. **Block 1 — NOT STARTED. Block 2 — NOT STARTED. Block 3 — NOT STARTED.** When a block
-lands, refresh this header in the same PR (the lag the `sensor-health-degraded.md` correction
-records is what a stale status line costs).
+**Status (as of 2026-08-24):** partly implemented. `src/main/sequence-rule-loader.js`,
+`tests/main/sequence-rule-loader.test.js` and `tests/fixtures/sequences/` now exist and are green;
+`rules/sequences/` does not, and nothing named in §2–§7 does either, so every other file path below
+is still a target, not a claim. **Block 1 — LOADER LANDED, its rule file and counters still to
+come (§7 prompt 2). Block 2 — NOT STARTED. Block 3 — NOT STARTED.** When a block lands, refresh
+this header in the same PR (the lag the `sensor-health-degraded.md` correction records is what a
+stale status line costs).
 **Branch context:** master @ `0611614`; every `file:line` reference below was verified against that
 commit on 2026-08-24. Line numbers drift with every edit to the file — treat them as the place to
 start reading, and re-verify before an edit that depends on one.

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 53 CommonJS modules (41 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 54 CommonJS modules (42 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle

--- a/src/main/sequence-rule-loader.js
+++ b/src/main/sequence-rule-loader.js
@@ -1,0 +1,992 @@
+// @ts-check
+'use strict';
+
+/**
+ * @file sequence-rule-loader.js
+ * @module main/sequence-rule-loader
+ * @description Loads the SEQUENCE ruleset — `rules/sequences/*.yaml|*.yml`, multi-document
+ *   YAML holding base detection documents plus the correlation documents that order them.
+ *   The accepted format is a deliberately small subset of Sigma correlations: `temporal_ordered`
+ *   only, grouped by `process.entity_id` only, over the ECS view `src/shared/ecs-normalizer.js`
+ *   projects (`docs/ECS-MAPPING.md` §4 is the field dictionary).
+ *
+ *   NOTHING CONSUMES THIS YET, and no rule file exists — the loader fixes the format and its
+ *   refusals before the engine is written against them, on the ecs-normalizer precedent (PR #294).
+ *   The top-level `rules/` gates are untouched by the subdirectory: `rule-loader.js` reads one
+ *   level of `rules/` filtered on `.yaml`/`.yml`, and so do the parity baseline and
+ *   `scripts/counts.js` `deriveRules()` — a directory entry named `sequences` passes none of them.
+ *
+ *   REJECTION IS PER FILE, NEVER PER RULE. A file that trips any reason contributes zero rules:
+ *   a correlation is a claim about ORDER between documents that were written together, so a
+ *   partially-loaded file would silently detect something nobody wrote. Every reason emits one
+ *   `logger.warn('sequence-loader', message, { rule, step, reason })` line and increments
+ *   `loadErrors`; the reason CODE is the stable half and the message is the operator half.
+ *
+ *   A WARNING IS NOT A REJECTION. Two warnings describe rules that load and run, and say what
+ *   they will and will not see — the dedup window in front of the file carrier, and the events
+ *   whose `process.entity_id` is absent so the group-by can never bucket them.
+ *
+ *   BOUNDS, STATED RATHER THAN IMPLIED. (a) Duplicate detection is WITHIN a file — two files
+ *   declaring the same `SEQ` id both load, because rejection is per file and neither file is
+ *   the wrong one. (b) A selection says which events a step accepts and nothing about how many
+ *   there are: a rule whose steps are satisfiable can still never fire in practice, and only the
+ *   two warnings below make any statement about that. (c) `loadErrors` counts REASONS, not files.
+ * @requires fs
+ * @requires path
+ * @requires js-yaml
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ * @since v0.14.0
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const logger = require('./logger');
+
+/** Logger module tag — every line this file emits carries it. @type {string} */
+const LOG_MODULE = 'sequence-loader';
+
+/** @type {string} */
+const DEFAULT_SEQUENCES_DIR = path.join(__dirname, '..', '..', 'rules', 'sequences');
+
+/** The reference key a correlation names. @type {RegExp} */
+const NAME_PATTERN = /^[a-z0-9_]+$/;
+
+/**
+ * A documented departure from Sigma's UUID: the id is also the stats key and the audit
+ * `action`, both of which a human reads.
+ * @type {RegExp}
+ */
+const ID_PATTERN = /^SEQ[0-9]{3}$/;
+
+/** @type {RegExp} */
+const TIMESPAN_PATTERN = /^[0-9]+[smhd]$/;
+
+/** @type {Readonly<Record<string, number>>} */
+const TIMESPAN_UNIT_MS = { s: 1000, m: 60000, h: 3600000, d: 86400000 };
+
+/** @type {number} */
+const MIN_TIMESPAN_MS = 1000;
+
+/** 24h. Above it a `<pid>:u` key (the linux/darwin steady state) stops being pid-reuse-safe. */
+const MAX_TIMESPAN_MS = 24 * 3600 * 1000;
+
+/** @type {ReadonlySet<string>} */
+const LEVELS = new Set(['informational', 'low', 'medium', 'high', 'critical']);
+
+/** @type {string} */
+const DEFAULT_LEVEL = 'medium';
+
+/** The one accepted correlation type. @type {string} */
+const ACCEPTED_TYPE = 'temporal_ordered';
+
+/** The one accepted `group-by` key — and the reason `process.entity_id` is banned in a selection. */
+const GROUP_BY_FIELD = 'process.entity_id';
+
+/** @type {ReadonlySet<string>} */
+const BASE_KEYS = new Set(['title', 'name', 'id', 'logsource', 'detection']);
+
+/** @type {ReadonlySet<string>} */
+const CORRELATION_KEYS = new Set(['title', 'id', 'level', 'status', 'description', 'correlation']);
+
+/** `aliases`, `condition` and `generate` are refused BY NAME below, so they are not listed here. */
+const CORRELATION_BODY_KEYS = new Set(['type', 'rules', 'group-by', 'timespan']);
+
+/**
+ * The closed field dictionary, per `logsource.category`. Taken from `docs/ECS-MAPPING.md` §4:
+ * a field absent from the row a category emits can never be satisfied by an event of that
+ * category, so a selection naming one is refused rather than silently never matching.
+ * Internal fields the normalizer does not map (`sensitive`, `verdict`, `severity` — §6) are
+ * absent on purpose: "a sensitive file" is written as a regex over `file.path`.
+ * @type {Readonly<Record<string, ReadonlySet<string>>>}
+ */
+const CATEGORY_FIELDS = {
+  file: new Set([
+    'event.action',
+    'event.type',
+    'file.path',
+    'process.working_directory',
+    'process.pid',
+    'aegis.agent.name',
+    'aegis.attribution.status',
+  ]),
+  network: new Set([
+    'destination.ip',
+    'destination.port',
+    'destination.domain',
+    'process.working_directory',
+    'aegis.agent.name',
+  ]),
+  process: new Set(['event.action', 'process.name', 'process.pid', 'aegis.agent.name']),
+};
+
+/**
+ * `event.action` is a closed union per category (ECS-MAPPING §3), so a value outside it is
+ * as unsatisfiable as a field outside the dictionary — and the message names the VALUE, which
+ * is what tells the two sub-cases apart in the log.
+ * @type {Readonly<Record<string, ReadonlySet<string>>>}
+ */
+const CATEGORY_ACTIONS = {
+  file: new Set([
+    'file-created',
+    'file-modified',
+    'file-deleted',
+    'file-accessed',
+    'file-handle-held',
+  ]),
+  process: new Set(['agent-enter', 'agent-exit']),
+};
+
+/** Every field any category emits — membership here separates "unknown" from "wrong category". */
+const KNOWN_FIELDS = new Set(Object.values(CATEGORY_FIELDS).flatMap((set) => [...set]));
+
+/**
+ * Accepted modifier chains, joined by `|`. `re|i` is the only two-token chain: the `i` flag is
+ * pinned onto the RegExp at compile time, so a matcher never carries a mutable flag.
+ * @type {ReadonlySet<string>}
+ */
+const MODIFIERS = new Set(['contains', 'startswith', 'endswith', 're', 're|i']);
+
+/** The attribution status whose events carry no `instanceId` at all (C-01, file-watcher.js). */
+const UNATTRIBUTED = 'unattributed';
+
+/** Categories whose carrier may hold a null `instanceId` under Event Schema v1. */
+const NULLABLE_KEY_CATEGORIES = new Set(['file', 'network']);
+
+/**
+ * @typedef {(doc: Record<string, unknown>) => boolean} StepMatcher
+ *   A compiled predicate over ONE ECS document, as `normalizeToEcs` emits it. Absent fields are
+ *   absent (never `null`), so a step that names a field the document lacks answers `false`.
+ */
+
+/**
+ * @typedef {object} SequenceStep
+ * @property {string} name - the base document's `name`, the reference key a correlation uses.
+ * @property {string} category - `file` | `network` | `process`, from its `logsource`.
+ * @property {StepMatcher} matcher - the compiled selection.
+ */
+
+/**
+ * @typedef {object} SequenceRule
+ * @property {string} id - `^SEQ[0-9]{3}$`.
+ * @property {string} title
+ * @property {string} level - `informational` … `critical`; `medium` when the document omits it.
+ * @property {number} timespanMs - the window, already in milliseconds.
+ * @property {SequenceStep[]} steps - 2 to 5, in the order the correlation lists them.
+ */
+
+/**
+ * @typedef {object} SequenceNotice
+ * @property {string|null} rule - the correlation id, or null when the defect is not inside one.
+ * @property {string|null} step - the base document name, or null when it is not about one step.
+ * @property {string} reason - the stable code.
+ * @property {string} message - the operator-facing line, prefixed with the file name.
+ */
+
+/**
+ * @typedef {object} SequenceLoadResult
+ * @property {SequenceRule[]} rules - every rule from every accepted file.
+ * @property {SequenceNotice[]} warnings - rules that LOADED, with what they will not see.
+ * @property {number} loadErrors - one per rejection REASON, not per rejected file.
+ */
+
+/**
+ * @param {unknown} v
+ * @returns {v is Record<string, unknown>}
+ */
+function _isMap(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * @param {unknown} v
+ * @returns {v is string}
+ */
+function _isText(v) {
+  return typeof v === 'string' && v !== '';
+}
+
+/**
+ * A YAML scalar a selection may compare against. An object or a null is neither a value nor a
+ * list of them, and is refused as a shape defect rather than coerced.
+ * @param {unknown} v
+ * @returns {v is string|number|boolean}
+ */
+function _isScalar(v) {
+  return typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
+}
+
+/**
+ * Collects the reasons one file produced. The whole file is skipped when it is non-empty.
+ * @typedef {object} Sink
+ * @property {SequenceNotice[]} errors
+ * @property {SequenceNotice[]} warnings
+ * @property {string} file
+ */
+
+/**
+ * @param {Sink} sink
+ * @param {string} reason
+ * @param {string} detail - the sentence after the file name.
+ * @param {{rule?: string|null, step?: string|null}} [where]
+ * @returns {void}
+ */
+function _reject(sink, reason, detail, where) {
+  sink.errors.push({
+    rule: (where && where.rule) || null,
+    step: (where && where.step) || null,
+    reason,
+    message: `${sink.file}: ${detail}`,
+  });
+}
+
+/**
+ * `where` is REQUIRED here and optional on {@link _reject}, and the difference is real rather
+ * than an oversight: a warning is only ever raised about a rule that loaded, so its id always
+ * exists, while a rejection can happen before any document has been read (a YAML parse failure
+ * names no rule at all).
+ * @param {Sink} sink
+ * @param {string} reason
+ * @param {string} detail
+ * @param {{rule: string, step?: string|null}} where
+ * @returns {void}
+ */
+function _warn(sink, reason, detail, where) {
+  sink.warnings.push({
+    rule: where.rule,
+    step: where.step || null,
+    reason,
+    message: `${sink.file}: ${detail}`,
+  });
+}
+
+/**
+ * Walks a dotted ECS path. Returns `undefined` for every absence — a missing branch, a
+ * non-object in the middle, or a missing leaf — because the ECS view omits what it did not
+ * observe and never writes `null` in its place.
+ * @param {Record<string, unknown>} doc
+ * @param {string} field
+ * @returns {unknown}
+ */
+function _lookup(doc, field) {
+  /** @type {unknown} */
+  let cursor = doc;
+  for (const part of field.split('.')) {
+    if (!_isMap(cursor)) return undefined;
+    cursor = cursor[part];
+  }
+  return cursor;
+}
+
+/**
+ * Case-folded text for a scalar comparison. Sigma compares string representations, so `443`
+ * and `'443'` are the same value; anything that is not a scalar has no representation to
+ * compare and is refused by the caller instead.
+ * @param {string|number|boolean} v
+ * @returns {string}
+ */
+function _fold(v) {
+  return String(v).toLowerCase();
+}
+
+/**
+ * One value's predicate. The RegExp is built ONCE here and its flags are pinned: no `g`, so no
+ * `lastIndex` survives between events, and `i` only when the author wrote `re|i`.
+ * @param {string} modifier - `''` for an unmodified value.
+ * @param {string|number|boolean} value
+ * @returns {(actual: unknown) => boolean}
+ */
+function _predicate(modifier, value) {
+  if (modifier === 're' || modifier === 're|i') {
+    const re = new RegExp(String(value), modifier === 're|i' ? 'i' : '');
+    return (actual) => _isScalar(actual) && re.test(String(actual));
+  }
+  const wanted = _fold(value);
+  if (modifier === 'contains') return (a) => _isScalar(a) && _fold(a).includes(wanted);
+  if (modifier === 'startswith') return (a) => _isScalar(a) && _fold(a).startsWith(wanted);
+  if (modifier === 'endswith') return (a) => _isScalar(a) && _fold(a).endsWith(wanted);
+  return (a) => _isScalar(a) && _fold(a) === wanted;
+}
+
+/**
+ * Splits `file.path|re|i` into its field and its modifier chain.
+ * @param {string} key
+ * @returns {{field: string, modifier: string}}
+ */
+function _splitKey(key) {
+  const cut = key.indexOf('|');
+  if (cut === -1) return { field: key, modifier: '' };
+  return { field: key.slice(0, cut), modifier: key.slice(cut + 1) };
+}
+
+/**
+ * Compiles one `field: value` pair into a test over an ECS document. A list is OR; an array in
+ * the DOCUMENT (`event.type` is `['creation']`) is containment, so either side being plural
+ * means "any of".
+ *
+ * ABSENCE IS DECIDED IN ONE PLACE — the `_isScalar` guard inside every predicate. An absent
+ * field arrives here as `undefined` and becomes the single candidate `[undefined]`, which no
+ * predicate accepts; a second early return for it would read as the mechanism while changing
+ * nothing, and a reader would then maintain the wrong one (ai-mistakes #27).
+ * @param {string} field
+ * @param {string} modifier
+ * @param {Array<string|number|boolean>} values
+ * @returns {StepMatcher}
+ */
+function _compilePair(field, modifier, values) {
+  const preds = values.map((v) => _predicate(modifier, v));
+  return (doc) => {
+    const actual = _lookup(doc, field);
+    const candidates = Array.isArray(actual) ? actual : [actual];
+    return preds.some((p) => candidates.some((c) => p(c)));
+  };
+}
+
+/**
+ * The selection as one predicate: every pair must hold (AND).
+ * @param {Record<string, unknown>} selection
+ * @returns {StepMatcher}
+ */
+function _compileSelection(selection) {
+  /** @type {StepMatcher[]} */
+  const tests = [];
+  for (const [key, raw] of Object.entries(selection)) {
+    const { field, modifier } = _splitKey(key);
+    const values = (Array.isArray(raw) ? raw : [raw]).filter(_isScalar);
+    tests.push(_compilePair(field, modifier, values));
+  }
+  return (doc) => tests.every((t) => t(doc));
+}
+
+/**
+ * Every value a pair accepts, or `null` when the pair is not a scalar/list of scalars.
+ * @param {unknown} raw
+ * @returns {Array<string|number|boolean>|null}
+ */
+function _valuesOf(raw) {
+  if (_isScalar(raw)) return [raw];
+  if (Array.isArray(raw) && raw.length > 0 && raw.every(_isScalar)) {
+    return /** @type {Array<string|number|boolean>} */ (raw);
+  }
+  return null;
+}
+
+/**
+ * Validates one selection against the dictionary for its category. Every defect is reported —
+ * a selection with two unknown fields yields two lines, because fixing one of them is not
+ * fixing the rule.
+ * @param {Sink} sink
+ * @param {Record<string, unknown>} selection
+ * @param {string} category
+ * @param {string} name - the base document's name, for the `step` meta.
+ * @returns {void}
+ */
+function _checkSelection(sink, selection, category, name) {
+  const dictionary = CATEGORY_FIELDS[category];
+  const where = { step: name };
+  for (const [key, raw] of Object.entries(selection)) {
+    const { field, modifier } = _splitKey(key);
+
+    if (modifier !== '' && !MODIFIERS.has(modifier)) {
+      _reject(
+        sink,
+        'unsupported-modifier',
+        `modifier "|${modifier}" on "${field}" is not supported — accepted: contains, ` +
+          `startswith, endswith, re, re|i`,
+        where,
+      );
+      continue;
+    }
+
+    if (field === GROUP_BY_FIELD) {
+      _reject(
+        sink,
+        'entity-id-in-selection',
+        `field "${GROUP_BY_FIELD}" is forbidden in a selection — it is reserved for group-by`,
+        where,
+      );
+      continue;
+    }
+    if (!KNOWN_FIELDS.has(field)) {
+      _reject(
+        sink,
+        'unknown-field',
+        `field "${field}" is not an ECS field AEGIS produces — see docs/ECS-MAPPING.md`,
+        where,
+      );
+      continue;
+    }
+    if (!dictionary.has(field)) {
+      _reject(
+        sink,
+        'unsatisfiable-selection',
+        `field "${field}" is never produced by logsource category "${category}"`,
+        where,
+      );
+      continue;
+    }
+
+    const values = _valuesOf(raw);
+    if (values === null) {
+      _reject(
+        sink,
+        'invalid-document',
+        `field "${key}" must hold a scalar or a non-empty list of scalars`,
+        where,
+      );
+      continue;
+    }
+
+    const actions = CATEGORY_ACTIONS[category];
+    if (field === 'event.action' && modifier === '' && actions) {
+      for (const v of values) {
+        if (!actions.has(String(v))) {
+          _reject(
+            sink,
+            'unsatisfiable-selection',
+            `event.action value "${v}" is never produced by logsource category "${category}"`,
+            where,
+          );
+        }
+      }
+    }
+
+    if (modifier === '') {
+      for (const v of values) {
+        if (typeof v === 'string' && /[*?]/.test(v)) {
+          _reject(
+            sink,
+            'unmodified-wildcard',
+            `field "${field}" holds a wildcard in an unmodified value ("${v}") — ` +
+              `use |contains or |re`,
+            where,
+          );
+        }
+      }
+    }
+
+    if (modifier === 're' || modifier === 're|i') {
+      for (const v of values) {
+        try {
+          new RegExp(String(v), modifier === 're|i' ? 'i' : '');
+        } catch (/** @type {*} */ err) {
+          _reject(
+            sink,
+            'invalid-regex',
+            `field "${key}" holds an invalid regular expression ("${v}") — ` +
+              `${/** @type {Error} */ (err).message}`,
+            where,
+          );
+        }
+      }
+    }
+
+    // C-01: an unattributed event keeps NO agent and no key at all
+    // (`readInstanceId(null)` → null), so a step that accepts nothing else can never be
+    // bucketed by the group-by and the rule can never fire. A list holding `unattributed`
+    // BESIDE another status still matches attributed events and is left alone.
+    if (field === 'aegis.attribution.status' && modifier === '') {
+      if (values.every((v) => String(v) === UNATTRIBUTED)) {
+        _reject(
+          sink,
+          'step-without-entity-id',
+          `step can only match events without ${GROUP_BY_FIELD}; a ${ACCEPTED_TYPE} rule ` +
+            `grouped by ${GROUP_BY_FIELD} can never fire`,
+          where,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Per-document shape validation for a base detection document.
+ * @param {Sink} sink
+ * @param {Record<string, unknown>} doc
+ * @param {number} index - 1-based document position, used when there is no name to point at.
+ * @returns {{name: string, category: string, selection: Record<string, unknown>}|null}
+ */
+function _checkBase(sink, doc, index) {
+  const label = _isText(doc.name) ? `"${doc.name}"` : `#${index}`;
+  const where = { step: _isText(doc.name) ? doc.name : null };
+
+  for (const key of Object.keys(doc)) {
+    if (!BASE_KEYS.has(key)) {
+      _reject(sink, 'invalid-document', `base document ${label} holds unknown key "${key}"`, where);
+    }
+  }
+  if (doc.title !== undefined && !_isText(doc.title)) {
+    _reject(sink, 'invalid-document', `base document ${label} has a non-string title`, where);
+  }
+  if (doc.id !== undefined && !_isText(doc.id)) {
+    _reject(sink, 'invalid-document', `base document ${label} has a non-string id`, where);
+  }
+  if (!_isText(doc.name) || !NAME_PATTERN.test(doc.name)) {
+    _reject(
+      sink,
+      'invalid-document',
+      `base document ${label} needs a name matching ${NAME_PATTERN.source}`,
+      where,
+    );
+    return null;
+  }
+  const name = doc.name;
+
+  const logsource = doc.logsource;
+  if (
+    !_isMap(logsource) ||
+    logsource.product !== 'aegis' ||
+    !_isText(logsource.category) ||
+    !CATEGORY_FIELDS[logsource.category] ||
+    Object.keys(logsource).length !== 2
+  ) {
+    _reject(
+      sink,
+      'invalid-document',
+      `base document "${name}" needs logsource product: aegis plus category: file|network|process`,
+      where,
+    );
+    return null;
+  }
+  const category = logsource.category;
+
+  const detection = doc.detection;
+  if (!_isMap(detection)) {
+    _reject(sink, 'invalid-document', `base document "${name}" has no detection`, where);
+    return null;
+  }
+  const selectionNames = Object.keys(detection).filter((k) => k !== 'condition');
+  if (selectionNames.length !== 1 || detection.condition !== selectionNames[0]) {
+    _reject(
+      sink,
+      'invalid-document',
+      `base document "${name}" needs exactly one named selection and a condition equal to ` +
+        `that name`,
+      where,
+    );
+    return null;
+  }
+  const selection = detection[selectionNames[0]];
+  if (!_isMap(selection) || Object.keys(selection).length === 0) {
+    _reject(
+      sink,
+      'invalid-document',
+      `base document "${name}" has a selection that is not a non-empty map of fields`,
+      where,
+    );
+    return null;
+  }
+
+  _checkSelection(sink, selection, category, name);
+  return { name, category, selection };
+}
+
+/**
+ * `^[0-9]+[smhd]$`, then the 1s–24h bounds. Both halves are separate messages: "5x" is a typo
+ * and "48h" is a decision the author has to revisit.
+ * @param {Sink} sink
+ * @param {unknown} raw
+ * @param {{rule: string|null}} where
+ * @returns {number|null}
+ */
+function _checkTimespan(sink, raw, where) {
+  if (!_isText(raw) || !TIMESPAN_PATTERN.test(raw)) {
+    _reject(
+      sink,
+      'invalid-timespan',
+      `timespan ${JSON.stringify(raw)} does not match ${TIMESPAN_PATTERN.source}`,
+      where,
+    );
+    return null;
+  }
+  const ms = Number(raw.slice(0, -1)) * TIMESPAN_UNIT_MS[raw.slice(-1)];
+  if (ms < MIN_TIMESPAN_MS || ms > MAX_TIMESPAN_MS) {
+    _reject(sink, 'invalid-timespan', `timespan "${raw}" is outside the bounds 1s to 24h`, where);
+    return null;
+  }
+  return ms;
+}
+
+/**
+ * Per-document shape validation for a correlation document. The three refusals Sigma allows and
+ * this subset does not — `aliases`, an inner `condition`, `generate` — are named one by one,
+ * BEFORE the unknown-key sweep, so the author is told which feature is missing rather than that
+ * a key was not recognised.
+ * @param {Sink} sink
+ * @param {Record<string, unknown>} doc
+ * @param {number} index
+ * @returns {{id: string, title: string, level: string, timespanMs: number, names: string[]}|null}
+ */
+function _checkCorrelation(sink, doc, index) {
+  const id = _isText(doc.id) ? doc.id : null;
+  const label = id !== null ? `"${id}"` : `#${index}`;
+  const where = { rule: id };
+
+  for (const key of Object.keys(doc)) {
+    if (!CORRELATION_KEYS.has(key)) {
+      _reject(sink, 'invalid-document', `correlation ${label} holds unknown key "${key}"`, where);
+    }
+  }
+  if (id === null || !ID_PATTERN.test(id)) {
+    _reject(
+      sink,
+      'invalid-document',
+      `correlation ${label} needs an id matching ${ID_PATTERN.source}`,
+      where,
+    );
+    return null;
+  }
+  if (!_isText(doc.title)) {
+    _reject(sink, 'invalid-document', `correlation "${id}" needs a title`, where);
+  }
+  for (const key of ['status', 'description']) {
+    if (doc[key] !== undefined && !_isText(doc[key])) {
+      _reject(sink, 'invalid-document', `correlation "${id}" has a non-string ${key}`, where);
+    }
+  }
+  const level = doc.level === undefined ? DEFAULT_LEVEL : doc.level;
+  if (!_isText(level) || !LEVELS.has(level)) {
+    _reject(
+      sink,
+      'invalid-document',
+      `correlation "${id}" has level ${JSON.stringify(doc.level)} outside ` +
+        `informational|low|medium|high|critical`,
+      where,
+    );
+  }
+
+  const body = doc.correlation;
+  if (!_isMap(body)) {
+    _reject(sink, 'invalid-document', `correlation "${id}" has no correlation body`, where);
+    return null;
+  }
+  if (body.aliases !== undefined) {
+    _reject(
+      sink,
+      'aliases-not-supported',
+      `correlation "${id}" uses aliases, not supported`,
+      where,
+    );
+  }
+  if (body.condition !== undefined) {
+    _reject(
+      sink,
+      'condition-in-correlation',
+      `correlation "${id}" holds a condition, not supported inside a correlation`,
+      where,
+    );
+  }
+  if (body.generate !== undefined) {
+    _reject(
+      sink,
+      'generate-not-supported',
+      `correlation "${id}" uses generate, not supported`,
+      where,
+    );
+  }
+  for (const key of Object.keys(body)) {
+    if (!CORRELATION_BODY_KEYS.has(key) && !['aliases', 'condition', 'generate'].includes(key)) {
+      _reject(
+        sink,
+        'invalid-document',
+        `correlation "${id}" holds unknown correlation key "${key}"`,
+        where,
+      );
+    }
+  }
+
+  if (body.type !== ACCEPTED_TYPE) {
+    _reject(
+      sink,
+      'unsupported-correlation-type',
+      `correlation type ${JSON.stringify(body.type)} is not supported — ${ACCEPTED_TYPE} is the ` +
+        `only accepted type`,
+      where,
+    );
+  }
+
+  const groupBy = body['group-by'];
+  if (!Array.isArray(groupBy) || groupBy.length !== 1 || groupBy[0] !== GROUP_BY_FIELD) {
+    _reject(
+      sink,
+      'unsupported-group-by',
+      `correlation "${id}" must group by exactly [${GROUP_BY_FIELD}]`,
+      where,
+    );
+  }
+
+  const timespanMs = _checkTimespan(sink, body.timespan, where);
+
+  const rules = body.rules;
+  if (!Array.isArray(rules) || !rules.every(_isText)) {
+    _reject(sink, 'invalid-document', `correlation "${id}" needs a rules list of names`, where);
+    return null;
+  }
+  if (rules.length < 2 || rules.length > 5) {
+    _reject(
+      sink,
+      'rule-count-out-of-range',
+      `correlation "${id}" lists ${rules.length} step(s) — a ${ACCEPTED_TYPE} rule needs 2 to 5`,
+      where,
+    );
+    return null;
+  }
+  if (timespanMs === null || !_isText(doc.title) || !_isText(level) || !LEVELS.has(level)) {
+    return null;
+  }
+  return { id, title: doc.title, level, timespanMs, names: /** @type {string[]} */ (rules) };
+}
+
+/**
+ * The two warnings, emitted only for a rule that LOADED.
+ * @param {Sink} sink
+ * @param {SequenceRule} rule
+ * @returns {void}
+ */
+function _checkWarnings(sink, rule) {
+  for (let i = 0; i + 1 < rule.steps.length; i++) {
+    const a = rule.steps[i];
+    if (a.category === 'file' && a.name === rule.steps[i + 1].name) {
+      _warn(
+        sink,
+        'adjacent-duplicate-step',
+        `steps ${i + 1} and ${i + 2} are both "${a.name}"; dedupFileEvent suppresses a repeat ` +
+          `of instanceId|file for 30s, so this rule fires only on two different paths`,
+        { rule: rule.id, step: a.name },
+      );
+    }
+  }
+  const nullable = rule.steps.filter((s) => NULLABLE_KEY_CATEGORIES.has(s.category));
+  if (nullable.length > 0) {
+    _warn(
+      sink,
+      'nullable-entity-id-steps',
+      `steps ${nullable.map((s) => `"${s.name}"`).join(', ')} are over file or network, where ` +
+        `${GROUP_BY_FIELD} is nullable — unattributed events on those steps are skipped and counted`,
+      { rule: rule.id },
+    );
+  }
+}
+
+/**
+ * Loads one multi-document file. PURE with respect to the filesystem — the text is the input —
+ * so a test needs no fixture on disk, while `loadDir` supplies the one that does.
+ *
+ * Validation is STAGED, and the stages do not run past a failure: a base document whose `name`
+ * is malformed has no reference key, so running the cross-document stage anyway would report an
+ * `unresolved-rule-reference` that describes the loader's own recovery rather than the file.
+ *
+ * @param {string} text - the file's YAML.
+ * @param {string} fileName - the name the messages are prefixed with.
+ * @returns {SequenceLoadResult}
+ * @since v0.14.0
+ */
+function loadFromString(text, fileName) {
+  /** @type {Sink} */
+  const sink = { errors: [], warnings: [], file: fileName };
+  /** @type {SequenceRule[]} */
+  const rules = [];
+
+  /** @type {unknown[]} */
+  let documents;
+  try {
+    documents = /** @type {unknown[]} */ (yaml.loadAll(text));
+  } catch (/** @type {*} */ err) {
+    _reject(sink, 'yaml-parse', `YAML parse failed — ${/** @type {Error} */ (err).message}`);
+    return _emit(sink, rules);
+  }
+
+  // ── Stage A: one document at a time ────────────────────────────────────────
+  /** @type {Map<string, {category: string, selection: Record<string, unknown>}>} */
+  const bases = new Map();
+  /** @type {Array<{id: string, title: string, level: string, timespanMs: number, names: string[]}>} */
+  const correlations = [];
+  /** @type {Set<string>} */
+  const seenIds = new Set();
+
+  let index = 0;
+  for (const raw of documents) {
+    index++;
+    if (raw === null || raw === undefined) continue;
+    if (!_isMap(raw)) {
+      _reject(sink, 'invalid-document', `document #${index} is not a mapping`);
+      continue;
+    }
+    if (_isText(raw.id) && seenIds.has(raw.id)) {
+      _reject(sink, 'duplicate-identifier', `duplicate id "${raw.id}"`, { rule: raw.id });
+    } else if (_isText(raw.id)) {
+      seenIds.add(raw.id);
+    }
+
+    if (raw.correlation !== undefined) {
+      const parsed = _checkCorrelation(sink, raw, index);
+      if (parsed !== null) correlations.push(parsed);
+      continue;
+    }
+    const parsed = _checkBase(sink, raw, index);
+    if (parsed === null) continue;
+    if (bases.has(parsed.name)) {
+      _reject(sink, 'duplicate-identifier', `duplicate name "${parsed.name}"`, {
+        step: parsed.name,
+      });
+      continue;
+    }
+    bases.set(parsed.name, { category: parsed.category, selection: parsed.selection });
+  }
+  if (sink.errors.length > 0) return _emit(sink, rules);
+
+  // ── Stage B: the documents against each other ──────────────────────────────
+  const correlationIds = new Set(correlations.map((c) => c.id));
+  /** @type {Set<string>} */
+  const referenced = new Set();
+  for (const correlation of correlations) {
+    for (const name of correlation.names) {
+      if (correlationIds.has(name)) {
+        _reject(
+          sink,
+          'correlation-chain',
+          `correlation "${correlation.id}" references correlation "${name}" — a correlation of ` +
+            `correlations is not supported`,
+          { rule: correlation.id, step: name },
+        );
+        continue;
+      }
+      if (!bases.has(name)) {
+        _reject(
+          sink,
+          'unresolved-rule-reference',
+          `correlation "${correlation.id}" references "${name}", which resolves to no base ` +
+            `document in this file`,
+          { rule: correlation.id, step: name },
+        );
+        continue;
+      }
+      referenced.add(name);
+    }
+  }
+  for (const name of bases.keys()) {
+    if (!referenced.has(name)) {
+      _reject(
+        sink,
+        'unreferenced-base-document',
+        `base document "${name}" is referenced by no correlation in this file`,
+        { step: name },
+      );
+    }
+  }
+  if (sink.errors.length > 0) return _emit(sink, rules);
+
+  // ── Stage C: compile ───────────────────────────────────────────────────────
+  for (const correlation of correlations) {
+    /** @type {SequenceStep[]} */
+    const steps = correlation.names.map((name) => {
+      const base = /** @type {{category: string, selection: Record<string, unknown>}} */ (
+        bases.get(name)
+      );
+      return { name, category: base.category, matcher: _compileSelection(base.selection) };
+    });
+    const rule = {
+      id: correlation.id,
+      title: correlation.title,
+      level: correlation.level,
+      timespanMs: correlation.timespanMs,
+      steps,
+    };
+    _checkWarnings(sink, rule);
+    rules.push(rule);
+  }
+  return _emit(sink, rules);
+}
+
+/**
+ * Writes every collected line to the operational log and answers the result.
+ *
+ * A rejected file contributes NO rules and NO warnings, and THE STAGING IS WHAT MAKES THAT TRUE:
+ * both stage guards return through here before stage C runs, so `rules` and `sink.warnings` are
+ * already empty on every path that carries an error. Re-emptying them here would read as the
+ * mechanism, survive any mutation of the real one, and leave the next reader maintaining the
+ * decoration instead of the guard (ai-mistakes #27).
+ * @param {Sink} sink
+ * @param {SequenceRule[]} rules
+ * @returns {SequenceLoadResult}
+ */
+function _emit(sink, rules) {
+  for (const line of sink.errors) {
+    logger.warn(LOG_MODULE, line.message, {
+      rule: line.rule,
+      step: line.step,
+      reason: line.reason,
+    });
+  }
+  for (const line of sink.warnings) {
+    logger.warn(LOG_MODULE, line.message, {
+      rule: line.rule,
+      step: line.step,
+      reason: line.reason,
+    });
+  }
+  return { rules, warnings: sink.warnings, loadErrors: sink.errors.length };
+}
+
+/**
+ * Loads every `*.yaml` / `*.yml` file in a directory, in name order. A missing directory is not
+ * an error: `rules/sequences/` is optional, and an absent one means "no sequence rules", which
+ * is a different statement from "the directory could not be read".
+ * @param {string} [dir] - defaults to `rules/sequences` beside the project's `rules/`.
+ * @returns {SequenceLoadResult}
+ * @since v0.14.0
+ */
+function loadDir(dir = DEFAULT_SEQUENCES_DIR) {
+  /** @type {SequenceLoadResult} */
+  const total = { rules: [], warnings: [], loadErrors: 0 };
+  if (!fs.existsSync(dir)) return total;
+
+  /** @type {string[]} */
+  let files;
+  try {
+    files = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+      .sort();
+  } catch (/** @type {*} */ err) {
+    logger.warn(
+      LOG_MODULE,
+      `${dir}: directory unreadable — ${/** @type {Error} */ (err).message}`,
+      {
+        rule: null,
+        step: null,
+        reason: 'file-read',
+      },
+    );
+    return { rules: [], warnings: [], loadErrors: 1 };
+  }
+
+  for (const file of files) {
+    /** @type {string} */
+    let text;
+    try {
+      text = fs.readFileSync(path.join(dir, file), 'utf8');
+    } catch (/** @type {*} */ err) {
+      logger.warn(LOG_MODULE, `${file}: unreadable — ${/** @type {Error} */ (err).message}`, {
+        rule: null,
+        step: null,
+        reason: 'file-read',
+      });
+      total.loadErrors++;
+      continue;
+    }
+    const one = loadFromString(text, file);
+    total.rules.push(...one.rules);
+    total.warnings.push(...one.warnings);
+    total.loadErrors += one.loadErrors;
+  }
+  return total;
+}
+
+module.exports = {
+  loadDir,
+  loadFromString,
+  DEFAULT_SEQUENCES_DIR,
+};

--- a/tests/fixtures/sequences/accepted/canonical.yaml
+++ b/tests/fixtures/sequences/accepted/canonical.yaml
@@ -1,0 +1,36 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/accepted/canonical.yml
+++ b/tests/fixtures/sequences/accepted/canonical.yml
@@ -1,0 +1,36 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/aliases-not-supported.yaml
+++ b/tests/fixtures/sequences/rejected/aliases-not-supported.yaml
@@ -1,0 +1,39 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  aliases:
+    path:
+      cred_file_read: file.path
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/condition-in-correlation.yaml
+++ b/tests/fixtures/sequences/rejected/condition-in-correlation.yaml
@@ -1,0 +1,38 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  condition:
+    gte: 1
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/correlation-chain.yaml
+++ b/tests/fixtures/sequences/rejected/correlation-chain.yaml
@@ -1,0 +1,47 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m
+---
+title: A correlation over a correlation
+id: SEQ002
+correlation:
+  type: temporal_ordered
+  rules:
+    - SEQ001
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/duplicate-id.yaml
+++ b/tests/fixtures/sequences/rejected/duplicate-id.yaml
@@ -1,0 +1,48 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/duplicate-name.yaml
+++ b/tests/fixtures/sequences/rejected/duplicate-name.yaml
@@ -1,0 +1,48 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Outbound network connection, again
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/entity-id-in-selection.yaml
+++ b/tests/fixtures/sequences/rejected/entity-id-in-selection.yaml
@@ -1,0 +1,37 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+    process.entity_id: '4242:1700000000000'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/generate-not-supported.yaml
+++ b/tests/fixtures/sequences/rejected/generate-not-supported.yaml
@@ -1,0 +1,37 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  generate: true
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/invalid-document.yaml
+++ b/tests/fixtures/sequences/rejected/invalid-document.yaml
@@ -1,0 +1,36 @@
+title: Credential file read
+name: Cred File Read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/invalid-regex.yaml
+++ b/tests/fixtures/sequences/rejected/invalid-regex.yaml
@@ -1,0 +1,37 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+    process.working_directory|re: '['
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/invalid-timespan-bounds.yaml
+++ b/tests/fixtures/sequences/rejected/invalid-timespan-bounds.yaml
@@ -1,0 +1,36 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 48h

--- a/tests/fixtures/sequences/rejected/invalid-timespan-grammar.yaml
+++ b/tests/fixtures/sequences/rejected/invalid-timespan-grammar.yaml
@@ -1,0 +1,36 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5x

--- a/tests/fixtures/sequences/rejected/rule-count-out-of-range.yaml
+++ b/tests/fixtures/sequences/rejected/rule-count-out-of-range.yaml
@@ -1,0 +1,35 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/step-without-entity-id.yaml
+++ b/tests/fixtures/sequences/rejected/step-without-entity-id.yaml
@@ -1,0 +1,37 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+    aegis.attribution.status: unattributed
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unknown-field.yaml
+++ b/tests/fixtures/sequences/rejected/unknown-field.yaml
@@ -1,0 +1,37 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+    file.hash: 9f86d0
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unmodified-wildcard.yaml
+++ b/tests/fixtures/sequences/rejected/unmodified-wildcard.yaml
@@ -1,0 +1,37 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+    process.working_directory: 'C:\Users\*'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unreferenced-base-document.yaml
+++ b/tests/fixtures/sequences/rejected/unreferenced-base-document.yaml
@@ -1,0 +1,46 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: A step nothing orders
+name: orphan_step
+logsource:
+  product: aegis
+  category: process
+detection:
+  selection:
+    event.action: agent-exit
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unresolved-rule-reference.yaml
+++ b/tests/fixtures/sequences/rejected/unresolved-rule-reference.yaml
@@ -1,0 +1,24 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - missing_step
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unsatisfiable-action.yaml
+++ b/tests/fixtures/sequences/rejected/unsatisfiable-action.yaml
@@ -1,0 +1,36 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - network-connection
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unsatisfiable-field.yaml
+++ b/tests/fixtures/sequences/rejected/unsatisfiable-field.yaml
@@ -1,0 +1,37 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+    destination.ip: 203.0.113.7
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unsupported-correlation-type.yaml
+++ b/tests/fixtures/sequences/rejected/unsupported-correlation-type.yaml
@@ -1,0 +1,36 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: event_count
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unsupported-group-by.yaml
+++ b/tests/fixtures/sequences/rejected/unsupported-group-by.yaml
@@ -1,0 +1,36 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - aegis.agent.name
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/unsupported-modifier.yaml
+++ b/tests/fixtures/sequences/rejected/unsupported-modifier.yaml
@@ -1,0 +1,37 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+    file.path|all: secrets
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/tests/fixtures/sequences/rejected/yaml-parse.yaml
+++ b/tests/fixtures/sequences/rejected/yaml-parse.yaml
@@ -1,0 +1,9 @@
+title: Broken
+name: broken
+logsource:
+  product: aegis
+   category: file
+detection:
+  selection:
+    file.path: x
+  condition: selection

--- a/tests/fixtures/sequences/warning/adjacent-file-steps.yaml
+++ b/tests/fixtures/sequences/warning/adjacent-file-steps.yaml
@@ -1,0 +1,23 @@
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Two credential reads in a row
+id: SEQ002
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - cred_file_read
+  group-by:
+    - process.entity_id
+  timespan: 10m

--- a/tests/main/sequence-rule-loader.test.js
+++ b/tests/main/sequence-rule-loader.test.js
@@ -1,0 +1,765 @@
+/**
+ * sequence-rule-loader — the accepted subset of Sigma correlations, and every refusal.
+ *
+ * The loader's only channel for a REJECTION is `logger.warn`; the return value carries the
+ * count, not the cause. `logger` is therefore pulled in through `createRequire`, which is the
+ * same native module instance `require('./logger')` resolves inside the loader — an ESM
+ * `import` of the same path yields a DIFFERENT object and a spy on it never fires (measured).
+ * The module under test stays on a plain ESM import so coverage instruments it.
+ *
+ * Every rejection row asserts the EXACT set of reasons the file produced, not a substring of
+ * one message: a fixture that trips its own reason plus two others would pass a `toContain`
+ * assertion and quietly stop being a test of anything in particular (ai-mistakes #21).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createRequire } from 'module';
+import loader from '../../src/main/sequence-rule-loader.js';
+import { normalizeToEcs } from '../../src/shared/ecs-normalizer.js';
+
+const require_ = createRequire(import.meta.url);
+const logger = require_('../../src/main/logger.js');
+
+const FIXTURES = path.resolve(__dirname, '../fixtures/sequences');
+const ACCEPTED_DIR = path.join(FIXTURES, 'accepted');
+const REJECTED_DIR = path.join(FIXTURES, 'rejected');
+const WARNING_DIR = path.join(FIXTURES, 'warning');
+
+/** @type {import('vitest').MockInstance} */
+let warnSpy;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // The createRequire instance is shared by every suite in this worker; an unrestored spy
+  // would leak into whichever file runs next (ai-mistakes #26).
+  vi.restoreAllMocks();
+});
+
+/** @param {string} dir @param {string} file @returns {string} */
+function read(dir, file) {
+  return fs.readFileSync(path.join(dir, file), 'utf8');
+}
+
+/** js-yaml appends a source excerpt to a parse error; the first line is the whole assertion. */
+const firstLine = (/** @type {string} */ text) => text.split('\n')[0];
+
+/** @returns {string[]} the reason code of every line the loader logged, in order. */
+const reasonsLogged = () => warnSpy.mock.calls.map((c) => c[2].reason);
+
+/** @returns {string[]} the first line of every message the loader logged, in order. */
+const messagesLogged = () => warnSpy.mock.calls.map((c) => firstLine(c[1]));
+
+/**
+ * Compiles one selection by wrapping it in the smallest file the loader accepts, so a matcher
+ * test exercises the real load path rather than a private compile helper.
+ * @param {string} category
+ * @param {string[]} selectionLines - YAML lines of the selection body, unindented.
+ * @returns {(doc: Record<string, unknown>) => boolean}
+ */
+function compileStep(category, selectionLines) {
+  const text = [
+    'title: Step under test',
+    'name: step_under_test',
+    'logsource:',
+    '  product: aegis',
+    `  category: ${category}`,
+    'detection:',
+    '  selection:',
+    ...selectionLines.map((l) => `    ${l}`),
+    '  condition: selection',
+    '---',
+    'title: Tail step',
+    'name: tail_step',
+    'logsource:',
+    '  product: aegis',
+    '  category: process',
+    'detection:',
+    '  selection:',
+    '    event.action: agent-exit',
+    '  condition: selection',
+    '---',
+    'title: Matcher probe',
+    'id: SEQ900',
+    'correlation:',
+    '  type: temporal_ordered',
+    '  rules:',
+    '    - step_under_test',
+    '    - tail_step',
+    '  group-by:',
+    '    - process.entity_id',
+    '  timespan: 5m',
+  ].join('\n');
+  const out = loader.loadFromString(text, 'matcher-probe.yaml');
+  expect(out.loadErrors).toBe(0);
+  return out.rules[0].steps[0].matcher;
+}
+
+describe('sequence-rule-loader — accepted format', () => {
+  for (const file of ['canonical.yaml', 'canonical.yml']) {
+    it(`accepts the canonical example in ${path.extname(file)}`, () => {
+      const out = loader.loadFromString(read(ACCEPTED_DIR, file), file);
+
+      expect(out.loadErrors).toBe(0);
+      expect(out.rules).toHaveLength(1);
+      const rule = out.rules[0];
+      expect(rule.id).toBe('SEQ001');
+      expect(rule.title).toBe('Credential file read followed by outbound connection');
+      expect(rule.level).toBe('high');
+      expect(rule.timespanMs).toBe(5 * 60 * 1000);
+      expect(rule.steps.map((s) => s.name)).toEqual(['cred_file_read', 'outbound_conn']);
+      expect(rule.steps.map((s) => s.category)).toEqual(['file', 'network']);
+      for (const step of rule.steps) expect(typeof step.matcher).toBe('function');
+    });
+  }
+
+  it('reads both extensions from a directory', () => {
+    const out = loader.loadDir(ACCEPTED_DIR);
+    // Both files carry the SAME canonical rule, and both load: duplicate detection is WITHIN a
+    // file, which is the bound the module header states. This pins it rather than implying it.
+    expect(out.rules.map((r) => r.id)).toEqual(['SEQ001', 'SEQ001']);
+    expect(out.loadErrors).toBe(0);
+  });
+
+  it('defaults level to medium when the correlation omits it', () => {
+    const out = loader.loadFromString(
+      read(WARNING_DIR, 'adjacent-file-steps.yaml'),
+      'adjacent-file-steps.yaml',
+    );
+    expect(out.rules[0].level).toBe('medium');
+  });
+
+  it('converts every timespan unit to milliseconds', () => {
+    const cases = [
+      ['1s', 1000],
+      ['90m', 90 * 60 * 1000],
+      ['2h', 2 * 3600 * 1000],
+      ['1d', 24 * 3600 * 1000],
+    ];
+    for (const [written, ms] of cases) {
+      const text = read(ACCEPTED_DIR, 'canonical.yaml').replace(
+        'timespan: 5m',
+        `timespan: ${written}`,
+      );
+      const out = loader.loadFromString(text, 'canonical.yaml');
+      expect(out.loadErrors).toBe(0);
+      expect(out.rules[0].timespanMs).toBe(ms);
+    }
+  });
+
+  it('an unreadable directory is not the same statement as an absent one', () => {
+    const out = loader.loadDir(path.join(FIXTURES, 'no-such-directory'));
+    expect(out).toEqual({ rules: [], warnings: [], loadErrors: 0 });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('the default directory is rules/sequences', () => {
+    expect(loader.DEFAULT_SEQUENCES_DIR.split(path.sep).slice(-2)).toEqual(['rules', 'sequences']);
+  });
+
+  it('a path that exists but is not a directory is a counted read error', () => {
+    // ENOTDIR from the real syscall, not an injected one: `existsSync` says yes and
+    // `readdirSync` refuses, which is exactly the shape a stray file at rules/sequences takes.
+    const notADir = path.join(ACCEPTED_DIR, 'canonical.yaml');
+    const out = loader.loadDir(notADir);
+
+    expect(out.rules).toEqual([]);
+    expect(out.loadErrors).toBe(1);
+    expect(reasonsLogged()).toEqual(['file-read']);
+    expect(messagesLogged()[0]).toContain(`${notADir}: directory unreadable — `);
+  });
+
+  it('one unreadable entry is counted and the rest of the directory still loads', () => {
+    // EISDIR: a directory named `*.yaml` passes the extension filter and then refuses to be read
+    // as a file. The point of the case is the `continue` — a bad entry must not cost the good
+    // ones, and the counter must still say something was lost.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-seq-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'unreadable.yaml'));
+      fs.copyFileSync(path.join(ACCEPTED_DIR, 'canonical.yaml'), path.join(tmp, 'zz-good.yaml'));
+
+      const out = loader.loadDir(tmp);
+
+      expect(out.rules.map((r) => r.id)).toEqual(['SEQ001']);
+      expect(out.warnings.map((w) => w.reason)).toEqual(['nullable-entity-id-steps']);
+      expect(out.loadErrors).toBe(1);
+      expect(reasonsLogged()).toEqual(['file-read', 'nullable-entity-id-steps']);
+      expect(messagesLogged()[0]).toContain('unreadable.yaml: unreadable — ');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('sequence-rule-loader — rejection matrix', () => {
+  /**
+   * One row per rejection reason. The message is the FIRST LINE of what the loader logged —
+   * every message is one line except `yaml-parse`, where js-yaml appends its own excerpt.
+   * @type {Array<[string, string, string]>}
+   */
+  const ROWS = [
+    [
+      'unsupported-correlation-type.yaml',
+      'unsupported-correlation-type',
+      'unsupported-correlation-type.yaml: correlation type "event_count" is not supported — temporal_ordered is the only accepted type',
+    ],
+    [
+      'unsupported-group-by.yaml',
+      'unsupported-group-by',
+      'unsupported-group-by.yaml: correlation "SEQ001" must group by exactly [process.entity_id]',
+    ],
+    [
+      'aliases-not-supported.yaml',
+      'aliases-not-supported',
+      'aliases-not-supported.yaml: correlation "SEQ001" uses aliases, not supported',
+    ],
+    [
+      'condition-in-correlation.yaml',
+      'condition-in-correlation',
+      'condition-in-correlation.yaml: correlation "SEQ001" holds a condition, not supported inside a correlation',
+    ],
+    [
+      'generate-not-supported.yaml',
+      'generate-not-supported',
+      'generate-not-supported.yaml: correlation "SEQ001" uses generate, not supported',
+    ],
+    [
+      'correlation-chain.yaml',
+      'correlation-chain',
+      'correlation-chain.yaml: correlation "SEQ002" references correlation "SEQ001" — a correlation of correlations is not supported',
+    ],
+    [
+      'unresolved-rule-reference.yaml',
+      'unresolved-rule-reference',
+      'unresolved-rule-reference.yaml: correlation "SEQ001" references "missing_step", which resolves to no base document in this file',
+    ],
+    [
+      'rule-count-out-of-range.yaml',
+      'rule-count-out-of-range',
+      'rule-count-out-of-range.yaml: correlation "SEQ001" lists 1 step(s) — a temporal_ordered rule needs 2 to 5',
+    ],
+    [
+      'unknown-field.yaml',
+      'unknown-field',
+      'unknown-field.yaml: field "file.hash" is not an ECS field AEGIS produces — see docs/ECS-MAPPING.md',
+    ],
+    [
+      'unsupported-modifier.yaml',
+      'unsupported-modifier',
+      'unsupported-modifier.yaml: modifier "|all" on "file.path" is not supported — accepted: contains, startswith, endswith, re, re|i',
+    ],
+    [
+      'invalid-regex.yaml',
+      'invalid-regex',
+      'invalid-regex.yaml: field "process.working_directory|re" holds an invalid regular expression ("[") — Invalid regular expression: /[/: Unterminated character class',
+    ],
+    [
+      'unmodified-wildcard.yaml',
+      'unmodified-wildcard',
+      'unmodified-wildcard.yaml: field "process.working_directory" holds a wildcard in an unmodified value ("C:\\Users\\*") — use |contains or |re',
+    ],
+    [
+      'invalid-timespan-grammar.yaml',
+      'invalid-timespan',
+      'invalid-timespan-grammar.yaml: timespan "5x" does not match ^[0-9]+[smhd]$',
+    ],
+    [
+      'invalid-timespan-bounds.yaml',
+      'invalid-timespan',
+      'invalid-timespan-bounds.yaml: timespan "48h" is outside the bounds 1s to 24h',
+    ],
+    [
+      'unreferenced-base-document.yaml',
+      'unreferenced-base-document',
+      'unreferenced-base-document.yaml: base document "orphan_step" is referenced by no correlation in this file',
+    ],
+    [
+      'duplicate-name.yaml',
+      'duplicate-identifier',
+      'duplicate-name.yaml: duplicate name "outbound_conn"',
+    ],
+    ['duplicate-id.yaml', 'duplicate-identifier', 'duplicate-id.yaml: duplicate id "SEQ001"'],
+    [
+      'unsatisfiable-field.yaml',
+      'unsatisfiable-selection',
+      'unsatisfiable-field.yaml: field "destination.ip" is never produced by logsource category "file"',
+    ],
+    [
+      'unsatisfiable-action.yaml',
+      'unsatisfiable-selection',
+      'unsatisfiable-action.yaml: event.action value "network-connection" is never produced by logsource category "file"',
+    ],
+    [
+      'entity-id-in-selection.yaml',
+      'entity-id-in-selection',
+      'entity-id-in-selection.yaml: field "process.entity_id" is forbidden in a selection — it is reserved for group-by',
+    ],
+    [
+      'step-without-entity-id.yaml',
+      'step-without-entity-id',
+      'step-without-entity-id.yaml: step can only match events without process.entity_id; a temporal_ordered rule grouped by process.entity_id can never fire',
+    ],
+    [
+      'invalid-document.yaml',
+      'invalid-document',
+      'invalid-document.yaml: base document "Cred File Read" needs a name matching ^[a-z0-9_]+$',
+    ],
+    [
+      'yaml-parse.yaml',
+      'yaml-parse',
+      'yaml-parse.yaml: YAML parse failed — bad indentation of a mapping entry (5:12)',
+    ],
+  ];
+
+  for (const [file, reason, message] of ROWS) {
+    it(`${file} → ${reason}, and the file contributes no rule`, () => {
+      const out = loader.loadFromString(read(REJECTED_DIR, file), file);
+
+      expect(out.rules).toEqual([]);
+      expect(out.warnings).toEqual([]);
+      expect(out.loadErrors).toBe(1);
+      expect(reasonsLogged()).toEqual([reason]);
+      expect(messagesLogged()).toEqual([message]);
+      expect(warnSpy.mock.calls[0][0]).toBe('sequence-loader');
+    });
+  }
+
+  it('every rejection fixture on disk owns a row in the table', () => {
+    const onDisk = fs.readdirSync(REJECTED_DIR).sort();
+    expect(ROWS.map(([file]) => file).sort()).toEqual(onDisk);
+  });
+
+  it('a rejected directory contributes nothing and counts every reason', () => {
+    const out = loader.loadDir(REJECTED_DIR);
+    expect(out.rules).toEqual([]);
+    expect(out.warnings).toEqual([]);
+    // Derived, never restated: one reason per fixture, and the fixture count comes off the tree.
+    expect(out.loadErrors).toBe(fs.readdirSync(REJECTED_DIR).length);
+  });
+
+  it('names the meta of a step-scoped reason and of a rule-scoped one', () => {
+    loader.loadFromString(read(REJECTED_DIR, 'unknown-field.yaml'), 'unknown-field.yaml');
+    expect(warnSpy.mock.calls[0][2]).toEqual({
+      rule: null,
+      step: 'cred_file_read',
+      reason: 'unknown-field',
+    });
+
+    warnSpy.mockClear();
+    loader.loadFromString(
+      read(REJECTED_DIR, 'unsupported-group-by.yaml'),
+      'unsupported-group-by.yaml',
+    );
+    expect(warnSpy.mock.calls[0][2]).toEqual({
+      rule: 'SEQ001',
+      step: null,
+      reason: 'unsupported-group-by',
+    });
+  });
+});
+
+describe('sequence-rule-loader — the shape validator, message by message', () => {
+  // `invalid-document` is ONE reason carrying many messages, and a reason is only as good as
+  // the branch that produces it. Every branch of the shape validator is listed here, because a
+  // must-match list is the entire protected set and not a sample of it (ai-mistakes #30). These
+  // stay inline rather than becoming 17 more fixtures: the fixture directory holds one file per
+  // REASON, which is the contract the rejection table above reads.
+  const HEAD = [
+    'title: Head step',
+    'name: head_step',
+    'logsource:',
+    '  product: aegis',
+    '  category: file',
+    'detection:',
+    '  selection:',
+    '    file.path: /tmp/x',
+    '  condition: selection',
+  ].join('\n');
+
+  const TAIL = [
+    'title: Tail step',
+    'name: tail_step',
+    'logsource:',
+    '  product: aegis',
+    '  category: process',
+    'detection:',
+    '  selection:',
+    '    event.action: agent-exit',
+    '  condition: selection',
+  ].join('\n');
+
+  const CORR = [
+    'title: Probe',
+    'id: SEQ001',
+    'correlation:',
+    '  type: temporal_ordered',
+    '  rules:',
+    '    - head_step',
+    '    - tail_step',
+    '  group-by:',
+    '    - process.entity_id',
+    '  timespan: 5m',
+  ].join('\n');
+
+  /**
+   * @param {{head?: string, corr?: string, extra?: string[]}} [parts]
+   * @returns {string}
+   */
+  const build = (parts = {}) =>
+    [parts.head ?? HEAD, TAIL, parts.corr ?? CORR, ...(parts.extra ?? [])].join('\n---\n');
+
+  /** @type {Array<[string, string, string]>} */
+  const SHAPE_ROWS = [
+    [
+      'a base document with a key outside the accepted five',
+      build({ head: HEAD + '\nlevel: high' }),
+      'shape.yaml: base document "head_step" holds unknown key "level"',
+    ],
+    [
+      'a base title that is not a string',
+      build({ head: HEAD.replace('title: Head step', 'title: 42') }),
+      'shape.yaml: base document "head_step" has a non-string title',
+    ],
+    [
+      'a base id that is not a string',
+      build({ head: HEAD + '\nid: 7' }),
+      'shape.yaml: base document "head_step" has a non-string id',
+    ],
+    [
+      'a logsource category outside file|network|process',
+      build({ head: HEAD.replace('  category: file', '  category: registry') }),
+      'shape.yaml: base document "head_step" needs logsource product: aegis plus category: file|network|process',
+    ],
+    [
+      'a detection that is not a mapping',
+      build({ head: HEAD.replace(/detection:[\s\S]*$/, 'detection: 7') }),
+      'shape.yaml: base document "head_step" has no detection',
+    ],
+    [
+      'a condition that does not name the selection',
+      build({ head: HEAD.replace('  condition: selection', '  condition: other') }),
+      'shape.yaml: base document "head_step" needs exactly one named selection and a condition equal to that name',
+    ],
+    [
+      'a selection that is not a non-empty map',
+      build({ head: HEAD.replace('  selection:\n    file.path: /tmp/x', '  selection: []') }),
+      'shape.yaml: base document "head_step" has a selection that is not a non-empty map of fields',
+    ],
+    [
+      'a field value that is neither a scalar nor a list of them',
+      build({ head: HEAD.replace('    file.path: /tmp/x', '    file.path:\n      nested: 1') }),
+      'shape.yaml: field "file.path" must hold a scalar or a non-empty list of scalars',
+    ],
+    [
+      'a correlation with a key outside the accepted six',
+      build({ corr: CORR + '\nfoo: bar' }),
+      'shape.yaml: correlation "SEQ001" holds unknown key "foo"',
+    ],
+    [
+      'a correlation with no id at all',
+      build({ corr: CORR.replace('id: SEQ001\n', '') }),
+      'shape.yaml: correlation #3 needs an id matching ^SEQ[0-9]{3}$',
+    ],
+    [
+      'a correlation with no title',
+      build({ corr: CORR.replace('title: Probe\n', '') }),
+      'shape.yaml: correlation "SEQ001" needs a title',
+    ],
+    [
+      'a correlation status that is not a string',
+      build({ corr: CORR + '\nstatus: 7' }),
+      'shape.yaml: correlation "SEQ001" has a non-string status',
+    ],
+    [
+      'a level outside the five',
+      build({ corr: CORR + '\nlevel: urgent' }),
+      'shape.yaml: correlation "SEQ001" has level "urgent" outside informational|low|medium|high|critical',
+    ],
+    [
+      'a correlation whose body is empty',
+      build({ corr: CORR.replace(/correlation:[\s\S]*$/, 'correlation:') }),
+      'shape.yaml: correlation "SEQ001" has no correlation body',
+    ],
+    [
+      'a correlation body key that is not type/rules/group-by/timespan',
+      build({ corr: CORR.replace('  timespan: 5m', '  timespan: 5m\n  foo: bar') }),
+      'shape.yaml: correlation "SEQ001" holds unknown correlation key "foo"',
+    ],
+    [
+      'a rules value that is not a list of names',
+      build({ corr: CORR.replace('  rules:\n    - head_step\n    - tail_step', '  rules: 7') }),
+      'shape.yaml: correlation "SEQ001" needs a rules list of names',
+    ],
+    [
+      'a base document with no name at all',
+      build({ head: HEAD.replace('name: head_step\n', '') }),
+      'shape.yaml: base document #1 needs a name matching ^[a-z0-9_]+$',
+    ],
+    [
+      'a document that is not a mapping at all',
+      build({ extra: ['just a scalar'] }),
+      'shape.yaml: document #4 is not a mapping',
+    ],
+  ];
+
+  for (const [label, text, message] of SHAPE_ROWS) {
+    it(`rejects ${label}`, () => {
+      const out = loader.loadFromString(text, 'shape.yaml');
+
+      expect(out.rules).toEqual([]);
+      expect(out.loadErrors).toBe(1);
+      expect(reasonsLogged()).toEqual(['invalid-document']);
+      expect(messagesLogged()).toEqual([message]);
+    });
+  }
+
+  it('refuses the unattributed step only where it can PROVE the step is empty', () => {
+    // Unmodified and alone: provably no entity id, so the file is rejected — that row is in
+    // the matrix above. The two cases here are the ones the loader must NOT refuse, because
+    // neither one says the step matches nothing else (ai-mistakes #27).
+    const beside = build({
+      head: HEAD.replace(
+        '    file.path: /tmp/x',
+        '    aegis.attribution.status:\n      - unattributed\n      - confirmed',
+      ),
+    });
+    const modified = build({
+      head: HEAD.replace(
+        '    file.path: /tmp/x',
+        '    aegis.attribution.status|contains: unattributed',
+      ),
+    });
+
+    for (const text of [beside, modified]) {
+      warnSpy.mockClear();
+      const out = loader.loadFromString(text, 'shape.yaml');
+      expect(out.loadErrors).toBe(0);
+      expect(out.rules.map((r) => r.id)).toEqual(['SEQ001']);
+    }
+  });
+
+  it('an EMPTY document is skipped in silence — a blank --- is not a defect', () => {
+    const out = loader.loadFromString(build({ extra: ['', '   '] }), 'shape.yaml');
+
+    expect(out.loadErrors).toBe(0);
+    expect(out.rules.map((r) => r.id)).toEqual(['SEQ001']);
+  });
+});
+
+describe('sequence-rule-loader — warnings, which are not rejections', () => {
+  it('warns on two adjacent steps that resolve to the same file document', () => {
+    const out = loader.loadFromString(
+      read(WARNING_DIR, 'adjacent-file-steps.yaml'),
+      'adjacent-file-steps.yaml',
+    );
+
+    expect(out.loadErrors).toBe(0);
+    expect(out.rules).toHaveLength(1);
+    expect(out.warnings.map((w) => w.reason)).toEqual([
+      'adjacent-duplicate-step',
+      'nullable-entity-id-steps',
+    ]);
+    expect(out.warnings[0].message).toBe(
+      'adjacent-file-steps.yaml: steps 1 and 2 are both "cred_file_read"; dedupFileEvent suppresses a repeat of instanceId|file for 30s, so this rule fires only on two different paths',
+    );
+    expect(out.warnings[0]).toMatchObject({ rule: 'SEQ002', step: 'cred_file_read' });
+  });
+
+  it('warns once per rule that carries a file or network step', () => {
+    const out = loader.loadFromString(read(ACCEPTED_DIR, 'canonical.yaml'), 'canonical.yaml');
+
+    expect(out.warnings.map((w) => w.reason)).toEqual(['nullable-entity-id-steps']);
+    expect(out.warnings[0].message).toBe(
+      'canonical.yaml: steps "cred_file_read", "outbound_conn" are over file or network, where process.entity_id is nullable — unattributed events on those steps are skipped and counted',
+    );
+    expect(out.warnings[0]).toMatchObject({ rule: 'SEQ001', step: null });
+  });
+
+  it('a rule whose steps are all over process carries no nullable-key warning', () => {
+    const text = [
+      'title: Agent enters',
+      'name: agent_in',
+      'logsource:',
+      '  product: aegis',
+      '  category: process',
+      'detection:',
+      '  selection:',
+      '    event.action: agent-enter',
+      '  condition: selection',
+      '---',
+      'title: Agent leaves',
+      'name: agent_out',
+      'logsource:',
+      '  product: aegis',
+      '  category: process',
+      'detection:',
+      '  selection:',
+      '    event.action: agent-exit',
+      '  condition: selection',
+      '---',
+      'title: A short-lived agent',
+      'id: SEQ901',
+      'correlation:',
+      '  type: temporal_ordered',
+      '  rules:',
+      '    - agent_in',
+      '    - agent_out',
+      '  group-by:',
+      '    - process.entity_id',
+      '  timespan: 1m',
+    ].join('\n');
+
+    const out = loader.loadFromString(text, 'process-only.yaml');
+    expect(out.loadErrors).toBe(0);
+    expect(out.warnings).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('two adjacent NETWORK steps carry no adjacency warning — the dedup window is the file one', () => {
+    const text = read(WARNING_DIR, 'adjacent-file-steps.yaml')
+      .replace('  category: file', '  category: network')
+      .replace(
+        / {4}event\.action:\n(?: {6}- \S+\n)+ {4}file\.path\|re\|i: .*\n/,
+        '    destination.port: 443\n',
+      );
+
+    const out = loader.loadFromString(text, 'adjacent-network.yaml');
+    expect(out.loadErrors).toBe(0);
+    expect(out.warnings.map((w) => w.reason)).toEqual(['nullable-entity-id-steps']);
+  });
+});
+
+describe('sequence-rule-loader — compiled matchers', () => {
+  it('an unmodified value is equality, case-folded', () => {
+    const m = compileStep('file', ['file.path: /home/me/.env']);
+    expect(m({ file: { path: '/home/me/.env' } })).toBe(true);
+    expect(m({ file: { path: '/HOME/ME/.ENV' } })).toBe(true);
+    expect(m({ file: { path: '/home/me/.envelope' } })).toBe(false);
+  });
+
+  it('|contains matches anywhere', () => {
+    const m = compileStep('file', ['file.path|contains: credentials']);
+    expect(m({ file: { path: 'C:\\aws\\CREDENTIALS.txt' } })).toBe(true);
+    expect(m({ file: { path: 'C:\\aws\\config' } })).toBe(false);
+  });
+
+  it('|startswith anchors at the head', () => {
+    const m = compileStep('file', ['file.path|startswith: C:\\Users']);
+    expect(m({ file: { path: 'C:\\Users\\me\\notes.txt' } })).toBe(true);
+    expect(m({ file: { path: 'D:\\Users\\me\\notes.txt' } })).toBe(false);
+  });
+
+  it('|endswith anchors at the tail', () => {
+    const m = compileStep('file', ['file.path|endswith: .pem']);
+    expect(m({ file: { path: '/etc/ssl/key.PEM' } })).toBe(true);
+    expect(m({ file: { path: '/etc/ssl/key.pem.bak' } })).toBe(false);
+  });
+
+  it('|re is case-SENSITIVE and |re|i is not — the flag is pinned at compile time', () => {
+    const sensitive = compileStep('file', ["file.path|re: 'cred[0-9]+'"]);
+    const insensitive = compileStep('file', ["file.path|re|i: 'cred[0-9]+'"]);
+    expect(sensitive({ file: { path: '/tmp/cred42' } })).toBe(true);
+    expect(sensitive({ file: { path: '/tmp/CRED42' } })).toBe(false);
+    expect(insensitive({ file: { path: '/tmp/CRED42' } })).toBe(true);
+  });
+
+  it('a compiled regex holds no lastIndex between events', () => {
+    const m = compileStep('file', ["file.path|re: 'secret'"]);
+    const doc = { file: { path: '/tmp/secret' } };
+    expect([m(doc), m(doc), m(doc)]).toEqual([true, true, true]);
+  });
+
+  it('a list of values is OR', () => {
+    const m = compileStep('file', ['event.action:', '  - file-created', '  - file-deleted']);
+    expect(m({ event: { action: 'file-created' } })).toBe(true);
+    expect(m({ event: { action: 'file-deleted' } })).toBe(true);
+    expect(m({ event: { action: 'file-modified' } })).toBe(false);
+  });
+
+  it('a map of fields is AND', () => {
+    const m = compileStep('network', [
+      'destination.port: 443',
+      'destination.domain: api.example.com',
+    ]);
+    expect(m({ destination: { port: 443, domain: 'api.example.com' } })).toBe(true);
+    expect(m({ destination: { port: 443, domain: 'cdn.example.com' } })).toBe(false);
+    expect(m({ destination: { port: 80, domain: 'api.example.com' } })).toBe(false);
+  });
+
+  it('an array in the DOCUMENT is containment — event.type is an ECS array', () => {
+    const m = compileStep('file', ['event.type: creation']);
+    expect(m({ event: { type: ['creation'] } })).toBe(true);
+    expect(m({ event: { category: ['file'], type: ['change'] } })).toBe(false);
+  });
+
+  it('an absent field is false, and never a crash', () => {
+    const m = compileStep('network', ['destination.ip: 203.0.113.7']);
+    expect(m({})).toBe(false);
+    expect(m({ destination: {} })).toBe(false);
+    expect(m({ file: { path: '/tmp/x' } })).toBe(false);
+    expect(m({ destination: 'not-an-object' })).toBe(false);
+  });
+
+  it('an absent field is never stringified into a match', () => {
+    // The discriminating case for the `_isScalar` guard: a matcher that reached
+    // `String(undefined)` would answer TRUE on a document that carries nothing at all, and every
+    // assertion above would still be green. Each of the three value shapes stringifies to a
+    // string a naive comparison would accept.
+    const equality = compileStep('network', ["destination.domain: 'undefined'"]);
+    const contains = compileStep('network', ["destination.domain|contains: 'undefin'"]);
+    const regex = compileStep('network', ["destination.domain|re: 'undef'"]);
+
+    for (const m of [equality, contains, regex]) expect(m({})).toBe(false);
+    for (const m of [equality, contains, regex]) {
+      expect(m({ destination: { domain: 'undefined' } })).toBe(true);
+    }
+  });
+
+  it('a number in the YAML and a number in the document are the same value', () => {
+    const m = compileStep('network', ['destination.port: 443']);
+    expect(m({ destination: { port: 443 } })).toBe(true);
+    expect(m({ destination: { port: 4433 } })).toBe(false);
+  });
+
+  it('matches the real projection of a real carrier, not a hand-built shape', () => {
+    const out = loader.loadFromString(read(ACCEPTED_DIR, 'canonical.yaml'), 'canonical.yaml');
+    const [fileStep, networkStep] = out.rules[0].steps;
+
+    const fileDoc = normalizeToEcs({
+      file: 'C:\\Users\\me\\.aws\\credentials',
+      action: 'accessed',
+      timestamp: 1_700_000_000_000,
+      instanceId: '4242:1700000000000',
+      pid: 4242,
+      agent: 'Claude Code',
+      attribution: { status: 'confirmed', evidence: ['os-file-handle'] },
+    });
+    expect(fileStep.matcher(fileDoc)).toBe(true);
+    expect(networkStep.matcher(fileDoc)).toBe(false);
+
+    const netDoc = normalizeToEcs({
+      remoteIp: '203.0.113.7',
+      remotePort: 443,
+      domain: 'api.anthropic.com',
+      instanceId: '4242:1700000000000',
+      pid: 4242,
+      agent: 'Claude Code',
+    });
+    expect(networkStep.matcher(netDoc)).toBe(true);
+    expect(fileStep.matcher(netDoc)).toBe(false);
+
+    // The same carrier with an ordinary path fails the credential step, so the regex is
+    // doing the work rather than the category.
+    const plainDoc = normalizeToEcs({
+      file: 'C:\\Users\\me\\notes.md',
+      action: 'accessed',
+      timestamp: 1_700_000_000_000,
+      instanceId: '4242:1700000000000',
+    });
+    expect(fileStep.matcher(plainDoc)).toBe(false);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -63,6 +63,7 @@ export default defineConfig({
         'src/main/exports.js',
         'src/main/tray-icon.js',
         'src/main/ipc-handlers.js',
+        'src/main/sequence-rule-loader.js',
         'src/renderer/lib/utils/risk-scoring.js',
         'src/renderer/lib/utils/threat-report.js',
         'src/renderer/lib/stores/toast.ts',


### PR DESCRIPTION
Block 1, prompt 1 of `docs/roadmap/sequence-rules.md`: the rule format and its loader, with no
engine, no consumer and no rule file — the shape and its refusals are fixed before anything is
written against them, on the `ecs-normalizer` precedent (PR #294).

## What it accepts

`rules/sequences/*.yaml|*.yml`, multi-document: base detection documents plus the correlation
documents that order them. A deliberately small subset of Sigma correlations — `temporal_ordered`
only, `group-by [process.entity_id]` only, `timespan` bounded to 1s–24h — over the ECS view
`src/shared/ecs-normalizer.js` projects, with `docs/ECS-MAPPING.md` §4 as the closed field
dictionary per `logsource.category`.

Output is `{ rules: [{ id, title, level, timespanMs, steps: [{ name, category, matcher }] }],
warnings, loadErrors }`. Each step's `matcher` is a compiled predicate over one ECS document;
regex flags are pinned at compile time, so no matcher carries a `lastIndex` between events.
`loadFromString(text, fileName)` is pure with respect to the filesystem and sits beside
`loadDir(dir)`.

## The existing gates are untouched

`rule-loader.js` reads one level of `rules/` filtered on `.yaml`/`.yml`, and so do the 8-file
parity baseline and `scripts/counts.js` `deriveRules()` — a directory entry named `sequences`
passes none of them. All three were re-run unchanged and stay green; none of those files is
touched by this PR.

## Rejection is per file, never per rule

A file that trips any reason contributes zero rules. A correlation is a claim about ORDER between
documents that were written together, so a partially-loaded file would silently detect something
nobody wrote. Each reason emits one `logger.warn('sequence-loader', message, { rule, step, reason })`
and increments `loadErrors`, which counts REASONS rather than files.

Validation is staged and does not run past a failure. That is load-bearing, not tidiness: a base
document whose `name` is malformed has no reference key, so running the cross-document stage anyway
would report an `unresolved-rule-reference` describing the loader's own recovery rather than the
file.

**21 rejection reason codes.** 20 of them have a fixture and a table row; three codes carry TWO fixtures each (`invalid-timespan` grammar/bounds, `duplicate-identifier` name/id, `unsatisfiable-selection` wrong-category / bad `event.action` value), so the table is 23 rows over 20 codes. The 21st, `file-read`, has no fixture — a directory cannot be committed as one — and is covered by two `loadDir` tests that build the ENOTDIR and EISDIR cases from real syscalls.

| | |
|---|---|
| correlation | `unsupported-correlation-type` · `unsupported-group-by` · `aliases-not-supported` · `condition-in-correlation` · `generate-not-supported` · `correlation-chain` · `rule-count-out-of-range` · `invalid-timespan` (grammar and bounds) |
| cross-document | `unresolved-rule-reference` · `unreferenced-base-document` · `duplicate-identifier` (name and id) |
| selection | `unknown-field` · `unsatisfiable-selection` (wrong category, and an `event.action` value outside the category's union) · `entity-id-in-selection` · `unsupported-modifier` · `invalid-regex` · `unmodified-wildcard` · `step-without-entity-id` |
| structural | `invalid-document` · `yaml-parse` · `file-read` |

Two of those the brief's list did not name, and the format requires both:
`entity-id-in-selection` (the design document reserves `process.entity_id` for `group-by`, so a
selection naming it must be refused and no listed reason covered that), and `yaml-parse` /
`file-read` for I/O the loader cannot proceed past — returning nothing silently would be the
failure mode `ecs-normalizer` refuses one layer up.

## Two warnings, which are not rejections

The rule still loads. Adjacent steps resolving to the same file document get one line, because
`dedupFileEvent` suppresses a repeat of `instanceId|file` for 30s and the rule therefore fires only
on two DIFFERENT paths. Every rule carrying file or network steps gets one line saying unattributed
events on those steps will be skipped and counted; a rule whose steps are all over `process` gets
none, and that absence is asserted.

## Verification

72 cases. The module measures **100% statements / branches / functions / lines** in isolation.

Every rejection row asserts the EXACT set of reasons the file produced, not a substring of one
message — a fixture that tripped its own reason plus two others would pass a `toContain` assertion
and quietly stop testing anything in particular (ai-mistakes #21). A guard case asserts that the
fixture directory on disk and the table agree, so a fixture cannot be added without a row.

Nine mutants were run against the suite and all nine go red: staging at both stage boundaries,
case folding, the absence guard in each of the three predicate shapes, the pinned regex flag, the
file scope of the adjacency warning, and a collapsed reason code. Two guards that NO mutant could
kill were removed rather than kept — both were re-emptying a value the staging had already emptied,
which reads as the mechanism, survives any mutation of the real one, and leaves the next reader
maintaining the decoration (ai-mistakes #27).

A deliberate type error was injected and `npm run typecheck` went red, confirming `@ts-check` gates
the new file under `checkJs: false`; it was then restored and the file is byte-identical.

The matchers are asserted against the REAL projection — documents built by `normalizeToEcs` from
real carrier shapes — not against a hand-written idea of an ECS document.

## Counts

`main.total` 53→54 and `main.topLevel` 41→42 (`CLAUDE.md`, `memory-bank/architecture.md`,
`docs/current-state/CORRECTNESS-AUDIT.md`); `size.over300` 31→32 (`CLAUDE.md`, `AGENTS.md`,
`docs/DEVELOPMENT.md`). `counts:check` was red until every site agreed. The roadmap document's
status header is refreshed in the same PR, which is the convention that document states for itself.

## Gates

All five required contexts green on CI. Eight of the nine local commands are green here too:
`build:renderer`, `format:check`, `lint`, `typecheck`, `typecheck:svelte`, `verify:gate`,
`counts:check`, `npm audit --audit-level=high --omit=dev`.

The ninth, `test:coverage`, is NOT green on this machine and never was during this work — see the
caveat below. Its 2353 passing cases include all 72 new ones, and CI's `test` job (which runs
exactly `npm run test:coverage`) passed. Because vitest suppresses the coverage table on a failing
run, the module's row was never observed in a whole-suite report; the 100% figure above is a
measurement of the module in isolation, and its presence on the list is the `vitest.config.js`
diff.

One caveat, stated rather than hidden: on the full local `test:coverage` run
`tests/shared/bench-scenarios/actor-secret-hold.test.js` times out — the known flake recorded as
ai-mistakes #36. It failed twice in a row, which #36 says is a signal to investigate, so it was
investigated: it is green in isolation at 3238ms of a 5000ms budget, and it fails identically on a
full run with this PR's test file removed from the tree. It is not this diff.
