### PR TITLE
feat: read audit history through the SQLite index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Explicit user instructions take precedence over anything in AGENTS.md or a skill
 
 ## Project facts
 
-`src/main/` contains 58 main modules: 46 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 40 invoke + 9 push = 49 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
+`src/main/` contains 59 main modules: 47 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 40 invoke + 9 push = 49 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
 
 A birth time is observed on the pass that stamps it or is `null`; no cache stores one. A snapshot outage freezes sessions and never splits them. For changes touching identity stamping, the audit chain, or the Windows git worktree flow, `memory-bank/ai-mistakes.md` holds the relevant failure history.
 

--- a/docs/ECS-MAPPING.md
+++ b/docs/ECS-MAPPING.md
@@ -270,3 +270,9 @@ truth; this table is the cross-reference.
 Deliberately absent: `hash` and `prev_hash` (§6 lists both as carried, not mapped). The chain is
 verified against the file by `verifyChain`, never against the index — `tests/main/audit-index.test.js`
 pins the absence through `PRAGMA table_info`.
+
+History reads now use `audit-index-query.js` through `audit-logger.getEntriesBefore`.
+The SQL query excludes loss markers, binds type filters, and normalizes the selected raw
+records. An explicit empty-string type filter checks the raw JSON type as well: the
+projection uses an empty string for absent types, which must remain distinguishable.
+Exports and chain verification continue to read JSONL.

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **58** = 46 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **59** = 47 top-level + 10 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/docs/recon/EXTERNAL-TECHNIQUES.md
+++ b/docs/recon/EXTERNAL-TECHNIQUES.md
@@ -213,6 +213,11 @@ Findings only where an external approach is **stronger** than inventing our own.
 
 ## 7. SQLite as rebuildable index over hash-chained JSONL
 
+> **[since recon: built]** The audit index writer and rebuild landed in PR #337.
+> History now reads the ready projection through `getEntriesBefore`, with JSONL fallback
+> on unavailability or query failure. `scripts/bench-audit-index.mjs` measures both paths;
+> `docs/roadmap/audit-index.md` records the contract and verification. FTS remains separate.
+
 ### 7.1 AgentSight: SQLite session store + query CLI (index pattern)
 
 - **Technique:** Materialize events into SQLite tables (`llm_calls`, `token_usage`, `audit_events`, …) for `report` / `token` / `audit` / `export` / `list` queries; treat DB as disposable projection.

--- a/docs/roadmap/audit-index.md
+++ b/docs/roadmap/audit-index.md
@@ -1,10 +1,10 @@
 # Audit index — a rebuildable SQLite projection over the hash-chained JSONL
 
-**Status (as of 2026-08-25): block 1 BUILT — the engine gate, the schema, the writer that projects
-JSONL lines into the index at flush time, and the rebuild-from-JSONL path, on
-`feat/audit-index-block-1` (§12 records what landed, where it deviates from §3, and the PR).
-Block 2 — the read path, `getEntriesBefore` dispatch, the fallback suite, the bench — is NOT
-started; §3.3, §5, §6, §8 tests 3/4/9 and M1/M4/M5 describe it.** Before block 1: UNBLOCKED —
+**Status (2026-09-07): blocks 1 and 2 are built.** The writer and rebuild landed in
+PR #337; the ready-index history query, JSONL fallback, integration suite and disposable
+benchmark are recorded in §13. §12 preserves the block-1 implementation record.
+
+**Historical runtime decision.** Before block 1: UNBLOCKED —
 Electron 43.4.1 (Node 24.18.1, `node:sqlite` Stability 1.2) merged to master on 2026-08-25 in #334.
 The record of the block, as it was written: the engine this plan chooses is
 `node:sqlite`, and the Node that ships inside the pinned Electron does not have it: `electron@33.4.11`
@@ -203,8 +203,7 @@ CREATE INDEX audit_events_entity   ON audit_events(process_entity_id, timestamp)
   recorded"), a v1 record's is in `raw`.
 - **The answer is `normalizeAuditEntry(JSON.parse(raw))`** — the same object the JSONL path returns,
   by construction; the typed columns exist for WHERE and ORDER only.
-- **Order of results:** `ORDER BY timestamp DESC, file DESC, line_no DESC LIMIT ?` — a seek on
-  `audit_events_ts`, O(limit). Ordering by `timestamp` rather than file-then-line is what makes the
+- **Order of results:** `ORDER BY timestamp DESC, file DESC, line_no DESC LIMIT ?` — a bounded query using the timestamp indexes. Ordering by `timestamp` rather than file-then-line is what makes the
   rollover straddle a non-event for the index: entries logged before midnight and flushed after it
   sit in the file of day D+1, and the index finds them by timestamp alone. Since 2026-08-25 the
   JSONL path finds them too (the D+1 file rule, §11), so the two paths AGREE on this case — test 9
@@ -225,7 +224,7 @@ filter** (one clause beside the marker exclusion), so behaviour does not depend 
 exists — the index's `queryBefore(beforeTs, limit, types)` must answer the SAME set, which is test 4.
 
 What the renderer gains from the index on top of that: for a cursor deep inside a large daily file,
-an O(limit) seek instead of a reverse read of the file's tail with `JSON.parse` on every line — and no
+an indexed seek instead of a reverse read of the file's tail with `JSON.parse` on every line — and no
 extra read of the D+1 file (§11). `flush()` before the read stays, so buffered entries remain visible
 (`tests/main/audit-logger.test.js`, "still flushes buffered entries into view on a valid read").
 
