### PR TITLE
fix: restrict project Codex sandbox permissions

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,9 @@
-sandbox_mode = "danger-full-access"
-approval_policy = "never"
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+
+[sandbox_workspace_write]
+network_access = true
+
+[features.network_proxy]
+enabled = true
+domains = { "github.com" = "allow", "api.github.com" = "allow" }


### PR DESCRIPTION
The public project config currently grants unrestricted filesystem access with no approval step. Replace that with workspace-write and on-request approvals. Workspace-write protects .git and .codex as read-only, so never would prevent the full Git cycle; no filesystem exemptions are added.

Enable sandbox_workspace_write.network_access and enforce a network allowlist through features.network_proxy.enabled and features.network_proxy.domains. Only github.com and api.github.com are allowed for HTTPS Git and GitHub CLI operations. This restricts destinations, not individual Git commands. No model, reasoning, or Git credential settings change. Only .codex/config.toml is in the diff.

Official references:
- https://learn.chatgpt.com/docs/agent-approvals-security#protected-paths-in-writable-roots
- https://learn.chatgpt.com/docs/agent-approvals-security#network-access
- https://learn.chatgpt.com/docs/config-file/config-reference

Validation:
- Codex CLI 0.153.4 config/read loads workspace-write, on-request, no additional writable roots, and the two-host proxy allowlist.
- All five requested gates passed: test:coverage, typecheck, typecheck:svelte, npx eslint src/, build:renderer. ESLint has 19 existing warnings and no errors.
- format:check, full lint, both mutation gates, counts:check, and production dependency audit also passed.
- In a fresh workspace-write CLI session, gh api repos/antropos17/Aegis returned antropos17/Aegis (exit 0). Git HTTPS initially failed with Windows Schannel SEC_E_NO_CREDENTIALS; git -c http.sslBackend=openssl ls-remote origin HEAD succeeded (exit 0) without extra permissions or persisted Git changes.

Live hook verification revealed an unresolved failure:
- Reviewed and trusted only the three project hooks via /hooks, after backing up local settings. Codex reports all three enabled and trusted. No hook definition changed.
- Feature branch: actual apply_patch updated the config; a fresh workspace-write session required explicit approval for an edit within protected .codex, then returned {} and applied the edit.
- Master: the initial session, started before the config correction, accepted a harmless comment edit. After restarting with workspace-write, the hook runner reported "hook exited with code 1" rather than a blocking exit 2, and Codex requested approval. Approval was declined; the edit was not applied. All temporary comment edits were removed on the feature branch.

The live branch guard is not verified as working. The sandbox approval barrier protected the config in the fresh-session master test. Hook files remain unchanged because this correction is explicitly restricted to .codex/config.toml.