### PR TITLE
docs: point branch-guard hook path at .codex/ in AGENTS.md and BRANCHING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ coverage thresholds are configured in `vitest.config.js`, so coverage cannot fai
 - **Conventional commits:** `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `style:`, `test:`
 - **Feature branches, always:** `feat/*` | `fix/*` | `chore/*` | `docs/*` → push → PR. One PR = one logical task.
 - **Merge commits only.** Squash and rebase are disabled on the repository, so `gh pr merge <n> --merge --delete-branch` is the only available method and every merge lands as a two-parent commit. Squash the noisy commits on your own branch *before* opening the PR — the merge will not do it for you.
-- **Direct commits to master are impossible, not merely discouraged.** `master` requires a pull request plus green `audit` / `build` / `lint` / `svelte-check` / `test`, with admin enforcement on, so a local commit on master cannot be pushed at all. `.claude/hooks/branch-guard.js` refuses edits on master before you reach that point.
+- **Direct commits to master are impossible, not merely discouraged.** `master` requires a pull request plus green `audit` / `build` / `lint` / `svelte-check` / `test`, with admin enforcement on, so a local commit on master cannot be pushed at all. `.codex/hooks/branch-guard.js` refuses edits on master before you reach that point.
 - **No Co-Authored-By lines.** No "Generated with" attribution in commits or PRs.
 
 ## What NOT to do

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -20,7 +20,7 @@
 4. **Direct commits to master are impossible, for anything — including typos, version bumps
    and CI config.** `master` requires a pull request plus green `audit` / `build` / `lint` /
    `svelte-check` / `test`, with admin enforcement on, so the push is rejected. The
-   `.claude/hooks/branch-guard.js` hook refuses edits on master before you get that far.
+   `.codex/hooks/branch-guard.js` hook refuses edits on master before you get that far.
 
 ## For AI agents (Claude Code)
 


### PR DESCRIPTION
Closes #281.

Both documents tell a contributor that a hook file at `.claude/hooks/branch-guard.js` guards commits on `master`. Nothing under `.claude/` is tracked in the repository; the only branch-guard hook is `.codex/hooks/branch-guard.js`, wired by `.codex/hooks.json`. This points both sentences at the file a contributor can actually locate in a fresh clone.

The surrounding text about `master` branch protection rejecting a direct push is accurate and unchanged — only the hook path is corrected.

Definition of done (from the issue):

```bash
git grep -n -F '.claude/hooks/branch-guard.js' -- AGENTS.md BRANCHING.md
# now returns nothing (exit 1)
```

Both edits are on the branch-guard line only. AGENTS.md had ten upstream commits since the fork point, but none touched the branch-guard line, so this branch merges cleanly into `master` (verified with a local three-way merge: `Auto-merging AGENTS.md`, no conflicts).