### PR TITLE
docs: fix the fork-PR approval condition, the 300-line rule and the version pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,4 +91,4 @@ coverage thresholds are configured in `vitest.config.js`, so coverage cannot fai
 - Don't skip tests — every new module needs a test file in `tests/`
 - Don't add features not explicitly requested
 - Don't modify files not mentioned in the task
-- Don't let a new file blow past 300 lines — extract instead
+- Don't treat 300 lines/file as a hard limit — it is a target for NEW files, not an invariant (see Code conventions): never split an existing file just to hit it, and do extract when adding to one already over

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -59,7 +59,7 @@ JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily r
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
 - **Tests**: Vitest; run `npm test` for current pass/skip and file counts
 - **License**: MIT
-- **Version**: see `version` in `package.json`
+- **Version**: 0.13.0-alpha
 - **Platform**: Windows, macOS, Linux
 
 ## Links

--- a/llms.txt
+++ b/llms.txt
@@ -25,7 +25,7 @@
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
 - **Tests**: Vitest; run `npm test` for current pass/skip and file counts
 - **License**: MIT
-- **Version**: see `version` in `package.json`
+- **Version**: 0.13.0-alpha
 - **Platform**: Windows, macOS, Linux
 
 ## Links

--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -433,6 +433,47 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     `gh api repos/{owner}/{repo}/actions/runs/{id}/approve -X POST`; the approved run comes
     back as `run_attempt: 2`. A run parked this way is indistinguishable from a slow one on
     the PR page, so find it by head SHA rather than waiting.
+    **Correction 2026-08-25 — (a) generalised from two first-time contributors. Approval is
+    gated on CONTRIBUTOR CLASS, not on the PR being a fork: a fork PR whose author already
+    has a merged PR here starts CI unapproved, and the setting that says so is readable.**
+    Found merging #304/#305/#306 (all `MsfPablo`), where every head ran on its own — three
+    PRs in a row, and again after `update-branch`.
+    **The setting is the answer, and it is neither of the two #35 ruled out.**
+    `gh api repos/antropos17/Aegis/actions/permissions/fork-pr-contributor-approval`
+    → `{"approval_policy":"first_time_contributors"}` — the middle of GitHub’s three
+    options, so only an author who has not yet landed a commit in this repository needs the
+    click. The endpoints #35 checked govern something else and always will:
+    `.../actions/permissions` is `enabled: true, allowed_actions: all,
+    sha_pinning_required: false`, and `.../actions/permissions/workflow` publishes only
+    `default_workflow_permissions` and `can_approve_pull_request_reviews`.
+    **The discriminator is attempt 1’s conclusion, NOT `run_attempt`** — #35 already
+    recorded an approved run coming back `run_attempt: 1`, so the counter cannot answer
+    this. A parked run’s `/actions/runs/{id}/attempts/1` reads `conclusion: action_required`;
+    a run that was never parked has ONE attempt reading `success`, with
+    `run_started_at == created_at`. MsfPablo’s first run (`32719377298`, #298, head
+    `7f474b2`) has attempt 1 `action_required` and attempt 2 `success`. #304’s two runs —
+    `32764969825` (`a30a74c`) and `32797158207` (`565f2a2`, post-`update-branch`) — each
+    have one attempt, `success`, started the second they were created.
+    **The waiver switches on at the MERGE, not at the approval — measured to the second.**
+    `32719377298` was approved 2026-08-24T10:57:24Z; #298 merged 10:58:43Z; #301’s head
+    `de28147` was created 10:59:09Z — 26 s later — and ran unapproved, as did every MsfPablo
+    run after it (#299, #300, all three heads of #304/#305/#306 on 08-24, and all three
+    post-`update-branch` heads on 08-25: `565f2a2`, `c5e44d4`, `1635592`). "One approval
+    waives the rest" is refuted by the same census: `mig-builds` was parked twice (`0ef5ec3`
+    08-22, `10c9592` 08-23) and `anupamme` twice (`1c20505`, `d4e586b`, both 08-21), each
+    pair falling entirely before that author’s first merge.
+    **Census, so the condition is not read off one case.** Every fork-originated run the API
+    still returns — `gh api 'repos/antropos17/Aegis/actions/runs?event=pull_request&per_page=100&page=N'`
+    over all five pages, 409 `pull_request` runs, 21 of them from forks across six
+    contributors (anupamme, mig-builds, frobel0520, MsfPablo, ElshadHu, travisbreaks) —
+    splits 21/21 on one line: parked while its author had no merged PR here, unparked after.
+    `ElshadHu` crossed it at #26 (2026-02-19) and `travisbreaks` at #50 (2026-03-01), each
+    with the same before/after shape.
+    **What this does NOT retire.** (b) stands exactly as written, and this entry is why:
+    mig-builds was STILL first-time when #273 was updated — the PR merged one minute after
+    the second approval — so the second round was required, not redundant. (c) and (d) are
+    untouched. #35 is untouched too: a release-please PR is parked because GITHUB_TOKEN
+    authored the event, which no contributor history waives.
     (b) **Merging one PR invalidates the approval of every other open one.** master is
     `strict: true`, so the moment #274 merged, #273 went `behind_by: 2` and CLEAN flipped to
     BEHIND. `gh pr update-branch` fixes it while `maintainerCanModify` is true — and it

