### PR TITLE
test(sequences): prove the engine gate is load-bearing with four injected mutants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,14 @@ jobs:
       # (memory-bank/ai-mistakes.md #21).
       - name: Verify the generation-witness gate is load-bearing
         run: npm run verify:gate
+      # The same proof for the sequence engine, inside the same job so no required
+      # status context changes: 4 sequence-engine mutants — m1 accepts a step at any
+      # index, m2 never expires a state, m3 collapses the state key to the rule, m4
+      # lifts both caps — and the gate suite must go red for each. The engine's own
+      # suite hard-imports the real module and runs as the control only: a kill by a
+      # suite that never loaded the mutant is not a kill (memory-bank/ai-mistakes.md #21).
+      - name: Verify the sequence-engine gate is load-bearing
+        run: npm run verify:seq-gate
       # Derives the repo's countable facts from the tree and fails on every tracked
       # file that declares a different number (memory-bank/ai-mistakes.md #24: nothing
       # went red when a hand-maintained count stopped being true). BLOCKING since the

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ bench/runs/
 # and it is replaced on every run. A verdict kept as a target lives in
 # tests/fixtures/bench/goldens/.
 bench/traces-runs/
-# Throwaway mutants written by scripts/verify-witness-gate.mjs (removed in a finally)
+# Throwaway mutants written by scripts/verify-witness-gate.mjs and
+# scripts/verify-sequence-gate.mjs (each removes its own in a finally)
 src/main/.mutants/
 # `npx tsc -b` writes one per referenced project, next to the config
 *.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ npm run typecheck        # one command, two tsc projects: tsconfig.main.json && 
 npm run typecheck:svelte # svelte-check — reads .svelte templates, which tsc never does
 npm run test:coverage    # vitest run --coverage — this, not npm test, is what CI runs
 npm run verify:gate      # injection proof: 4 mutants must turn the witness suite red
+npm run verify:seq-gate  # injection proof: 4 sequence-engine mutants must turn the gate suite red
 npm run counts:check     # derived counts vs the numbers tracked files declare
 npm audit --audit-level=high --omit=dev   # production dependencies only
 ```
@@ -50,11 +51,11 @@ Three counts, deliberately kept apart:
   `gh api repos/antropos17/Aegis/branches/master/protection --jq '.required_status_checks'`
   (`strict: true`, so the branch must also be up to date). `/rulesets` and
   `/rules/branches/master` both return `[]` — nothing else is enforced.
-- **9 verification commands** inside those 5 jobs. The counts differ because `lint` runs
+- **10 verification commands** inside those 5 jobs. The counts differ because `lint` runs
   `format:check` then `lint`, `svelte-check` runs `typecheck` then `typecheck:svelte`, and
-  `test` runs `test:coverage`, `verify:gate`, then `counts:check`. `format:check` is a step,
-  not a job, and has no status context of its own.
-- **9 local pre-merge commands** — the block above, one per verification command.
+  `test` runs `test:coverage`, `verify:gate`, `verify:seq-gate`, then `counts:check`.
+  `format:check` is a step, not a job, and has no status context of its own.
+- **10 local pre-merge commands** — the block above, one per verification command.
 
 `npm test` (`vitest run`) is a convenience alias, not a gate: CI runs `npm run test:coverage`
 (`vitest run --coverage`). Same suite, plus v8 instrumentation and an lcov artifact. No

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ npm run lint              # ESLint
 npm run format            # Prettier
 npm test                  # Vitest — the suite prints its own counts; do not copy them here
 npm run verify:gate       # Injection proof: 4 mutants (witness gate + birth-time freshness) must go red
+npm run verify:seq-gate   # Injection proof: 4 sequence-engine mutants (order, expiry, group key, caps) must go red
 npm run counts:check      # Every counted fact derived from the tree; a stale declaration is red
 npm run dist              # Electron-builder NSIS installer
 
@@ -20,20 +21,20 @@ npm run dist              # Electron-builder NSIS installer
 date before merge). No rulesets add more: `/rulesets` and `/rules/branches/master` return `[]`.
 A context is a JOB, not a command — `lint` and `svelte-check` run two commands each.
 
-**9 verification commands** live inside those 5 jobs (`.github/workflows/ci.yml`):
+**10 verification commands** live inside those 5 jobs (`.github/workflows/ci.yml`):
 
 | required context | commands the job runs, after `npm ci` |
 |---|---|
 | build | `npm run build:renderer` |
 | lint | `npm run format:check`, then `npm run lint` |
 | svelte-check | `npm run typecheck`, then `npm run typecheck:svelte` |
-| test | `npm run test:coverage`, `npm run verify:gate`, then `npm run counts:check` |
+| test | `npm run test:coverage`, `npm run verify:gate`, `npm run verify:seq-gate`, then `npm run counts:check` |
 | audit | `npm audit --audit-level=high --omit=dev` |
 
-`format:check` is a STEP of `lint`, and `verify:gate` and `counts:check` are STEPS of `test` —
-none is a job, and none is a context of its own.
+`format:check` is a STEP of `lint`, and `verify:gate`, `verify:seq-gate` and `counts:check` are
+STEPS of `test` — none is a job, and none is a context of its own.
 
-## Local pre-merge set — the same 9 commands
+## Local pre-merge set — the same 10 commands
 npm run build:renderer
 npm run format:check      # the checker; `npm run format` WRITES and is not a gate
 npm run lint
@@ -41,6 +42,7 @@ npm run typecheck         # ONE command, TWO tsc projects: main.json && renderer
 npm run typecheck:svelte  # svelte-check; tsc never reads .svelte templates
 npm run test:coverage     # what CI runs — `npm test` (vitest run) is NOT the CI command
 npm run verify:gate       # a STEP of the `test` job: a surviving mutant fails that context
+npm run verify:seq-gate   # a STEP of the `test` job: a surviving sequence-engine mutant fails it too
 npm run counts:check      # a STEP of the `test` job: derives every counted fact from the tree
 npm audit --audit-level=high --omit=dev   # production deps only, not your diff
 Every job also runs `npm ci`, which is not `npm install` — see ai-mistakes 23 before

--- a/docs/roadmap/sequence-rules.md
+++ b/docs/roadmap/sequence-rules.md
@@ -20,12 +20,14 @@ rules — a flat-rule edit never reaches that reset — and both watchers push `
 `{ count, file, sequenceCount }`; `tests/main/sequence-integration.test.js` drives loader → tap →
 engine → emission → reload end to end. One cost, stated rather than hidden: the engine's `init` is
 a fresh engine, so the §3 counters restart at zero after a reload and the durable trace of the
