### PR TITLE
fix: preserve branch guard exit code on Windows

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -7,7 +7,8 @@
           {
             "type": "command",
             "command": "node -e \"const cp=require('child_process');const root=cp.execFileSync('git',['rev-parse','--show-toplevel'],{encoding:'utf8'}).trim();const r=cp.spawnSync(process.execPath,[require('path').join(root,'.codex/hooks/branch-guard.js')],{stdio:'inherit'});process.exit(r.status===null?1:r.status);\"",
-            "timeout": 5
+            "timeout": 5,
+            "commandWindows": "node -e \"const cp=require('child_process');const root=cp.execFileSync('git',['rev-parse','--show-toplevel'],{encoding:'utf8'}).trim();const r=cp.spawnSync(process.execPath,[require('path').join(root,'.codex/hooks/branch-guard.js')],{stdio:'inherit'});process.exit(r.status===null?1:r.status);\"; exit $LASTEXITCODE"
           }
         ]
       }

--- a/.codex/hooks/branch-guard.js
+++ b/.codex/hooks/branch-guard.js
@@ -20,6 +20,9 @@
 // it does not document a project-root environment variable for command hooks.
 // Block: exit code 2 + a plain-language message on stderr (the canonical form).
 // Allow: exit code 0.
+// The Windows hook launcher must end with `exit $LASTEXITCODE`: PowerShell
+// otherwise maps a native exit 2 to exit 1, which Codex treats as a hook error
+// rather than a blocking decision that prevents the edit.
 //
 // Registered in .codex/hooks.json beside the project .codex/config.toml.
 // Test the logic: require this module and call decide() with mock rows, OR pipe


### PR DESCRIPTION
A blocked edit on master made branch-guard.js exit 2 with the intended stderr, but PowerShell converted the native exit code to 1. Codex therefore treated the result as a hook error instead of preventing the edit.

Add the documented Windows command override ending in `exit $LASTEXITCODE`, and document that requirement in the guard header. The existing payload parsing and branch decision logic remain unchanged: neither was throwing.

Validation:
- Captured real hook stderr and reproduced Node exit 2, old PowerShell launcher exit 1, corrected launcher exit 2.
- Trusted the revised hook through `/hooks`, then tested fresh Codex CLI 0.153.4 sessions: the feature-branch edit applied; the master attempt returned `Command blocked by PreToolUse hook` before an edit approval, with no write.
- Master stderr: `Cannot edit on master: X:\Future\ESCAPE\AEGIS\.codex\hooks\branch-guard.js` followed by `Create a feature branch first (feat/* | fix/* | chore/* | docs/*).` Feature stderr was empty.
- Passed test:coverage, typecheck, typecheck:svelte, eslint src/, build:renderer, format:check, lint, verify:gate, verify:seq-gate, counts:check, production dependency audit, and formatting checks for both changed files. Existing lint warnings only.
