### PR TITLE
feat(sequences): feed the engine through the five scan taps and init it from the loader

### DIFF
--- a/bench/trace/harness.js
+++ b/bench/trace/harness.js
@@ -9,7 +9,9 @@
  *   `_state.onFileEvent`. The path from a detection to an Event Schema v1 record is
  *   closed OUTSIDE the watcher, in three places — `main.js`'s `onFileEvent`, and
  *   `scan-loop.js`'s `doFileScan` and `doHotReadScan`. None of those three is
- *   exported, so a replay has to perform the same steps itself.
+ *   reachable from a replay: the two scan-loop sites are not exported, and `main.js`
+ *   exports its handler only for its own test, behind a `require('electron')` a bench
+ *   cannot satisfy — so a replay has to perform the same steps itself.
  *
  *   That duplication is real, and it drifts silently by default: if an original grew
  *   a step, this file would keep replaying yesterday's wiring and the bench would stay
@@ -70,7 +72,7 @@ const ORCHESTRATION = Object.freeze({
  * @type {Readonly<Record<string, {file: string, anchor: string}>>}
  */
 const ORCHESTRATION_SITES = Object.freeze({
-  'fs.event': Object.freeze({ file: 'src/main/main.js', anchor: 'onFileEvent: (ev) =>' }),
+  'fs.event': Object.freeze({ file: 'src/main/main.js', anchor: 'function onFileEvent(ev) {' }),
   'handles.tick': Object.freeze({
     file: 'src/main/scan-loop.js',
     anchor: 'async function doFileScan(',

--- a/docs/roadmap/sequence-rules.md
+++ b/docs/roadmap/sequence-rules.md
@@ -7,11 +7,15 @@
 now exist and are green, and so do `src/main/sequence-engine.js` and
 `tests/main/sequence-engine.test.js` — the §2 state machine with the §3 caps and counters, the
 `agent-exit` cleanup with `recentlyExited`, the §4 null policy and the §5 detection payload with
-weakest-link attribution, still with no production caller. No gate and no wiring named in §5–§7
-exists yet — the mutation gate (§6) is prompt 3 of block 2 — so every file path below other than
-Block 1's and the engine module is still a target, not a claim. **Block 1 — LANDED. Block 2 —
+weakest-link attribution — now fed by the five §5 taps in `src/main/main.js` and
+`src/main/scan-loop.js` (engine init from the loader's rules, `sweep()` once per process tick;
+`onDetection` only logs for now). No gate and no emission named in §5–§7 exists yet — the mutation
+gate (§6) is prompt 3 of block 2, the audit record / score merge / `sequences` stats block are
+block 3 prompt 2 and the second watcher is prompt 3 — so every file path below other than Block
+1's, the engine module and the taps is still a target, not a claim. **Block 1 — LANDED. Block 2 —
 ENGINE CORE LANDED (§7 prompt 1); CAPS AND PAYLOAD LANDED (prompt 2); the mutation gate still to
-come (prompt 3). Block 3 — NOT STARTED.** When a block lands, refresh this header in the same PR
+come (prompt 3). Block 3 — TAPS AND INIT LANDED (prompt 1); emission (prompt 2) and the
+`rules/sequences` watcher (prompt 3) pending.** When a block lands, refresh this header in the same PR
 (the lag the `sensor-health-degraded.md` correction records is what a stale status line costs).
 **Branch context:** master @ `2e9e37f`; every `file:line` reference below was verified against that
 commit on 2026-08-24. Line numbers drift with every edit to the file — treat them as the place to

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -63,6 +63,7 @@ let baselines,
   exporter,
   audit,
   scanLoop,
+  sequenceEngine,
   network,
   platform,
   ideDetector,
@@ -140,6 +141,7 @@ function loadDeferredModules() {
   exporter = require('./exports');
   audit = require('./audit-logger');
   scanLoop = require('./scan-loop');
+  sequenceEngine = require('./sequence-engine');
   network = require('./network-monitor');
   platform = require('./platform');
   ideDetector = require('./ide-extension-detector');
@@ -496,6 +498,44 @@ function startWatchersWhenLoaded(webContents) {
   }
 }
 
+/**
+ * The chokidar file-event handler `file-watcher.js` calls once per event that survived
+ * its own filters: dedup, the display batch, the tray, the audit record — and tap 1 of
+ * docs/roadmap/sequence-rules.md §5. Module-level rather than a closure inside
+ * {@link initDeferredSubsystems} so the tap is reachable by a test with the two
+ * collaborators injected (`_setScanLoopForTest`, `_setSequenceEngineForTest`).
+ *
+ * The record handed to the engine is the SAME object `logAuditForFile` received —
+ * deduped, `repeatCount` stamped — and it is not pre-filtered on `instanceId`: the
+ * engine's null policy skips and counts a keyless record itself (roadmap §4). `ingest`
+ * carries its own error boundary (sequence-engine.js), so nothing here wraps it.
+ * @param {Object} ev - the FileEvent as the watcher built it.
+ * @returns {void}
+ * @since v0.14.0
+ */
+function onFileEvent(ev) {
+  const deduped = scanLoop.dedupFileEvent(ev);
+  if (!deduped) return;
+  fileAccessBatcher.push(deduped);
+  // An unattributed hit carries category 'other' (no agent to take it from),
+  // so the ai-only gate would silence exactly the crown-jewel case: a secret
+  // touched with no known owner. A vague alert beats no alert.
+  if (
+    deduped.sensitive &&
+    (deduped.category === 'ai' || deduped.attribution?.status === 'unattributed')
+  ) {
+    tray.notifySensitive([deduped]);
+  }
+  // Lazy on purpose: this fires per file event, and the batcher is 'latest' with a
+  // 1000 ms window — every payload but the last is discarded. Passing the producer
+  // builds exactly one, at flush.
+  statsUpdateBatcher.pushLazy(getStats);
+  tray.updateTrayIcon();
+  scanLoop.logAuditForFile(deduped);
+  // Tap 1 (roadmap §5): after the audit record, the same deduped object.
+  sequenceEngine.ingest(deduped);
+}
+
 /** Wires deferred modules and starts scanning. Called after ready-to-show. */
 function initDeferredSubsystems(userData) {
   loadDeferredModules();
@@ -505,6 +545,35 @@ function initDeferredSubsystems(userData) {
   require('./platform').probeReadDetection?.();
   const network = require('./network-monitor');
   const analysis = require('./ai-analysis');
+  const sequenceLoader = require('./sequence-rule-loader');
+
+  // Sequence rules (docs/roadmap/sequence-rules.md §5): `rules/sequences/` is read ONCE
+  // here and the engine takes the compiled rules. The loader has already written one
+  // `sequence-loader` warn line per warning and per load error; this is the one-line
+  // summary a reader of the log finds first, on the warn level only when there is
+  // something to warn about.
+  const sequences = sequenceLoader.loadDir();
+  const sequenceSummary = {
+    rules: sequences.rules.map((r) => r.id),
+    warnings: sequences.warnings.length,
+    loadErrors: sequences.loadErrors,
+  };
+  if (sequences.warnings.length > 0 || sequences.loadErrors > 0) {
+    logger.warn('sequence-loader', 'Sequence rules loaded with notices', {
+      ...sequenceSummary,
+      reasons: sequences.warnings.map((w) => w.reason),
+    });
+  } else {
+    logger.info('sequence-loader', 'Sequence rules loaded', sequenceSummary);
+  }
+  sequenceEngine.init({
+    rules: sequences.rules,
+    // Block 3 prompt 1: the detection is LOGGED and nothing else. The audit record
+    // (`sequence-detection`), the score merge and the `sequences` stats block are the
+    // next prompt (roadmap §5 "Emission").
+    onDetection: (detection) =>
+      logger.info('sequence-engine', `Sequence ${detection.ruleId} detected`, detection),
+  });
 
   scanLoop.init({
     scanner,
@@ -516,6 +585,7 @@ function initDeferredSubsystems(userData) {
     audit,
     tray,
     logger,
+    sequenceEngine,
     sendToRenderer,
     fileAccessBatcher,
     statsUpdateBatcher,
@@ -553,26 +623,7 @@ function initDeferredSubsystems(userData) {
     recordFileAccess: baselines.recordFileAccess,
     onActivityPush,
     onActivityEvict,
-    onFileEvent: (ev) => {
-      const deduped = scanLoop.dedupFileEvent(ev);
-      if (!deduped) return;
-      fileAccessBatcher.push(deduped);
-      // An unattributed hit carries category 'other' (no agent to take it from),
-      // so the ai-only gate would silence exactly the crown-jewel case: a secret
-      // touched with no known owner. A vague alert beats no alert.
-      if (
-        deduped.sensitive &&
-        (deduped.category === 'ai' || deduped.attribution?.status === 'unattributed')
-      ) {
-        tray.notifySensitive([deduped]);
-      }
-      // Lazy on purpose: this fires per file event, and the batcher is 'latest' with a
-      // 1000 ms window — every payload but the last is discarded. Passing the producer
-      // builds exactly one, at flush.
-      statsUpdateBatcher.pushLazy(getStats);
-      tray.updateTrayIcon();
-      scanLoop.logAuditForFile(deduped);
-    },
+    onFileEvent,
     isOtherPanelExpanded: () => otherPanelExpanded,
   });
   exporter.init({
@@ -727,6 +778,24 @@ function _setScannerForTest(mod) {
   scanner = mod;
 }
 
+/**
+ * @internal Inject the scan-loop module, normally set by loadDeferredModules (for tests).
+ * {@link onFileEvent} reads its dedup and audit entry points off this reference.
+ * @param {Object|undefined} mod
+ */
+function _setScanLoopForTest(mod) {
+  scanLoop = mod;
+}
+
+/**
+ * @internal Inject the sequence engine, normally set by loadDeferredModules (for tests).
+ * A fake with `ingest` is enough to prove tap 1 hands over the deduped record.
+ * @param {Object|undefined} mod
+ */
+function _setSequenceEngineForTest(mod) {
+  sequenceEngine = mod;
+}
+
 /** @internal Clear the one-shot guard and the registered watcher list (for tests). */
 function _resetWatchersForTest() {
   watchersStarted = false;
@@ -743,6 +812,9 @@ function _getWatchersForTest() {
 module.exports = {
   startWatchers,
   startWatchersWhenLoaded,
+  // The watcher's per-event handler, exposed so the sequence-engine tap inside it can
+  // be driven with a real dedup and a fake engine (tests/main/main-file-event-tap.test.js).
+  onFileEvent,
   // Read-only. Exposed so a test can assert the payload SHAPE — that `appHealth`,
   // `ipc` and `monitoringPaused` are siblings, and that the pre-`loadDeferredModules`
   // branch answers BOOTING instead of throwing.
@@ -750,6 +822,8 @@ module.exports = {
   getAppHealth,
   _setWatcherForTest,
   _setScannerForTest,
+  _setScanLoopForTest,
+  _setSequenceEngineForTest,
   _resetWatchersForTest,
   _getWatchersForTest,
 };

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -113,6 +113,29 @@ function logAuditForFile(ev) {
   });
 }
 
+/**
+ * Offer one live carrier to the sequence engine — the taps of
+ * docs/roadmap/sequence-rules.md §5, fed the SAME record the audit / baseline call
+ * beside each tap receives, after the existing dedup. The engine is an injected
+ * collaborator like every other one here (`deps.sequenceEngine`, wired in main.js);
+ * absent — a test that stubs only the collaborator its assertions are about — the tap
+ * is a no-op and the scan runs as before.
+ *
+ * Deliberately no try/catch: `ingest` carries its own error boundary
+ * (sequence-engine.js — an unrecognised shape or a throwing matcher is counted and
+ * dropped, never rethrown), and a second boundary here would hide a defect of the
+ * first. Records without an `instanceId` (file and network events in Schema v1) are
+ * passed through unfiltered: the engine's null policy skips and COUNTS them, and a
+ * pre-filter here would turn that count into silence (roadmap §4).
+ * @param {Object} carrier - a `FileEvent`, a `NetworkConnection` or a session record.
+ * @returns {void}
+ * @since v0.14.0
+ */
+function ingestSequence(carrier) {
+  const engine = deps.sequenceEngine;
+  if (engine && typeof engine.ingest === 'function') engine.ingest(carrier);
+}
+
 function stopScanIntervals() {
   for (const t of startupTimers) clearTimeout(t);
   startupTimers = [];
@@ -254,6 +277,8 @@ function doNetworkScan() {
             ]),
             extra: { domain: conn.domain, flagged: conn.flagged },
           });
+          // Tap 3 (roadmap §5): the connection object itself, keyless ones included.
+          ingestSequence(conn);
         }
         sendToRenderer('network-update', connections);
         logger.debug('scan', 'network', {
@@ -416,7 +441,7 @@ async function doProcessScan() {
       reliable: result.reliable !== false,
       identityDegraded,
     });
-    for (const s of entered)
+    for (const s of entered) {
       audit.log('agent-enter', {
         agent: s.agent,
         // pid and instanceId are TOP-LEVEL in v1. They were in `extra` on the belief that
@@ -433,7 +458,11 @@ async function doProcessScan() {
         attribution: null,
         extra: { startTime: s.firstSeen },
       });
-    for (const s of exited)
+      // Tap 4 (roadmap §5): the session record as session-tracker returned it — no
+      // `lastSeen` on an enter, which is how the normalizer tells the two apart.
+      ingestSequence(s);
+    }
+    for (const s of exited) {
       audit.log('agent-exit', {
         agent: s.agent,
         pid: s.pid,
@@ -445,6 +474,10 @@ async function doProcessScan() {
         // resolution step to describe.
         attribution: null,
       });
+      // Tap 4 (roadmap §5): `lastSeen` present ⇒ `agent-exit`, which the engine first
+      // offers as a step and then uses to close the instance's open states.
+      ingestSequence(s);
+    }
     watcher.pruneKnownHandles(agents);
     procUtil.annotateHostApps(agents);
     // Same `forceRefresh` contract as the identity stamp at the top of this scan:
@@ -561,6 +594,12 @@ async function doProcessScan() {
       _lastTriggeredNetScan = Date.now();
       doNetworkScan();
     }
+    // Tap 5 (roadmap §5): once per process tick, after this tick's session taps —
+    // expired open sequences and stale exit marks leave without waiting for the next
+    // event of the same key. Same optional-collaborator shape as `ingestSequence`.
+    if (deps.sequenceEngine && typeof deps.sequenceEngine.sweep === 'function') {
+      deps.sequenceEngine.sweep();
+    }
     logger.debug('scan', 'process', {
       ms: Math.round(performance.now() - t0),
       agents: agents.length,
@@ -669,6 +708,8 @@ async function doFileScan() {
       for (const ev of events) deps.fileAccessBatcher.push(ev);
       tray.notifySensitive(events.filter((e) => e.sensitive && e.category === 'ai'));
       for (const ev of events) logAuditForFile(ev);
+      // Tap 2 (roadmap §5): the deduped handle-scan events, same list the audit saw.
+      for (const ev of events) ingestSequence(ev);
     }
     // Producer, not payload: the batcher is 'latest', so a payload built here would be
     // discarded by the next push inside the same 1000 ms window.
@@ -712,6 +753,8 @@ async function doHotReadScan() {
       for (const ev of events) deps.fileAccessBatcher.push(ev);
       tray.notifySensitive(events.filter((e) => e.sensitive && e.category === 'ai'));
       for (const ev of events) logAuditForFile(ev);
+      // Tap 2 (roadmap §5): the same dedup → batch → audit pipeline as doFileScan.
+      for (const ev of events) ingestSequence(ev);
       deps.statsUpdateBatcher.pushLazy(getStats);
       tray.updateTrayIcon();
     }

--- a/tests/main/main-file-event-tap.test.js
+++ b/tests/main/main-file-event-tap.test.js
@@ -1,0 +1,150 @@
+/**
+ * Tap 1 of docs/roadmap/sequence-rules.md §5: main.js `onFileEvent` hands the record
+ * that survived `dedupFileEvent` to the sequence engine — the SAME object the audit call
+ * receives, after it — and hands nothing over for a record dedup dropped.
+ *
+ * The REAL scan-loop module does the dedup here, so "passed" and "dropped" are the
+ * production 30 s window and not a stub's opinion; only the engine and the audit sink
+ * are fakes. `app.whenReady()` never resolves in this harness, so `loadDeferredModules`
+ * never runs and the two `_set…ForTest` seams are the only collaborators main.js holds.
+ */
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import Module from 'module';
+import os from 'os';
+import { createRequire } from 'module';
+
+// ── electron stub ─────────────────────────────────────────────────────────────
+const fakeElectron = {
+  app: {
+    name: 'Aegis',
+    getPath: () => os.tmpdir(),
+    getVersion: () => '0.0.0-test',
+    setName: () => {},
+    disableHardwareAcceleration: () => {},
+    requestSingleInstanceLock: () => true,
+    whenReady: () => new Promise(() => {}),
+    on: () => {},
+    quit: () => {},
+  },
+  BrowserWindow: class {},
+  globalShortcut: { register: () => {}, unregisterAll: () => {} },
+  shell: { openExternal: () => {} },
+  ipcMain: { handle: () => {}, on: () => {} },
+  dialog: {},
+  Notification: class {},
+  Tray: class {},
+  Menu: { buildFromTemplate: (t) => t },
+  nativeImage: { createFromBuffer: (b) => b },
+  safeStorage: { isEncryptionAvailable: () => false },
+};
+
+const originalLoad = Module._load;
+Module._load = function (request, _parent, _isMain) {
+  if (request === 'electron') return fakeElectron;
+  return originalLoad.apply(this, arguments);
+};
+
+const originalArgv = process.argv;
+// main.js exits early via a module-scope `return` when argv carries a CLI flag —
+// vitest's own argv must not trip that branch and blank out module.exports.
+process.argv = ['node', 'main.js'];
+
+// createRequire, not `import`: main.js is CommonJS with a module-scope `return`, which
+// is a syntax error under an ESM transform but legal for the CJS loader.
+const require_ = createRequire(import.meta.url);
+const main = require_('../../src/main/main.js');
+
+afterAll(() => {
+  Module._load = originalLoad;
+  process.argv = originalArgv;
+});
+
+/** One attributed, non-sensitive FileEvent as file-watcher.js builds it. */
+function fileEvent() {
+  return {
+    agent: 'Claude Code',
+    pid: 100,
+    instanceId: '100:1717000000000',
+    file: 'C:\\Users\\me\\passwords.txt',
+    action: 'accessed',
+    sensitive: false,
+    category: 'ai',
+    attribution: { status: 'confirmed', evidence: ['cwd-containment'] },
+    timestamp: 1717000005000,
+  };
+}
+
+describe('main — file-event tap into the sequence engine', () => {
+  let engine;
+  let auditLog;
+
+  beforeEach(() => {
+    // Fake timers: the two batchers `onFileEvent` pushes into would otherwise arm real
+    // flush timers that fire after this file is torn down.
+    vi.useFakeTimers();
+    // A FRESH scan-loop per test: its dedup map is module state, and a record dropped
+    // here must be dropped by THIS test's window, not a previous test's.
+    const scanLoopPath = require_.resolve('../../src/main/scan-loop.js');
+    delete require_.cache[scanLoopPath];
+    const scanLoop = require_('../../src/main/scan-loop.js');
+    auditLog = vi.fn();
+    scanLoop.init({ audit: { log: auditLog } });
+    engine = { ingest: vi.fn(), sweep: vi.fn() };
+    main._setScanLoopForTest(scanLoop);
+    main._setSequenceEngineForTest(engine);
+  });
+
+  afterEach(() => {
+    main._setScanLoopForTest(undefined);
+    main._setSequenceEngineForTest(undefined);
+    vi.useRealTimers();
+  });
+
+  it('ingests the record that passed dedup — the very object the audit call received', () => {
+    const ev = fileEvent();
+    main.onFileEvent(ev);
+
+    expect(engine.ingest).toHaveBeenCalledTimes(1);
+    // Identity, not equality: the deduped record carries `repeatCount` now, and the
+    // engine must see that object, not a copy taken before dedup.
+    expect(engine.ingest.mock.calls[0][0]).toBe(ev);
+    expect(ev.repeatCount).toBe(1);
+    expect(auditLog).toHaveBeenCalledTimes(1);
+    expect(auditLog.mock.calls[0][1].instanceId).toBe(ev.instanceId);
+    // After the audit record, never before it.
+    expect(engine.ingest.mock.invocationCallOrder[0]).toBeGreaterThan(
+      auditLog.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('hands nothing over for a record dedup dropped, and does again past the window', () => {
+    main.onFileEvent(fileEvent());
+    // Same instance + same path inside 30 s: dedup returns null, so neither the audit
+    // nor the engine sees it.
+    main.onFileEvent(fileEvent());
+    expect(engine.ingest).toHaveBeenCalledTimes(1);
+    expect(auditLog).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(31000);
+    main.onFileEvent(fileEvent());
+    expect(engine.ingest).toHaveBeenCalledTimes(2);
+    expect(auditLog).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes a keyless (unattributed) record through unfiltered — the engine counts it', () => {
+    const ev = {
+      ...fileEvent(),
+      agent: '',
+      pid: null,
+      instanceId: null,
+      category: 'other',
+      attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+    };
+    main.onFileEvent(ev);
+
+    // Roadmap §4: the null policy lives in the engine (`skippedNullInstanceId`); a tap
+    // that dropped the record first would turn a counted skip into silence.
+    expect(engine.ingest).toHaveBeenCalledTimes(1);
+    expect(engine.ingest.mock.calls[0][0]).toBe(ev);
+  });
+});

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -1550,4 +1550,260 @@ describe('scan-loop', () => {
       expect(records.some((r) => r.pid === 100)).toBe(true);
     });
   });
+
+  // ── sequence-engine taps (docs/roadmap/sequence-rules.md §5) ──
+
+  describe('sequence-engine taps', () => {
+    /** A fake engine: the two calls the taps make, nothing else. */
+    function makeEngine() {
+      return { ingest: vi.fn(), sweep: vi.fn() };
+    }
+
+    /**
+     * Two file events of one instance on ONE path: the first passes `dedupFileEvent`
+     * and the second is dropped by the 30 s window — so a tap fed the RAW list would
+     * call ingest twice and a tap fed the deduped list exactly once.
+     * @returns {Array<Object>}
+     */
+    function twoEventsOnePath() {
+      return [
+        {
+          agent: 'Claude Code',
+          pid: 100,
+          instanceId: '100:1717000000000',
+          file: 'C:\\Users\\me\\passwords.txt',
+          action: 'holding',
+          sensitive: true,
+          category: 'ai',
+          attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
+        },
+        {
+          agent: 'Claude Code',
+          pid: 100,
+          instanceId: '100:1717000000000',
+          file: 'C:\\Users\\me\\passwords.txt',
+          action: 'holding',
+          sensitive: true,
+          category: 'ai',
+          attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
+        },
+      ];
+    }
+
+    it('tap 2: doFileScan ingests each event that passed dedup and none that dedup dropped', async () => {
+      const sequenceEngine = makeEngine();
+      const raw = twoEventsOnePath();
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue([{ agent: 'Claude Code' }]),
+        watcher: {
+          pruneKnownHandles: vi.fn(),
+          scanAllFileHandles: vi.fn().mockResolvedValue(raw),
+        },
+        sequenceEngine,
+      });
+      scanLoop.init(deps);
+      // staggeredStartup(_, paused=true): doProcessScan @3s, doFileScan @8s, no warmup
+      scanLoop.staggeredStartup(5000, true);
+      await vi.advanceTimersByTimeAsync(8000);
+
+      expect(sequenceEngine.ingest).toHaveBeenCalledTimes(1);
+      // The SAME record the audit call received — dedup stamps `repeatCount` on it.
+      expect(sequenceEngine.ingest).toHaveBeenCalledWith(raw[0]);
+      expect(sequenceEngine.ingest).not.toHaveBeenCalledWith(raw[1]);
+      expect(deps.audit.log.mock.calls.filter((c) => c[0] === 'file-access')).toHaveLength(1);
+    });
+
+    it('tap 2: doHotReadScan ingests the deduped hot-read events through the same tap', async () => {
+      const sequenceEngine = makeEngine();
+      const raw = twoEventsOnePath();
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue([{ agent: 'Claude Code' }]),
+        watcher: {
+          pruneKnownHandles: vi.fn(),
+          scanAllFileHandles: vi.fn().mockResolvedValue([]),
+          scanHotFileHolders: vi.fn().mockResolvedValue(raw),
+          isHotReadScanActive: vi.fn().mockReturnValue(true),
+        },
+        sequenceEngine,
+      });
+      scanLoop.init(deps);
+      // The hot-read interval is 10 s and only exists when the watcher reports it
+      // active; the process tick is pushed past it so the first hot read is the only
+      // scan that has run.
+      scanLoop.startScanIntervals(20000);
+      await vi.advanceTimersByTimeAsync(10000);
+
+      expect(deps.watcher.scanHotFileHolders).toHaveBeenCalledTimes(1);
+      expect(sequenceEngine.ingest).toHaveBeenCalledTimes(1);
+      expect(sequenceEngine.ingest).toHaveBeenCalledWith(raw[0]);
+      expect(sequenceEngine.ingest).not.toHaveBeenCalledWith(raw[1]);
+    });
+
+    it('tap 3: doNetworkScan ingests every connection it records, keyless ones included', async () => {
+      const sequenceEngine = makeEngine();
+      const connections = [
+        {
+          agent: 'Claude Code',
+          pid: 100,
+          instanceId: '100:1717000000000',
+          remoteIp: '1.2.3.4',
+          remotePort: 443,
+          state: 'ESTABLISHED',
+          flagged: false,
+        },
+        // Matched no agent: the engine's own null policy skips and counts it — the
+        // tap does not pre-filter (roadmap §4).
+        {
+          agent: '',
+          pid: null,
+          instanceId: null,
+          remoteIp: '9.9.9.9',
+          remotePort: 80,
+          state: 'ESTABLISHED',
+          flagged: true,
+        },
+      ];
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue([{ agent: 'Claude Code' }]),
+        network: {
+          isNetworkScanRunning: vi.fn().mockReturnValue(false),
+          setNetworkScanRunning: vi.fn(),
+          scanNetworkConnections: vi.fn().mockResolvedValue(connections),
+        },
+        sequenceEngine,
+      });
+      scanLoop.init(deps);
+      scanLoop.doNetworkScan();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sequenceEngine.ingest.mock.calls.map((c) => c[0])).toEqual(connections);
+      // Beside `recordNetworkEndpoint`: one ingest per endpoint recorded, same objects.
+      expect(deps.baselines.recordNetworkEndpoint).toHaveBeenCalledTimes(2);
+    });
+
+    /**
+     * Deps whose scanner returns a stamped agent on the ticks `present` says so, so
+     * session-tracker reports an enter on the first tick and — after the exit grace —
+     * an exit once the agent is gone.
+     * @param {Object} sequenceEngine
+     * @param {(tick: number) => boolean} present
+     * @returns {Object}
+     */
+    function makeSessionDeps(sequenceEngine, present) {
+      let tick = 0;
+      return makeDeps({
+        scanner: {
+          scanProcesses: vi.fn().mockImplementation(async () => {
+            tick++;
+            return {
+              agents: present(tick)
+                ? [
+                    {
+                      agent: 'Claude Code',
+                      process: 'claude.exe',
+                      pid: 100,
+                      startTime: 1717000000000,
+                      instanceId: '100:1717000000000',
+                      instanceIdSource: 'os',
+                      category: 'ai',
+                    },
+                  ]
+                : [],
+              changed: false,
+              reliable: true,
+            };
+          }),
+        },
+        sequenceEngine,
+      });
+    }
+
+    it('tap 4: doProcessScan ingests the session record of an agent that entered', async () => {
+      require_('../../src/main/session-tracker.js')._resetForTest();
+      const sequenceEngine = makeEngine();
+      const deps = makeSessionDeps(sequenceEngine, () => true);
+      scanLoop.init(deps);
+      scanLoop.startScanIntervals(5000);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const enter = deps.audit.log.mock.calls.find((c) => c[0] === 'agent-enter');
+      expect(enter).toBeTruthy();
+      expect(sequenceEngine.ingest).toHaveBeenCalledTimes(1);
+      // What session-tracker returned, unchanged: `firstSeen` and NO `lastSeen`, which
+      // is how the normalizer tells an enter from an exit.
+      const [record] = sequenceEngine.ingest.mock.calls[0];
+      expect(record).toEqual({
+        pid: 100,
+        instanceId: '100:1717000000000',
+        agent: 'Claude Code',
+        process: 'claude.exe',
+        firstSeen: expect.any(Number),
+      });
+      expect(record).not.toHaveProperty('lastSeen');
+      expect(record.firstSeen).toBe(enter[1].extra.startTime);
+    });
+
+    it('tap 4: doProcessScan ingests the session record of an agent that exited', async () => {
+      const sessionTracker = require_('../../src/main/session-tracker.js');
+      sessionTracker._resetForTest();
+      const sequenceEngine = makeEngine();
+      // Present on tick 1 only; the exit is reported after DEFAULT_EXIT_GRACE misses.
+      const deps = makeSessionDeps(sequenceEngine, (tick) => tick === 1);
+      scanLoop.init(deps);
+      scanLoop.startScanIntervals(5000);
+      for (let i = 0; i < 1 + sessionTracker.DEFAULT_EXIT_GRACE; i++) {
+        await vi.advanceTimersByTimeAsync(5000);
+      }
+
+      const exit = deps.audit.log.mock.calls.find((c) => c[0] === 'agent-exit');
+      expect(exit).toBeTruthy();
+      // One enter, one exit — and the exit carrier carries `lastSeen`.
+      expect(sequenceEngine.ingest).toHaveBeenCalledTimes(2);
+      const [record] = sequenceEngine.ingest.mock.calls[1];
+      expect(record).toEqual({
+        pid: 100,
+        instanceId: '100:1717000000000',
+        agent: 'Claude Code',
+        process: 'claude.exe',
+        firstSeen: expect.any(Number),
+        lastSeen: expect.any(Number),
+      });
+      expect(record.instanceId).toBe(exit[1].instanceId);
+    });
+
+    it('tap 5: sweep runs exactly once per process tick, after the scans', async () => {
+      const sequenceEngine = makeEngine();
+      const deps = makeDeps({ sequenceEngine });
+      scanLoop.init(deps);
+      scanLoop.startScanIntervals(5000);
+
+      expect(sequenceEngine.sweep).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(sequenceEngine.sweep).toHaveBeenCalledTimes(1);
+      // The sweep follows the tick's session reconcile: the enter/exit taps have
+      // already run when it fires.
+      const sweepOrder = sequenceEngine.sweep.mock.invocationCallOrder[0];
+      const scanOrder = deps.scanner.scanProcesses.mock.invocationCallOrder[0];
+      expect(sweepOrder).toBeGreaterThan(scanOrder);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(sequenceEngine.sweep).toHaveBeenCalledTimes(2);
+    });
+
+    it('a scan without an injected engine still completes — the tap is a no-op', async () => {
+      const deps = makeDeps({
+        getLatestAgents: vi.fn().mockReturnValue([{ agent: 'Claude Code' }]),
+        watcher: {
+          pruneKnownHandles: vi.fn(),
+          scanAllFileHandles: vi.fn().mockResolvedValue(twoEventsOnePath()),
+        },
+      });
+      scanLoop.init(deps);
+      scanLoop.staggeredStartup(5000, true);
+      await vi.advanceTimersByTimeAsync(8000);
+
+      expect(deps.logger.error).not.toHaveBeenCalled();
+      expect(deps.audit.log.mock.calls.filter((c) => c[0] === 'file-access')).toHaveLength(1);
+      expect(deps.sendToRenderer).toHaveBeenCalledWith('scan-batch', expect.any(Object));
+    });
+  });
 });

--- a/tests/shared/bench-trace/orchestration-drift.test.js
+++ b/tests/shared/bench-trace/orchestration-drift.test.js
@@ -6,8 +6,10 @@
  *   WHY THE DUPLICATION EXISTS. `handleWatcherEvent` does not write to the audit log;
  *   the path from a detection to an Event Schema v1 record is closed outside the
  *   watcher, in `main.js`'s `onFileEvent` and in `scan-loop.js`'s `doFileScan` and
- *   `doHotReadScan`. None of those three is exported, so a replay performs the same
- *   steps itself — and a copy drifts silently by default. If an original grew a step,
+ *   `doHotReadScan`. None of those three is reachable from a replay (the scan-loop
+ *   sites are not exported; `main.js` exports its handler for its own test only, behind
+ *   an `electron` require), so a replay performs the same steps itself — and a copy
+ *   drifts silently by default. If an original grew a step,
  *   the harness would keep replaying yesterday's wiring while every suite stayed
  *   green, and the bench's green would stop meaning anything.
  *


### PR DESCRIPTION
## What

Block 3 prompt 1 of `docs/roadmap/sequence-rules.md` — the sequence engine gets its first production caller. Taps and init only; emission (audit record, score merge, `sequences` stats block) and the second watcher are prompts 2 and 3.

### main.js
- `loadDeferredModules` requires `sequence-engine`; `initDeferredSubsystems` requires `sequence-rule-loader`, calls `loadDir()` once, logs a one-line `sequence-loader` summary (`warn` only when the loader reported warnings or load errors, `info` otherwise — the loader already writes one line per cause), and calls `sequenceEngine.init({ rules, onDetection })`. `onDetection` only does `logger.info('sequence-engine', ...)` with the payload.
- The engine is injected into `scanLoop.init` like every other collaborator (no module-level require inside scan-loop).
- **Tap 1** — the chokidar `onFileEvent` handler is now a module-level function (same body as the inline closure, plus `sequenceEngine.ingest(deduped)` after `logAuditForFile`), so a test can drive it with `_setScanLoopForTest` / `_setSequenceEngineForTest`.

### scan-loop.js
- `ingestSequence(carrier)` — one helper: `deps.sequenceEngine.ingest` when injected, no-op when absent. No second try/catch (ingest has its own boundary); no `instanceId` pre-filter (the engine's null policy counts keyless records).
- **Tap 2** `doFileScan` / `doHotReadScan` — the deduped events, same list the audit saw.
- **Tap 3** `doNetworkScan` — every connection, beside `recordNetworkEndpoint` / the audit call.
- **Tap 4** `doProcessScan` — the session record on both the `entered` and the `exited` loop, as session-tracker returned it (`lastSeen` is what the normalizer keys enter/exit on).
- **Tap 5** — `sequenceEngine.sweep()` once per process tick, after the session taps.

### Tests
- `tests/main/scan-loop.test.js` +7: taps 2 (file + hot read), 3, 4 (enter + exit), 5 (exactly once per tick, after the scan), plus a scan with no engine injected. Each tap test asserts ingest received the record that passed dedup and **not** the one dedup dropped.
- `tests/main/main-file-event-tap.test.js` (new): tap 1 on the real `dedupFileEvent` with a fake engine — identity of the object, the dropped duplicate, the window reopening, and a keyless record passed through. Mutating the tap out turns all three red.
- `bench/trace/harness.js` + `tests/shared/bench-trace/orchestration-drift.test.js`: the drift guard anchors `fs.event` on the `onFileEvent` site and went red on the move; the anchor now reads `function onFileEvent(ev) {` (the guard's own message names the harness as the file to update). The derived sequence is unchanged — `ingestSequence` is not a watched step. Both headers stop claiming the handler is unexported.

### Docs
- `docs/roadmap/sequence-rules.md` Status header only: block 3 prompt 1 landed, prompts 2–3 pending.

## Live check (isolated `--user-data-dir`, main-process inspector)

See the PR conversation for the `getStats()` snapshots and the `sequence-engine` log line from a `claude.exe`-named holder that read `~/.env.aegis-smoke-passwords` and held a 443 connection.

## Gates

`build:renderer`, `format:check`, `lint`, `typecheck`, `typecheck:svelte`, `test:coverage`, `verify:gate`, `counts:check`, `npm audit --audit-level=high --omit=dev` — all green locally on this branch.