-discard is the `discarded … reason: 'reload'` log line. No gate named in §6–§7 exists yet — the
-mutation gate (§6) is prompt 3 of block 2, so that file path below is still a target, not a claim.
-**Block 1 — LANDED. Block 2 — ENGINE CORE LANDED (§7 prompt 1); CAPS AND PAYLOAD LANDED
-(prompt 2); the mutation gate still to come (prompt 3). Block 3 — LANDED (taps and init, emission,
-hot-reload). All blocks complete except block 2 prompt 3 (mutation gate), which remains
-pending.** When a block lands, refresh this header in the same PR
+discard is the `discarded … reason: 'reload'` log line. And now GATED:
+`scripts/verify-sequence-gate.mjs` (`npm run verify:seq-gate`, a step of the `test` job) runs
+four sequence-engine mutants — order, expiry, group key, caps — against the override-aware
+`tests/main/sequence-engine-gate.test.js` and exits 1 on a survivor, with `seqGate.mutants`
+derived in `scripts/counts.js`; every file path named in §6–§7 now exists. **Block 1 — LANDED.
+Block 2 — LANDED (engine core, §7 prompt 1; caps and payload, prompt 2; the mutation gate,
+prompt 3). Block 3 — LANDED (taps and init, emission, hot-reload). All blocks complete.** When a
+block lands, refresh this header in the same PR
 (the lag the `sensor-health-degraded.md` correction records is what a stale status line costs).
 **Branch context:** master @ `2e9e37f`; every `file:line` reference below was verified against that
 commit on 2026-08-24. Line numbers drift with every edit to the file — treat them as the place to
@@ -319,11 +321,11 @@ record and the score surface.
 (mutant copies in `src/main/.mutants/`, env `AEGIS_SEQ_UNDER_TEST`, refusal to report without an
 override-aware suite — "refuse rather than annotate"); the override-aware suite
 `tests/main/sequence-engine-gate.test.js` (import through the env variable as in
-`tests/main/process-utils-witness.test.js:10–12`). Four mutants = four properties: m1 — order check
-removed (a match is accepted at any index); m2 — expiry comparison removed; m3 — group key collapsed
-to ruleId; m4 — caps removed. What the mutants prove is exactly the order, maxspan-boundary,
-group-by-isolation and eviction tests. npm script `verify:seq-gate` — a step of the existing `test`
-job in `ci.yml` (beside `:56` / `:63` / `:70`; no new status context).
+`tests/main/process-utils-witness.test.js:10–12`). Four sequence-engine mutants = four properties:
+m1 — order check removed (a match is accepted at any index); m2 — expiry comparison removed; m3 —
+group key collapsed to ruleId; m4 — caps removed. What the mutants prove is exactly the order,
+maxspan-boundary, group-by-isolation and eviction tests. npm script `verify:seq-gate` — a step of
+the existing `test` job in `ci.yml` (beside `:56` / `:63` / `:70`; no new status context).
 
 ## 7. Blocks — each at most 3 prompts, each merged green on its own
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "verify:gate": "node scripts/verify-witness-gate.mjs",
+    "verify:seq-gate": "node scripts/verify-sequence-gate.mjs",
     "counts:check": "node scripts/counts.js",
     "build:sidecar": "node scripts/build-sidecar.js",
     "bench:generation": "node scripts/bench-generation.js",

