### PR TITLE
feat(sequences): run the temporal_ordered state machine on an injected clock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ coverage thresholds are configured in `vitest.config.js`, so coverage cannot fai
 
 ## Code conventions
 
-- 300 lines/file is a target for NEW files, not an invariant — 32 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+- 300 lines/file is a target for NEW files, not an invariant — 33 existing src files already exceed it (`npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 - **Main process:** CommonJS (`require`/`module.exports`). Never use `import` in `src/main/`.
 - **Renderer:** ES modules (`import`/`export`). Never use `require()` in `src/renderer/`.
 - **Svelte 5 runes:** `$state`, `$derived`, `$effect`, `$props`. No legacy `let` reactivity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ regenerating a lockfile.
 ## Critical Rules
 1. Read memory-bank/ai-mistakes.md before ANY code change
 2. Do ONLY what the prompt says — no extra features, no unrequested changes
-3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 32 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
+3. Main = CJS (require). Renderer = ESM (import). 300 lines/file is a target for NEW files, not an invariant — 33 existing src code files already exceed it (`git ls-files -z src | xargs -0 wc -l`, `.json` excluded; `npm run counts:check` prints the current largest src and test files). Don't split an existing file just to hit the number; do extract when adding to one that's already over
 4. CSS: var() from tokens.css ONLY. Svelte 5 runes only ($state/$derived/$effect)
 5. Svelte MCP autofixer on all .svelte files. JSDoc on all exports
 6. Conventional commits. NEVER add "Co-Authored-By" or "Generated with Claude Code"
@@ -78,7 +78,7 @@ regenerating a lockfile.
 8. TypeScript: new files in .ts, `npx eslint` + `npm run typecheck` + `npm run typecheck:svelte` before commit, zero `any`. Root tsconfig.json is a solution file (`files: []` + references) — a bare `npx tsc --noEmit` checks NOTHING and always exits 0; use `npm run typecheck` (both projects) or `npx tsc -b`
 
 ## Key Paths
-- src/main/ — 54 CommonJS modules (42 top-level + platform/ 10 + token-adapters/ 2)
+- src/main/ — 55 CommonJS modules (43 top-level + platform/ 10 + token-adapters/ 2)
 - src/renderer/ — Svelte 5 components + stores + utils + tokens.css/global.css
   (count: `git ls-files 'src/renderer/**/*.svelte' | wc -l`)
 - src/shared/ — agent-database.json (110 agents / 262 signatures), types/ (9 TS files), constants.js (ignore patterns, config paths)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -295,7 +295,7 @@ Key token namespaces:
 
 ## Conventions
 
-- **300-line soft limit** per file — a target for NEW files, not an invariant; 32 existing `src/` files already exceed it. Not enforced by the linter
+- **300-line soft limit** per file — a target for NEW files, not an invariant; 33 existing `src/` files already exceed it. Not enforced by the linter
 - **JSDoc on all exported functions**: `@param`, `@returns`, `@since`
 - **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `security:`
 - **IPC channel names**: `kebab-case`

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **54** = 42 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **55** = 43 top-level + 10 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/docs/roadmap/sequence-rules.md
+++ b/docs/roadmap/sequence-rules.md
@@ -4,11 +4,15 @@
 `tests/main/sequence-rule-loader.test.js`, `tests/fixtures/sequences/`,
 `rules/sequences/sequences.yaml` (1 sequence correlation rule, SEQ001, in 1 sequence rule file),
 `tests/main/sequence-rules-parity.test.js` and the `sequences.*` counters in `scripts/counts.js`
-now exist and are green. No engine, gate or wiring named in §2–§7 exists yet, so every file path
-below other than Block 1's is still a target, not a claim. **Block 1 — LANDED. Block 2 — NOT
-STARTED. Block 3 — NOT STARTED.** When a block lands, refresh this header in the same PR (the lag
-the `sensor-health-degraded.md` correction records is what a stale status line costs).
-**Branch context:** master @ `0611614`; every `file:line` reference below was verified against that
+now exist and are green, and so do `src/main/sequence-engine.js` and
+`tests/main/sequence-engine.test.js` — the §2 state machine with no production caller. No gate
+and no wiring named in §3, §5–§7 exists yet, and neither do the caps, the `agent-exit` cleanup or
+the per-rule counters §3 specifies, so every file path below other than Block 1's and the engine
+module is still a target, not a claim. **Block 1 — LANDED. Block 2 — ENGINE CORE LANDED (§7 prompt
+1); caps, exit cleanup and the mutation gate still to come (prompts 2–3). Block 3 — NOT
+STARTED.** When a block lands, refresh this header in the same PR (the lag the
+`sensor-health-degraded.md` correction records is what a stale status line costs).
+**Branch context:** master @ `2e9e37f`; every `file:line` reference below was verified against that
 commit on 2026-08-24. Line numbers drift with every edit to the file — treat them as the place to
 start reading, and re-verify before an edit that depends on one.
 **Date:** 2026-08-24

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 54 CommonJS modules (42 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 55 CommonJS modules (43 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle

--- a/src/main/sequence-engine.js
+++ b/src/main/sequence-engine.js
@@ -1,0 +1,477 @@
+// @ts-check
+'use strict';
+
+/**
+ * @file sequence-engine.js
+ * @module main/sequence-engine
+ * @description The `temporal_ordered` state machine over the rules `sequence-rule-loader.js`
+ *   compiles. State is `Map<ruleId, Map<instanceId, OpenSeq>>` — EXACTLY one open sequence per
+ *   (rule, instanceId), so one instance's progress through one rule is one object and a noisy
+ *   instance cannot crowd the others out of a rule.
+ *
+ *   NOTHING CONSUMES THIS YET. No tap calls `ingest`, no tick calls `sweep` and no rule file
+ *   exists — the machine is written and pinned before anything is wired to it, on the
+ *   ecs-normalizer precedent (PR #294, landed before its first caller).
+ *
+ *   WHAT IS HERE, AND WHAT IS DELIBERATELY NOT. Ingest, advance, slide, expiry, sweep and
+ *   completion, with the clock as the test seam. The bounded-memory caps and eviction
+ *   (roadmap §3), the `agent-exit` cleanup with `recentlyExited`, the per-rule counter tables and
+ *   the audit record a detection becomes are the NEXT prompts (§7 block 2 prompt 2, block 3) —
+ *   `getStats()` publishes exactly the global counters this file produces, and an unbounded map
+ *   is what an engine with no caller is allowed to be.
+ *
+ *   TRANSITION ORDER on an event with key K under rule R — fixed, and covered case by case in
+ *   `tests/main/sequence-engine.test.js`:
+ *   1. a state whose `elapsed > timespanMs` is discarded (`expired`) and then treated as ABSENT,
+ *      so the same event may still open a fresh sequence on step 0;
+ *   2. a state whose `step[stepIndex]` matches ADVANCES; on the last step (`elapsed ≤ timespanMs`,
+ *      the boundary is inclusive) it emits and is deleted (`completed`). Advance beats 3 and 4:
+ *      one event satisfies exactly one step of one rule, and a completion never re-opens on the
+ *      event that completed it;
+ *   3. a state at `stepIndex === 1` whose event matches `step[0]` SLIDES — `openedAt` and
+ *      `evidence[0]` are replaced (`slid`), which widens the window at no memory cost. At
+ *      `stepIndex ≥ 2` the same event is IGNORED (`retriggerIgnored`);
+ *   4. no state and a match on `step[0]` OPENS (`opened`).
+ *
+ *   THE RESIDUAL THE SLIDE DOES NOT COVER, written as the guarantee rather than the impression
+ *   (ai-mistakes #27). Because the slide is confined to `stepIndex === 1`, a repeat of step 0
+ *   arriving after the SECOND step has landed cannot widen the window: `A₁ B₁ A₂ B₂ C` under
+ *   `[A, B, C]` fires nothing once A₁'s window closes before C, even though `A₂ B₂ C` fit inside
+ *   one window. `A₁ A₂ B C` — the shape roadmap §2 names in passing — is NOT that case and does
+ *   fire: A₂ arrives at `stepIndex 1` and slides, and A₁'s expiry stops mattering the moment it
+ *   does. Both are pinned by tests. An event that matches no step of a rule leaves that rule
+ *   untouched and is counted nowhere; the invariant is that no dropped STATE is silent.
+ *
+ *   ONE CLOCK, INJECTED. `observedAt = now()` at ingest, for both the window and the order: a
+ *   `NetworkConnection` carries no timestamp at all (ECS-MAPPING §5) and a file event carries the
+ *   `Date.now()` of its emission, so the two carrier scales are never mixed. Order is arrival
+ *   order, which is well defined because every tap is synchronous and ingest is atomic. A
+ *   negative elapsed (a clock jump) is clamped to 0 — there is no early expiry.
+ *
+ *   RESOLUTION, so a rule author knows what a window can measure: scan cadences of 10 s / 30 s
+ *   plus chokidar's 2 s per-path debounce mean a meaningful `timespan` starts at about 60 s. A
+ *   shorter window can invert the file → network order and fail to fire; the loader's 1 s floor
+ *   is a grammar bound, not a promise that 1 s observes anything.
+ *
+ *   THE KEY IS `carrier.instanceId` VERBATIM, never parsed — parsing it here would be a second
+ *   identity resolution (ai-mistakes #19). All three value spaces are accepted as opaque strings:
+ *   `pid:startTime`, `0:<name>` for a synthetic, and `<pid>:u`. `<pid>:u` — the linux/darwin
+ *   steady state — is not pid-reuse-safe over long windows, and the loader's 24 h `timespan`
+ *   ceiling is what bounds that damage. The `attachModels` pid-0 synthetics carry
+ *   `instanceId: null` even with confirmed attribution (`src/shared/types/events.ts:74–76`) and
+ *   fall under the null policy: counted as `skippedNullInstanceId`, never opening or advancing.
+ *
+ *   LIFECYCLE: in-memory only, for the life of the process. A state is destroyed on completion,
+ *   on expiry, and on `reset` (the hot-reload path, `reloadDiscarded`); an AEGIS restart drops
+ *   every open sequence, which is a declared bound and not a defect.
+ * @requires ./logger
+ * @requires ../shared/ecs-normalizer
+ * @author AEGIS Contributors
+ * @license MIT
+ * @version 0.1.0
+ * @since v0.14.0
+ */
+
+const logger = require('./logger');
+const { normalizeToEcs } = require('../shared/ecs-normalizer');
+
+/** Logger module tag — every line this file emits carries it. @type {string} */
+const LOG_MODULE = 'sequence-engine';
+
+/** At most one ingest-error warn per this many ms, on the INJECTED clock. @type {number} */
+const WARN_INTERVAL_MS = 60000;
+
+/** Evidence keeps a path only as identification, never as content. @type {number} */
+const EVIDENCE_PATH_MAX = 256;
+
+/** @type {readonly unknown[]} */
+const NO_CATEGORIES = Object.freeze([]);
+
+/** @typedef {import('./sequence-rule-loader').SequenceRule} SequenceRule */
+/** @typedef {import('./sequence-rule-loader').SequenceStep} SequenceStep */
+
+/**
+ * @typedef {object} SequenceEvidence
+ * @property {string} step - the base document name the event satisfied.
+ * @property {string} category - that step's `logsource.category`.
+ * @property {number} observedAt - ingest time on the injected clock.
+ * @property {string} [action] - the ECS `event.action`, when the projection carries one.
+ * @property {string} [path] - `file.path`, truncated to {@link EVIDENCE_PATH_MAX}.
+ */
+
+/**
+ * @typedef {object} OpenSeq
+ * @property {number} stepIndex - the index of the step still WANTED, so an open sequence is at 1.
+ * @property {number} openedAt - the window origin; the slide moves it.
+ * @property {SequenceEvidence[]} evidence - one entry per satisfied step, in order.
+ */
+
+/**
+ * @typedef {object} SequenceDetection
+ * @property {string} ruleId
+ * @property {string} title
+ * @property {string} level
+ * @property {string} instanceId - the group key, verbatim.
+ * @property {number} openedAt
+ * @property {number} completedAt
+ * @property {number} elapsedMs - `completedAt − openedAt`, clamped at 0.
+ * @property {SequenceEvidence[]} evidence - the emitting state's own array; the state is deleted
+ *   in the same call, so nothing shares it afterwards.
+ */
+
+/**
+ * @typedef {object} SequenceCounters
+ * @property {number} opened
+ * @property {number} completed
+ * @property {number} expired
+ * @property {number} slid
+ * @property {number} retriggerIgnored
+ * @property {number} reloadDiscarded
+ * @property {number} ingestErrors
+ * @property {number} skippedNullInstanceId
+ */
+
+/** @returns {SequenceCounters} */
+function _zeroCounters() {
+  return {
+    opened: 0,
+    completed: 0,
+    expired: 0,
+    slid: 0,
+    retriggerIgnored: 0,
+    reloadDiscarded: 0,
+    ingestErrors: 0,
+    skippedNullInstanceId: 0,
+  };
+}
+
+/** @type {SequenceRule[]} */
+let _rules = [];
+
+/** @type {((detection: SequenceDetection) => void)|null} */
+let _onDetection = null;
+
+/** @type {() => number} */
+let _now = Date.now;
+
+/** @type {Map<string, Map<string, OpenSeq>>} */
+const _open = new Map();
+
+/** @type {SequenceCounters} */
+let _counters = _zeroCounters();
+
+/** The clock reading of the last ingest-error warn. @type {number} */
+let _lastIngestWarnAt = Number.NEGATIVE_INFINITY;
+
+/**
+ * @param {unknown} v
+ * @returns {v is Record<string, unknown>}
+ */
+function _isMap(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * The window a state has already consumed. A clock that ran backwards yields a negative
+ * difference, which is clamped to 0 in ONE place so neither expiry nor the completion boundary
+ * has to restate it.
+ * @param {OpenSeq} state
+ * @param {number} observedAt
+ * @returns {number}
+ */
+function _elapsed(state, observedAt) {
+  const delta = observedAt - state.openedAt;
+  return delta > 0 ? delta : 0;
+}
+
+/**
+ * The ECS categorization of one projection. `event.category` is what the step's own
+ * `logsource.category` is compared against, and containment is the comparison rather than
+ * equality: a `config-access` record projects `['configuration', 'file']` and IS a file event.
+ * Two projections carry no category the dictionary knows — an `anomaly-alert` (`intrusion_detection`)
+ * and an audit `type` outside the closed union (no `category` key at all) — and both therefore
+ * match no step of any rule. That is the intended reading, not an omission to repair.
+ * @param {Record<string, unknown>} doc
+ * @returns {readonly unknown[]}
+ */
+function _categoriesOf(doc) {
+  const event = doc.event;
+  return _isMap(event) && Array.isArray(event.category) ? event.category : NO_CATEGORIES;
+}
+
+/**
+ * @param {SequenceStep} step
+ * @param {Record<string, unknown>} doc
+ * @param {readonly unknown[]} categories
+ * @returns {boolean}
+ */
+function _matches(step, doc, categories) {
+  return categories.includes(step.category) && step.matcher(doc);
+}
+
+/**
+ * One evidence entry. Absence is written as absence — a field the projection does not carry is
+ * OMITTED rather than emitted as `null`, the convention `ecs-normalizer.js` states.
+ * @param {SequenceStep} step
+ * @param {Record<string, unknown>} doc
+ * @param {number} observedAt
+ * @returns {SequenceEvidence}
+ */
+function _evidence(step, doc, observedAt) {
+  /** @type {SequenceEvidence} */
+  const out = { step: step.name, category: step.category, observedAt };
+  const event = doc.event;
+  if (_isMap(event) && typeof event.action === 'string' && event.action !== '') {
+    out.action = event.action;
+  }
+  const file = doc.file;
+  if (_isMap(file) && typeof file.path === 'string' && file.path !== '') {
+    out.path = file.path.slice(0, EVIDENCE_PATH_MAX);
+  }
+  return out;
+}
+
+/**
+ * Drops one state and keeps the outer map free of empty inner maps. The inner map is passed in
+ * rather than looked up: every caller already holds it, and a lookup here would need an
+ * `undefined` branch that no event could ever reach.
+ * @param {Map<string, OpenSeq>} states
+ * @param {string} ruleId
+ * @param {string} key
+ * @returns {void}
+ */
+function _drop(states, ruleId, key) {
+  states.delete(key);
+  if (states.size === 0) _open.delete(ruleId);
+}
+
+/**
+ * One rule's transition for one event. Returns after the FIRST transition it takes: the
+ * priority written in the file header is this function's control flow, in order.
+ * @param {SequenceRule} rule
+ * @param {string} key
+ * @param {Record<string, unknown>} doc
+ * @param {readonly unknown[]} categories
+ * @param {number} observedAt
+ * @returns {void}
+ */
+function _applyRule(rule, key, doc, categories, observedAt) {
+  const states = _open.get(rule.id);
+  if (states !== undefined) {
+    let state = states.get(key);
+
+    // 1 — an expired state leaves as `expired` and the event goes on as if there were none.
+    if (state !== undefined && _elapsed(state, observedAt) > rule.timespanMs) {
+      _drop(states, rule.id, key);
+      _counters.expired++;
+      state = undefined;
+    }
+
+    if (state !== undefined) {
+      const wanted = rule.steps[state.stepIndex];
+      // 2 — advance, and complete on the last step. The boundary is inclusive by construction:
+      // anything past `timespanMs` was already discarded above.
+      if (_matches(wanted, doc, categories)) {
+        state.evidence.push(_evidence(wanted, doc, observedAt));
+        if (state.stepIndex === rule.steps.length - 1) {
+          _drop(states, rule.id, key);
+          _counters.completed++;
+          _emit(rule, key, state, observedAt);
+        } else {
+          state.stepIndex++;
+        }
+        return;
+      }
+      // 3 — a repeat of step 0: slide at stepIndex 1, ignored above it.
+      if (_matches(rule.steps[0], doc, categories)) {
+        if (state.stepIndex === 1) {
+          state.openedAt = observedAt;
+          state.evidence[0] = _evidence(rule.steps[0], doc, observedAt);
+          _counters.slid++;
+        } else {
+          _counters.retriggerIgnored++;
+        }
+      }
+      return;
+    }
+  }
+
+  // 4 — open. The inner map is re-read rather than reused from above: the expiry branch may
+  // have deleted it, and writing into that detached Map would lose the state silently.
+  if (!_matches(rule.steps[0], doc, categories)) return;
+  let bucket = _open.get(rule.id);
+  if (bucket === undefined) {
+    bucket = new Map();
+    _open.set(rule.id, bucket);
+  }
+  bucket.set(key, {
+    stepIndex: 1,
+    openedAt: observedAt,
+    evidence: [_evidence(rule.steps[0], doc, observedAt)],
+  });
+  _counters.opened++;
+}
+
+/**
+ * Hands a completed sequence to the consumer. The callback is NOT wrapped: a consumer that
+ * throws is a consumer defect, and swallowing it here would hide a lost detection.
+ * @param {SequenceRule} rule
+ * @param {string} key
+ * @param {OpenSeq} state
+ * @param {number} completedAt
+ * @returns {void}
+ */
+function _emit(rule, key, state, completedAt) {
+  if (_onDetection === null) return;
+  _onDetection({
+    ruleId: rule.id,
+    title: rule.title,
+    level: rule.level,
+    instanceId: key,
+    openedAt: state.openedAt,
+    completedAt,
+    elapsedMs: _elapsed(state, completedAt),
+    evidence: state.evidence,
+  });
+}
+
+/**
+ * One warn per {@link WARN_INTERVAL_MS} on the injected clock. The counter is exact; the log is
+ * not, because a broken carrier arrives once per event and would otherwise fill the log with one
+ * line per scan tick.
+ * @param {unknown} err
+ * @param {number} observedAt
+ * @returns {void}
+ */
+function _warnIngestError(err, observedAt) {
+  if (observedAt - _lastIngestWarnAt < WARN_INTERVAL_MS) return;
+  _lastIngestWarnAt = observedAt;
+  // `String(err)` rather than a `instanceof Error` ternary: the refusals this catches are always
+  // Errors, so the other arm would be a branch nothing can reach, and the `TypeError: ` prefix it
+  // keeps is the half of the line an operator reads first.
+  logger.warn(LOG_MODULE, `ingest refused an event: ${String(err)}`, {
+    reason: 'ingest-error',
+    ingestErrors: _counters.ingestErrors,
+  });
+}
+
+/**
+ * Installs the ruleset and the seams. A re-init is a FRESH engine: state and counters both go to
+ * zero, which is why the hot-reload path is {@link reset} and not this function — a reload that
+ * zeroed `reloadDiscarded` would erase the count of what it had just discarded.
+ * @param {object} options
+ * @param {SequenceRule[]} [options.rules] - as `sequence-rule-loader` compiled them.
+ * @param {(detection: SequenceDetection) => void} [options.onDetection]
+ * @param {() => number} [options.now] - epoch ms; `Date.now` when omitted.
+ * @returns {void}
+ * @since v0.14.0
+ */
+function init(options) {
+  const opts = _isMap(options) ? options : {};
+  _rules = Array.isArray(opts.rules) ? opts.rules.slice() : [];
+  _onDetection = typeof opts.onDetection === 'function' ? opts.onDetection : null;
+  _now = typeof opts.now === 'function' ? opts.now : Date.now;
+  _open.clear();
+  _counters = _zeroCounters();
+  _lastIngestWarnAt = Number.NEGATIVE_INFINITY;
+}
+
+/**
+ * Offers one live carrier to every loaded rule. Never throws: an unrecognised shape is counted
+ * and dropped, because the taps run inside the scan cycle and an exception there would cost the
+ * whole tick.
+ * @param {unknown} carrier - a `FileEvent`, a `NetworkConnection`, a session record or an audit
+ *   record — the four shapes `normalizeToEcs` accepts.
+ * @returns {void}
+ * @since v0.14.0
+ */
+function ingest(carrier) {
+  // With no rules there is nothing an event could open, and the projection is the expensive
+  // part: the engine costs a length check per event until a ruleset is loaded.
+  if (_rules.length === 0) return;
+  const observedAt = _now();
+  if (!_isMap(carrier)) {
+    // The same refusal `normalizeToEcs` makes, taken one step earlier so the `instanceId` read
+    // below is safe on any argument.
+    _counters.ingestErrors++;
+    _warnIngestError(
+      new TypeError(`expected an event object, received ${typeof carrier}`),
+      observedAt,
+    );
+    return;
+  }
+  const key = carrier.instanceId;
+  if (typeof key !== 'string' || key === '') {
+    _counters.skippedNullInstanceId++;
+    return;
+  }
+  /** @type {Record<string, unknown>} */
+  let doc;
+  try {
+    doc = normalizeToEcs(carrier);
+  } catch (err) {
+    _counters.ingestErrors++;
+    _warnIngestError(err, observedAt);
+    return;
+  }
+  const categories = _categoriesOf(doc);
+  for (const rule of _rules) _applyRule(rule, key, doc, categories, observedAt);
+}
+
+/**
+ * Discards every state whose window has closed, so memory does not wait for the next event of
+ * the same key. Called once per tick by the scan loop (block 3).
+ * @returns {void}
+ * @since v0.14.0
+ */
+function sweep() {
+  const at = _now();
+  for (const rule of _rules) {
+    const states = _open.get(rule.id);
+    if (states === undefined) continue;
+    for (const [key, state] of states) {
+      if (_elapsed(state, at) > rule.timespanMs) {
+        states.delete(key);
+        _counters.expired++;
+      }
+    }
+    if (states.size === 0) _open.delete(rule.id);
+  }
+}
+
+/**
+ * Drops every open sequence — the hot-reload path, where the rules the states were opened
+ * against no longer exist. Counters survive: they describe the process, not the ruleset.
+ * @param {string} reason - what asked for it, for the log line.
+ * @returns {void}
+ * @since v0.14.0
+ */
+function reset(reason) {
+  let discarded = 0;
+  for (const states of _open.values()) discarded += states.size;
+  _open.clear();
+  _counters.reloadDiscarded += discarded;
+  if (discarded > 0) {
+    logger.info(LOG_MODULE, `discarded ${discarded} open sequence(s)`, { reason, discarded });
+  }
+}
+
+/**
+ * A snapshot of the global counters plus the live `openNow` gauge. A fresh object every call:
+ * a caller holding a reference must not be able to move a counter.
+ * @returns {SequenceCounters & {openNow: number}}
+ * @since v0.14.0
+ */
+function getStats() {
+  let openNow = 0;
+  for (const states of _open.values()) openNow += states.size;
+  return { ..._counters, openNow };
+}
+
+module.exports = {
+  init,
+  ingest,
+  sweep,
+  reset,
+  getStats,
+};

--- a/tests/main/sequence-engine.test.js
+++ b/tests/main/sequence-engine.test.js
@@ -1,0 +1,723 @@
+/**
+ * sequence-engine — the `temporal_ordered` state machine, driven by an INJECTED clock.
+ *
+ * The seam is `init({ now })`, not `vi.useFakeTimers()`: the engine reads the clock only through
+ * that function and schedules nothing, so a fake timer would advance a mechanism this module does
+ * not have while leaving `observedAt` untouched. Every case below sets `clock` explicitly, which
+ * is what makes the maxspan boundary an assertion rather than a race.
+ *
+ * The RULES are hand-built here and the CARRIERS are real: each event goes through the real
+ * `normalizeToEcs` projection inside `ingest`, so the category gate and the matchers see exactly
+ * what production would hand them. One case at the end drives a loader-compiled rule instead,
+ * which is what pins that the shape `sequence-rule-loader` produces is the shape this engine
+ * consumes.
+ *
+ * `logger` is pulled in through `createRequire` — the same native module instance the CJS module
+ * under test requires. An ESM `import` of the same path yields a DIFFERENT object and a spy on it
+ * never fires (the convention `sequence-rule-loader.test.js` records).
+ *
+ * Every counter asserted below is produced by the path under test (ai-mistakes #21): no case
+ * asserts a zero that the engine could not have moved anyway, and each counter is read from
+ * `getStats()` after the exact transition that owns it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'module';
+import engine from '../../src/main/sequence-engine.js';
+import loader from '../../src/main/sequence-rule-loader.js';
+
+const require_ = createRequire(import.meta.url);
+const logger = require_('../../src/main/logger.js');
+
+/** The window every hand-built rule below uses unless it says otherwise. @type {number} */
+const SPAN = 60000;
+
+/** @type {number} */
+let clock = 0;
+
+/** @type {Array<Record<string, unknown>>} */
+let detections = [];
+
+/** @type {import('vitest').MockInstance} */
+let warnSpy;
+/** @type {import('vitest').MockInstance} */
+let infoSpy;
+
+const now = () => clock;
+
+/** @param {number} t @returns {void} */
+function at(t) {
+  clock = t;
+}
+
+/**
+ * @param {string} name
+ * @param {string} category
+ * @param {(doc: Record<string, any>) => boolean} matcher
+ * @returns {{name: string, category: string, matcher: (doc: Record<string, any>) => boolean}}
+ */
+function step(name, category, matcher) {
+  return { name, category, matcher };
+}
+
+/**
+ * @param {string} id
+ * @param {Array<{name: string, category: string, matcher: Function}>} steps
+ * @param {number} [timespanMs]
+ * @returns {Record<string, unknown>}
+ */
+function rule(id, steps, timespanMs = SPAN) {
+  return { id, title: `${id} — under test`, level: 'high', timespanMs, steps };
+}
+
+/** `event.action` is what the ECS projection carries for both file and process carriers. */
+const actionIs = (/** @type {string} */ want) => (doc) => doc.event.action === want;
+const portIs = (/** @type {number} */ want) => (doc) =>
+  doc.destination !== undefined && doc.destination.port === want;
+
+/** A file step matching an `accessed` event, the canonical first step. */
+const stepA = () => step('a_read', 'file', actionIs('file-accessed'));
+/** A network step matching an outbound 443, the canonical second step. */
+const stepB = () => step('b_conn', 'network', portIs(443));
+/** A second FILE step, for the three-step rules. */
+const stepC = () => step('c_write', 'file', actionIs('file-modified'));
+
+/**
+ * @param {string|null} instanceId
+ * @param {string} [action]
+ * @param {string} [file]
+ * @returns {Record<string, unknown>}
+ */
+function fileEvent(instanceId, action = 'accessed', file = 'C:\\work\\creds.txt') {
+  return { instanceId, file, action, timestamp: 1_700_000_000_000, agent: 'Claude Code' };
+}
+
+/**
+ * @param {string|null} instanceId
+ * @param {number} [remotePort]
+ * @returns {Record<string, unknown>}
+ */
+function netEvent(instanceId, remotePort = 443) {
+  return { instanceId, remoteIp: '203.0.113.5', remotePort, agent: 'Claude Code' };
+}
+
+/**
+ * Installs a ruleset on a zeroed engine. Every test starts from here, so no case can inherit a
+ * state or a counter from the one before it.
+ * @param {Array<Record<string, unknown>>} rules
+ * @returns {void}
+ */
+function start(rules) {
+  engine.init({ rules, onDetection: (d) => detections.push(d), now });
+}
+
+beforeEach(() => {
+  clock = 0;
+  detections = [];
+  warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // The createRequire instance is shared by every suite in this worker; an unrestored spy would
+  // leak into whichever file runs next (ai-mistakes #26).
+  vi.restoreAllMocks();
+  engine.init({ rules: [] });
+});
+
+describe('sequence-engine — order', () => {
+  it('A then B fires, and the detection carries the rule, the key and both evidence entries', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('4242:900'));
+    at(31000);
+    engine.ingest(netEvent('4242:900'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0]).toEqual({
+      ruleId: 'SEQ001',
+      title: 'SEQ001 — under test',
+      level: 'high',
+      instanceId: '4242:900',
+      openedAt: 1000,
+      completedAt: 31000,
+      elapsedMs: 30000,
+      evidence: [
+        {
+          step: 'a_read',
+          category: 'file',
+          observedAt: 1000,
+          action: 'file-accessed',
+          path: 'C:\\work\\creds.txt',
+        },
+        {
+          step: 'b_conn',
+          category: 'network',
+          observedAt: 31000,
+          action: 'network-connection',
+        },
+      ],
+    });
+    expect(engine.getStats()).toMatchObject({ opened: 1, completed: 1, openNow: 0 });
+  });
+
+  it('B then A does not fire — the second step cannot open a sequence', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(netEvent('i1'));
+    at(2000);
+    engine.ingest(fileEvent('i1'));
+
+    expect(detections).toHaveLength(0);
+    expect(engine.getStats()).toMatchObject({ opened: 1, completed: 0, openNow: 1 });
+  });
+
+  it('A X B fires — an event matching no step leaves the sequence exactly where it was', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(fileEvent('i1', 'modified')); // X: matches neither step of this rule
+    at(3000);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(1);
+    // X is counted nowhere, and it did not slide the window: `openedAt` is still A's.
+    expect(detections[0].openedAt).toBe(1000);
+    expect(engine.getStats()).toMatchObject({ opened: 1, completed: 1, slid: 0 });
+  });
+
+  it('a rule [A, A] needs two events — one event never satisfies two steps', () => {
+    start([rule('SEQ002', [stepA(), stepA()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    expect(detections).toHaveLength(0);
+
+    at(2000);
+    engine.ingest(fileEvent('i1'));
+    expect(detections).toHaveLength(1);
+    expect(detections[0].evidence.map((e) => e.observedAt)).toEqual([1000, 2000]);
+  });
+
+  it('advance beats open — the second A completes [A, A] instead of opening a new sequence', () => {
+    start([rule('SEQ002', [stepA(), stepA()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(fileEvent('i1'));
+
+    // opened stays at 1: had `open` won, this would read 2 and the sequence would still be open.
+    expect(engine.getStats()).toMatchObject({ opened: 1, completed: 1, slid: 0, openNow: 0 });
+  });
+
+  it('completion does not re-open on the event that completed it, and a later A opens again', () => {
+    start([rule('SEQ002', [stepA(), stepA()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(fileEvent('i1'));
+    expect(engine.getStats()).toMatchObject({ opened: 1, openNow: 0 });
+
+    at(3000);
+    engine.ingest(fileEvent('i1'));
+    expect(engine.getStats()).toMatchObject({ opened: 2, completed: 1, openNow: 1 });
+    expect(detections).toHaveLength(1);
+  });
+
+  it('one event is offered to every rule — two rules on the same step 0 both open', () => {
+    start([rule('SEQ001', [stepA(), stepB()]), rule('SEQ003', [stepA(), stepC()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+
+    expect(engine.getStats()).toMatchObject({ opened: 2, openNow: 2 });
+  });
+
+  it('a step matches only its own category — a matcher that accepts everything still does not', () => {
+    // The matcher answers true for any document; the step is `network` and the carrier projects
+    // `['file']`, so the category gate alone decides this case.
+    start([rule('SEQ004', [step('any_net', 'network', () => true), stepC()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+
+    expect(engine.getStats()).toMatchObject({ opened: 0, openNow: 0 });
+  });
+
+  it('a projection with no ECS category matches no step at all', () => {
+    // `permission-deny` is outside the closed audit union, so `normalizeToEcs` emits an `event`
+    // branch with an `action` and NO `category` — the case the module header names.
+    start([rule('SEQ004', [step('any_step', 'file', () => true), stepB()])]);
+
+    at(1000);
+    engine.ingest({ instanceId: 'i1', type: 'permission-deny', timestamp: '2026-08-24T00:00:00Z' });
+
+    expect(engine.getStats()).toMatchObject({ opened: 0, ingestErrors: 0 });
+  });
+});
+
+describe('sequence-engine — the maxspan boundary', () => {
+  it('exactly timespan fires — the boundary is inclusive', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(1000 + SPAN);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0].elapsedMs).toBe(SPAN);
+    expect(engine.getStats()).toMatchObject({ completed: 1, expired: 0 });
+  });
+
+  it('timespan + 1 ms expires, and that same B opens nothing', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(1000 + SPAN + 1);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(0);
+    // `opened` stays 1: B is not step 0, so the discarded state is not replaced by a new one.
+    expect(engine.getStats()).toMatchObject({ opened: 1, expired: 1, completed: 0, openNow: 0 });
+  });
+
+  it('a new A after the expiry opens a fresh sequence, and it completes', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(1000 + SPAN + 1);
+    engine.ingest(fileEvent('i1')); // expires the first state, then opens on step 0
+    at(1000 + SPAN + 2);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0].openedAt).toBe(1000 + SPAN + 1);
+    expect(engine.getStats()).toMatchObject({ opened: 2, expired: 1, completed: 1 });
+  });
+
+  it('a clock that runs backwards clamps the elapsed to 0 — there is no early expiry', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(500000);
+    engine.ingest(fileEvent('i1'));
+    at(400000); // the jump: `observedAt − openedAt` is −100000
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0].elapsedMs).toBe(0);
+    expect(engine.getStats()).toMatchObject({ expired: 0, completed: 1 });
+  });
+
+  it('sweep removes an idle expired state, and leaves a live one alone', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+
+    at(1000 + SPAN);
+    engine.sweep();
+    expect(engine.getStats()).toMatchObject({ expired: 0, openNow: 1 });
+
+    at(1000 + SPAN + 1);
+    engine.sweep();
+    expect(engine.getStats()).toMatchObject({ expired: 1, openNow: 0 });
+  });
+
+  it('sweep is a no-op when nothing is open', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(999999);
+    engine.sweep();
+
+    expect(engine.getStats()).toMatchObject({ expired: 0, openNow: 0 });
+  });
+});
+
+describe('sequence-engine — group-by isolation', () => {
+  it('A(i1) A(i2) B(i1) B(i2) gives two detections with separate evidence', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1', 'accessed', 'C:\\one\\creds.txt'));
+    at(2000);
+    engine.ingest(fileEvent('i2', 'accessed', 'C:\\two\\creds.txt'));
+    at(3000);
+    engine.ingest(netEvent('i1'));
+    at(4000);
+    engine.ingest(netEvent('i2'));
+
+    expect(detections.map((d) => d.instanceId)).toEqual(['i1', 'i2']);
+    expect(detections[0].evidence[0].path).toBe('C:\\one\\creds.txt');
+    expect(detections[1].evidence[0].path).toBe('C:\\two\\creds.txt');
+    expect(detections[0].evidence).not.toBe(detections[1].evidence);
+    expect(engine.getStats()).toMatchObject({ opened: 2, completed: 2, openNow: 0 });
+  });
+
+  it('A(i1) then B(i2) fires nothing — the group key is not shared', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(netEvent('i2'));
+
+    expect(detections).toHaveLength(0);
+    expect(engine.getStats()).toMatchObject({ opened: 1, openNow: 1 });
+  });
+
+  it('one instance never holds more than one slot per rule, however many step-0 events it sends', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    for (let i = 1; i <= 5; i++) {
+      at(i * 1000);
+      engine.ingest(fileEvent('i1'));
+    }
+
+    // One open, four slides: the fifth A replaced the window rather than adding a slot.
+    expect(engine.getStats()).toMatchObject({ opened: 1, slid: 4, openNow: 1 });
+  });
+
+  it('the key is taken verbatim — two keys differing only in their birth time never merge', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('4242:900'));
+    at(2000);
+    engine.ingest(netEvent('4242:901'));
+
+    expect(detections).toHaveLength(0);
+    expect(engine.getStats()).toMatchObject({ opened: 1, openNow: 1 });
+  });
+});
+
+describe('sequence-engine — slide and the residual it does not cover', () => {
+  it('slides at stepIndex 1: the window is measured from the LAST step 0, not the first', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(0);
+    engine.ingest(fileEvent('i1', 'accessed', 'C:\\first\\creds.txt'));
+    at(40000);
+    engine.ingest(fileEvent('i1', 'accessed', 'C:\\second\\creds.txt'));
+    at(90000); // 90 s after A₁ — outside its window; 50 s after A₂ — inside
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0].openedAt).toBe(40000);
+    // evidence[0] was REPLACED, not appended to: the slide widens the window at no memory cost.
+    expect(detections[0].evidence).toHaveLength(2);
+    expect(detections[0].evidence[0].path).toBe('C:\\second\\creds.txt');
+    expect(engine.getStats()).toMatchObject({ opened: 1, slid: 1, expired: 0, completed: 1 });
+  });
+
+  it('A₁ A₂ B C fires on a three-step rule — the slide repairs exactly this shape', () => {
+    // Roadmap §2 names `A₁ … A₂ … B … C, A₁'s window expired` as the residual miss. It is not
+    // one: A₂ arrives at stepIndex 1 and SLIDES, so A₁'s expiry stops mattering. Pinned here as
+    // the behaviour the code actually has (ai-mistakes #27 — write the guarantee, not the
+    // impression); the real residual is the next case.
+    start([rule('SEQ003', [stepA(), stepB(), stepC()])]);
+
+    at(0);
+    engine.ingest(fileEvent('i1'));
+    at(50000);
+    engine.ingest(fileEvent('i1'));
+    at(70000);
+    engine.ingest(netEvent('i1'));
+    at(90000); // 90 s after A₁, 40 s after A₂
+    engine.ingest(fileEvent('i1', 'modified'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0].openedAt).toBe(50000);
+    expect(engine.getStats()).toMatchObject({ slid: 1, retriggerIgnored: 0, completed: 1 });
+  });
+
+  it('the residual: at stepIndex ≥ 2 a repeated step 0 is ignored, and A₂ B₂ C is lost', () => {
+    // `A₁ B₁ A₂ B₂ C` — A₂ arrives with the sequence already past step 1, so it cannot widen the
+    // window; B₂ matches neither the wanted step nor step 0 and is dropped with no counter (no
+    // STATE was dropped, which is what the invariant covers). C then finds an expired state.
+    // A declared v1 bound, not a defect: the fix is a second open slot per (rule, key).
+    start([rule('SEQ003', [stepA(), stepB(), stepC()])]);
+
+    at(0);
+    engine.ingest(fileEvent('i1'));
+    at(10000);
+    engine.ingest(netEvent('i1'));
+    at(20000);
+    engine.ingest(fileEvent('i1')); // A₂ — ignored at stepIndex 2
+    at(30000);
+    engine.ingest(netEvent('i1')); // B₂ — matches no step in this position
+    at(70000); // inside A₂'s window, outside A₁'s
+    engine.ingest(fileEvent('i1', 'modified'));
+
+    expect(detections).toHaveLength(0);
+    expect(engine.getStats()).toMatchObject({
+      opened: 1,
+      slid: 0,
+      retriggerIgnored: 1,
+      expired: 1,
+      completed: 0,
+      openNow: 0,
+    });
+  });
+});
+
+describe('sequence-engine — refusals, reset and stats', () => {
+  it('a null instanceId is counted and skipped, and never opens or advances', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent(null));
+    at(2000);
+    engine.ingest(fileEvent('i1'));
+    at(3000);
+    engine.ingest(netEvent(null)); // would have completed, had the key been read from anywhere
+
+    expect(detections).toHaveLength(0);
+    expect(engine.getStats()).toMatchObject({
+      skippedNullInstanceId: 2,
+      opened: 1,
+      completed: 0,
+      openNow: 1,
+    });
+  });
+
+  it('a carrier with no instanceId field at all falls under the same policy', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest({ file: 'C:\\work\\creds.txt', action: 'accessed', timestamp: 1 });
+
+    expect(engine.getStats()).toMatchObject({ skippedNullInstanceId: 1, ingestErrors: 0 });
+  });
+
+  it('an unrecognised carrier counts an ingest error, warns once, and throws nothing', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    expect(() => engine.ingest({ instanceId: 'i1', somethingElse: true })).not.toThrow();
+
+    expect(engine.getStats()).toMatchObject({ ingestErrors: 1, opened: 0 });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toBe('sequence-engine');
+    expect(warnSpy.mock.calls[0][1]).toContain('unrecognised event shape');
+    expect(warnSpy.mock.calls[0][2]).toMatchObject({ reason: 'ingest-error' });
+  });
+
+  it('a non-object carrier is refused the same way, one step before the normalizer', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    expect(() => engine.ingest(null)).not.toThrow();
+    expect(() => engine.ingest('not an event')).not.toThrow();
+
+    expect(engine.getStats()).toMatchObject({ ingestErrors: 2, skippedNullInstanceId: 0 });
+    expect(warnSpy.mock.calls[0][1]).toContain('expected an event object');
+  });
+
+  it('the ingest warn is rate limited on the injected clock while the counter stays exact', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    at(1000);
+    engine.ingest({ instanceId: 'i1', somethingElse: true });
+    at(1000 + 59999);
+    engine.ingest({ instanceId: 'i1', somethingElse: true });
+    expect(engine.getStats()).toMatchObject({ ingestErrors: 2 });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    at(1000 + 60000);
+    engine.ingest({ instanceId: 'i1', somethingElse: true });
+    expect(engine.getStats()).toMatchObject({ ingestErrors: 3 });
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('reset discards every open sequence, counts them, and keeps the other counters', () => {
+    start([rule('SEQ001', [stepA(), stepB()]), rule('SEQ003', [stepA(), stepC()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(fileEvent('i2'));
+    expect(engine.getStats()).toMatchObject({ opened: 4, openNow: 4 });
+
+    engine.reset('rules-reloaded');
+
+    expect(engine.getStats()).toMatchObject({ reloadDiscarded: 4, openNow: 0, opened: 4 });
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][2]).toMatchObject({ reason: 'rules-reloaded', discarded: 4 });
+  });
+
+  it('a reset with nothing open counts nothing and logs nothing', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    engine.reset('rules-reloaded');
+
+    expect(engine.getStats()).toMatchObject({ reloadDiscarded: 0 });
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  it('with no rules loaded ingest returns before every other check', () => {
+    engine.init({ rules: [], onDetection: (d) => detections.push(d), now });
+
+    at(1000);
+    engine.ingest(fileEvent(null));
+    engine.ingest({ instanceId: 'i1', somethingElse: true });
+
+    // Both counters stay 0: an engine with no ruleset does not project, does not count and does
+    // not warn — the length check is the whole cost per event.
+    expect(engine.getStats()).toMatchObject({ skippedNullInstanceId: 0, ingestErrors: 0 });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('init with no argument yields an engine with no rules and zeroed counters', () => {
+    engine.init();
+
+    expect(engine.getStats()).toEqual({
+      opened: 0,
+      completed: 0,
+      expired: 0,
+      slid: 0,
+      retriggerIgnored: 0,
+      reloadDiscarded: 0,
+      ingestErrors: 0,
+      skippedNullInstanceId: 0,
+      openNow: 0,
+    });
+  });
+
+  it('a completion with no onDetection installed still counts and still deletes the state', () => {
+    engine.init({ rules: [rule('SEQ001', [stepA(), stepB()])], now });
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(netEvent('i1'));
+
+    expect(engine.getStats()).toMatchObject({ completed: 1, openNow: 0 });
+  });
+
+  it('re-init zeroes the counters and drops the state without counting a reload', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    expect(engine.getStats()).toMatchObject({ opened: 0, openNow: 0, reloadDiscarded: 0 });
+  });
+
+  it('getStats hands out a fresh object — a caller cannot move a counter', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+
+    const snapshot = engine.getStats();
+    snapshot.opened = 99;
+
+    expect(engine.getStats().opened).toBe(1);
+  });
+
+  it('evidence omits what the projection does not carry, rather than writing it as null', () => {
+    // `renamed` is outside the closed `FileAction` union, so the projection keeps the `file`
+    // category and invents no `event.action` — the absence-is-absence convention, end to end.
+    start([rule('SEQ004', [step('any_file', 'file', () => true), stepB()])]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1', 'renamed'));
+    at(2000);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections[0].evidence[0]).toEqual({
+      step: 'any_file',
+      category: 'file',
+      observedAt: 1000,
+      path: 'C:\\work\\creds.txt',
+    });
+  });
+
+  it('an evidence path is truncated to 256 characters', () => {
+    start([rule('SEQ001', [stepA(), stepB()])]);
+
+    const longPath = `C:\\work\\${'d'.repeat(400)}\\creds.txt`;
+    at(1000);
+    engine.ingest(fileEvent('i1', 'accessed', longPath));
+    at(2000);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections[0].evidence[0].path).toHaveLength(256);
+    expect(detections[0].evidence[0].path).toBe(longPath.slice(0, 256));
+  });
+});
+
+describe('sequence-engine — against a loader-compiled rule', () => {
+  const SOURCE = [
+    'title: Credential file read',
+    'name: cred_file_read',
+    'logsource:',
+    '  product: aegis',
+    '  category: file',
+    'detection:',
+    '  selection:',
+    '    event.action: file-accessed',
+    '    file.path|contains: creds',
+    '  condition: selection',
+    '---',
+    'title: Outbound connection',
+    'name: outbound_conn',
+    'logsource:',
+    '  product: aegis',
+    '  category: network',
+    'detection:',
+    '  selection:',
+    '    destination.port: 443',
+    '  condition: selection',
+    '---',
+    'title: Credential read followed by an outbound connection',
+    'id: SEQ001',
+    'level: high',
+    'correlation:',
+    '  type: temporal_ordered',
+    '  rules:',
+    '    - cred_file_read',
+    '    - outbound_conn',
+    '  group-by:',
+    '    - process.entity_id',
+    '  timespan: 5m',
+  ].join('\n');
+
+  it('consumes the shape the loader produces, matchers and timespanMs included', () => {
+    const loaded = loader.loadFromString(SOURCE, 'engine-parity.yaml');
+    expect(loaded.loadErrors).toBe(0);
+    start(loaded.rules);
+
+    at(1000);
+    engine.ingest(fileEvent('i1', 'accessed', 'C:\\work\\creds.txt'));
+    at(1000 + 5 * 60 * 1000); // exactly the compiled timespan
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0]).toMatchObject({
+      ruleId: 'SEQ001',
+      level: 'high',
+      title: 'Credential read followed by an outbound connection',
+      elapsedMs: 5 * 60 * 1000,
+    });
+    expect(detections[0].evidence.map((e) => e.step)).toEqual(['cred_file_read', 'outbound_conn']);
+  });
+
+  it('a path the compiled selection does not match opens nothing', () => {
+    const loaded = loader.loadFromString(SOURCE, 'engine-parity.yaml');
+    start(loaded.rules);
+
+    at(1000);
+    engine.ingest(fileEvent('i1', 'accessed', 'C:\\work\\notes.txt'));
+
+    expect(engine.getStats()).toMatchObject({ opened: 0 });
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -64,6 +64,7 @@ export default defineConfig({
         'src/main/tray-icon.js',
         'src/main/ipc-handlers.js',
         'src/main/sequence-rule-loader.js',
+        'src/main/sequence-engine.js',
         'src/renderer/lib/utils/risk-scoring.js',
         'src/renderer/lib/utils/threat-report.js',
         'src/renderer/lib/stores/toast.ts',


### PR DESCRIPTION
Block 2, prompt 1 of `docs/roadmap/sequence-rules.md`: the `temporal_ordered` state machine over
the rules `sequence-rule-loader.js` compiles, with no production caller — the ecs-normalizer
precedent (PR #294) and the same shape block 1 shipped in.

## What it is

`src/main/sequence-engine.js` — `init({ rules, onDetection, now })`, `ingest(carrier)`, `sweep()`,
`reset(reason)`, `getStats()`. State is `Map<ruleId, Map<instanceId, OpenSeq>>` with
`OpenSeq = { stepIndex, openedAt, evidence[] }`, exactly one open sequence per (rule, instanceId).

**Transition order**, fixed and covered case by case:

1. an expired state (`elapsed > timespanMs`) is discarded (`expired`) and then treated as ABSENT,
   so the same event may still open on step 0;
2. a match on `step[stepIndex]` ADVANCES; the last step emits and deletes (`completed`), the
   boundary inclusive. Advance beats 3 and 4 — one event satisfies exactly one step of one rule,
   and a completion never re-opens on the event that completed it;
3. a repeat of `step[0]` SLIDES at `stepIndex 1` (`slid`) and is IGNORED at `stepIndex ≥ 2`
   (`retriggerIgnored`);
4. no state plus a match on `step[0]` OPENS (`opened`).

A step matches only inside its own `logsource.category`, and the gate is containment in the
projection's `event.category`: a `config-access` record (`['configuration', 'file']`) IS a file
event, while an `anomaly-alert` and an audit `type` outside the closed union match no step at all.

**One clock, injected.** `observedAt = now()` at ingest for both the window and the order, so the
two carrier time scales are never mixed; a negative elapsed is clamped to 0 in one place, so a
clock jump cannot expire a live sequence early.

**The key is `carrier.instanceId` verbatim**, never parsed (ai-mistakes #19). A null key is
counted (`skippedNullInstanceId`) and takes part in nothing. The ECS projection runs inside a
`try/catch`: an unrecognised carrier counts `ingestErrors` and writes a warn rate-limited on the
same injected clock, and no exception reaches the scan cycle.

## One correction to the roadmap, made in the open

§2 names the residual miss as `A₁ … A₂ … B … C, A₁'s window expired`. That shape is **not** a
miss: A₂ arrives at `stepIndex 1` and SLIDES, so A₁'s expiry stops mattering — and it is pinned
here as firing. The real residual is the `stepIndex ≥ 2` case, `A₁ B₁ A₂ B₂ C`, which fires
nothing though `A₂ B₂ C` fit inside one window. Both are in the tests, and the module header
states which is which (ai-mistakes #27 — write the guarantee, not the impression).

## Verification

- 38 cases in `tests/main/sequence-engine.test.js`; the module measures **100% statements /
  branches / functions / lines** in isolation. The rules are hand-built and the CARRIERS are real,
  so every event goes through the real `normalizeToEcs` projection; two closing cases drive a
  loader-compiled rule, which pins that what the loader produces is what this engine consumes.
- **Fifteen mutants, fifteen red**: the order check, the expiry comparison, the group key, the
  slide, the category gate, the boundary direction, the negative clamp, advance priority, the
  completion index, `sweep`, the null-key skip, the warn rate limit, the reload count, the path
  truncation and the shared-stats reference. The tree was restored byte-identical after each.
- Two guards no mutant could kill were REMOVED rather than kept as decoration the next reader
  would maintain instead of the real mechanism (the block-1 convention).
- `git grep sequence-engine -- src/main` returns the module itself and nothing else.

## Scope, stated rather than implied

Caps and eviction (§3), the `agent-exit` cleanup with `recentlyExited`, the per-rule counter
tables and the audit record a detection becomes are prompts 2–3 and block 3. The module header
says so, so that an unbounded map and a short stats block read as a scope and not an oversight.

## Counts and the roadmap header

`main.total` 54 → 55 and `main.topLevel` 42 → 43 (CLAUDE.md, `memory-bank/architecture.md`,
`docs/current-state/CORRECTNESS-AUDIT.md`), `size.over300` 32 → 33 (CLAUDE.md, AGENTS.md,
`docs/DEVELOPMENT.md`). `counts:check` was red until every site agreed. The roadmap status header
is refreshed in the same PR, which is the convention that document states for itself.

## One pre-existing red, not from this branch

`tests/main/sequence-rule-loader.test.js > two adjacent NETWORK steps carry no adjacency warning`
fails on a **Windows checkout** at master `2e9e37f`, before this branch's first byte: the case
rewrites the fixture with `/ {4}event\.action:\n(?: {6}- \S+\n)+…/`, and under
`* text=auto` + `core.autocrlf=true` the fixture is CRLF, so `- \S+\n` cannot match, the
`file.*` selection survives a rewrite to `category: network`, and the file yields two
`unsatisfiable-field` errors instead of zero. On an LF checkout — every CI runner — the regex
matches and the case is green, which is why it merged that way. Reported, not touched: it belongs
to block 1's files.