@@ -504,3 +503,57 @@ DDL, the insert list and the JSDoc house style; with `audit-index-rebuild.js` (~
 The cut line named at the go — the resume path — was not taken: the overrun is SQL text and
 comments, not logic, and the resume path is what keeps the current day file from being re-read in
 full on every start.
+
+
+## 13. Block 2 — history reads through the index (2026-09-07)
+
+`audit-index-query.js` owns prepared history statements, cached per connection and filter
+length. Cursors, limits and type names are bound parameters. `audit-index.js` exposes a
+constant-time readiness check and the query boundary; `audit-logger.getEntriesBefore`
+validates inputs and flushes first, then tries the ready index. An unavailable, building,
+closed or failed index uses the existing JSONL reader in the same call. A query/decoding
+failure closes the index and publishes a generic error without raw audit contents; the
+next initialization reconciles it again. A failed post-write stat now invalidates the
+projection too, so a newly persisted record cannot be hidden behind a stale ready flag.
+
+Returned objects come from `normalizeAuditEntry(JSON.parse(raw))`. Loss markers are
+excluded even when named in a filter; absent types remain distinct from an explicit
+empty-string filter. The selected page is reversed for the existing oldest-first IPC
+contract. No renderer or IPC change was needed. Exports and chain verification keep their
+JSONL inputs, and neither the schema nor the JSONL writer format changed.
+
+The SQL query orders by timestamp with file and line ordinal as tie breakers. The fallback
+retains file/line order and its D+1 file bound. Clock reversals or records flushed several
+days late can therefore select a different page while the fallback is active; ordinary
+chronological records and the midnight straddle agree. This preserves the timestamp
+choice in §10 question 3 without rewriting the fallback's behavior.
+
+`tests/main/audit-index-fallback.test.js` exercises real log/flush traffic, v0 normalization,
+malformed lines, markers, filter/limit validation, injection-shaped type names, cursor
+exclusion, the midnight straddle, clock steps, every unavailable state, corrupt/missing
+startup files, actual SQL/JSON decoding failures, live append and continuity rebuilding.
+The healthy-page test asserts no JSONL file opens. The query helper is in coverage.include.
+
+`node scripts/bench-audit-index.mjs` generates disposable chained daily files, verifies the
+chains before adding a deliberate malformed line, compares both query paths on every
+cursor/limit/filter combination, and records p50/p95, rebuild/resume, memory, append cost
+and storage. Resume is interrupted after a committed batch and compared with full rows
+and accounting. The fixture and output are not committed. Timing is reported without a
+CI threshold. `--rows=` and `--samples=` allow a smaller diagnostic run.
+
+Measured on this Windows host with 200,000 generated records and 50 samples per case.
+Electron was run with `ELECTRON_RUN_AS_NODE=1`; these are runtime measurements,
+not a packaged-app UI measurement. Values below are milliseconds.
+
+| Runtime | Middle / 25 / unfiltered p50 JSONL | p50 SQLite | Rebuild | Resume | Append 50 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Node 24.11.1 | 16.891 | 0.050 | 5218.753 | 3997.521 | 2.676 |
+| Electron 43.4.1 / Node 24.18.1 | 13.559 | 0.075 | 2626.847 | 2590.455 | 2.402 |
+
+Generated JSONL: 63,955,157 bytes; checkpointed index after the append: 154,636,288 bytes. Peak RSS sampled during the first rebuild was 293,384,192 bytes on system Node and 177,606,656 bytes on Electron. The full case table is recorded in the PR body.
+
+Mutation checks ran against the native modules the integration suite loads: M1 removed
+the readiness/fallback boundary (11 failures), M4 removed the JSONL types clause (3),
+M5 replaced timestamp order with file/line order (1), and the additional post-write-stat
+mutation removed failed-state invalidation (1). Each source file was restored byte for
+byte after its run. No new CI context or mutation script was added.

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 58 CommonJS modules (46 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 59 CommonJS modules (47 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle
@@ -23,6 +23,7 @@ Core modules:
 - ai-analysis.js — Anthropic API threat analysis
 - audit-logger.js — persistent JSONL audit trail (the canon; hash-chained per daily file)
 - audit-index.js — `node:sqlite` projection of the audit JSONL, fed at flush time strictly after the line is on disk, capability-gated (`state: 'unavailable'` without the engine); never the source of truth, no hash columns (docs/roadmap/audit-index.md)
+- audit-index-query.js — bounded timestamp-ordered history queries with bound type filters; audit-logger falls back to JSONL when the index is unavailable or fails
 - audit-index-rebuild.js — rebuild/reconcile of the index from the daily files after `cleanOldLogs` on every init, resumed from `indexed_bytes`, ~2000-line transactions between `setImmediate` yields
 - exports.js — JSON/CSV/HTML report export
 - tray-icon.js — system tray with procedural icon

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -656,3 +656,30 @@ AGENTS.md blob matched HEAD; the desktop change card did not represent an uncomm
 Next product work: audit-index block 2 in `docs/roadmap/audit-index.md`. On this master,
 block 1's writer and rebuild are present; `getEntriesBefore` still reads JSONL. No read-path
 completion is claimed by this entry. Issue #332 remains in the ordinary queue.
+
+## Audit index block 2 — history read path (2026-09-07, `feat/audit-index-read-path`)
+
+`getEntriesBefore` now uses the ready SQLite projection after validation and flush, with
+JSONL fallback in the same call for unavailable/building/failed state or query errors.
+`audit-index-query.js` holds bound, cached statements; raw records retain v0 normalization,
+type filtering, marker exclusion and oldest-first presentation. A failed post-write stat
+invalidates the index so a persisted record remains visible. Errors from raw JSON decoding
+are not copied into status. Exports and hash verification still read canonical JSONL.
+
+The new fallback suite has 15 cases; it passed inside the final full coverage run. Deliberate removal of fallback, JSONL filtering, timestamp ordering and post-write
+invalidation made the new suite fail, and original source bytes were restored after each.
+Full test:coverage, both typechecks, formatting, lint and renderer build passed; lint had
+existing warnings only. counts:check passes with the extracted query module included.
+
+The disposable benchmark compared both paths on 200,000 generated records, 50 calls per
+cursor/limit/filter case, with intact chains verified before injecting one malformed line.
+On Electron 43.4.1's Node 24.18.1, a middle-file page of 25 entries measured p50 13.559 ms
+for JSONL and 0.075 ms for SQLite; initial rebuild took 2,626.847 ms and a 50-entry index
+append 2.402 ms. Resume after a committed-batch interruption matched the complete rows
+and file accounting. The runtime was launched with ELECTRON_RUN_AS_NODE=1; no UI timing
+is inferred. System Node results and the storage/RSS costs are in audit-index.md §13.
+
+Timestamp order is the roadmap's chosen behavior. Clock reversals and multi-day delayed
+flushes can select a different page under the unchanged JSONL fallback, which retains
+file/line order and its D+1 bound. A failed query keeps fallback active until reinitialization.
+No workflow, dependency, IPC, renderer, identity or hash-chain format change was needed.

--- a/scripts/bench-audit-index.mjs
+++ b/scripts/bench-audit-index.mjs
@@ -1,0 +1,219 @@
+// Disposable benchmark: node scripts/bench-audit-index.mjs [--samples=50] [--rows=25000]
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const audit = require('../src/main/audit-logger');
+const index = require('../src/main/audit-index');
+const rebuild = require('../src/main/audit-index-rebuild');
+const chain = require('../src/main/audit-hashchain');
+const option = (name, fallback) => {
+  const arg = process.argv.find((v) => v.startsWith(`--${name}=`));
+  const n = arg ? Number(arg.split('=')[1]) : fallback;
+  assert(Number.isSafeInteger(n) && n > 0 && n <= 1000000, `invalid ${name}`);
+  return n;
+};
+const samples = option('samples', 50);
+const perDay = option('rows', 25000);
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-index-bench-'));
+const logDir = path.join(root, 'audit-logs');
+const ms = (start) => Number(process.hrtime.bigint() - start) / 1e6;
+const types = ['file-access', 'network-connection', 'config-access'];
+const dailyFiles = [];
+const starts = [];
+const now = new Date();
+const midnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+const originalReady = index.isReady;
+let monitor;
+let originalWrite;
+try {
+  fs.mkdirSync(logDir);
+  let jsonlBytes = 0;
+  for (let day = 0; day < 8; day++) {
+    const start = midnight - (7 - day) * 86400000;
+    starts.push(start);
+    const file = path.join(
+      logDir,
+      `aegis-audit-${new Date(start).toISOString().slice(0, 10)}.json`,
+    );
+    dailyFiles.push(file);
+    let prev = chain.GENESIS;
+    const rows = [];
+    for (let i = 0; i < perDay; i++) {
+      const slot = i % 100;
+      const type =
+        slot < 70
+          ? 'file-access'
+          : slot < 85
+            ? 'network-connection'
+            : slot < 90
+              ? 'config-access'
+              : slot < 95
+                ? i % 2
+                  ? 'agent-enter'
+                  : 'agent-exit'
+                : 'anomaly-alert';
+      const rec = {
+        timestamp: new Date(start + Math.floor((i * 80000000) / perDay)).toISOString(),
+        type: day === 7 && i < 3 ? 'buffer-overflow-drop' : type,
+        agent: 'bench-fixture',
+        action: 'read',
+        path: '/fixture/example',
+        severity: 'normal',
+        details: slot < 5 ? { pid: 42, attribution: 'confirmed' } : null,
+      };
+      if (slot >= 5)
+        Object.assign(rec, {
+          schemaVersion: 1,
+          pid: 42,
+          instanceId: '42:fixture',
+          attribution: null,
+        });
+      const hash = chain.computeHash(prev, rec);
+      rows.push(JSON.stringify({ ...rec, seq: i, hash }));
+      prev = hash;
+    }
+    fs.writeFileSync(file, rows.join('\n') + '\n');
+    assert.equal(chain.verifyChain(file).valid, true, 'generated chain');
+    jsonlBytes += fs.statSync(file).size;
+  }
+  // Deliberate rejected line: the intact chains were checked before adding it.
+  fs.appendFileSync(dailyFiles[0], 'malformed\n');
+  jsonlBytes += Buffer.byteLength('malformed\n');
+  assert.equal(chain.verifyChain(dailyFiles[0]).valid, false);
+  let peakRss = process.memoryUsage().rss;
+  monitor = setInterval(() => {
+    peakRss = Math.max(peakRss, process.memoryUsage().rss);
+  }, 5);
+  index.open({ userDataPath: root });
+  let start = process.hrtime.bigint();
+  await rebuild.reconcile(logDir);
+  const rebuildMs = ms(start);
+  const rebuildPeakRss = Math.max(peakRss, process.memoryUsage().rss);
+  const totalRows = perDay * 8;
+  assert.equal(index.status().rows, totalRows);
+  assert.equal(index.status().malformedLines, 1);
+  const fullAccounting = index.files();
+  const fullEvents = index
+    ._dbForTest()
+    .prepare('SELECT file, line_no, raw FROM audit_events ORDER BY file, line_no')
+    .all();
+  index._dbForTest().exec('DELETE FROM audit_files');
+  index.setState('building');
+  originalWrite = index.writeBatch;
+  let batches = 0;
+  index.writeBatch = (batch) => {
+    const value = originalWrite(batch);
+    if (++batches === 3) throw new Error('benchmark interruption after committed batch');
+    return value;
+  };
+  await assert.rejects(rebuild.reconcile(logDir), /benchmark interruption/);
+  index.writeBatch = originalWrite;
+  originalWrite = null;
+  start = process.hrtime.bigint();
+  await rebuild.reconcile(logDir);
+  const resumeMs = ms(start);
+  assert.deepEqual(index.files(), fullAccounting);
+  assert.deepEqual(
+    index
+      ._dbForTest()
+      .prepare('SELECT file, line_no, raw FROM audit_events ORDER BY file, line_no')
+      .all(),
+    fullEvents,
+  );
+  audit.init({ userDataPath: root });
+  await audit._awaitIndexForTest();
+  const positions = [
+    ['tail', starts[7] + 80000000],
+    ['middle', starts[7] + 40000000],
+    ['head', starts[7] + 1000],
+    ['boundary', starts[7]],
+  ];
+  const timings = [];
+  for (const [position, t] of positions) {
+    for (const limit of [25, 500]) {
+      for (const filter of [undefined, types]) {
+        const before = new Date(t).toISOString();
+        const one = (indexed) => {
+          index.isReady = indexed ? originalReady : () => false;
+          const began = process.hrtime.bigint();
+          const answer = audit.getEntriesBefore(before, limit, filter);
+          return { elapsed: ms(began), answer };
+        };
+        assert.deepEqual(one(true).answer, one(false).answer);
+        for (const indexed of [false, true]) {
+          const times = [];
+          for (let i = 0; i < samples; i++) times.push(one(indexed).elapsed);
+          times.sort((a, b) => a - b);
+          timings.push({
+            position,
+            limit,
+            filtered: !!filter,
+            path: indexed ? 'sqlite' : 'jsonl',
+            p50Ms: times[Math.ceil(samples * 0.5) - 1],
+            p95Ms: times[Math.ceil(samples * 0.95) - 1],
+          });
+        }
+      }
+    }
+  }
+  index.isReady = originalReady;
+  // Persist the batch to canon before measuring its projection cost.
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const file = `aegis-audit-${today}.json`;
+  const fp = path.join(logDir, file);
+  const existing = fs.existsSync(fp) ? fs.readFileSync(fp, 'utf8').trim().split('\n') : [];
+  let prev = existing.length ? JSON.parse(existing.at(-1)).hash : chain.GENESIS;
+  const lines = [];
+  for (let i = 0; i < 50; i++) {
+    const rec = {
+      timestamp: new Date().toISOString(),
+      type: 'file-access',
+      agent: 'append-fixture',
+    };
+    const hash = chain.computeHash(prev, rec);
+    lines.push(JSON.stringify({ ...rec, seq: existing.length + i, hash }));
+    prev = hash;
+  }
+  const text = lines.join('\n') + '\n';
+  const offsetBefore = fs.existsSync(fp) ? fs.statSync(fp).size : 0;
+  fs.appendFileSync(fp, text);
+  start = process.hrtime.bigint();
+  assert.equal(index.append({ file, offsetBefore, bytes: Buffer.byteLength(text), lines }), true);
+  const appendMs = ms(start);
+  assert.equal(chain.verifyChain(fp).valid, true);
+  assert.equal(index.status().rows, totalRows + 50);
+  const db = index._dbForTest();
+  db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  const databaseBytes = fs.statSync(path.join(root, 'audit-index', 'audit-index.sqlite')).size;
+  peakRss = Math.max(peakRss, process.memoryUsage().rss);
+  console.log(
+    JSON.stringify(
+      {
+        runtime: process.versions,
+        samples,
+        generatedRows: totalRows,
+        jsonlBytes,
+        databaseBytes,
+        rebuildMs,
+        rebuildPeakRss,
+        resumeMs,
+        peakRss,
+        append50Ms: appendMs,
+        timings,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  clearInterval(monitor);
+  index.isReady = originalReady;
+  if (originalWrite) index.writeBatch = originalWrite;
+  await audit._awaitIndexForTest();
+  audit.shutdown();
+  index.close();
+  fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+}

--- a/src/main/audit-index-query.js
+++ b/src/main/audit-index-query.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { normalizeAuditEntry } = require('./audit-normalize');
+const { MARKER_TYPE } = require('./audit-drop-tracker');
+
+// At most one statement per validated filter length, per connection. Closed connections
+// are not retained by this cache. Values are always bound, including event type names.
+const statements = new WeakMap();
+
+/**
+ * Read a bounded history page from a ready projection. Parameters are validated by
+ * audit-logger.getEntriesBefore. Timestamp order handles clock steps; reversing the
+ * selected page preserves the renderer's oldest-first contract. Raw records retain
+ * fields the projection does not model, including the absence of v0 evidence.
+ * @param {import('node:sqlite').DatabaseSync} db
+ * @param {string} beforeTs - exclusive timestamp cursor
+ * @param {number} limit - validated page size
+ * @param {Set<string>|null} types - normalized filter
+ * @returns {Object[]} normalized records, oldest first
+ * @since v0.14.0
+ */
+function queryBefore(db, beforeTs, limit, types) {
+  const values = types ? [...types] : [];
+  let cache = statements.get(db);
+  if (!cache) statements.set(db, (cache = new Map()));
+  let stmt = cache.get(values.length);
+  if (!stmt) {
+    // A missing/non-string type projects to ''. An explicitly empty-string filter
+    // must match only a recorded empty string, as it does in the JSONL reader.
+    const filter = values.length
+      ? ` AND type IN (${values.map(() => '?').join(',')})
+          AND (type != '' OR json_type(raw, '$.type') = 'text')`
+      : '';
+    stmt = db.prepare(`SELECT raw FROM audit_events
+      WHERE timestamp != '' AND timestamp < ? AND type != ?${filter}
+      ORDER BY timestamp DESC, file DESC, line_no DESC LIMIT ?`);
+    cache.set(values.length, stmt);
+  }
+  return stmt
+    .all(beforeTs, MARKER_TYPE, ...values, limit)
+    .map(({ raw }) => normalizeAuditEntry(JSON.parse(raw)))
+    .reverse();
+}
+
+module.exports = { queryBefore };

--- a/src/main/audit-index.js
+++ b/src/main/audit-index.js
@@ -30,6 +30,7 @@ const path = require('path');
 const logger = require('./logger');
 const { normalizeAuditEntry } = require('./audit-normalize');
 const { normalizeToEcs } = require('../shared/ecs-normalizer');
+const historyQuery = require('./audit-index-query');
 
 /**
  * Schema version stored in `PRAGMA user_version`. NOT the record's `SCHEMA_VERSION` in
@@ -440,6 +441,32 @@ function forget(file) {
   return true;
 }
 
+/** @returns {boolean} Whether history can use the projection. @since v0.14.0 */
+function isReady() {
+  return _state === 'ready' && _db !== null;
+}
+
+/**
+ * Query the ready index; an error closes it so subsequent reads use JSONL.
+ * @param {string} beforeTs
+ * @param {number} limit
+ * @param {Set<string>|null} types
+ * @returns {Object[]} normalized history, oldest first
+ * @throws when unavailable or the query fails; the caller falls back in the same call
+ * @since v0.14.0
+ */
+function queryBefore(beforeTs, limit, types) {
+  if (!isReady()) throw new Error('audit-index: history is not ready');
+  try {
+    return historyQuery.queryBefore(_db, beforeTs, limit, types);
+  } catch (_) {
+    // JSON.parse errors can quote raw audit data. Do not publish them in status/logs.
+    const error = new Error('audit-index: history query failed; using JSONL');
+    _fail(error);
+    throw error;
+  }
+}
+
 /**
  * Every `audit_files` row, for the reconcile.
  * @returns {Array<{file: string, file_date: string, indexed_bytes: number, indexed_lines: number,
@@ -517,6 +544,8 @@ module.exports = {
   open,
   close,
   append,
+  isReady,
+  queryBefore,
   writeBatch,
   forget,
   files,

--- a/src/main/audit-logger.js
+++ b/src/main/audit-logger.js
@@ -201,6 +201,7 @@ function _indexAppend(fp, bytes, lines) {
       _indexTask = indexRebuild.schedule(_logDir);
     }
   } catch (err) {
+    auditIndex.setState('failed', new Error('audit-index: flush projection failed'));
     console.error('[audit-logger] index append failed:', err.message);
   }
 }
@@ -680,7 +681,9 @@ function _nextDateStr(dateStr) {
 
 /**
  * Return up to `limit` audit entries with timestamps strictly before `beforeTs`.
- * Reads log files in reverse-chronological order for efficiency.
+ * Uses the ready SQLite projection; otherwise reads JSONL in the same call.
+ * The index orders by timestamp, then file and line ordinal; the fallback preserves
+ * file/line order, so a clock step can change which records a bounded page selects.
  *
  * All three parameters cross the IPC boundary raw (ipc-handlers.js passes them through),
  * so all three are validated HERE rather than at the handler — every caller gets the same
@@ -729,6 +732,11 @@ function getEntriesBefore(beforeTs, limit = DEFAULT_READ_LIMIT, types) {
   const typeFilter = _typeFilter(types);
   flush();
   if (!_logDir) return [];
+  try {
+    if (auditIndex.isReady()) return auditIndex.queryBefore(beforeTs, limit, typeFilter);
+  } catch (_) {
+    // The index records its failure without raw audit data; canon remains readable.
+  }
   const results = [];
   try {
     // The last file worth opening: the day after the cursor's UTC date (see the JSDoc).

--- a/tests/main/audit-index-fallback.test.js
+++ b/tests/main/audit-index-fallback.test.js
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Integration mutations must replace the module audit-logger requires natively.
+const require_ = createRequire(import.meta.url);
+const index = require_('../../src/main/audit-index.js');
+const hashchain = require_('../../src/main/audit-hashchain.js');
+const dateStr = (d) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+describe('audit index history and fallback', () => {
+  let audit;
+  let root;
+  let today;
+  const cursor = () => new Date(Date.now() + 86400000).toISOString();
+  const logDir = () => path.join(root, 'audit-logs');
+  const dayFile = (day) => path.join(logDir(), `aegis-audit-${day}.json`);
+  const writeDay = (day, rows) => {
+    fs.mkdirSync(logDir(), { recursive: true });
+    fs.writeFileSync(
+      dayFile(day),
+      rows.map((r) => (typeof r === 'string' ? r : JSON.stringify(r))).join('\n') + '\n',
+    );
+  };
+  const open = async (opts = {}) => {
+    audit.init({ userDataPath: root, ...opts });
+    await audit._awaitIndexForTest();
+  };
+  const jsonl = (...args) => {
+    const spy = vi.spyOn(index, 'isReady').mockReturnValue(false);
+    try {
+      return audit.getEntriesBefore(...args);
+    } finally {
+      spy.mockRestore();
+    }
+  };
+  const event = (timestamp, type = 'file-access', extra = {}) => ({
+    timestamp,
+    type,
+    agent: 'fixture',
+    ...extra,
+  });
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-index-read-'));
+    today = dateStr(new Date());
+    vi.resetModules();
+    audit = (await import('../../src/main/audit-logger.js')).default;
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    await audit._awaitIndexForTest();
+    audit.shutdown();
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  it('serves the real log/flush history through SQL with JSONL parity across dates, cursors and filters', async () => {
+    const now = Date.now();
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(now - 86400000);
+    await open();
+    const timestamps = [];
+    for (let i = 0; i < 300; i++) {
+      vi.setSystemTime(now - (i < 150 ? 86400000 : 0) + (i % 150) * 1000);
+      timestamps.push(new Date().toISOString());
+      audit.log(i % 3 ? 'file-access' : 'agent-enter', { agent: 'fixture', path: `/fixture/${i}` });
+      if (i === 149) audit.flush();
+    }
+    audit.flush();
+    const query = vi.spyOn(index, 'queryBefore');
+    for (const before of [timestamps[50], timestamps[160], cursor()]) {
+      for (const limit of [1, 25, 500]) {
+        for (const types of [undefined, ['file-access'], ['agent-enter'], ['absent']]) {
+          const expected = jsonl(before, limit, types);
+          const reads = vi.spyOn(fs, 'openSync');
+          expect(audit.getEntriesBefore(before, limit, types)).toEqual(expected);
+          expect(reads).not.toHaveBeenCalled();
+          reads.mockRestore();
+        }
+      }
+    }
+    expect(query).toHaveBeenCalledTimes(36);
+    for (const file of fs.readdirSync(logDir()))
+      expect(hashchain.verifyChain(path.join(logDir(), file)).valid).toBe(true);
+  });
+
+  it('normalizes v0, skips malformed lines and markers, and preserves the raw export', async () => {
+    const rows = [
+      event(`${today}T08:00:00.000Z`, 'file-access', {
+        details: { pid: 42, attribution: 'confirmed' },
+      }),
+      'malformed',
+      event(`${today}T09:00:00.000Z`, 'buffer-overflow-drop', { droppedCount: 3 }),
+      event(`${today}T10:00:00.000Z`, 'config-access', {
+        schemaVersion: 1,
+        pid: 7,
+        attribution: null,
+      }),
+      { timestamp: `${today}T11:00:00.000Z` },
+      event(`${today}T12:00:00.000Z`, ''),
+      { type: 'file-access' },
+    ];
+    writeDay(today, rows);
+    await open();
+    for (const types of [undefined, ['buffer-overflow-drop'], [''], [null], [], 'file-access']) {
+      expect(audit.getEntriesBefore(cursor(), 500, types)).toEqual(jsonl(cursor(), 500, types));
+    }
+    expect(audit.getEntriesBefore(cursor(), 500)[0].attribution).toEqual({
+      status: 'confirmed',
+      evidence: null,
+    });
+    expect(audit.exportAll()).toEqual(rows.filter((r) => typeof r !== 'string'));
+  });
+
+  it('binds type values and shares validation and limits with the JSONL reader', async () => {
+    const injection = "x') OR 1=1 --";
+    writeDay(today, [event(`${today}T10:00:00.000Z`, injection), event(`${today}T11:00:00.000Z`)]);
+    await open();
+    for (const types of [
+      [injection],
+      [null, 'file-access'],
+      ['x'.repeat(65)],
+      [...Array(16).fill('absent'), 'file-access'],
+    ]) {
+      for (const limit of [0, -1, 1.8, NaN, Infinity, '2']) {
+        expect(audit.getEntriesBefore(cursor(), limit, types)).toEqual(
+          jsonl(cursor(), limit, types),
+        );
+      }
+    }
+    const query = vi.spyOn(index, 'queryBefore');
+    for (const before of [null, 4, '', 'invalid'])
+      expect(audit.getEntriesBefore(before)).toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('includes a pre-midnight record flushed into the next daily file and excludes the cursor itself', async () => {
+    const prior = new Date(Date.now() - 86400000);
+    const d = dateStr(prior);
+    writeDay(d, [event(`${d}T22:00:00.000Z`)]);
+    writeDay(today, [event(`${d}T23:59:58.000Z`), event(`${today}T00:00:02.000Z`)]);
+    await open();
+    const before = `${d}T23:59:59.000Z`;
+    expect(audit.getEntriesBefore(before, 1)).toEqual(jsonl(before, 1));
+    expect(audit.getEntriesBefore(before, 1)[0].timestamp).toBe(`${d}T23:59:58.000Z`);
+    expect(audit.getEntriesBefore(`${d}T23:59:58.000Z`, 1)[0].timestamp).toBe(`${d}T22:00:00.000Z`);
+  });
+
+  it('orders clock-step records by timestamp, with file and line ordinal as tie breakers', async () => {
+    writeDay(today, [
+      event(`${today}T12:00:00.000Z`, 'file-access', { action: 'first' }),
+      event(`${today}T11:00:00.000Z`),
+      event(`${today}T12:00:00.000Z`, 'file-access', { action: 'last' }),
+    ]);
+    await open();
+    expect(audit.getEntriesBefore(cursor(), 2).map((r) => r.action)).toEqual(['first', 'last']);
+    expect(audit.getEntriesBefore(cursor(), 1)[0].action).toBe('last');
+  });
+
+  it.each(['unavailable', 'building', 'failed', 'closed'])(
+    'falls back in the same call while %s',
+    async (state) => {
+      writeDay(today, [
+        event(`${today}T10:00:00.000Z`),
+        event(`${today}T11:00:00.000Z`, 'agent-enter'),
+      ]);
+      await open(state === 'unavailable' ? { loadSqlite: () => null } : {});
+      const expected = jsonl(cursor(), 25, ['file-access']);
+      if (state === 'closed') index.close();
+      else if (state !== 'unavailable') index.setState(state, new Error('fixture failure'));
+      const query = vi.spyOn(index, 'queryBefore');
+      expect(audit.getEntriesBefore(cursor(), 25, ['file-access'])).toEqual(expected);
+      expect(query).not.toHaveBeenCalled();
+    },
+  );
+
+  it('falls back on an actual SQL error and marks the index failed', async () => {
+    writeDay(today, [event(`${today}T10:00:00.000Z`)]);
+    await open();
+    const expected = jsonl(cursor(), 25);
+    index._dbForTest().exec('DROP TABLE audit_events');
+    expect(audit.getEntriesBefore(cursor(), 25)).toEqual(expected);
+    expect(index.isReady()).toBe(false);
+    expect(index.status().state).toBe('failed');
+    expect(audit.getEntriesBefore(cursor(), 25)).toEqual(expected);
+  });
+
+  it.each(['missing', 'corrupt'])(
+    'reads JSONL while a %s index is being opened and rebuilt',
+    async (kind) => {
+      writeDay(today, [event(`${today}T10:00:00.000Z`)]);
+      if (kind === 'corrupt') {
+        fs.mkdirSync(path.join(root, 'audit-index'));
+        fs.writeFileSync(path.join(root, 'audit-index', 'audit-index.sqlite'), 'not a database');
+      }
+      audit.init({ userDataPath: root });
+      const query = vi.spyOn(index, 'queryBefore');
+      expect(audit.getEntriesBefore(cursor(), 25)[0].agent).toBe('fixture');
+      expect(query).not.toHaveBeenCalled();
+      await audit._awaitIndexForTest();
+      expect(index.isReady()).toBe(true);
+      expect(audit.getEntriesBefore(cursor(), 25)).toEqual(jsonl(cursor(), 25));
+      expect(query).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('does not serve a stale ready index when the post-write stat fails', async () => {
+    await open();
+    audit.log('file-access', { agent: 'just-written' });
+    const stat = fs.statSync;
+    const spy = vi.spyOn(fs, 'statSync').mockImplementation((...args) => {
+      if (String(args[0]) === dayFile(today)) throw new Error('fixture stat failure');
+      return stat(...args);
+    });
+    const result = audit.getEntriesBefore(cursor(), 25);
+    spy.mockRestore();
+    expect(result[0].agent).toBe('just-written');
+    expect(index.isReady()).toBe(false);
+  });
+
+  it('falls back without exposing raw record contents when indexed raw JSON is damaged', async () => {
+    writeDay(today, [event(`${today}T10:00:00.000Z`)]);
+    await open();
+    index
+      ._dbForTest()
+      .prepare('UPDATE audit_events SET raw = ?')
+      .run('SECRET-FIXTURE-invalid-json');
+    expect(audit.getEntriesBefore(cursor(), 25)).toEqual(jsonl(cursor(), 25));
+    expect(index.status().lastError).not.toContain('SECRET-FIXTURE');
+  });
+
+  it('flushes buffered entries before the indexed read and falls back during a continuity rebuild', async () => {
+    await open();
+    audit.log('file-access', { agent: 'buffered' });
+    expect(audit.getEntriesBefore(cursor(), 25)[0].agent).toBe('buffered');
+    fs.appendFileSync(
+      dayFile(today),
+      JSON.stringify(event(new Date().toISOString(), 'file-access', { agent: 'external' })) + '\n',
+    );
+    audit.log('file-access', { agent: 'next' });
+    const result = audit.getEntriesBefore(cursor(), 25);
+    expect(result.map((r) => r.agent)).toContain('external');
+    expect(index.isReady()).toBe(false);
+    await audit._awaitIndexForTest();
+    expect(index.isReady()).toBe(true);
+    expect(audit.getEntriesBefore(cursor(), 25)).toEqual(jsonl(cursor(), 25));
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
         'src/main/logger.js',
         'src/main/audit-logger.js',
         'src/main/audit-index.js',
+        'src/main/audit-index-query.js',
         'src/main/audit-index-rebuild.js',
         'src/main/config-manager.js',
         'src/main/baselines.js',


### PR DESCRIPTION
History pagination previously scanned daily JSONL files even when the SQLite projection was ready. Route validated `getEntriesBefore` requests through a bounded SQL query, preserving raw-record normalization, marker exclusion, type filtering and the existing oldest-first response shape. Unavailable/building/failed indexes and actual query errors fall back to JSONL in the same call.

Extract the query into a small module with bound parameters and per-connection statement caching. A failure of the post-write stat now invalidates the ready projection, preventing a successfully written record from being hidden by a stale index. SQL/JSON decoding failures publish a generic status error without raw audit contents. Add the integration suite, coverage entry, disposable benchmark and completion notes; update derived module counts.

The source remains JSONL: exports and chain verification keep their existing inputs. The planned timestamp ordering differs from fallback file/line order when the clock moves backwards. SQL also sees all indexed daily files, while the unchanged fallback keeps its D+1 bound; multi-day delayed writes can therefore select different pages during fallback. A query failure leaves JSONL active until the next initialization reconciles the index.

Validation:
- 15 new integration cases, including 300 events through real log/flush, cursor/limit/type grids, no JSONL opens on healthy reads, v0/malformed/marker cases, injection-shaped type values, midnight straddles, clock steps, every unavailable state, missing/corrupt startup, actual SQL/JSON errors, live append and continuity rebuilding.
- Mutation M1 (readiness/fallback removed): 11 failed; M4 (JSONL types removed): 3 failed; M5 (file/line ordering): 1 failed; post-write-stat invalidation removed: 1 failed. Restored original bytes after each.

Benchmark: generated fixture, 8 daily files / 200,000 records, 50 calls per case. The chains verify before the deliberate malformed line is added. Both paths deep-equal on every measured case. Resume after an injected committed-batch interruption matches full event rows and file accounting. Neither fixtures nor timing gates enter CI. Electron uses ELECTRON_RUN_AS_NODE=1; this is its bundled runtime, not an in-app UI benchmark.

| Runtime | Position | Limit | Filtered | JSONL p50 / p95 ms | SQLite p50 / p95 ms |
| --- | --- | ---: | --- | ---: | ---: |
| Node 24.11.1 | tail | 25 | False | 0.580 / 0.774 | 0.046 / 0.239 |
| Node 24.11.1 | tail | 25 | True | 0.565 / 0.830 | 0.079 / 0.195 |
| Node 24.11.1 | tail | 500 | False | 1.074 / 1.358 | 0.726 / 1.243 |
| Node 24.11.1 | tail | 500 | True | 1.294 / 1.993 | 1.678 / 4.335 |
| Node 24.11.1 | middle | 25 | False | 16.891 / 21.819 | 0.050 / 0.077 |
| Node 24.11.1 | middle | 25 | True | 25.616 / 44.641 | 0.144 / 0.511 |
| Node 24.11.1 | middle | 500 | False | 37.158 / 44.721 | 1.646 / 2.584 |
| Node 24.11.1 | middle | 500 | True | 37.290 / 43.251 | 3.374 / 4.930 |
| Node 24.11.1 | head | 25 | False | 63.459 / 88.600 | 0.116 / 0.225 |
| Node 24.11.1 | head | 25 | True | 42.221 / 46.269 | 0.102 / 0.167 |
| Node 24.11.1 | head | 500 | False | 42.405 / 52.588 | 0.992 / 1.465 |
| Node 24.11.1 | head | 500 | True | 42.251 / 47.275 | 2.188 / 2.781 |
| Node 24.11.1 | boundary | 25 | False | 41.658 / 59.960 | 0.103 / 0.208 |
| Node 24.11.1 | boundary | 25 | True | 66.674 / 74.464 | 0.199 / 0.585 |
| Node 24.11.1 | boundary | 500 | False | 68.445 / 79.806 | 1.567 / 2.450 |
| Node 24.11.1 | boundary | 500 | True | 69.749 / 78.338 | 3.553 / 4.843 |
| Electron 43.4.1 | tail | 25 | False | 0.128 / 0.201 | 0.039 / 0.054 |
| Electron 43.4.1 | tail | 25 | True | 0.158 / 0.273 | 0.109 / 0.246 |
| Electron 43.4.1 | tail | 500 | False | 0.969 / 2.155 | 0.553 / 0.691 |
| Electron 43.4.1 | tail | 500 | True | 0.693 / 1.265 | 1.707 / 4.006 |
| Electron 43.4.1 | middle | 25 | False | 13.559 / 24.752 | 0.075 / 0.109 |
| Electron 43.4.1 | middle | 25 | True | 15.029 / 26.037 | 0.085 / 0.300 |
| Electron 43.4.1 | middle | 500 | False | 14.407 / 27.524 | 0.521 / 1.151 |
| Electron 43.4.1 | middle | 500 | True | 14.833 / 23.137 | 1.580 / 4.536 |
| Electron 43.4.1 | head | 25 | False | 27.325 / 43.651 | 0.035 / 0.064 |
| Electron 43.4.1 | head | 25 | True | 28.801 / 42.220 | 0.071 / 0.147 |
| Electron 43.4.1 | head | 500 | False | 29.578 / 43.530 | 0.526 / 1.139 |
| Electron 43.4.1 | head | 500 | True | 31.059 / 45.175 | 1.445 / 2.267 |
| Electron 43.4.1 | boundary | 25 | False | 27.079 / 40.279 | 0.032 / 0.091 |
| Electron 43.4.1 | boundary | 25 | True | 49.834 / 61.480 | 0.076 / 0.114 |
| Electron 43.4.1 | boundary | 500 | False | 40.679 / 68.224 | 1.533 / 2.624 |
| Electron 43.4.1 | boundary | 500 | True | 38.180 / 70.285 | 3.582 / 4.721 |

Electron 43.4.1: rebuild 2626.847 ms; resume 2590.455 ms; 50-entry append 2.402 ms; first-rebuild peak RSS 177,606,656 bytes.


System Node: rebuild 5218.753 ms; resume 3997.521 ms; append 2.676 ms; first-rebuild peak RSS 293,384,192 bytes. JSONL 63,955,157 bytes; checkpointed index after append 154,636,288 bytes on both runtimes.

Final local gates passed: test:coverage, typecheck, typecheck:svelte, format:check, lint, build:renderer and counts:check. Existing lint warnings only; audit-index-query.js has 100% statement/branch/function/line coverage in this run.