--- a/scripts/counts.js
+++ b/scripts/counts.js
@@ -110,16 +110,19 @@ function readTracked(rel) {
 // re-run it by hand.
 // ---------------------------------------------------------------------------
 
-/** @returns {number} mutants in the `MUTANTS` array of the injection-proof script. */
-function deriveMutants() {
-  const src = readTracked('scripts/verify-witness-gate.mjs');
+/**
+ * @param {string} script - repo-relative path of an injection-proof script.
+ * @returns {number} mutants in its `MUTANTS` array.
+ */
+function deriveMutants(script) {
+  const src = readTracked(script);
   const start = src.indexOf('const MUTANTS = [');
-  if (start === -1) throw new Error('scripts/verify-witness-gate.mjs: no `const MUTANTS = [`');
+  if (start === -1) throw new Error(`${script}: no \`const MUTANTS = [\``);
   const end = src.indexOf('\n];', start);
-  if (end === -1) throw new Error('scripts/verify-witness-gate.mjs: MUTANTS array is unterminated');
+  if (end === -1) throw new Error(`${script}: MUTANTS array is unterminated`);
   const body = src.slice(start, end);
   const ids = body.match(/^ {4}id: '/gm);
-  if (!ids) throw new Error('scripts/verify-witness-gate.mjs: MUTANTS has no `id:` entries');
+  if (!ids) throw new Error(`${script}: MUTANTS has no \`id:\` entries`);
   return ids.length;
 }
 
@@ -234,7 +237,8 @@ function deriveVersion() {
   return pkg.version;
 }
 
-const mutants = deriveMutants();
+const mutants = deriveMutants('scripts/verify-witness-gate.mjs');
+const seqMutants = deriveMutants('scripts/verify-sequence-gate.mjs');
 const ci = deriveCi();
 const preload = derivePreload();
 const database = deriveAgentDatabase();
@@ -296,6 +300,13 @@ const COUNTERS = [
     value: mutants,
     command:
       "sed -n '/const MUTANTS = \\[/,/^\\];/p' scripts/verify-witness-gate.mjs | grep -c \"^    id: '\"",
+  },
+  {
+    key: 'seqGate.mutants',
+    label: 'verify:seq-gate mutants',
+    value: seqMutants,
+    command:
+      "sed -n '/const MUTANTS = \\[/,/^\\];/p' scripts/verify-sequence-gate.mjs | grep -c \"^    id: '\"",
   },
   {
     key: 'ci.commands',
@@ -497,6 +508,13 @@ const NUM = `\\b(\\d+|${WORD_ALT})\\b`;
  * contexts, 8 commands, 2 token-adapters) keep NUM.
  */
 const DIGITS = '\\b(\\d+)\\b';
+/**
+ * The noun that names the sequence-engine gate's mutants. `gate.mutants` is read off a
+ * bare `N mutants`; `seqGate.mutants` only off `N <this noun>`, so a count of one gate
+ * can never be read as the other (the separation `sequence-rules` keeps from
+ * `detection-rules`).
+ */
+const SEQ_MUTANT_NOUN = '(?:sequence-engine|sequence-gate|seq-gate|sequence)\\s+mutants?';
 
 /**
  * @param {string|undefined} token
@@ -584,6 +602,15 @@ const SCANNERS = [
         ['gate.mutants', new RegExp(`${NUM}\\s+mutants?\\b`, 'i')],
         ['gate.mutants', new RegExp(`\\bgate\\b[^.]{0,40}${NUM}\\s+ways\\b`, 'i')],
       ]),
+  },
+  {
+    id: 'verify-seq-gate-mutants',
+    // `verify-gate-mutants` above cannot fire on these lines: its `N mutants` needs
+    // the number directly before the noun, and here `sequence-engine` (or one of its
+    // siblings in SEQ_MUTANT_NOUN) always sits between them.
+    locate: new RegExp(`\\b${SEQ_MUTANT_NOUN}\\b`, 'i'),
+    parse: (line) =>
+      pick(line, [['seqGate.mutants', new RegExp(`${NUM}\\s+${SEQ_MUTANT_NOUN}\\b`, 'i')]]),
   },
   {
     id: 'ci-commands',

--- a/scripts/verify-sequence-gate.mjs
+++ b/scripts/verify-sequence-gate.mjs
@@ -1,0 +1,286 @@
+/**
+ * @file scripts/verify-sequence-gate.mjs
+ * @description Injection proof for the `temporal_ordered` state machine in
+ *   src/main/sequence-engine.js — the sibling of verify-witness-gate.mjs.
+ *
+ *   A green suite proves the suite ran, not that it inspected anything
+ *   (memory-bank/ai-mistakes.md #21). This script breaks the engine on purpose — one
+ *   mutant at a time, in a throwaway copy — and requires the override-aware suite to
+ *   go RED for every mutant. A mutant that survives is reported and the script exits 1.
+ *
+ *   FOUR PROPERTIES, one mutant each (docs/roadmap/sequence-rules.md §6):
+ *   m1 ORDER — a step match is accepted at any index, not only the one the state is
+ *   waiting for, so `B A` fires where only `A B` may; m2 EXPIRY — the maxspan comparison
+ *   is gone, so a state never expires; m3 GROUP KEY — the state key collapses to the
+ *   ruleId, so two instances share one sequence; m4 CAPS — MAX_OPEN_PER_RULE and
+ *   MAX_OPEN_TOTAL become effectively unbounded, so nothing is ever evicted.
+ *
+ *   Nothing under version control is modified: each mutant is written to
+ *   `src/main/.mutants/` (gitignored, removed in a finally), and the suite is pointed at
+ *   it through AEGIS_SEQ_UNDER_TEST. The mutants live inside src/main so that a single
+ *   depth adjustment (`./x` → `../x`) makes every relative require resolve; each
+ *   rewritten path is checked on disk before the run, and each mutant is checked to
+ *   have actually changed the source, so a broken or unapplied copy can never be
+ *   mistaken for a killed mutant.
+ *
+ *   Usage: npm run verify:seq-gate
+ */
+
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE = path.join(ROOT, 'src', 'main', 'sequence-engine.js');
+const MUTANT_DIR = path.join(ROOT, 'src', 'main', '.mutants');
+/** The environment variable the gate suite resolves its module through. */
+const OVERRIDE_ENV = 'AEGIS_SEQ_UNDER_TEST';
+/**
+ * The suites every mutant is run against.
+ *
+ * A suite has KILLING POWER only if it resolves its module through
+ * `AEGIS_SEQ_UNDER_TEST`. One that hard-imports `src/main/sequence-engine.js` loads the
+ * REAL module and stays green whatever the mutant did — so listing it here buys a
+ * regression net for the control run and NOT one assertion of gate strength. Both
+ * kinds are run; only the override-aware ones are the gate, they are labelled as
+ * such in the report, and the script refuses to report anything at all if none is
+ * present. A mutant "killed" by a suite that never loaded it is precisely the
+ * green-proves-nothing failure this script exists to prevent
+ * (memory-bank/ai-mistakes.md #21).
+ * @type {string[]}
+ */
+const TEST_FILES = [
+  path.join('tests', 'main', 'sequence-engine-gate.test.js'),
+  path.join('tests', 'main', 'sequence-engine.test.js'),
+];
+const VITEST = path.join(ROOT, 'node_modules', 'vitest', 'vitest.mjs');
+
+/**
+ * Whether a suite resolves its module under test through `AEGIS_SEQ_UNDER_TEST`, and
+ * can therefore ever see a mutant.
+ * @param {string} relPath - repo-relative path to the suite.
+ * @returns {boolean}
+ */
+function honoursOverride(relPath) {
+  return fs.readFileSync(path.join(ROOT, relPath), 'utf8').includes(OVERRIDE_ENV);
+}
+
+/**
+ * Each mutant is a named, surgical breakage of one property of the engine. `find` must
+ * match exactly once — a mutant that silently changed nothing would "survive" for the
+ * wrong reason.
+ */
+const MUTANTS = [
+  {
+    id: 'm1-order-check-removed',
+    why: 'a step match is accepted at any index, so B then A completes a rule written A then B',
+    // Two edits, because order is enforced at two transitions: the ADVANCE compares the
+    // event against `steps[stepIndex]` only, and the OPEN compares it against `steps[0]`
+    // only. Relaxing the advance alone leaves `B A` unable to open on B, so the mutant
+    // would "survive" by never reaching the relaxed branch.
+    edits: [
+      {
+        find: '      const wanted = rule.steps[state.stepIndex];',
+        replace:
+          '      const wanted =\n' +
+          '        rule.steps.find((s) => _matches(s, doc, categories)) ?? rule.steps[state.stepIndex];',
+      },
+      {
+        find: '  if (_matches(rule.steps[0], doc, categories)) _openState(rule, key, doc, observedAt);',
+        replace:
+          '  if (rule.steps.some((s) => _matches(s, doc, categories))) {\n' +
+          '    _openState(rule, key, doc, observedAt);\n' +
+          '  }',
+      },
+    ],
+  },
+  {
+    id: 'm2-expiry-comparison-removed',
+    why: 'an open state never expires by maxspan, so a step landing past the window still completes',
+    // Two edits, because expiry is decided at two places that must agree: transition 1
+    // inside `_applyRule` and the `_sweepRule` the tick and the caps' micro-sweep share.
+    edits: [
+      {
+        find: '    if (state !== undefined && _elapsed(state, observedAt) > rule.timespanMs) {',
+        replace: '    if (state !== undefined && false) {',
+      },
+      {
+        find: '    if (_elapsed(state, at) > rule.timespanMs) {',
+        replace: '    if (_elapsed(state, at) > rule.timespanMs && false) {',
+      },
+    ],
+  },
+  {
+    id: 'm3-group-key-collapsed-to-rule',
+    why: 'the state key drops the instanceId, so two instances advance one shared sequence',
+    edits: [
+      {
+        find:
+          'function _applyRule(rule, key, doc, categories, observedAt) {\n' +
+          '  const states = _open.get(rule.id);',
+        replace:
+          'function _applyRule(rule, key, doc, categories, observedAt) {\n' +
+          '  key = rule.id;\n' +
+          '  const states = _open.get(rule.id);',
+      },
+    ],
+  },
+  {
+    id: 'm4-caps-removed',
+    why: 'both caps are effectively unbounded, so the 129th instance under one rule evicts nothing',
+    edits: [
+      {
+        find: 'const MAX_OPEN_PER_RULE = 128;',
+        replace: 'const MAX_OPEN_PER_RULE = Number.MAX_SAFE_INTEGER;',
+      },
+      {
+        find: 'const MAX_OPEN_TOTAL = 1024;',
+        replace: 'const MAX_OPEN_TOTAL = Number.MAX_SAFE_INTEGER;',
+      },
+    ],
+  },
+];
+
+/**
+ * Re-point every relative require one directory deeper, and prove each target
+ * exists.
+ * @param {string} code
+ * @returns {string}
+ */
+function reparentRequires(code) {
+  return code.replace(/require\('(\.[^']*)'\)/g, (_match, specifier) => {
+    const deeper = `../${specifier.startsWith('./') ? specifier.slice(2) : specifier}`;
+    const resolved = path.resolve(MUTANT_DIR, deeper);
+    const exists =
+      fs.existsSync(resolved) ||
+      fs.existsSync(`${resolved}.js`) ||
+      fs.existsSync(path.join(resolved, 'index.js'));
+    if (!exists) {
+      throw new Error(`mutant require rewrite points nowhere: ${specifier} → ${deeper}`);
+    }
+    return `require('${deeper}')`;
+  });
+}
+
+/**
+ * @param {{id: string, edits: Array<{find: string, replace: string}>}} mutant
+ * @param {string} original
+ * @returns {string} the mutated module path.
+ */
+function writeMutant(mutant, original) {
+  let code = original;
+  for (const edit of mutant.edits) {
+    const occurrences = code.split(edit.find).length - 1;
+    if (occurrences !== 1) {
+      throw new Error(
+        `${mutant.id}: expected its target to appear exactly once, found ${occurrences}. ` +
+          'The engine was refactored — update this mutant instead of deleting it.',
+      );
+    }
+    code = code.replace(edit.find, edit.replace);
+  }
+  // A rewrite whose replacement equals its target would pass the count above and run the
+  // REAL engine under a mutant's name; that is the unapplied-mutant failure, and it must
+  // stop the run rather than be scored.
+  if (code === original) {
+    throw new Error(
+      `${mutant.id}: its edits left the source byte-identical — nothing was mutated.`,
+    );
+  }
+  const file = path.join(MUTANT_DIR, `sequence-engine.${mutant.id}.js`);
+  fs.writeFileSync(file, reparentRequires(code), 'utf8');
+  return file;
+}
+
+/**
+ * @param {string|null} modulePath - null runs the suite against the real module.
+ * @returns {{code: number, output: string}}
+ */
+function runSuite(modulePath) {
+  const env = { ...process.env };
+  if (modulePath) env[OVERRIDE_ENV] = pathToFileURL(modulePath).href;
+  else delete env[OVERRIDE_ENV];
+  const res = spawnSync(process.execPath, [VITEST, 'run', '--project', 'main', ...TEST_FILES], {
+    cwd: ROOT,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    code: res.status === null ? 1 : res.status,
+    output: `${res.stdout || ''}${res.stderr || ''}`,
+  };
+}
+
+// Newlines are normalised before matching: the repository normalises line endings
+// per checkout (`.gitattributes` text=auto), so a mutant that only matched LF would
+// find nothing on a Windows working tree and report a false "refactored" error.
+const original = fs.readFileSync(SOURCE, 'utf8').replace(/\r\n/g, '\n');
+const results = [];
+let failed = false;
+
+// Which of the listed suites can actually see a mutant. Checked before anything is
+// run: if none can, every RED below would be somebody else's failure and every green
+// would mean nothing, so there is no result worth printing. Refuse rather than
+// annotate (memory-bank/ai-mistakes.md #25).
+const overrideAware = TEST_FILES.filter(honoursOverride);
+if (overrideAware.length === 0) {
+  console.error(
+    `No suite in TEST_FILES resolves ${OVERRIDE_ENV}, so every mutant would run\n` +
+      'against the real module. There is no gate to report — refusing.',
+  );
+  process.exit(1);
+}
+
+try {
+  fs.mkdirSync(MUTANT_DIR, { recursive: true });
+
+  // The control run: an unmutated module must be GREEN, or a red mutant proves
+  // nothing at all.
+  const control = runSuite(null);
+  results.push({
+    id: 'control (unmutated)',
+    expected: 'green',
+    got: control.code === 0 ? 'green' : 'RED',
+  });
+  if (control.code !== 0) {
+    failed = true;
+    console.error(control.output);
+  }
+
+  for (const mutant of MUTANTS) {
+    const file = writeMutant(mutant, original);
+    const run = runSuite(file);
+    const killed = run.code !== 0;
+    results.push({
+      id: mutant.id,
+      expected: 'RED',
+      got: killed ? 'RED (killed)' : 'green (SURVIVED)',
+    });
+    if (!killed) {
+      failed = true;
+      console.error(`\nMutant SURVIVED: ${mutant.id}\n  ${mutant.why}\n`);
+      console.error(run.output);
+    }
+  }
+} finally {
+  fs.rmSync(MUTANT_DIR, { recursive: true, force: true });
+}
+
+console.log('\nSequence-engine injection proof');
+console.log('  suites run:');
+for (const f of TEST_FILES) {
+  const role = honoursOverride(f) ? 'sees the mutant' : 'real module only — no killing power';
+  console.log(`    ${f} — ${role}`);
+}
+for (const r of results) {
+  console.log(`  ${r.got.startsWith('green (SURV') ? '✗' : '✓'} ${r.id}: ${r.got}`);
+}
+if (failed) {
+  console.error('\nThe gate is not fully load-bearing — a break in it left the suite green.');
+  process.exit(1);
+}
+console.log(
+  `\nEvery mutant was killed by ${overrideAware.join(', ')}: order, the maxspan boundary,` +
+    '\ngroup-by isolation and the caps are load-bearing.',
+);

--- a/tests/main/sequence-engine-gate.test.js
+++ b/tests/main/sequence-engine-gate.test.js
@@ -1,0 +1,264 @@
+/**
+ * sequence-engine — the GATE suite: exactly the four properties `scripts/verify-sequence-gate.mjs`
+ * mutates, one describe each, on an injected clock. Order (m1), the maxspan boundary (m2),
+ * group-by isolation (m3) and the caps (m4). Everything else the engine does is pinned by
+ * `tests/main/sequence-engine.test.js`, which hard-imports the real module and therefore has no
+ * killing power against a mutant (memory-bank/ai-mistakes.md #21).
+ *
+ * The rules are hand-built in the shape `sequence-rule-loader` compiles — `{ id, title, level,
+ * timespanMs, steps: [{ name, category, matcher }] }`, the parity the engine suite pins against a
+ * loader-compiled rule — and the carriers are real: every event goes through `normalizeToEcs`
+ * inside `ingest`. The caps case runs on the module DEFAULTS on purpose: a cap lowered through
+ * `init` would still be honoured by a mutant that only lifted the constants.
+ *
+ * `logger` is pulled in through `createRequire` — the same native module instance the CJS module
+ * under test (real or mutant) requires; an ESM import of the same path yields a different object
+ * and a spy on it never fires.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'module';
+
+/**
+ * The module path is overridable so `scripts/verify-sequence-gate.mjs` can point this suite at
+ * a deliberately broken copy and prove the gate is load-bearing. ai-mistakes #21: a passing
+ * command proves the command ran, not that it inspected anything.
+ */
+const MODULE_UNDER_TEST =
+  process.env.AEGIS_SEQ_UNDER_TEST ||
+  new URL('../../src/main/sequence-engine.js', import.meta.url).href;
+const engine = (await import(/* @vite-ignore */ MODULE_UNDER_TEST)).default;
+
+const require_ = createRequire(import.meta.url);
+const logger = require_('../../src/main/logger.js');
+
+/** The window every rule below uses. @type {number} */
+const SPAN = 60000;
+
+/** The per-rule cap the module declares, pinned by the caps case on the defaults. */
+const DEFAULT_PER_RULE = 128;
+
+/** @type {number} */
+let clock = 0;
+
+/** @type {Array<Record<string, any>>} */
+let detections = [];
+
+/** @type {import('vitest').MockInstance} */
+let warnSpy;
+
+const now = () => clock;
+
+/** @param {number} t @returns {void} */
+function at(t) {
+  clock = t;
+}
+
+/**
+ * @param {string} name
+ * @param {string} category
+ * @param {(doc: Record<string, any>) => boolean} matcher
+ * @returns {{name: string, category: string, matcher: (doc: Record<string, any>) => boolean}}
+ */
+function step(name, category, matcher) {
+  return { name, category, matcher };
+}
+
+/**
+ * A two-step rule, A (a file read) then B (an outbound 443), in the loader's compiled shape.
+ * @param {number} [timespanMs]
+ * @returns {Record<string, unknown>}
+ */
+function ruleAB(timespanMs = SPAN) {
+  return {
+    id: 'SEQ001',
+    title: 'SEQ001 — under the gate',
+    level: 'high',
+    timespanMs,
+    steps: [
+      step('a_read', 'file', (doc) => doc.event.action === 'file-accessed'),
+      step(
+        'b_conn',
+        'network',
+        (doc) => doc.destination !== undefined && doc.destination.port === 443,
+      ),
+    ],
+  };
+}
+
+/**
+ * A `FileEvent` as file-watcher stamps it — the step-A carrier.
+ * @param {string} instanceId
+ * @returns {Record<string, unknown>}
+ */
+function fileEvent(instanceId) {
+  return {
+    instanceId,
+    file: 'C:\\work\\creds.txt',
+    action: 'accessed',
+    timestamp: 1_700_000_000_000,
+    agent: 'Claude Code',
+    pid: 4242,
+    attribution: { status: 'confirmed', evidence: ['handle-scan-pid'] },
+  };
+}
+
+/**
+ * A `NetworkConnection` as the scan hands it over — the step-B carrier.
+ * @param {string} instanceId
+ * @returns {Record<string, unknown>}
+ */
+function netEvent(instanceId) {
+  return {
+    instanceId,
+    remoteIp: '203.0.113.5',
+    remotePort: 443,
+    agent: 'Claude Code',
+    pid: 4242,
+  };
+}
+
+/**
+ * Installs the ruleset on a zeroed engine with the module's default caps.
+ * @param {Array<Record<string, unknown>>} rules
+ * @returns {void}
+ */
+function start(rules) {
+  engine.init({ rules, onDetection: (d) => detections.push(d), now });
+}
+
+beforeEach(() => {
+  clock = 0;
+  detections = [];
+  warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  engine.init({ rules: [] });
+});
+
+describe('sequence-engine gate — order (m1)', () => {
+  it('B then A fires nothing: B opens no state and A only opens one', () => {
+    start([ruleAB()]);
+
+    at(1000);
+    engine.ingest(netEvent('i1'));
+    at(2000);
+    engine.ingest(fileEvent('i1'));
+
+    expect(detections).toEqual([]);
+    expect(engine.getStats()).toMatchObject({ opened: 1, completed: 0, openNow: 1 });
+  });
+
+  it('A then B fires once, with the steps in that order', () => {
+    start([ruleAB()]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0]).toMatchObject({ ruleId: 'SEQ001', instanceId: 'i1' });
+    expect(detections[0].steps.map((s) => s.step)).toEqual(['a_read', 'b_conn']);
+    expect(engine.getStats()).toMatchObject({ opened: 1, completed: 1, openNow: 0 });
+  });
+});
+
+describe('sequence-engine gate — maxspan boundary (m2)', () => {
+  it('B exactly timespan after A fires', () => {
+    start([ruleAB()]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(1000 + SPAN);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0].steps[1].at - detections[0].steps[0].at).toBe(SPAN);
+    expect(engine.getStats()).toMatchObject({ completed: 1, expired: 0 });
+  });
+
+  it('B one millisecond past timespan fires nothing, expires the state and opens nothing', () => {
+    start([ruleAB()]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(1000 + SPAN + 1);
+    engine.ingest(netEvent('i1'));
+
+    expect(detections).toEqual([]);
+    expect(engine.getStats()).toMatchObject({ opened: 1, completed: 0, expired: 1, openNow: 0 });
+    expect(engine.getStats().rules.SEQ001).toMatchObject({ expired: 1, openNow: 0 });
+  });
+});
+
+describe('sequence-engine gate — group-by isolation (m3)', () => {
+  it('A on one instance and B on another fires nothing', () => {
+    start([ruleAB()]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(netEvent('i2'));
+
+    expect(detections).toEqual([]);
+    expect(engine.getStats()).toMatchObject({ opened: 1, completed: 0, openNow: 1 });
+  });
+
+  it('A(i1) A(i2) B(i1) B(i2) gives two detections, one per instance, with separate evidence', () => {
+    start([ruleAB()]);
+
+    at(1000);
+    engine.ingest(fileEvent('i1'));
+    at(2000);
+    engine.ingest(fileEvent('i2'));
+    at(3000);
+    engine.ingest(netEvent('i1'));
+    at(4000);
+    engine.ingest(netEvent('i2'));
+
+    expect(detections.map((d) => d.instanceId)).toEqual(['i1', 'i2']);
+    expect(detections[0].steps.map((s) => s.at)).toEqual([1000, 3000]);
+    expect(detections[1].steps.map((s) => s.at)).toEqual([2000, 4000]);
+    expect(engine.getStats()).toMatchObject({ opened: 2, completed: 2, slid: 0, openNow: 0 });
+  });
+});
+
+describe('sequence-engine gate — caps (m4)', () => {
+  it('the (MAX_OPEN_PER_RULE + 1)th instance under one rule evicts the oldest, counted and warned', () => {
+    start([ruleAB()]);
+
+    for (let i = 1; i <= DEFAULT_PER_RULE + 1; i += 1) {
+      at(i * 10);
+      engine.ingest(fileEvent(`i${i}`));
+    }
+
+    expect(engine.getStats()).toMatchObject({
+      opened: DEFAULT_PER_RULE + 1,
+      evicted: 1,
+      expired: 0,
+      openNow: DEFAULT_PER_RULE,
+      peakOpen: DEFAULT_PER_RULE,
+    });
+    expect(engine.getStats().rules.SEQ001).toMatchObject({
+      opened: DEFAULT_PER_RULE + 1,
+      evicted: 1,
+      openNow: DEFAULT_PER_RULE,
+      peakOpen: DEFAULT_PER_RULE,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][2]).toMatchObject({
+      reason: 'cap-evicted',
+      rule: 'SEQ001',
+      cap: 'per-rule',
+      limit: DEFAULT_PER_RULE,
+    });
+
+    // i1 is the one that went: its B completes nothing, while i2's does.
+    at(5000);
+    engine.ingest(netEvent('i1'));
+    engine.ingest(netEvent('i2'));
+    expect(detections.map((d) => d.instanceId)).toEqual(['i2']);
+  });
+});


### PR DESCRIPTION
## What

Block 2 prompt 3 of `docs/roadmap/sequence-rules.md`: the injection proof for `src/main/sequence-engine.js`, on the `scripts/verify-witness-gate.mjs` model.

- `scripts/verify-sequence-gate.mjs` — four textual mutants of the engine, each written to the gitignored `src/main/.mutants/` (removed in a `finally`), each checked to appear exactly once AND to actually change the source before the run, each run against the suites through `AEGIS_SEQ_UNDER_TEST`. Exit 1 on a survivor; refuses to report at all when no listed suite resolves the override.
- `tests/main/sequence-engine-gate.test.js` — resolves the module through the override with the real path as the fallback (the three lines of `process-utils-witness.test.js:10–12`), and holds exactly the four properties the mutants break, one `describe` each, on `init({ now })`. The caps case runs on the module DEFAULTS on purpose: a cap lowered through `init` would still be honoured by a mutant that only lifted the constants.
- `tests/main/sequence-engine.test.js` is listed as the non-killing control and labelled as such in the report — it hard-imports the real module.
- `npm run verify:seq-gate`; one step in the existing `test` job (no new job, no new status context); `seqGate.mutants` derived in `scripts/counts.js` with its own locate + parse scanner keyed on `N sequence-engine mutants`, so `gate.mutants` and `seqGate.mutants` can never be read as each other.
- The extra CI step moves `ci.commands` 9 → 10 at its four declaration sites (CLAUDE.md, AGENTS.md), and both files list the new command next to `verify:gate`. Roadmap header: block 2 fully landed; the §6 sentence now reads "Four sequence-engine mutants = four properties" so the scanner attributes it to the right counter.

## Mutants

| id | engine rewrite | property | killed by |
|---|---|---|---|
| m1-order-check-removed | `_applyRule`: the wanted step becomes any step whose matcher matches; the open accepts any step, not `steps[0]` | order | gate suite (4 cases red) |
| m2-expiry-comparison-removed | `_applyRule` transition 1 and `_sweepRule`: both `elapsed > timespanMs` comparisons neutralised | maxspan boundary | gate suite (1 case red) |
| m3-group-key-collapsed-to-rule | `_applyRule`: `key = rule.id` before the state lookup | group-by isolation | gate suite (4 cases red) |
| m4-caps-removed | `MAX_OPEN_PER_RULE` and `MAX_OPEN_TOTAL` → `Number.MAX_SAFE_INTEGER` | caps | gate suite (1 case red) |

Control suite (`sequence-engine.test.js`, 79 tests) green under every mutant — it has no killing power, by construction.

## Verified locally

- `npm run verify:seq-gate` exit 0: control green, m1–m4 each `RED (killed)`; `src/main/.mutants/` absent afterwards, `git status` clean.
- Breaking m3 so its replace equals its find: the script exits 1 with `its edits left the source byte-identical — nothing was mutated`. A semantically inert rewrite of m3 (`key = String(key)`) is reported `SURVIVED`, exit 1. Both reverted, script byte-identical to the committed copy.
- `npm run counts:check` green: `seqGate.mutants = 4` (5 sites), `gate.mutants = 4` (5 sites), `ci.commands = 10`.
- format:check, lint, typecheck, typecheck:svelte, build:renderer, test:coverage green on the rebased tree (see the PR checks for the CI run).
