### PR TITLE
chore(release): bump the llms version lines via release-please extra-files

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -59,7 +59,7 @@ JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily r
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
 - **Tests**: Vitest; run `npm test` for current pass/skip and file counts
 - **License**: MIT
-- **Version**: 0.13.0-alpha
+- **Version**: 0.13.0-alpha <!-- x-release-please-version -->
 - **Platform**: Windows, macOS, Linux
 
 ## Links

--- a/llms.txt
+++ b/llms.txt
@@ -25,7 +25,7 @@
 - **Stack**: Electron 33, Svelte 5, Vite 7, TypeScript
 - **Tests**: Vitest; run `npm test` for current pass/skip and file counts
 - **License**: MIT
-- **Version**: 0.13.0-alpha
+- **Version**: 0.13.0-alpha <!-- x-release-please-version -->
 - **Platform**: Windows, macOS, Linux
 
 ## Links

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,7 +14,11 @@
       ],
       "bump-minor-pre-major": true,
       "prerelease": true,
-      "prerelease-type": "alpha"
+      "prerelease-type": "alpha",
+      "extra-files": [
+        { "type": "generic", "path": "llms.txt" },
+        { "type": "generic", "path": "llms-full.txt" }
+      ]
     }
   }
 }

--- a/scripts/counts.js
+++ b/scripts/counts.js
@@ -264,8 +264,12 @@ const mainTop = trackedTopLevel('src/main', (f) => f.endsWith('.js'));
  * printed like every other, and a disagreement is reported under its own heading — it
  * simply does not exit 1. That is a THIRD position between "checked" and
  * `DERIVED_ONLY`, not a skip flag: the counter keeps its declaration sites, so the
- * undeclared gate and the unparseable gate still apply to it in full. `package.version`
- * is the only one, and carries the reason at its entry.
+ * undeclared gate and the unparseable gate still apply to it in full. NO entry carries
+ * it today: `package.version` was the only one, and it went blocking the moment
+ * release-please `extra-files` took over its two prose sites. The position is kept
+ * because a future counter can land in the same bind, and the report prints its two
+ * clauses only while something occupies it — an empty set stated out loud reads as an
+ * occupied one.
  * @type {Array<{key: string, label: string, value: number|string, command: string,
  *   blocking?: boolean}>}
  */
@@ -414,19 +418,27 @@ const COUNTERS = [
     label: 'package.json version',
     value: version,
     command: 'node -p "require(\'./package.json\').version"',
-    // `blocking: false`, and the reason is release-please. Its release PR bumps
-    // `version` in package.json and touches neither llms file, so a blocking compare
-    // would turn the `test` context red on that PR and STAY red on master afterwards
-    // until somebody hand-edited prose — a required context failing on the one commit
-    // nobody authors by hand, which is the exact failure the DERIVED_ONLY block below
-    // was written about. Moving the version there instead would take its declaration
-    // sites away, and two files free to say anything is how llms.txt and llms-full.txt
-    // came to answer "see `version` in `package.json`" — true, and useless to a crawler
-    // reading either file standalone. So it is located, compared and reported, and only
-    // the exit code is withheld. Making it blocking is a release-please `extra-files`
-    // change (it would have to rewrite both prose sites in the bump commit), not a
-    // change here.
-    blocking: false,
+    // BLOCKING, because release-please now carries the bump. `release-please-config.json`
+    // lists llms.txt and llms-full.txt as `extra-files` of type `generic`, and the
+    // generic updater rewrites the semver on any line holding the inline annotation
+    // `x-release-please-version` — so one release PR bumps `version` in package.json AND
+    // both `- **Version**: <semver>` prose sites in the same commit. That removes the
+    // reason the entry used to carry `blocking: false`: before the config existed, the
+    // release PR touched neither llms file, and a blocking compare would have turned the
+    // `test` context red on the one commit nobody authors by hand and kept master red
+    // until somebody hand-edited prose. Moving the version to DERIVED_ONLY instead would
+    // have taken its declaration sites away, and two files free to say anything is how
+    // llms.txt and llms-full.txt came to answer "see `version` in `package.json`" — true,
+    // and useless to a crawler reading either file standalone.
+    //
+    // What the annotation guarantees, and what it does not (ai-mistakes #27). The updater
+    // replaces the FIRST semver-looking match on the marked line with
+    // `version.toString()` — no leading `v`, which the `app-version` parser below
+    // tolerates either way. The guarantee therefore covers a line whose only
+    // `\d+\.\d+\.\d+` IS the version field, which both sites are: the label and the
+    // annotation carry no digits. Put the marker on a line holding an earlier number and
+    // release-please rewrites that number instead, leaving the field stale — this compare
+    // is what goes red then, which is the whole point of it being blocking again.
   },
 ];
 
