### PR TITLE
feat(rules): land rules/sequences/sequences.yaml with SEQ001, its parity test and derived counters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ src/main/           Electron main process (CommonJS, require/module.exports)
 src/renderer/       Svelte 5 dashboard UI (ES modules, runes)
 src/shared/         Constants + agent-database.json (110 agents, 262 name signatures) + types/ (9 .ts)
 rules/              73 detection rules in 8 YAML files + _schema.json
+rules/sequences/    1 sequence correlation rule (SEQ001) in 1 sequence rule file; loaded, no consumer yet
 tests/              Vitest unit tests with v8 coverage
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ regenerating a lockfile.
   (count: `git ls-files 'src/renderer/**/*.svelte' | wc -l`)
 - src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (9 TS files), constants.js (ignore patterns, config paths)
 - rules/ — 73 active detection rules in 8 YAML files, validated by rules/_schema.json
+- rules/sequences/ — 1 sequence correlation rule (SEQ001) in 1 sequence rule file, read by src/main/sequence-rule-loader.js; no engine consumes it yet (docs/roadmap/sequence-rules.md)
 - memory-bank/ — ai-mistakes.md (READ FIRST), progress.md, architecture.md
 - .claude/skills/ — 11 skills: aegis-context, design-system, electron-main, svelte-patterns, testing, ship, pr-monitor, ci-monitor, prompt-craft, audit-check, commit-and-track
 - IPC: preload.js — 40 invoke + 9 push = 49 channels via contextBridge

--- a/docs/roadmap/sequence-rules.md
+++ b/docs/roadmap/sequence-rules.md
@@ -1,12 +1,13 @@
 # Sequence rules — `temporal_ordered` correlations keyed on `process.entity_id`
 
-**Status (as of 2026-08-24):** partly implemented. `src/main/sequence-rule-loader.js`,
-`tests/main/sequence-rule-loader.test.js` and `tests/fixtures/sequences/` now exist and are green;
-`rules/sequences/` does not, and nothing named in §2–§7 does either, so every other file path below
-is still a target, not a claim. **Block 1 — LOADER LANDED, its rule file and counters still to
-come (§7 prompt 2). Block 2 — NOT STARTED. Block 3 — NOT STARTED.** When a block lands, refresh
-this header in the same PR (the lag the `sensor-health-degraded.md` correction records is what a
-stale status line costs).
+**Status (as of 2026-08-24):** Block 1 implemented. `src/main/sequence-rule-loader.js`,
+`tests/main/sequence-rule-loader.test.js`, `tests/fixtures/sequences/`,
+`rules/sequences/sequences.yaml` (1 sequence correlation rule, SEQ001, in 1 sequence rule file),
+`tests/main/sequence-rules-parity.test.js` and the `sequences.*` counters in `scripts/counts.js`
+now exist and are green. No engine, gate or wiring named in §2–§7 exists yet, so every file path
+below other than Block 1's is still a target, not a claim. **Block 1 — LANDED. Block 2 — NOT
+STARTED. Block 3 — NOT STARTED.** When a block lands, refresh this header in the same PR (the lag
+the `sensor-health-degraded.md` correction records is what a stale status line costs).
 **Branch context:** master @ `0611614`; every `file:line` reference below was verified against that
 commit on 2026-08-24. Line numbers drift with every edit to the file — treat them as the place to
 start reading, and re-verify before an edit that depends on one.