--- a/scripts/counts.js
+++ b/scripts/counts.js
@@ -220,6 +220,20 @@ function deriveFileSizes() {
   };
 }
 
+/**
+ * The one derivation here that does not answer a number. `package.json` is the single
+ * source — CLAUDE.md's own header runs this command rather than quoting a version — and
+ * a semver string compares by identity exactly the way an integer does: everything
+ * downstream of a value is `!==` or `String()`.
+ * @returns {string} the `version` field of package.json.
+ */
+function deriveVersion() {
+  const pkg = /** @type {*} */ (JSON.parse(readTracked('package.json')));
+  if (typeof pkg.version !== 'string' || pkg.version === '')
+    throw new Error('package.json: no `version` string');
+  return pkg.version;
+}
+
 const mutants = deriveMutants();
 const ci = deriveCi();
 const preload = derivePreload();
@@ -227,6 +241,7 @@ const database = deriveAgentDatabase();
 const ruleset = deriveRules();
 const sequences = deriveSequences();
 const sizes = deriveFileSizes();
+const version = deriveVersion();
 
 const mainAll = trackedUnder('src/main', (p) => p.endsWith('.js'));
 const mainTop = trackedTopLevel('src/main', (f) => f.endsWith('.js'));
@@ -240,7 +255,15 @@ const mainTop = trackedTopLevel('src/main', (f) => f.endsWith('.js'));
  * A counter earns a place here only if prose can restate its value and stay true for
  * more than one commit. One that moves on an ordinary single-line edit belongs in
  * `DERIVED_ONLY` below instead.