@@ -1083,11 +1095,21 @@ if (failed) {
   process.exit(1);
 }
 
+// Both `blocking: false` clauses are printed only while a counter carries the flag.
+// With none, `(0 of them reported-only: )` and `and 0 drifted without blocking` are two
+// true sentences about an empty set, and a summary that keeps stating the position reads
+// as one where the position is still occupied.
+const reportedOnlyClause =
+  nonBlocking.length > 0
+    ? ` (${nonBlocking.length} of them reported-only: ${nonBlocking.map((c) => c.key).join(', ')})`
+    : '';
+const driftClause = nonBlocking.length > 0 ? ` and ${drifted.length} drifted without blocking` : '';
+
 console.log(
-  `\ncounts:check OK — ${COUNTERS.length} checked counters derived from the tree ` +
-    `(${nonBlocking.length} of them reported-only: ${nonBlocking.map((c) => c.key).join(', ')}), ` +
-    `${declarations.length - drifted.length} of ${declarations.length} declaration sites agree ` +
-    `and ${drifted.length} drifted without blocking; ` +
+  `\ncounts:check OK — ${COUNTERS.length} checked counters derived from the tree` +
+    `${reportedOnlyClause}, ` +
+    `${declarations.length - drifted.length} of ${declarations.length} declaration sites agree` +
+    `${driftClause}; ` +
     `${DERIVED_ONLY.length} derived-only counters printed and declared nowhere by ` +
     `design (${COUNTERS.length + DERIVED_ONLY.length} counters derived in total).`,
 );


### PR DESCRIPTION
## What

The release PR bumped `package.json` alone, so `package.version` in `scripts/counts.js` carried
`blocking: false`. Its two declaration sites — `llms.txt:28` and `llms-full.txt:62` — could only be
corrected by hand, and a blocking compare would have turned the `test` context red on the one commit
nobody authors. Both files are now `extra-files` of type `generic`, both `- **Version**:` lines carry
the inline annotation, and the counter is blocking again.

## The annotation

```
llms.txt:28       - **Version**: 0.13.0-alpha <!-- x-release-please-version -->
llms-full.txt:62  - **Version**: 0.13.0-alpha <!-- x-release-please-version -->
```

Syntax and semantics taken from the documentation, not from memory:
<https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files>
— `extra-files` in the manifest configuration, inline annotation `x-release-please-version`, and
"for these annotations, we will try to replace the value on that line only". The annotation lives in
a trailing HTML comment because these are Markdown-shaped `.txt` files.

The updater itself, read at `src/updaters/generic.ts`:

- `INLINE_UPDATE_REGEX = /x-release-please-(?<scope>major|minor|patch|version-date|version|date)/`
  — the marker only has to appear somewhere on the line.
- `line.replace(VERSION_REGEX, version.toString())` — the FIRST semver-looking match on that line,
  substituted with a bare semver and **no leading `v`**. The rendered field therefore stays
  `0.14.0-alpha`, which is what keeps the `counts.js` `app-version` parse
  (`/\*\*Version\*\*\s*:\s*`?v?(\d+\.\d+\.\d+[\w.+-]*)`?/i`) matching after the bump.

## Proof obtained

Three, all stronger than the regex one-liner allowed as a fallback.

**1. The real updater, executed against these two files.** `release-please@17.11.2` — the version
family `googleapis/release-please-action@45996ed` (v5.0.0) depends on, `release-please: ^17.6.0` —
its `Generic` class run over both working-tree files with `Version.parse('0.14.0-alpha')`:

