### PR TITLE
feat(ipc): retain sensitive events under file-access batcher capacity pressure

### DIFF
--- a/src/main/file-access-batching.js
+++ b/src/main/file-access-batching.js
@@ -17,7 +17,9 @@
  * JSONL with its hash chain — owns completeness independently of this number.
  *
  * An eviction here is a frame the UI never saw. It is not a sensor `lossCount` and it
- * is not an audit drop; see the ipc-batcher module header for that boundary.
+ * is not an audit drop; see the ipc-batcher module header for that boundary. Which frame
+ * goes is {@link fileAccessRetain}'s call: the oldest non-sensitive one while any is
+ * buffered.
  * @type {number}
  * @since v0.13.0
  */
@@ -101,19 +103,50 @@ function fileAccessCoalesceKey(value) {
 }
 
 /**
+ * Retention predicate for the `file-access` display lane: `true` for a sensitive event,
+ * `false` for everything else.
+ *
+ * WHAT IT GUARANTEES, and its bound. Under capacity pressure ipc-batcher evicts the
+ * oldest entry this predicate does not retain, so a sensitive event is delivered to the
+ * renderer as long as ANY non-sensitive frame shares its 150 ms window — a burst of
+ * self-churn or project-directory noise can no longer push a credential read out of the
+ * live list. The bound is the window itself: more than {@link FILE_ACCESS_CAPACITY}
+ * sensitive events inside one window evicts the oldest sensitive one, and that loss is
+ * counted in `getStats().retainedEvicted` rather than hidden. The record of the event is
+ * unaffected either way — the activityLog ring and the audit JSONL hold it before the
+ * batcher ever sees it (file-watcher.js, scan-loop.js `logAuditForFile`).
+ *
+ * `sensitive === true` exactly, the same reading {@link fileAccessCoalesceKey} makes: a
+ * merely truthy value is not a sensitive event as file-watcher.js builds one
+ * (`sensitive: reason !== null && !selfAccess`).
+ *
+ * Pure and total: no throw for any input, because ipc-batcher resolves this on the push
+ * path before any counter moves.
+ * @param {unknown} value - A file event as built by file-watcher.js, or anything else.
+ * @returns {boolean} Whether capacity pressure must spare this entry while it can.
+ * @since v0.14.0
+ */
+function fileAccessRetain(value) {
+  if (value === null || typeof value !== 'object') return false;
+  return /** @type {Record<string, unknown>} */ (value).sensitive === true;
+}
+
+/**
  * The exact options main.js passes to `createBatcher('file-access', …)`.
  *
- * Frozen and exported as ONE object rather than three loose constants so a test can
+ * Frozen and exported as ONE object rather than four loose constants so a test can
  * exercise the production configuration itself instead of re-assembling something that
  * merely looks like it — a re-assembled config proves the values, never the wiring.
  * @type {Readonly<{intervalMs: number, capacity: number,
- *   coalesceKey: (value: unknown) => string | null}>}
+ *   coalesceKey: (value: unknown) => string | null,
+ *   retain: (value: unknown) => boolean}>}
  * @since v0.13.0
  */
 const FILE_ACCESS_BATCHER_OPTIONS = Object.freeze({
   intervalMs: FILE_ACCESS_INTERVAL_MS,
   capacity: FILE_ACCESS_CAPACITY,
   coalesceKey: fileAccessCoalesceKey,
+  retain: fileAccessRetain,
 });
 
 module.exports = {
@@ -122,4 +155,5 @@ module.exports = {
   FILE_ACCESS_BATCHER_OPTIONS,
   KEY_SEP,
   fileAccessCoalesceKey,
+  fileAccessRetain,
 };

--- a/src/main/ipc-batcher.js
+++ b/src/main/ipc-batcher.js
@@ -17,6 +17,9 @@
  *   unbounded, which is exactly the behaviour every caller had before v0.13.0.
  * @property {(value: unknown) => string | null} [coalesceKey] - 'append' only. Merge key
  *   for a pushed value, or null when the value must never merge.
+ * @property {(value: unknown) => boolean} [retain] - 'append' only. Under `capacity`
+ *   pressure the oldest entry it does NOT retain is evicted first; a retained entry goes
+ *   only when every buffered entry is retained. It picks the victim — one always goes.
  */
 
 /**
@@ -25,6 +28,8 @@
  * @property {number} coalesced - Pushes that replaced a same-key entry, lifetime.
  * @property {number} evicted - Entries dropped to honour `capacity`, lifetime.
  * @property {number} evictedSinceFlush - Evictions since the last flush that SENT.
+ * @property {number} retainedEvicted - Evictions that took a RETAINED entry because the
+ *   buffer held nothing else, lifetime. A subset of `evicted`; stays 0 without `retain`.
  * @property {number} highWater - Largest buffered length ever observed.
  * @property {number} buffered - Entries the next flush would send, right now.
  */
@@ -51,15 +56,16 @@
  * audit drop. The durable record — the activityLog ring and the audit-logger JSONL with
  * its hash chain and buffer-overflow-drop markers — is a separate lane that accounts for
  * its own loss. A number from {@link BatcherStats} answers "what did the UI not see",
- * never "what was not observed" or "what was not recorded".
+ * never "what was not observed" or "what was not recorded". `retain` narrows WHAT the lane
+ * drops, not what the lane is: capacity pressure spares retained entries while it can, and
+ * the residual is `retainedEvicted`, never silence.
  *
  * @param {string} channel - IPC channel name (e.g. 'file-access').
  * @param {(channel: string, data: unknown) => void} sendFn - Function that sends data to renderer.
  * @param {BatcherOptions} [options]
  * @returns {Batcher}
- * @throws {Error} when `capacity` is not a positive integer, when `coalesceKey` is not a
- *   function, or when either is passed in 'latest' mode, where a one-slot buffer can
- *   neither overflow nor merge.
+ * @throws {Error} when `capacity` is not a positive integer, when `coalesceKey` or `retain`
+ *   is not a function, or when any of the three is passed in 'latest' mode.
  * @since v0.5.0
  */
 function createBatcher(channel, sendFn, options = {}) {
@@ -67,33 +73,32 @@ function createBatcher(channel, sendFn, options = {}) {
   const mode = options.mode || 'append';
   const capacity = options.capacity;
   const coalesceKey = options.coalesceKey;
+  const retain = options.retain;
 
   if (capacity !== undefined) {
-    if (mode !== 'append') {
-      throw new Error("ipc-batcher: capacity requires mode 'append'");
-    }
+    if (mode !== 'append') throw new Error("ipc-batcher: capacity requires mode 'append'");
     if (!Number.isInteger(capacity) || capacity < 1) {
       throw new Error('ipc-batcher: capacity must be a positive integer');
     }
   }
-  if (coalesceKey !== undefined) {
-    if (mode !== 'append') {
-      throw new Error("ipc-batcher: coalesceKey requires mode 'append'");
-    }
-    if (typeof coalesceKey !== 'function') {
-      throw new Error('ipc-batcher: coalesceKey must be a function');
-    }
+  for (const name of /** @type {const} */ (['coalesceKey', 'retain'])) {
+    const fn = options[name];
+    if (fn === undefined) continue;
+    if (mode !== 'append') throw new Error(`ipc-batcher: ${name} requires mode 'append'`);
+    if (typeof fn !== 'function') throw new Error(`ipc-batcher: ${name} must be a function`);
   }
 
   /** @type {unknown} */
   let buffer = mode === 'append' ? [] : undefined;
   /**
-   * Merge keys, parallel to the append buffer — index i holds the key of entry i, or
-   * null for an entry that must never merge. Stays null while coalescing is off, so a
-   * batcher without `coalesceKey` allocates and walks nothing extra.
+   * Parallel to the append buffer: `keys[i]` is entry i's merge key (null = never merges),
+   * `retained[i]` whether entry i is retained. Each stays null while its option is off, so
+   * a batcher without it allocates and walks nothing extra.
    * @type {(string | null)[] | null}
    */
   let keys = coalesceKey ? [] : null;
+  /** @type {boolean[] | null} */
+  let retained = retain ? [] : null;
   /**
    * A pending {@link pushLazy} producer, or null. Held in its own slot rather than in
    * `buffer` so a payload that happens to be a function is still a payload.
@@ -108,6 +113,7 @@ function createBatcher(channel, sendFn, options = {}) {
   let coalesced = 0;
   let evicted = 0;
   let evictedSinceFlush = 0;
+  let retainedEvicted = 0;
   let highWater = 0;
 
   /** Schedule a flush if one isn't already pending. */
@@ -134,35 +140,42 @@ function createBatcher(channel, sendFn, options = {}) {
    * REPLACES that entry where it stands — position preserved, last value wins — instead
    * of extending the buffer. A merge adds no entry, so it can never trigger an eviction.
    *
-   * With `capacity` set, a push that would exceed it drops the OLDEST buffered entry
-   * first and the pushed value always enters. Eviction is oldest-first regardless of what
-   * an entry holds: selective retention is the caller's job via `coalesceKey`, and the
-   * durable lane owns completeness.
+   * With `capacity` set, a push that would exceed it evicts ONE entry and always enters.
+   * Without `retain` the oldest goes; with it, the oldest entry the predicate does not
+   * retain — a retained entry goes only from a buffer that is all retained, and that is
+   * what `retainedEvicted` counts. The durable lane still owns completeness.
    * @param {unknown} value - Event object (append) or full replacement value (latest).
    */
   function push(value) {
     if (destroyed) return;
     if (mode === 'append') {
       const buf = /** @type {unknown[]} */ (buffer);
-      // Resolved before any counter moves: a throwing coalesceKey must leave the
-      // batcher exactly as it found it.
+      // Resolved before any counter moves: a throw here leaves the batcher as it was.
       const key = coalesceKey ? coalesceKey(value) : null;
+      const keep = retain ? retain(value) === true : false;
       pushed++;
       // Only a string merges. null, undefined, or anything else means this value must
       // never merge, and two such values both occupy their own slot.
       const at = typeof key === 'string' && keys !== null ? keys.indexOf(key) : -1;
       if (at !== -1) {
         buf[at] = value;
+        // The flag describes the value buffered NOW, not the one it replaced.
+        if (retained !== null) retained[at] = keep;
         coalesced++;
       } else {
         if (capacity !== undefined && buf.length >= capacity) {
-          buf.shift();
-          if (keys !== null) keys.shift();
+          // Victim: oldest non-retained entry, else slot 0 — a retained one, counted below.
+          const victim = retained === null ? 0 : Math.max(0, retained.indexOf(false));
+          if (retained !== null && retained[victim]) retainedEvicted++;
+          buf.splice(victim, 1);
+          if (keys !== null) keys.splice(victim, 1);
+          if (retained !== null) retained.splice(victim, 1);
           evicted++;
           evictedSinceFlush++;
         }
         buf.push(value);
         if (keys !== null) keys.push(typeof key === 'string' ? key : null);
+        if (retained !== null) retained.push(keep);
       }
     } else {
       buffer = value;
@@ -222,6 +235,7 @@ function createBatcher(channel, sendFn, options = {}) {
       if (buf.length === 0) return;
       buffer = [];
       if (keys !== null) keys = [];
+      if (retained !== null) retained = [];
       evictedSinceFlush = 0;
       sendFn(channel, buf);
     } else {
@@ -252,10 +266,10 @@ function createBatcher(channel, sendFn, options = {}) {
   /**
    * Snapshot of this batcher's own accounting, as a fresh object per call.
    *
-   * `pushed`, `coalesced` and `evicted` are lifetime totals; `evictedSinceFlush` returns
-   * to 0 on every flush that actually sent; `highWater` is a lifetime maximum and never
-   * returns to 0. Still readable after {@link destroy}, which leaves the totals standing
-   * and `buffered` at 0.
+   * `pushed`, `coalesced`, `evicted` and `retainedEvicted` are lifetime totals;
+   * `evictedSinceFlush` returns to 0 on every flush that actually sent; `highWater` is a
+   * lifetime maximum and never returns to 0. Still readable after {@link destroy}, which
+   * leaves the totals standing and `buffered` at 0.
    *
    * Two exclusions, stated rather than implied. A push refused because the batcher was
    * destroyed is not counted anywhere — it never entered. And {@link pushLazy} is outside
@@ -263,8 +277,8 @@ function createBatcher(channel, sendFn, options = {}) {
    * `buffered: 0`, because what it will build does not exist yet.
    *
    * In 'latest' mode only the counters that can apply do: `buffered` is 0 or 1, and
-   * `coalesced`, `evicted` and `evictedSinceFlush` stay 0 — a one-slot buffer can neither
-   * overflow nor merge.
+   * `coalesced`, `evicted`, `evictedSinceFlush` and `retainedEvicted` stay 0 — a one-slot
+   * buffer can neither overflow nor merge.
    * @returns {BatcherStats}
    * @since v0.13.0
    */
@@ -274,6 +288,7 @@ function createBatcher(channel, sendFn, options = {}) {
       coalesced,
       evicted,
       evictedSinceFlush,
+      retainedEvicted,
       highWater,
       buffered: bufferedCount(),
     };

--- a/tests/main/file-access-batching.test.js
+++ b/tests/main/file-access-batching.test.js
@@ -26,6 +26,7 @@ import {
   FILE_ACCESS_BATCHER_OPTIONS,
   KEY_SEP,
   fileAccessCoalesceKey,
+  fileAccessRetain,
 } from '../../src/main/file-access-batching.js';
 
 /**
@@ -188,6 +189,35 @@ describe('fileAccessCoalesceKey', () => {
   });
 });
 
+describe('fileAccessRetain', () => {
+  it('retains a sensitive event', () => {
+    expect(fileAccessRetain(sensitiveEvent())).toBe(true);
+  });
+
+  it('does not retain benign self-churn', () => {
+    expect(fileAccessRetain(selfChurn())).toBe(false);
+  });
+
+  it('does not retain an ordinary non-sensitive event either', () => {
+    expect(fileAccessRetain(selfChurn({ selfAccess: false, reason: '' }))).toBe(false);
+  });
+
+  it('reads `sensitive === true` exactly — a merely truthy value is not a sensitive event', () => {
+    expect(fileAccessRetain(sensitiveEvent({ sensitive: 1 }))).toBe(false);
+    expect(fileAccessRetain(sensitiveEvent({ sensitive: 'yes' }))).toBe(false);
+    expect(fileAccessRetain(sensitiveEvent({ sensitive: 'true' }))).toBe(false);
+  });
+
+  it('is total: anything that is not an object answers false and never throws', () => {
+    // ipc-batcher resolves this on the push path before any counter moves, so a throw
+    // would leave the batcher mid-update — the same contract fileAccessCoalesceKey keeps.
+    for (const v of [null, undefined, 0, 1, '', 'x', true, false, Symbol('s'), () => {}]) {
+      expect(fileAccessRetain(v)).toBe(false);
+    }
+    expect(() => fileAccessRetain(undefined)).not.toThrow();
+  });
+});
+
 describe('FILE_ACCESS_BATCHER_OPTIONS', () => {
   it('carries the documented bounds and is frozen', () => {
     expect(FILE_ACCESS_CAPACITY).toBe(1000);
@@ -196,6 +226,7 @@ describe('FILE_ACCESS_BATCHER_OPTIONS', () => {
       intervalMs: 150,
       capacity: 1000,
       coalesceKey: fileAccessCoalesceKey,
+      retain: fileAccessRetain,
     });
     expect(Object.isFrozen(FILE_ACCESS_BATCHER_OPTIONS)).toBe(true);
   });
@@ -273,10 +304,7 @@ describe('file-access batcher under the production options', () => {
     vi.advanceTimersByTime(FILE_ACCESS_INTERVAL_MS);
     const payload = send.mock.calls[0][1];
     expect(payload).toHaveLength(2);
-    expect(payload.map((e) => e.instanceId)).toEqual([
-      '4321:1699887000000',
-      '9876:1699887000000',
-    ]);
+    expect(payload.map((e) => e.instanceId)).toEqual(['4321:1699887000000', '9876:1699887000000']);
     expect(batcher.getStats().coalesced).toBe(18);
     batcher.destroy();
   });
@@ -322,6 +350,51 @@ describe('file-access batcher under the production options', () => {
     expect(stats.evicted).toBe(0);
     expect(stats.buffered).toBe(1);
     expect(stats.coalesced).toBe(FILE_ACCESS_CAPACITY * 3 - 1);
+    batcher.destroy();
+  });
+
+  it('ACCEPTANCE: a sensitive event pushed FIRST survives a full-capacity burst of distinct self-churn', () => {
+    // The oldest entry is the one plain oldest-first eviction would drop. With the
+    // production `retain`, capacity pressure takes the oldest NON-sensitive frame instead,
+    // so the sensitive event is delivered and the drop lands on self-churn. Restore an
+    // unconditional `buf.shift()` in ipc-batcher and this case goes red.
+    const { send, batcher } = makeProductionBatcher();
+    const sensitive = sensitiveEvent();
+    batcher.push(sensitive);
+    // Distinct files → distinct keys → nothing merges, so capacity is what answers.
+    for (let i = 0; i < FILE_ACCESS_CAPACITY; i += 1) {
+      batcher.push(selfChurn({ file: `C:\\Users\\me\\.claude\\f${i}.json` }));
+    }
+
+    const stats = batcher.getStats();
+    expect(stats.pushed).toBe(FILE_ACCESS_CAPACITY + 1);
+    expect(stats.evicted).toBe(1);
+    expect(stats.retainedEvicted).toBe(0);
+    expect(stats.buffered).toBe(FILE_ACCESS_CAPACITY);
+
+    vi.advanceTimersByTime(FILE_ACCESS_INTERVAL_MS);
+    const payload = send.mock.calls[0][1];
+    expect(payload).toHaveLength(FILE_ACCESS_CAPACITY);
+    // Same object, still first: retention keeps position as well as presence.
+    expect(payload[0]).toBe(sensitive);
+    // The frame that went instead is the oldest self-churn, f0; f1 now leads the churn.
+    expect(payload[1].file).toBe('C:\\Users\\me\\.claude\\f1.json');
+    expect(payload[FILE_ACCESS_CAPACITY - 1].file).toBe(
+      `C:\\Users\\me\\.claude\\f${FILE_ACCESS_CAPACITY - 1}.json`,
+    );
+    batcher.destroy();
+  });
+
+  it('the honest bound: a window holding MORE sensitive events than capacity evicts a sensitive one, and counts it', () => {
+    const { batcher } = makeProductionBatcher();
+    for (let i = 0; i < FILE_ACCESS_CAPACITY + 1; i += 1) {
+      batcher.push(sensitiveEvent({ file: `C:\\Users\\me\\.aws\\cred${i}` }));
+    }
+    const stats = batcher.getStats();
+    expect(stats.pushed).toBe(FILE_ACCESS_CAPACITY + 1);
+    expect(stats.evicted).toBe(1);
+    expect(stats.retainedEvicted).toBe(1);
+    expect(stats.buffered).toBe(FILE_ACCESS_CAPACITY);
     batcher.destroy();
   });
 });

--- a/tests/main/ipc-batcher.test.js
+++ b/tests/main/ipc-batcher.test.js
@@ -302,6 +302,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 7,
         evictedSinceFlush: 7,
+        retainedEvicted: 0,
         highWater: 3,
         buffered: 3,
       });
@@ -429,6 +430,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 4,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 2,
         buffered: 0,
       });
@@ -570,6 +572,7 @@ describe('ipc-batcher', () => {
         coalesced: 1,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 2,
         buffered: 2,
       });
@@ -641,6 +644,7 @@ describe('ipc-batcher', () => {
         coalesced: 297,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 3,
         buffered: 3,
       });
@@ -650,10 +654,190 @@ describe('ipc-batcher', () => {
     });
   });
 
+  // ── retain (append mode) ──
+
+  describe('retain (append mode)', () => {
+    it('evicts the oldest NON-retained entry first — the retained one keeps its place', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        capacity: 3,
+        retain: (v) => v.keep === true,
+      });
+
+      b.push({ id: 'r1', keep: true });
+      b.push({ id: 'n1', keep: false });
+      b.push({ id: 'n2', keep: false }); // full
+      b.push({ id: 'n3', keep: false }); // evicts n1, the oldest non-retained — not r1
+
+      expect(b.getStats()).toMatchObject({
+        pushed: 4,
+        evicted: 1,
+        retainedEvicted: 0,
+        buffered: 3,
+      });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { id: 'r1', keep: true },
+        { id: 'n2', keep: false },
+        { id: 'n3', keep: false },
+      ]);
+      b.destroy();
+    });
+
+    it('a buffer that is ALL retained evicts its oldest entry, and counts it as retainedEvicted', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, capacity: 2, retain: () => true });
+      b.push('a');
+      b.push('b');
+      b.push('c'); // nothing non-retained to take, so the oldest retained goes
+      expect(b.getStats()).toMatchObject({
+        pushed: 3,
+        evicted: 1,
+        retainedEvicted: 1,
+        buffered: 2,
+      });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', ['b', 'c']);
+      b.destroy();
+    });
+
+    it('ACCEPTANCE: retained entries at the head survive a non-retained burst three times the capacity', () => {
+      // The discriminating case. Plain oldest-first eviction drops r1 and r2 on the first
+      // two overflows; retention takes the oldest NON-retained entry every time instead,
+      // so the two retained entries are still there after twelve pushes into four slots.
+      // Restore an unconditional `buf.shift()` and this case goes red.
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        capacity: 4,
+        retain: (v) => v.keep === true,
+      });
+
+      b.push({ id: 'r1', keep: true });
+      b.push({ id: 'r2', keep: true });
+      for (let i = 1; i <= 12; i += 1) b.push({ id: `n${i}`, keep: false });
+
+      expect(b.getStats()).toMatchObject({
+        pushed: 14,
+        evicted: 10,
+        retainedEvicted: 0,
+        buffered: 4,
+        highWater: 4,
+      });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { id: 'r1', keep: true },
+        { id: 'r2', keep: true },
+        { id: 'n11', keep: false },
+        { id: 'n12', keep: false },
+      ]);
+      b.destroy();
+    });
+
+    it('an eviction from the MIDDLE keeps the key table in step with the buffer', () => {
+      // With retention the evicted slot is no longer always slot 0, so the key table must
+      // lose the same index the buffer lost, or a later merge lands on the wrong entry.
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        capacity: 3,
+        coalesceKey: (v) => v.k,
+        retain: (v) => v.keep === true,
+      });
+
+      b.push({ k: 'a', keep: true, n: 1 });
+      b.push({ k: 'b', keep: false, n: 2 });
+      b.push({ k: 'c', keep: false, n: 3 }); // full: [a, b, c]
+      b.push({ k: 'd', keep: false, n: 4 }); // evicts b (slot 1): [a, c, d]
+      b.push({ k: 'c', keep: false, n: 5 }); // must merge onto slot 1 (c), not slot 2 (d)
+
+      expect(b.getStats()).toMatchObject({ pushed: 5, coalesced: 1, evicted: 1, buffered: 3 });
+
+      b.push({ k: 'e', keep: false, n: 6 }); // evicts c (slot 1, the oldest non-retained): [a, d, e]
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { k: 'a', keep: true, n: 1 },
+        { k: 'd', keep: false, n: 4 },
+        { k: 'e', keep: false, n: 6 },
+      ]);
+      b.destroy();
+    });
+
+    it('a merge re-evaluates retain on the replacement value', () => {
+      // A retained entry replaced by a non-retained value of the same key must become
+      // evictable: the flag describes the value that is buffered NOW, not the first one.
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        capacity: 2,
+        coalesceKey: (v) => v.k,
+        retain: (v) => v.keep === true,
+      });
+
+      b.push({ k: 'a', keep: true, n: 1 });
+      b.push({ k: 'b', keep: false, n: 2 }); // full: [a, b]
+      b.push({ k: 'a', keep: false, n: 3 }); // merge: a is no longer retained
+      b.push({ k: 'c', keep: false, n: 4 }); // evicts slot 0 (a), the oldest non-retained: [b, c]
+
+      expect(b.getStats()).toMatchObject({
+        pushed: 4,
+        coalesced: 1,
+        evicted: 1,
+        retainedEvicted: 0,
+        buffered: 2,
+      });
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', [
+        { k: 'b', keep: false, n: 2 },
+        { k: 'c', keep: false, n: 4 },
+      ]);
+      b.destroy();
+    });
+
+    it('a throwing retain leaves the batcher exactly as it found it', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, {
+        intervalMs: 100,
+        capacity: 2,
+        retain: (v) => {
+          if (v === 'boom') throw new Error('retain exploded');
+          return false;
+        },
+      });
+
+      b.push('ok');
+      expect(() => b.push('boom')).toThrow(/retain exploded/);
+      expect(b.getStats()).toMatchObject({
+        pushed: 1,
+        evicted: 0,
+        retainedEvicted: 0,
+        buffered: 1,
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(send).toHaveBeenCalledWith('ch', ['ok']);
+      b.destroy();
+    });
+
+    it('without capacity, retain never fires and changes nothing', () => {
+      const send = vi.fn();
+      const b = createBatcher('ch', send, { intervalMs: 100, retain: () => false });
+      for (let i = 0; i < 50; i += 1) b.push(i);
+      expect(b.getStats()).toMatchObject({
+        pushed: 50,
+        evicted: 0,
+        retainedEvicted: 0,
+        buffered: 50,
+      });
+      b.destroy();
+    });
+  });
+
   // ── getStats ──
 
   describe('getStats', () => {
-    it('exposes exactly the six documented fields', () => {
+    it('exposes exactly the seven documented fields', () => {
       const b = createBatcher('ch', vi.fn(), { intervalMs: 100 });
       expect(Object.keys(b.getStats()).sort()).toEqual([
         'buffered',
@@ -662,6 +846,7 @@ describe('ipc-batcher', () => {
         'evictedSinceFlush',
         'highWater',
         'pushed',
+        'retainedEvicted',
       ]);
       b.destroy();
     });
@@ -673,6 +858,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 0,
         buffered: 0,
       });
@@ -689,6 +875,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 2,
         buffered: 2,
       });
@@ -709,6 +896,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 1,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 2,
         buffered: 0,
       });
@@ -723,6 +911,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 0,
         buffered: 0,
       });
@@ -741,7 +930,7 @@ describe('ipc-batcher', () => {
   // ── latest mode stats ──
 
   describe('getStats (latest mode)', () => {
-    it('reports the same six fields with only the counters that can apply', () => {
+    it('reports the same seven fields with only the counters that can apply', () => {
       const send = vi.fn();
       const b = createBatcher('stats', send, { intervalMs: 100, mode: 'latest' });
 
@@ -750,6 +939,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 0,
         buffered: 0,
       });
@@ -761,6 +951,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 1,
         buffered: 1,
       });
@@ -773,6 +964,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 1,
         buffered: 0,
       });
@@ -788,6 +980,7 @@ describe('ipc-batcher', () => {
         coalesced: 0,
         evicted: 0,
         evictedSinceFlush: 0,
+        retainedEvicted: 0,
         highWater: 0,
         buffered: 0,
       });
@@ -834,6 +1027,20 @@ describe('ipc-batcher', () => {
       expect(() =>
         createBatcher('ch', vi.fn(), { mode: 'latest', coalesceKey: () => 'k' }),
       ).toThrow(/coalesceKey requires mode 'append'/);
+    });
+
+    it('refuses a retain that is not a function', () => {
+      for (const bad of ['sensitive', 42, {}, null]) {
+        expect(() => createBatcher('ch', vi.fn(), { retain: bad })).toThrow(
+          /retain must be a function/,
+        );
+      }
+    });
+
+    it('refuses retain in latest mode: a one-slot buffer never chooses what to evict', () => {
+      expect(() => createBatcher('ch', vi.fn(), { mode: 'latest', retain: () => true })).toThrow(
+        /retain requires mode 'append'/,
+      );
     });
   });
 

--- a/tests/main/main-ipc-stats.test.js
+++ b/tests/main/main-ipc-stats.test.js
@@ -57,7 +57,7 @@ process.argv = ['node', 'main.js'];
 const require_ = createRequire(import.meta.url);
 const main = require_('../../src/main/main.js');
 
-/** The six fields ipc-batcher's getStats() publishes, sorted. */
+/** The seven fields ipc-batcher's getStats() publishes, sorted. */
 const BATCHER_STATS_KEYS = [
   'buffered',
   'coalesced',
@@ -65,6 +65,7 @@ const BATCHER_STATS_KEYS = [
   'evictedSinceFlush',
   'highWater',
   'pushed',
+  'retainedEvicted',
 ];
 
 /** Only what the loaded `getStats` branch reads off the scanner. */
@@ -90,7 +91,7 @@ afterAll(() => {
 });
 
 describe('getStats().ipc — display-lane delivery accounting', () => {
-  it('the scanner-absent branch carries the full six-field batcher shape', () => {
+  it('the scanner-absent branch carries the full seven-field batcher shape', () => {
     const stats = main.getStats();
     expect(stats).toHaveProperty('ipc');
     expect(Object.keys(stats.ipc)).toEqual(['fileAccess']);


### PR DESCRIPTION
## What

`ipc-batcher.js` gains a third `'append'`-only option, `retain: (value) => boolean`, validated exactly like `coalesceKey`. Under `capacity` pressure the oldest entry the predicate does **not** retain is evicted first; a retained entry is evicted only when every buffered entry is retained, and that loss is counted in a new seventh `getStats()` field, `retainedEvicted`. The pushed value still always enters, the flushed payload stays a flat array, and a batcher without `retain` evicts from slot 0 exactly as before.

`file-access-batching.js` supplies `fileAccessRetain` (`sensitive === true`, total, never throws) inside the frozen `FILE_ACCESS_BATCHER_OPTIONS` that main.js passes verbatim — so main.js, preload and the renderer are untouched.

## Why

Before this change the `file-access` display lane evicted oldest-first regardless of content (`ipc-batcher.js` `buf.shift()`), so a sensitive event arriving early in a 150 ms window that then filled with >1000 distinct-path frames (an `npm ci` / `git checkout` in the watched project dir is enough) was dropped from renderer delivery — counted in `evicted` on the main side, but never shown, and never distinguishable from churn. The event was not lost: the activityLog ring and the audit JSONL hold it before the batcher sees it. It was a silent display gap, and one a noisy burst could exploit to hide a credential read from the live feed.

The bound is stated, not hidden: more than `FILE_ACCESS_CAPACITY` sensitive events inside one window evicts the oldest sensitive one, and `retainedEvicted` reports it.

## Tests

`tests/main/ipc-batcher.test.js` (+9), `tests/main/file-access-batching.test.js` (+7), `tests/main/main-ipc-stats.test.js` (key list +1): option validation, oldest-non-retained-first, all-retained buffer counts `retainedEvicted`, the discriminating retained-head-survives-3×-capacity case, key table kept in step on a mid-buffer splice, merge re-evaluates `retain`, throwing `retain` leaves the batcher untouched, `retain` without `capacity` is a no-op, seven stats fields, `fileAccessRetain` exact-`true` reading and totality, the production-options object carries `retain`, the sensitive-first production burst, and the honest bound.

Mutant check by hand: victim forced back to slot 0 (unconditional shift) → 4 red across the two files, including the retained-head acceptance case and the sensitive-first production-burst case; restored, SHA-256 identical.

## Local pre-merge set

`format:check`, `lint` (0 errors, 30 pre-existing warnings), `typecheck`, `typecheck:svelte`, `build:renderer`, `test:coverage` (135 files, 2494 passed / 4 skipped), `verify:gate`, `verify:seq-gate`, `counts:check` (OK — `ipc-batcher.js` trimmed to exactly 300 lines so `size.over300` does not move), `npm audit --audit-level=high --omit=dev` (0).

## Out of scope, named

Renderer-side retention (`events` store cap 500 / feed 200, ux-audit U8), rendering `ipc.fileAccess.*` in the UI, the tray 30 s throttle, and the audit lane's own best-effort marker.