--- a/rules/sequences/sequences.yaml
+++ b/rules/sequences/sequences.yaml
@@ -1,0 +1,45 @@
+# Sequence rules — temporal_ordered correlations keyed on process.entity_id.
+# Format: docs/roadmap/sequence-rules.md §1. Loader: src/main/sequence-rule-loader.js
+# (loadDir) — a multi-document file of base detection documents plus the correlation
+# documents that order them. Rejection is per FILE: one bad document drops every rule here.
+#
+# v1 noise note for SEQ001: the network step matches ANY destination on port 443 or 80,
+# including the agent's own API host, which every agent talks to continuously. Negation
+# (`not`, a `filter` selection, `condition: selection and not filter`) is outside the
+# accepted subset, so that noise is expected in v1 and is not a defect of the engine.
+title: Credential file read
+name: cred_file_read
+logsource:
+  product: aegis
+  category: file
+detection:
+  selection:
+    event.action:
+      - file-accessed
+      - file-handle-held
+    file.path|re|i: '[\\/](?:[^\\/]*[._\d-])?(?:passwords?|credentials?)[^\\/]*$'
+  condition: selection
+---
+title: Outbound network connection
+name: outbound_conn
+logsource:
+  product: aegis
+  category: network
+detection:
+  selection:
+    destination.port:
+      - 443
+      - 80
+  condition: selection
+---
+title: Credential file read followed by outbound connection
+id: SEQ001
+level: high
+correlation:
+  type: temporal_ordered
+  rules:
+    - cred_file_read
+    - outbound_conn
+  group-by:
+    - process.entity_id
+  timespan: 5m

--- a/scripts/counts.js
+++ b/scripts/counts.js
@@ -176,6 +176,30 @@ function deriveRules() {
 }
 
 /**
+ * Sequence correlations under `rules/sequences/` — the subdirectory `deriveRules()` never
+ * sees, because `trackedTopLevel` is one level deep. Each file is multi-document YAML: a
+ * correlation is a document carrying a `correlation` key, and the base documents it orders
+ * are not rules of their own (`src/main/sequence-rule-loader.js`).
+ * @returns {{total: number, files: number}}
+ */
+function deriveSequences() {
+  const files = trackedTopLevel(
+    'rules/sequences',
+    (f) => f.endsWith('.yaml') || f.endsWith('.yml'),
+  );
+  let total = 0;
+  for (const file of files) {
+    const docs = /** @type {unknown[]} */ (yaml.loadAll(readTracked(file)));
+    const correlations = docs.filter(
+      (d) => typeof d === 'object' && d !== null && !Array.isArray(d) && 'correlation' in d,
+    ).length;
+    if (correlations === 0) throw new Error(`${file}: no correlation document`);
+    total += correlations;
+  }
+  return { total, files: files.length };
+}
+
+/**
  * @returns {{over300: number, largestSrc: {file: string, lines: number},
  *   largestTest: {file: string, lines: number}}}
  */
@@ -201,6 +225,7 @@ const ci = deriveCi();
 const preload = derivePreload();
 const database = deriveAgentDatabase();
 const ruleset = deriveRules();
+const sequences = deriveSequences();
 const sizes = deriveFileSizes();
 
 const mainAll = trackedUnder('src/main', (p) => p.endsWith('.js'));