```
--- llms.txt (generic) ---
  before : "- **Version**: 0.13.0-alpha <!-- x-release-please-version -->"
  after  : "- **Version**: 0.14.0-alpha <!-- x-release-please-version -->"
  lines changed by the updater : 1
  counts.js locate fires       : true
  counts.js parse extracts     : 0.14.0-alpha
  leading "v" introduced       : false
  VERDICT: PASS
```

Identical for `llms-full.txt`. Negative control: with the annotation stripped, the updater returns
the file unchanged — the marker is what makes it fire. The discriminating line is
`counts.js parse extracts`: the POST-bump line is fed back through the `app-version` scanner and
parses to `0.14.0-alpha`. Proving only the pre-bump line parses would say nothing about the release
commit, which is the commit this counter now has to survive.

**2. `release-please release-pr --dry-run` against this branch on GitHub.** Same CLI, with
`--default-branch=chore/release-please-llms-extra-files`:

```
updates: 9
> Fetching llms.txt from branch chore/release-please-llms-extra-files
> Fetching llms-full.txt from branch chore/release-please-llms-extra-files
  llms.txt:  [class Generic extends DefaultUpdater]
  llms-full.txt:  [class Generic extends DefaultUpdater]
```

The same command against `master` reports `updates: 7` and neither file. The edited config was also
validated against release-please's own `schemas/config.json` (draft-07, ajv 8.20.0): valid.

**3. The counter is load-bearing (ai-mistakes #21).** `llms.txt` mutated to `9.9.9-alpha`:

```
Stale declarations (1)
    package.version declared 9.9.9-alpha, derived 0.13.0-alpha  (package.json version)
counts:check FAILED — 1 stale, 0 unparseable, 0 undeclared, 0 dead exemption(s).
EXIT=1
```

Reported under **Stale declarations** and exiting 1, not under "Drift reported, not blocking".
Mutant reverted, `git diff --numstat` back to `1 1` on that file.

## scripts/counts.js

`blocking: false` is dropped from the `package.version` entry, and its comment rewritten to state
that `extra-files` carries the bump — plus what the annotation does and does not guarantee: the
substitution covers a line whose only `\d+\.\d+\.\d+` IS the version field, which both sites are,
and a marker on a line holding an earlier number would bump the wrong one.

The `blocking: false` position itself is kept, since a future counter can land in the same bind, but
nothing occupies it now — so the OK summary prints its two non-blocking clauses only while something
does, instead of stating an empty set out loud:

```
before: counts:check OK — 23 checked counters derived from the tree (1 of them reported-only:
        package.version), 109 of 109 declaration sites agree and 0 drifted without blocking; 2
        derived-only counters printed and declared nowhere by design (25 counters derived in total).

after:  counts:check OK — 23 checked counters derived from the tree, 109 of 109 declaration sites
        agree; 2 derived-only counters printed and declared nowhere by design (25 counters derived
        in total).
```

## Gates

All ten local pre-merge commands, run in a dedicated `X:\tmp` worktree off `e64e76d`.

| command | result |
| --- | --- |
| `build:renderer` | green, built in 2.27s |
| `format:check` | green — `.txt` is outside every prettier glob; `release-please-config.json` is root JSON and matches Prettier style |
| `lint` | green, 0 errors / 30 warnings (pre-existing `no-console`) |
| `typecheck` | green, both projects |
| `typecheck:svelte` | 416 files, 0 errors, 0 warnings |
| `test:coverage` | 135 files, 2478 passed / 4 skipped |
| `verify:gate` | 4/4 mutants red |
| `verify:seq-gate` | 4/4 mutants red |
| `counts:check` | OK, 109 of 109 declaration sites agree |
| `npm audit --audit-level=high --omit=dev` | 0 vulnerabilities |

CRLF check on the two `.txt` edits, this checkout being `i/lf w/crlf`: the marker sits before the
`\r`, no stray CR mid-line, no bare-LF line, no NUL byte, and `git diff --numstat` reads exactly
`1 1` for each file.
