### PR TITLE
docs: record Codex migration and PowerShell hook lesson

### DIFF
--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -1,6 +1,6 @@
 # AI Mistakes Log — AEGIS
 
-Repeated mistakes by Claude Code — 45 numbered lessons, grouped by category (the newest is not at the bottom: #44–#45 sit under Tooling). READ BEFORE EVERY CHANGE.
+Repeated mistakes by Claude Code — 46 numbered lessons, grouped by category (the newest is not at the bottom: #46 sits under PowerShell). READ BEFORE EVERY CHANGE.
 
 ## CSS / Styles
 1. Adds text-transform: uppercase to h2 globally — breaks settings/modal headers
@@ -103,6 +103,23 @@ Repeated mistakes by Claude Code — 45 numbered lessons, grouped by category (t
     rule 3 is the one to cite.
 
 ## PowerShell
+46. **PowerShell `-Command` converted a blocking hook exit into a non-blocking hook error.**
+    Diagnosed 2026-09-07 in PR #344 (merge `8db8765`). The Codex branch guard wrote
+    `Cannot edit on master` to stderr and Node exited 2; its PowerShell launcher exited 1.
+    No exception occurred in the guard. The same payload returned 2 through Node directly,
+    1 through the old launcher, and 2 when the command ended with `; exit $LASTEXITCODE`.
+    PowerShell `-Command` maps a final native exit code other than 0 or 1 to 1 unless
+    explicitly propagated; this does not describe every PowerShell invocation mode.
+    **For command hooks, preserve the native status at the shell boundary.** Codex treats
+    exit 2 plus stderr as a blocking decision. The Windows override in `.codex/hooks.json`
+    now propagates it. Fresh CLI sessions after `/hooks` trust confirmed a feature-branch
+    edit succeeded and a master edit was blocked before approval. Capture actual stderr
+    and compare child and launcher status before concluding that a hook script threw.
+    [PowerShell exit-code semantics](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#-command).
+    Multiline PR bodies were also created successfully from PowerShell in this session:
+    write the here-string to a UTF-8 temporary file and pass `gh pr create --body-file`.
+    The body then bypasses native argument quoting; switching to Git Bash was unnecessary.
+
 18. Uses && in PowerShell commands instead of ; or powershell.exe -NoProfile -Command wrapper
 
 ## CI

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -633,3 +633,26 @@ See git log for Steps 1-54. Previous progress.md content archived in git history
 - **Mutations, each applied by exact-string replacement with an asserted count, the two suites run RED, reverted with `git checkout --`, `git diff HEAD` empty:** M2 index fed BEFORE `appendFileSync` with the pre-write offset → 3 red (T5′, rows ≤ lines, T8); M3 byte-offset check dropped → 2 red (T5′, T8); M6 reconcile's orphan branch removed → 1 red (T8); M7 `enableForeignKeyConstraints: false` at both opens → 4 red (T5′, T6, T8, CASCADE); M8 gate ignores the `loadSqlite` seam → 1 red (T1).
 - **Gates on the branch (worktree with its own `npm ci`, Node 24.11.1):** `typecheck` 0, `typecheck:svelte` 0 errors, `build:renderer` 0, `format:check` 0, `lint` 0 errors, `verify:gate` and `verify:seq-gate` every mutant killed, `counts:check` OK (109/109 sites; `main.total` 58, `main.topLevel` 46, `size.over300` 36), `npm audit --audit-level=high --omit=dev` 0. **One environment finding, not a defect:** the first full run in the fresh worktree lost `population-scope-gate.test.js` and `scan-loop.test.js` to `Electron failed to install correctly` — Electron 42+ downloads its binary lazily (#334's own note), `npm ci` leaves no `node_modules/electron/dist`, and those two suites reach the real `require('electron')`; `node node_modules/electron/install.js` fixed it and both passed 100/100 in isolation before the final full run. A worktree that will run the whole suite needs that step after `npm ci`.
 - **Docs.** `docs/ECS-MAPPING.md` §8 "Index columns"; the roadmap's status header, branch-context note (§1–§11 line references pre-date #331 and this block) and §12; `memory-bank/architecture.md` two module lines and the counter; the three `size.over300` sites and the three `main.*` sites. Worktree `X:\tmp\aegis-audit-index-b1` from `origin/master f7bd134`, own `npm ci` (ai-mistakes #37, #41, #45); `origin/master` moved to `16e761e` (#336, ai-mistakes only) while the PR was open and was merged in with an anchored marker grep clean.
+
+## Codex harness migration completed (2026-09-07, PRs #342–#345; master `feb1436`)
+
+Codex CLI 0.153.4 was verified with the project hooks and GPT-6 Astra. PR #342 adapted
+hook payloads and launchers, removed literal escape artifacts from the agent definitions,
+and introduced the project config. PR #343 replaced full filesystem access with
+`workspace-write`, `on-request` approvals, and network access restricted to GitHub and its API.
+PR #344 (merge `8db8765`) fixed Windows hook exit propagation: PowerShell had converted
+Node's blocking exit 2 into exit 1. Fresh trusted-hook sessions applied a feature-branch
+edit and blocked an edit on master before approval. Lesson 46 in `ai-mistakes.md` records
+that shell boundary and the captured evidence.
+
+PR #345 (merge `feb1436`) made AGENTS.md canonical, reducing its Git blob from 6,685 to
+3,967 bytes; CLAUDE.md is a three-line pointer. The file now carries identity invariants,
+test and git-cycle authorisation, scoped human stopping points, testing calibration,
+writing style and instruction precedence. Sequence-rule consumption and branch-guard paths
+were corrected. Its PR body records that PR #339 is superseded. The five required CI
+contexts passed on each merged PR. After the final merge, master was clean and the local
+AGENTS.md blob matched HEAD; the desktop change card did not represent an uncommitted edit.
+
+Next product work: audit-index block 2 in `docs/roadmap/audit-index.md`. On this master,
+block 1's writer and rebuild are present; `getEntriesBefore` still reads JSONL. No read-path
+completion is claimed by this entry. Issue #332 remains in the ordinary queue.


### PR DESCRIPTION
Record the completed Codex harness migration and the PowerShell hook failure in the project logs. The lesson distinguishes a native child exit from the shell launcher exit: PowerShell -Command converted the guard's blocking 2 into 1 until the Windows command propagated LASTEXITCODE.

The entry records live feature/master verification, the working PowerShell --body-file approach for multiline PR bodies, and the clean-tree check after the documentation merge. The next product item is audit-index block 2, whose read path is still absent on this base.

Validation: counts:check and git diff --check pass. Changes are limited to the two historical log files; required CI contexts must pass before merge.