@@ -303,7 +328,21 @@ const COUNTERS = [
     key: 'rules.files',
     label: 'rule YAML files (= categories)',
     value: ruleset.files,
-    command: "git ls-files -z rules | tr '\\0' '\\n' | grep -c '\\.yaml$'",
+    // Anchored to the top level: `git ls-files rules` lists the whole subtree, and
+    // `rules/sequences/*.yaml` is counted by `sequences.files`, not here.
+    command: "git ls-files -z rules | tr '\\0' '\\n' | grep -c '^rules/[^/]*\\.yaml$'",
+  },
+  {
+    key: 'sequences.total',
+    label: 'sequence correlation rules under rules/sequences',
+    value: sequences.total,
+    command: "grep -c '^correlation:' rules/sequences/*.yaml | awk -F: '{s+=$NF} END {print s}'",
+  },
+  {
+    key: 'sequences.files',
+    label: 'sequence rule YAML files under rules/sequences',
+    value: sequences.files,
+    command: "git ls-files -z rules/sequences | tr '\\0' '\\n' | grep -cE '\\.ya?ml$'",
   },
   {
     key: 'renderer.components',
@@ -553,6 +592,29 @@ const SCANNERS = [
         ],
         ['rules.files', new RegExp(`(?:across|in)\\s+${DIGITS}\\s+(?:YAML|categories)\\b`, 'i')],
         ['rules.files', new RegExp(`,\\s*${DIGITS}\\s+categories\\b`, 'i')],
+      ]),
+  },
+  {
+    id: 'sequence-rules',
+    // NUM, not DIGITS: one rule and one file is exactly the count prose spells out. The
+    // `detection-rules` scanner above never fires on these lines — "sequence" sits between
+    // the number and "rules", and its parser allows only "active"/"detection" there — so
+    // the two counters cannot be read as each other. The negative lookahead keeps
+    // "1 sequence rule file" a declaration of `sequences.files` alone.
+    locate: new RegExp(`${NUM}\\s+sequence\\s+(?:correlation|rules?|YAML|files?)\\b`, 'i'),
+    parse: (line) =>
+      pick(line, [
+        [
+          'sequences.total',
+          new RegExp(
+            `${NUM}\\s+sequence\\s+(?:correlation\\s+)?rules?\\b(?!\\s+(?:YAML\\s+)?files?\\b)`,
+            'i',
+          ),
+        ],
+        [
+          'sequences.files',
+          new RegExp(`${NUM}\\s+sequence\\s+(?:rule\\s+)?(?:YAML\\s+)?files?\\b`, 'i'),
+        ],
       ]),
   },
   {

--- a/tests/main/sequence-rules-parity.test.js
+++ b/tests/main/sequence-rules-parity.test.js
@@ -1,0 +1,222 @@
+/**
+ * sequence-rules — parity of the PRODUCTION rule file with the loader that reads it.
+ *
+ * The counterpart of `rule-loader-yaml-parity.test.js` for `rules/sequences/`: a frozen
+ * baseline of what the directory holds and what the loader must make of it, so a js-yaml
+ * change that re-resolved a scalar, a rule edit that tripped a refusal, or a second file
+ * landing in the directory all move at least one assertion. `loadDir` reads the REAL
+ * `rules/sequences/`, never a fixture copy — a parity test over a copy proves parity with
+ * the copy (ai-mistakes #21).
+ *
+ * The loader's only channel for its notices is `logger.warn`, so `logger` is pulled in
+ * through `createRequire` — the same native module instance `require('./logger')` resolves
+ * inside the loader; an ESM `import` of the same path yields a DIFFERENT object and a spy on
+ * it never fires. The module under test stays on a plain ESM import so coverage instruments it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { createRequire } from 'module';
+// js-yaml 5 dropped the default export — the ESM entry only has named exports.
+import { loadAll as loadYamlAll } from 'js-yaml';
+import loader from '../../src/main/sequence-rule-loader.js';
+import { normalizeToEcs } from '../../src/shared/ecs-normalizer.js';
+
+const require_ = createRequire(import.meta.url);
+const logger = require_('../../src/main/logger.js');
+
+const ROOT = path.resolve(__dirname, '../..');
+const PROD_SEQUENCES_DIR = path.join(ROOT, 'rules', 'sequences');
+
+/**
+ * Frozen snapshot of the production sequence ruleset, captured from
+ * `rules/sequences/sequences.yaml` as it first landed. A new file in the directory, a new
+ * document in the file, or a rule the loader reads differently moves one of these.
+ */
+const BASELINE = {
+  /** Every tracked file under rules/sequences, repo-relative, as `git ls-files` prints it. */
+  trackedFiles: ['rules/sequences/sequences.yaml'],
+  /** The one file's documents in order — base documents by `name`, correlations by `id`. */
+  documents: ['cred_file_read', 'outbound_conn', 'SEQ001'],
+  /** Every `|re` / `|re|i` pair in the file, as `[document name, selection key]`. */
+  regexPairs: [['cred_file_read', 'file.path|re|i']],
+  rules: [
+    {
+      id: 'SEQ001',
+      title: 'Credential file read followed by outbound connection',
+      level: 'high',
+      timespanMs: 300_000,
+      steps: [
+        { name: 'cred_file_read', category: 'file' },
+        { name: 'outbound_conn', category: 'network' },
+      ],
+    },
+  ],
+  /** The one notice the file is expected to raise: both steps sit on nullable-entity carriers. */
+  warnings: [{ rule: 'SEQ001', step: null, reason: 'nullable-entity-id-steps' }],
+};
+
+/** @type {import('vitest').MockInstance} */
+let warnSpy;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // The createRequire instance is shared by every suite in this worker; an unrestored spy
+  // would leak into whichever file runs next (ai-mistakes #26).
+  vi.restoreAllMocks();
+});
+
+/**
+ * Parses one production file straight through js-yaml, with no loader pass, so the
+ * assertions see what the parser produced rather than what the loader compiled from it.
+ * @param {string} file - file name inside rules/sequences/
+ * @returns {Array<Record<string, *>>}
+ */
+function parseRaw(file) {
+  const content = fs.readFileSync(path.join(PROD_SEQUENCES_DIR, file), 'utf8');
+  return /** @type {Array<Record<string, *>>} */ (loadYamlAll(content));
+}
+
+/** @param {Record<string, *>} doc @returns {string} the reference key a document carries. */
+const keyOf = (doc) => (doc.correlation === undefined ? doc.name : doc.id);
+
+describe('sequence rules — production file parity', () => {
+  it('rules/sequences holds exactly the 1 tracked file of the baseline', () => {
+    // The INDEX, not a directory walk: counts.js derives `sequences.files` the same way, and
+    // a file that is on disk but untracked never reaches CI (ai-mistakes #28).
+    const tracked = execFileSync('git', ['ls-files', '-z', 'rules/sequences'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    })
+      .split('\0')
+      .filter(Boolean)
+      .sort();
+    expect(tracked).toEqual(BASELINE.trackedFiles);
+    // And the directory itself carries nothing else — no stray `.yml`, no notes, no backup.
+    expect(fs.readdirSync(PROD_SEQUENCES_DIR).sort()).toEqual(
+      BASELINE.trackedFiles.map((p) => path.basename(p)),
+    );
+  });
+
+  it("the loader's default directory IS the production directory", () => {
+    expect(path.resolve(loader.DEFAULT_SEQUENCES_DIR)).toBe(PROD_SEQUENCES_DIR);
+  });
+
+  it('sequences.yaml parses to exactly the baseline documents, in document order', () => {
+    const docs = parseRaw('sequences.yaml');
+    expect(docs.map(keyOf)).toEqual(BASELINE.documents);
+    // Exactly one correlation document; the other two are the base documents it orders.
+    expect(docs.filter((d) => d.correlation !== undefined).map((d) => d.id)).toEqual(
+      BASELINE.rules.map((r) => r.id),
+    );
+  });
+
+  it('loadDir on the real directory: 0 load errors, the one expected warning, exactly SEQ001', () => {
+    const out = loader.loadDir(PROD_SEQUENCES_DIR);
+
+    expect(out.loadErrors).toBe(0);
+    expect(out.warnings).toHaveLength(BASELINE.warnings.length);
+    expect(out.warnings.map(({ rule, step, reason }) => ({ rule, step, reason }))).toEqual(
+      BASELINE.warnings,
+    );
+    expect(out.warnings[0].message.startsWith('sequences.yaml: ')).toBe(true);
+
+    expect(out.rules).toHaveLength(BASELINE.rules.length);
+    const [rule] = out.rules;
+    expect(rule.id).toBe('SEQ001');
+    expect(rule.title).toBe(BASELINE.rules[0].title);
+    expect(rule.level).toBe('high');
+    expect(rule.timespanMs).toBe(300_000);
+    expect(rule.steps).toHaveLength(2);
+    expect(rule.steps.map(({ name, category }) => ({ name, category }))).toEqual(
+      BASELINE.rules[0].steps,
+    );
+    for (const step of rule.steps) expect(typeof step.matcher).toBe('function');
+
+    // The logger saw exactly the warning line and no rejection line: the return value
+    // carries the counts, the log carries the causes, and the two must agree.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toBe('sequence-loader');
+    expect(warnSpy.mock.calls[0][2]).toEqual({
+      rule: 'SEQ001',
+      step: null,
+      reason: 'nullable-entity-id-steps',
+    });
+  });
+
+  it('loadDir with no argument reads the same production file', () => {
+    const out = loader.loadDir();
+    expect(out.loadErrors).toBe(0);
+    expect(out.rules.map((r) => r.id)).toEqual(BASELINE.rules.map((r) => r.id));
+  });
+
+  it('every re pattern reaches RegExp byte-for-byte as written in YAML, flags pinned', () => {
+    /** @type {Array<[string, string]>} */
+    const seen = [];
+    for (const doc of parseRaw('sequences.yaml')) {
+      if (doc.correlation !== undefined) continue;
+      for (const [key, value] of Object.entries(doc.detection.selection)) {
+        const modifier = key.slice(key.indexOf('|') + 1);
+        if (!key.includes('|') || (modifier !== 're' && modifier !== 're|i')) continue;
+        seen.push([doc.name, key]);
+        expect(typeof value, `${doc.name} ${key} is not a single string`).toBe('string');
+        // The loader builds `new RegExp(String(value), flags)` and nothing else: the source
+        // has to equal the string the YAML file spells out, or the parser re-resolved,
+        // unescaped or trimmed it on the way in.
+        const flags = modifier === 're|i' ? 'i' : '';
+        const re = new RegExp(value, flags);
+        expect(re.source, `${doc.name} ${key} mangled`).toBe(value);
+        expect(re.flags, `${doc.name} ${key} flags`).toBe(flags);
+      }
+    }
+    // Pinned as the whole list, so the loop above is never vacuous (ai-mistakes #21).
+    expect(seen).toEqual(BASELINE.regexPairs);
+  });
+
+  it('the compiled steps decide on the ECS documents the normalizer emits', () => {
+    const [fileStep, networkStep] = loader.loadDir(PROD_SEQUENCES_DIR).rules[0].steps;
+    const file = (/** @type {string} */ p, action = 'accessed') =>
+      normalizeToEcs({
+        file: p,
+        action,
+        timestamp: 1_700_000_000_000,
+        instanceId: '4242:1700000000000',
+        pid: 4242,
+        agent: 'Claude Code',
+        attribution: { status: 'confirmed', evidence: ['os-file-handle'] },
+      });
+    const net = (/** @type {number} */ port) =>
+      normalizeToEcs({
+        remoteIp: '203.0.113.7',
+        remotePort: port,
+        domain: 'api.anthropic.com',
+        instanceId: '4242:1700000000000',
+        pid: 4242,
+        agent: 'Claude Code',
+      });
+
+    expect(fileStep.matcher(file('C:\\Users\\me\\.aws\\credentials'))).toBe(true);
+    expect(fileStep.matcher(file('/home/me/passwords.txt'))).toBe(true);
+    // `re|i` reached the RegExp: the same basename in capitals still matches.
+    expect(fileStep.matcher(file('C:\\Users\\me\\PASSWORDS.TXT'))).toBe(true);
+    // A digit adjacent to the keyword — the case `[._\d-]` exists for (ai-mistakes #30).
+    expect(fileStep.matcher(file('C:\\Users\\me\\1password_backup.csv'))).toBe(true);
+    // The keyword in a DIRECTORY name is not a credential file.
+    expect(fileStep.matcher(file('C:\\Users\\me\\password-manager\\README.md'))).toBe(false);
+    expect(fileStep.matcher(file('C:\\Users\\me\\notes.md'))).toBe(false);
+    // The action list is doing work too: a creation is not a read.
+    expect(fileStep.matcher(file('C:\\Users\\me\\.aws\\credentials', 'created'))).toBe(false);
+    expect(fileStep.matcher(file('C:\\Users\\me\\.aws\\credentials', 'holding'))).toBe(true);
+
+    expect(networkStep.matcher(net(443))).toBe(true);
+    expect(networkStep.matcher(net(80))).toBe(true);
+    expect(networkStep.matcher(net(8080))).toBe(false);
+    // Neither step accepts the other's carrier.
+    expect(networkStep.matcher(file('C:\\Users\\me\\.aws\\credentials'))).toBe(false);
+    expect(fileStep.matcher(net(443))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Block 1 of `docs/roadmap/sequence-rules.md`, prompt 2 (§7): the first production sequence rule file, the parity test that proves the loader from #308 accepts it byte-for-byte, and the derived `sequences.*` counters. **No engine, no consumer.**

- `rules/sequences/sequences.yaml` — exactly the three roadmap documents: `cred_file_read` (file), `outbound_conn` (network), `SEQ001` (`temporal_ordered`, `timespan: 5m`, `level: high`). Top comment carries the v1 noise note: the network step matches any 443/80 destination including the agent's own API host, and negation is outside the accepted subset.
- `tests/main/sequence-rules-parity.test.js` (7 tests) — `loadDir` on the **real** `rules/sequences/`: `loadErrors 0`, exactly the one `nullable-entity-id-steps` warning, one rule `SEQ001` with two steps and `timespanMs 300000`; every `|re` pattern reaches `RegExp` with `.source` equal to the YAML string and flags pinned to `i`; the compiled steps decide on `normalizeToEcs` documents (`.aws\credentials`, `PASSWORDS.TXT`, `1password_backup.csv` in; `password-manager\README.md`, `notes.md`, a creation event out; 443/80 in, 8080 out); and `rules/sequences` holds exactly one tracked file, so a second file cannot land silently.
- `scripts/counts.js` — `deriveSequences()` (correlation documents across `rules/sequences/*.yaml|*.yml`; files through `trackedTopLevel` scoped to the subdirectory), counters `sequences.total` and `sequences.files`, and a `sequence-rules` scanner whose parser cannot be read as `detection-rules` (a negative lookahead keeps "1 sequence rule file" a `files` declaration only). The printed `rules.files` command is anchored to the top level, because `git ls-files rules` now lists the subtree.
- Prose declarations: `CLAUDE.md` (Key Paths), `AGENTS.md` (tree), roadmap Status header refreshed to **Block 1 — LANDED**.

## Derived (`npm run counts:check`)

```
rules.total      = 73   (unchanged)
rules.files      =  8   (unchanged)
sequences.total  =  1   declared at 3 sites
sequences.files  =  1   declared at 3 sites
counts:check OK — 21 checked counters, 103 declaration sites agree
```

The three existing gates still do not see the subdirectory: the 8-file parity baseline (`rule-loader-yaml-parity.test.js`, green), `deriveRules` (73/8 above), and `rule-loader.js`'s top-level read.

## Local gates

`build:renderer`, `format:check`, `lint` (0 errors), `typecheck`, `typecheck:svelte`, `verify:gate` (4/4 killed), `counts:check`, `npm audit` — all green. `test:coverage`: 129/130 files green; the one red is the pre-existing `sequence-rule-loader.test.js › two adjacent NETWORK steps` case, which regex-replaces `\n` over a fixture that this Windows checkout holds as CRLF (`git ls-files --eol` → `i/lf w/crlf`; the regex matches after LF normalisation). Neither the test nor the fixture is touched here; CI runs on LF.

## Not touched

`src/main/sequence-rule-loader.js` (its header still says "no rule file exists" — out of scope by the prompt), `src/main/rule-loader.js`, top-level `rules/*.yaml`, `tests/main/rule-loader-yaml-parity.test.js`, `tests/fixtures/`.
