### PR TITLE
test(bench): stage a small executable in the actor secret-hold cases

### DIFF
--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -308,6 +308,32 @@ Repeated mistakes by Claude Code. READ BEFORE EVERY CHANGE.
     is the isolated command, and either of those is a different signal from this one. This
     note RECORDS the flake and nothing more: the test, its timeouts and the vitest config
     are untouched, and no green here is a claim about them (cf. #21).
+    **Corrected 2026-08-24 in #317 — it was not machine cost, it was one measurable
+    thing and it is gone.** The gap between `spawn()` and the child's `'spawn'` event is
+    Windows scanning a freshly written PE in full the first time it is EXECUTED, and
+    `copy-binary` had just written an ~86 MB copy of `node.exe` for `hold-secret-file` to
+    launch. Measured isolated on the affected machine: a fresh 86 MB copy took 3812 ms to
+    reach `'spawn'`, the SECOND launch of that same copy 8 ms, a second fresh 86 MB copy
+    3754 ms, and a fresh copy of a 45–455 KB system binary 86–123 ms — the cost is per new
+    file and roughly proportional to its size, never per launch. The case's own phases,
+    five cold runs and five under a parallel `typecheck:svelte`: `copy-binary` 156–193 ms,
+    `seed-secret-file` 3–8 ms, `hold-secret-file` 3472–3962 ms, the cleanup kill 1–2 ms,
+    the `afterEach` removal 15–25 ms with its retry loop never once spinning — 3664–4159 ms
+    of a 5000 ms budget on an IDLE machine. The paragraph above reads the remainder as "a
+    cold whole-suite run is exactly what eats the ~1.8 s that is left"; there was no ~1.8 s
+    left to eat, and 2.9–3.2 s was the low end of that range, not its centre.
+    **The fix is the test's staging source, and no production code.** Nothing the file
+    asserts needs an interpreter — every assertion is about the argv the actor built and
+    the catalogue row it wrote, and no case runs the child, because `execute()` kills what
+    it spawned in its `finally` before a hold script could open anything — so `STAGE_STEP`
+    copies a small system executable (`ping.exe` on win32, the same source
+    `bench/scenarios/S1-agent-lifecycle` already stages; `/bin/true` elsewhere) and falls
+    back to `process.execPath` where no candidate exists. `bench/lib/actor.js`,
+    `vitest.config.js` and every timeout are untouched: raising the budget was the
+    fallback and it was not needed. After: the case is 87–120 ms (10/10 green — 5 cold,
+    5 loaded), the whole file 142–216 ms of test time against ~4.3 s before, and 365 ms
+    inside a full `test:coverage` run. **"Rerun first" is retired for this case** — a red
+    here is a signal again, and per #21 that is a claim about this case only.
 
 38. **A test that builds its input by regex-replacing `\n` over a fixture read from disk is red
     on a Windows checkout and green on Linux CI, and two sessions in a row called it "known local

--- a/tests/shared/bench-scenarios/actor-secret-hold.test.js
+++ b/tests/shared/bench-scenarios/actor-secret-hold.test.js
@@ -64,13 +64,47 @@ function execute(steps, opts) {
   return actor.execute({ id: 'T-unit', steps }, opts);
 }
 
-/** A `copy-binary` step staging this interpreter under an agent name. */
+/**
+ * The executable these cases stage, chosen for its SIZE.
+ *
+ * `process.execPath` was the obvious source and it cost this file ~3.6 s in the one
+ * case that LAUNCHES what it staged. Windows scans a freshly written PE in full the
+ * first time it is executed, and the interpreter is ~86 MB. Measured on this machine,
+ * `hold-secret-file`'s `spawn()` → `'spawn'` gap was 3472–3962 ms for a fresh copy of
+ * `node.exe`, 8 ms for the SECOND launch of that same copy, and 86–123 ms for a fresh
+ * copy of a 45–455 KB one. The cost is the loader's, it is paid per newly written
+ * file, and it left ~1000 ms of Vitest's 5000 ms default for everything else — which
+ * is why the case timed out on five cold full-suite runs and was green on every rerun.
+ *
+ * Nothing here needs an interpreter. Every assertion below is about the argv the
+ * actor built and the catalogue row it wrote, and no case runs the child: `execute()`
+ * kills what it spawned in its `finally`, before a hold script could open anything.
+ * Per this file's header, the branch itself is confirmed by a live arm-A run and by
+ * nothing a unit test can do. `bench/scenarios/S1-agent-lifecycle` already stages
+ * `ping.exe` for the same reason — a step that only has to LAUNCH is not choosy about
+ * what.
+ * @type {string[]} Candidates in preference order, per platform.
+ */
+const SMALL_EXECUTABLES =
+  process.platform === 'win32'
+    ? [path.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'ping.exe')]
+    : ['/bin/true', '/usr/bin/true'];
+
+/**
+ * @type {string} What `copy-binary` copies. Falls back to the interpreter rather than
+ *   failing: a machine without any of the candidates still runs the cases correctly,
+ *   it only runs them slower.
+ */
+const STAGE_SOURCE =
+  SMALL_EXECUTABLES.find((candidate) => fs.existsSync(candidate)) ?? process.execPath;
+
+/** A `copy-binary` step staging that executable under an agent name. */
 const STAGE_STEP = {
   id: 'stage',
   kind: 'copy-binary',
   expect: 'E1',
   with: {
-    from: process.execPath,
+    from: STAGE_SOURCE,
     agentId: 'claude-code',
     agentName: 'claude.exe',
   },


### PR DESCRIPTION
## What went red, and why it is not noise

`tests/shared/bench-scenarios/actor-secret-hold.test.js` › `hold-secret-file` ›
`spawns the staged binary against the seeded file, and bounds its own lifetime`
has timed out on the first cold `npm run test:coverage` run in five sessions
(#308, #311, #312, #313, #314), always `Test timed out in 5000ms`, always green on
the immediate rerun. `memory-bank/ai-mistakes.md` #36 recorded it at 2.9–3.2 s,
attributed the residue to "machine cost" and told the next session to rerun first.
Five is past the threshold #36 itself set for investigating.

## Cause — one measurable thing

Windows scans a freshly written PE **in full the first time it is executed**.
`copy-binary` had just written an ~86 MB copy of `node.exe` into the run's
`stage/`, and `hold-secret-file` was the first thing to launch it.

Isolated measurement on the affected machine (`spawn()` → the child's `'spawn'`
event):

| what is launched | ms |
|---|---|
| the original `node.exe` (an image the OS has launched before) | 10.6 |
| a **fresh** 86 MB copy of it | **3812** |
| the **same copy**, second launch | 8.3 |
| the same copy, third launch | 6.3 |
| a **second fresh** 86 MB copy | **3754** |
| a fresh copy of `ping.exe` (45 KB) | 86 |
| a fresh copy of `cmd.exe` (348 KB) | 115 |
| a fresh copy of `powershell.exe` (455 KB) | 123 |

Per new file, roughly proportional to its size, not per launch.

## Phase table

Five cold runs and five under a parallel `npm run typecheck:svelte`, phases taken
from `execute()`'s own `log` sink with `performance.now()`:

| phase | before (ms) | after (ms) |
|---|---|---|
| `copy-binary` — copy + sha256 of the source | 156–193 | 8–13 |
| `seed-secret-file` | 3–8 | 3–14 |
| **`hold-secret-file` — `spawn()` → `'spawn'`** | **3472–3962** | **88–101** |
| `cleanup()` kill + return | 1–2 | 1–2 |
| `afterEach` run-dir removal | 15–25 (0 spins) | 2–54 (≤1 spin) |
| **case total** | **3664–4159** | **102–124** |

#36 read the remainder as "a cold whole-suite run eats the ~1.8 s that is left".
There was no ~1.8 s to eat: the case was already at 74–83 % of its 5000 ms budget
on an **idle** machine.

## Fix

`STAGE_STEP` copies a small system executable instead of `process.execPath`
(`ping.exe` on win32 — the same source `bench/scenarios/S1-agent-lifecycle`
already stages; `/bin/true` elsewhere), and falls back to `process.execPath` where
no candidate exists, so a machine without them still runs the cases correctly,
only slower.

Nothing the file asserts needs an interpreter. Every assertion is about the argv
the actor built and the catalogue row it wrote, and no case runs the child:
`execute()` kills what it spawned in its `finally` before a hold script could open
anything. This file's header already states that the branch itself is confirmed by
a live arm-A run and by nothing a unit test can do.

`bench/lib/actor.js`, `vitest.config.js` and every timeout are **untouched** — the
timeout was the fallback and it was not needed.

## Verification

- 10/10 green on the case: five cold runs, five under a parallel
  `npm run typecheck:svelte`. Max case duration **120 ms**.
- Whole file: 142–216 ms of test time (was ~4.3 s); **365 ms** inside a full
  `npm run test:coverage` run.
- Local pre-merge set green: `build:renderer`, `format:check`, `lint` (0 errors),
  `typecheck`, `typecheck:svelte`, `test:coverage` (132 files, 2441 passed,
  4 skipped), `verify:gate` (4/4 mutants killed), `counts:check` (105/105
  declaration sites agree), `npm audit --audit-level=high --omit=dev`.

`memory-bank/ai-mistakes.md` #36 carries a dated correction; no entry is renumbered.