- * @type {Array<{key: string, label: string, value: number, command: string}>}
+ *
+ * An entry may also carry `blocking: false`. It is derived, located, compared and
+ * printed like every other, and a disagreement is reported under its own heading — it
+ * simply does not exit 1. That is a THIRD position between "checked" and
+ * `DERIVED_ONLY`, not a skip flag: the counter keeps its declaration sites, so the
+ * undeclared gate and the unparseable gate still apply to it in full. `package.version`
+ * is the only one, and carries the reason at its entry.
+ * @type {Array<{key: string, label: string, value: number|string, command: string,
+ *   blocking?: boolean}>}
  */
 const COUNTERS = [
   {
@@ -375,6 +398,25 @@ const COUNTERS = [
     command:
       "git ls-files -z src | grep -zv '\\.json$' | xargs -0 wc -l | awk '$1 > 300 && $2 != \"total\"' | wc -l",
   },
+  {
+    key: 'package.version',
+    label: 'package.json version',
+    value: version,
+    command: 'node -p "require(\'./package.json\').version"',
+    // `blocking: false`, and the reason is release-please. Its release PR bumps
+    // `version` in package.json and touches neither llms file, so a blocking compare
+    // would turn the `test` context red on that PR and STAY red on master afterwards
+    // until somebody hand-edited prose — a required context failing on the one commit
+    // nobody authors by hand, which is the exact failure the DERIVED_ONLY block below
+    // was written about. Moving the version there instead would take its declaration
+    // sites away, and two files free to say anything is how llms.txt and llms-full.txt
+    // came to answer "see `version` in `package.json`" — true, and useless to a crawler
+    // reading either file standalone. So it is located, compared and reported, and only
+    // the exit code is withheld. Making it blocking is a release-please `extra-files`
+    // change (it would have to rewrite both prose sites in the bump commit), not a
+    // change here.
+    blocking: false,
+  },
 ];
 
 /**
@@ -415,7 +457,8 @@ const DERIVED_ONLY = [
 /**
  * Checked counters only. A `DERIVED_ONLY` key is absent from this map by construction,
  * which is what stops the stale gate from ever resolving one.
- * @type {Map<string, {key: string, label: string, value: number, command: string}>}
+ * @type {Map<string, {key: string, label: string, value: number|string, command: string,
+ *   blocking?: boolean}>}
  */
 const BY_KEY = new Map(COUNTERS.map((c) => [c.key, c]));
 
@@ -485,11 +528,30 @@ function pick(line, rules) {
 }
 
 /**
+ * `pick` for a counter whose value is not an integer. The capture is taken as written
+ * instead of going through `toInt`, which answers null for a semver and would drop the
+ * declaration silently — an absent site rather than a wrong one, which is the failure
+ * mode this file exists to prevent.
+ * @param {string} line
+ * @param {Array<[string, RegExp]>} rules
+ * @returns {Array<{key: string, value: string}>}
+ */
+function pickText(line, rules) {
+  /** @type {Array<{key: string, value: string}>} */
+  const found = [];
+  for (const [key, re] of rules) {
+    const m = line.match(re);
+    if (m && m[1]) found.push({ key, value: m[1] });
+  }
+  return found;
+}
+
+/**
  * Each scanner's `locate` is intentionally wider than its `parse`. When `locate`
  * fires and `parse` returns nothing, the site is reported as UNPARSEABLE and the run
  * goes red — a reworded declaration must never read as an absent one.
  * @type {Array<{id: string, locate: RegExp, parse: (line: string) =>
- *   Array<{key: string, value: number}>}>}
+ *   Array<{key: string, value: number|string}>}>}
  */
 const SCANNERS = [
   {
@@ -661,6 +723,25 @@ const SCANNERS = [
     locate: new RegExp(`\\bexceeds?\\s+it\\b|${DIGITS}\\s+existing\\b`, 'i'),
     parse: (line) => pick(line, [['size.over300', new RegExp(`${DIGITS}\\s+existing\\b`, 'i')]]),
   },
+  {
+    id: 'app-version',
+    // The declaration is a labelled prose field — `- **Version**: <semver>` in llms.txt
+    // and llms-full.txt, the two files a crawler reads standalone and cannot resolve a
+    // pointer out of. The locator is the LABEL alone, so a value that stops being a
+    // version ("latest", a range, a codename) locates, parses to nothing and goes red.
+    //
+    // One reword it cannot catch, stated rather than left to be discovered
+    // (ai-mistakes #27): `hasNumber()` gates every line before any scanner sees it, and
+    // "**Version**: see `version` in `package.json`" — the sentence this counter
+    // replaces — carries no digit and no spelled-out number, so it is skipped, not
+    // reported. What catches that reword is the UNDECLARED gate, and only once BOTH
+    // sites are gone; reword one and the other still declares the counter, and the run
+    // stays green. Widening `hasNumber` is not the fix — it is load-bearing for every
+    // scanner above, and loosening it turns each of them into a noise source.
+    locate: /\*\*Version\*\*\s*:/i,
+    parse: (line) =>
+      pickText(line, [['package.version', /\*\*Version\*\*\s*:\s*`?v?(\d+\.\d+\.\d+[\w.+-]*)`?/i]]),
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -794,7 +875,10 @@ function hasNumber(line) {
 // Scan.
 // ---------------------------------------------------------------------------
 
-/** @type {Array<{file: string, line: number, key: string, declared: number, text: string}>} */
+/**
+ * @type {Array<{file: string, line: number, key: string, declared: number|string,
+ *   text: string}>}
+ */
 const declarations = [];
 /** @type {Array<{file: string, line: number, scanner: string, text: string}>} */
 const unparseable = [];
@@ -849,7 +933,10 @@ for (const file of TRACKED) {
 // Compare and report.
 // ---------------------------------------------------------------------------
 
-const mismatches = declarations.filter((d) => BY_KEY.get(d.key).value !== d.declared);
+const disagreements = declarations.filter((d) => BY_KEY.get(d.key).value !== d.declared);
+const mismatches = disagreements.filter((d) => BY_KEY.get(d.key).blocking !== false);
+const drifted = disagreements.filter((d) => BY_KEY.get(d.key).blocking === false);
+const nonBlocking = COUNTERS.filter((c) => c.blocking === false);
 const undeclared = COUNTERS.filter((c) => !declarations.some((d) => d.key === c.key));
 const staleSiteExemptions = SITE_EXEMPTIONS.filter((_, i) => !usedSiteExemptions.has(i));
 const staleArchival = ARCHIVAL.filter((a) => !usedArchival.has(a.file));
@@ -864,7 +951,10 @@ for (const c of COUNTERS) {
   const sites = declarations.filter((d) => d.key === c.key).length;
   console.log(`  ${c.key.padEnd(20)} = ${String(c.value).padStart(5)}   ${c.label}`);
   console.log(`  ${' '.repeat(20)}     ${c.command}`);
-  console.log(`  ${' '.repeat(20)}     declared at ${sites} site${sites === 1 ? '' : 's'}`);
+  console.log(
+    `  ${' '.repeat(20)}     declared at ${sites} site${sites === 1 ? '' : 's'}` +
+      (c.blocking === false ? ' — reported, never blocking' : ''),
+  );
 }
 
 head('Derived only — no declaration sites by design');
@@ -894,6 +984,22 @@ for (const e of SITE_EXEMPTIONS) console.log(`    line      ${e.file} "${e.conta
 console.log(`    self      ${SELF_EXCLUSION.file} — ${SELF_EXCLUSION.why}`);
 
 let failed = false;
+
+if (drifted.length > 0) {
+  head(`Drift reported, not blocking (${drifted.length})`);
+  console.log(
+    '  These sites disagree with the tree and this run still exits 0, because their\n' +
+      '  counter is marked `blocking: false` for the reason recorded at its COUNTERS\n' +
+      '  entry. Nothing else will catch them: fix the prose.',
+  );
+  for (const d of drifted) {
+    const c = BY_KEY.get(d.key);
+    console.log(`  ${d.file}:${d.line}`);
+    console.log(`    ${d.key} declared ${d.declared}, derived ${c.value}  (${c.label})`);
+    console.log(`    ${c.command}`);
+    console.log(`    > ${d.text.slice(0, 160)}`);
+  }
+}
 
 if (mismatches.length > 0) {
   failed = true;
@@ -951,8 +1057,10 @@ if (failed) {
 }
 
 console.log(
-  `\ncounts:check OK — ${COUNTERS.length} checked counters derived from the tree, ` +
-    `${declarations.length} declaration sites agree; ` +
+  `\ncounts:check OK — ${COUNTERS.length} checked counters derived from the tree ` +
+    `(${nonBlocking.length} of them reported-only: ${nonBlocking.map((c) => c.key).join(', ')}), ` +
+    `${declarations.length - drifted.length} of ${declarations.length} declaration sites agree ` +
+    `and ${drifted.length} drifted without blocking; ` +
     `${DERIVED_ONLY.length} derived-only counters printed and declared nowhere by ` +
     `design (${COUNTERS.length + DERIVED_ONLY.length} counters derived in total).`,
 );


### PR DESCRIPTION
Three documentation debts surfaced while merging #304-#306 and #311. Nothing under `src/`, `tests/`, `docs/roadmap/`, `memory-bank/progress.md` or `CONTRIBUTING.md` is touched.

## 1. ai-mistakes #34(a) named the wrong approval condition

#34(a) said a fork PR's workflow run sits at `action_required` until somebody approves it. That generalised from #273 and #274, whose authors were both first-time contributors. Approval is gated on **contributor class, not on the PR being a fork.**

**The setting, which is readable and is neither of the two #35 ruled out:**

```
gh api repos/antropos17/Aegis/actions/permissions/fork-pr-contributor-approval
{"approval_policy":"first_time_contributors"}
```

The middle of GitHub's three options: only an author who has not yet landed a commit here needs the click.

**The discriminator is attempt 1's conclusion, not `run_attempt`** — #35 already recorded an approved release run coming back `run_attempt: 1`, so the counter cannot answer this. A parked run's `/attempts/1` reads `conclusion: action_required`; a run that was never parked has one attempt reading `success` with `run_started_at == created_at`.

| | run | attempt 1 | outcome |
|---|---|---|---|
| MsfPablo's first (#298, `7f474b2`) | `32719377298` | `action_required` | approved → attempt 2 `success` |
| #304 first head (`a30a74c`) | `32764969825` | `success` | never parked |
| #304 post-`update-branch` (`565f2a2`) | `32797158207` | `success` | never parked |

**The waiver switches on at the MERGE, not at the approval.** `32719377298` was approved 2026-08-24T10:57:24Z; #298 merged 10:58:43Z; #301's head `de28147` was created 10:59:09Z — 26 s later — and ran unapproved, as did every MsfPablo run after it, including all three heads of #304/#305/#306 and all three post-`update-branch` heads. "One approval waives the rest" is refuted by the same data: `mig-builds` was parked twice and `anupamme` twice, each pair falling entirely before that author's first merge.

**Census, so the rule is not read off one case.** All 21 fork-originated runs the API still returns (409 `pull_request` runs, six contributors) split 21/21 on one line: parked while the author had no merged PR here, unparked after.

The correction is appended inside #34 as a dated block, the way #35 and #36 are written. Nothing is renumbered and no line is deleted. It states explicitly what it does **not** retire: (b) stands and is now explained — mig-builds was still first-time when #273 was updated, so its second round genuinely needed a second approval; (c), (d) and #35 are untouched.

## 2. AGENTS.md:94 contradicted CLAUDE.md rule 3

`AGENTS.md:66` and `CLAUDE.md` rule 3 call 300 lines/file a target for NEW files and not an invariant. The "What NOT to do" bullet at line 94 said the opposite. ai-mistakes #39 recorded the decision that rule 3 wins and left the edit to the next docs pass; this is that edit. One line.

```diff
-- Don't let a new file blow past 300 lines — extract instead
+- Don't treat 300 lines/file as a hard limit — it is a target for NEW files, not an invariant (see Code conventions): never split an existing file just to hit it, and do extract when adding to one already over
```

## 3. `llms.txt` / `llms-full.txt` pointed at a file the reader does not have

Both answered `**Version**: see \`version\` in \`package.json\`` — true, and useless to a crawler reading either file standalone. Both now state the version, and `scripts/counts.js` derives it from `package.json`, so the two sites are checked rather than free to say anything.

```
package.version      = 0.13.0-alpha   package.json version
                         node -p "require('./package.json').version"
                         declared at 2 sites — reported, never blocking
```

**The counter is `blocking: false`, and that is a decision, not an oversight.** It is a third position between "checked" and `DERIVED_ONLY`: derived, located, compared, and printed under its own `Drift reported, not blocking` heading — it just does not exit 1. The reason is release-please: its release PR bumps `version` in `package.json` and touches neither llms file, so a blocking compare would turn the `test` context red on that PR and keep master red afterwards, on the one commit nobody authors by hand. That is the failure the `DERIVED_ONLY` block was written about. Moving the version there instead would take its declaration sites away, which is how these two files came to say "see `package.json`" in the first place. Making it blocking is a release-please `extra-files` change (the bump commit would have to rewrite both prose sites), not a change in `counts.js`.

The undeclared and unparseable gates still apply to it in full.

**Six mutation probes over the new counter, all passing:**

| probe | expect | result |
|---|---|---|
| A release-please bump: `package.json` alone → `0.14.0-alpha` | exit 0, drift reported at both sites | PASS |
| B one site reverted to the pointer wording | exit 0, `declared at 1 site` | PASS |
| C **both** sites reverted | exit 1, undeclared gate | PASS |
| D a site reworded to a digit-bearing non-version | exit 1, unparseable gate | PASS |
| E a site stating the wrong version | exit 0, drift reported | PASS |
| F that rewording is claimed by no other scanner | exit 1, `0 stale, 1 unparseable` | PASS |

**One stated limit, recorded at the scanner rather than left to be discovered** (ai-mistakes #27): `hasNumber()` gates every line before any scanner sees it, and the old pointer sentence carries no digit, so reverting **one** site to it is skipped, not reported — the other still declares the counter and the run stays green. Only losing both sites goes red. Widening `hasNumber` is not the fix; it is load-bearing for every scanner in the file.

## Verification

All nine local pre-merge commands, in the worktree, at `d5c4e6a` + this commit:

| command | result |
|---|---|
| `build:renderer` | built in 3.02s |
| `format:check` | all matched files use Prettier code style |
| `lint` | 0 errors, 30 warnings — identical to the pre-change baseline (`git stash` check) |
| `typecheck` | exit 0 |
| `typecheck:svelte` | 416 files, 0 errors, 0 warnings |
| `test:coverage` | 131/131 test files, exit 0 |
| `verify:gate` | 4/4 mutants killed |
| `counts:check` | exit 0 — 22 checked counters, 105/105 sites agree, 0 drifted |
| `npm audit --audit-level=high --omit=dev` | 0 vulnerabilities |

`eslint` and `prettier` are additionally clean on `scripts/counts.js` alone (neither `format:check` nor `lint-staged` covers `scripts/`).

`tests/shared/bench-scenarios/actor-secret-hold.test.js` went red on one run that shared the machine with `svelte-check` and `npm audit`, and green alone on the run before and the run after — ai-mistakes #36, not a regression from this diff.
