### PR TITLE
fix: default export save dialogs to Downloads

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -707,3 +707,12 @@ this handoff does not start that fix. The user is moving to a new project chat.
 For Windows shell work, lesson 46 in `memory-bank/ai-mistakes.md` records explicit native
 exit-code propagation with `exit $LASTEXITCODE`. Multiline gh bodies use a UTF-8 file and
 `--body-file`; Git Bash is not required. AGENTS.md remains the canonical project guidance.
+
+## Issue #332 — export dialog Downloads paths (2026-09-07)
+
+All six save dialogs in `exports.js` and `ipc-handlers.js` now join their existing file
+names to `app.getPath('downloads')`. This supplies an absolute default path independent
+of the launch directory. Local verification: 45 existing export/IPC tests passed,
+`format:check` and `build:renderer` passed, and lint reported zero errors (32 warnings).
+The native Windows dialog and a packaged installer were not exercised in this session.
+Audit-index blocks 1–2 remain complete; no further product task has been selected.

--- a/src/main/exports.js
+++ b/src/main/exports.js
@@ -98,7 +98,10 @@ async function exportLog() {
   const mw = _state.getMainWindow();
   const result = await dialog.showSaveDialog(mw, {
     title: 'Export AEGIS Activity Log',
-    defaultPath: `aegis-log-${new Date().toISOString().slice(0, 10)}.json`,
+    defaultPath: path.join(
+      app.getPath('downloads'),
+      `aegis-log-${new Date().toISOString().slice(0, 10)}.json`,
+    ),
     filters: [{ name: 'JSON Files', extensions: ['json'] }],
   });
   if (result.canceled || !result.filePath) return { success: false };
@@ -140,7 +143,10 @@ async function exportCsv() {
   const mw = _state.getMainWindow();
   const result = await dialog.showSaveDialog(mw, {
     title: 'Export AEGIS Activity Log (CSV)',
-    defaultPath: `aegis-log-${new Date().toISOString().slice(0, 10)}.csv`,
+    defaultPath: path.join(
+      app.getPath('downloads'),
+      `aegis-log-${new Date().toISOString().slice(0, 10)}.csv`,
+    ),
     filters: [{ name: 'CSV Files', extensions: ['csv'] }],
   });
   if (result.canceled || !result.filePath) return { success: false };

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -236,7 +236,7 @@ ${findingsHtml}${recsHtml}
       const merged = { ...scanner.agentDb, customAgents: config.getCustomAgents() };
       const { filePath } = await dialog.showSaveDialog(deps.getWindow(), {
         title: 'Export Agent Database',
-        defaultPath: 'aegis-agents.json',
+        defaultPath: path.join(app.getPath('downloads'), 'aegis-agents.json'),
         filters: [{ name: 'JSON', extensions: ['json'] }],
       });
       if (!filePath) return { success: false };
@@ -283,7 +283,7 @@ ${findingsHtml}${recsHtml}
       const defaultName = `aegis-full-audit-${new Date().toISOString().slice(0, 10)}.json`;
       const { filePath } = await dialog.showSaveDialog(deps.getWindow(), {
         title: 'Export Full Audit Log',
-        defaultPath: defaultName,
+        defaultPath: path.join(app.getPath('downloads'), defaultName),
         filters: [{ name: 'JSON', extensions: ['json'] }],
       });
       if (!filePath) return { success: false };
@@ -300,7 +300,7 @@ ${findingsHtml}${recsHtml}
     try {
       const { filePath } = await dialog.showSaveDialog(deps.getWindow(), {
         title: 'Export Config',
-        defaultPath: 'aegis-config.json',
+        defaultPath: path.join(app.getPath('downloads'), 'aegis-config.json'),
         filters: [{ name: 'JSON', extensions: ['json'] }],
       });
       if (!filePath) return { success: false };
@@ -376,7 +376,7 @@ ${findingsHtml}${recsHtml}
       const defaultName = `aegis-export-${new Date().toISOString().slice(0, 10)}.zip`;
       const { filePath } = await dialog.showSaveDialog(deps.getWindow(), {
         title: 'Export All Data (ZIP)',
-        defaultPath: defaultName,
+        defaultPath: path.join(app.getPath('downloads'), defaultName),
         filters: [{ name: 'ZIP', extensions: ['zip'] }],
       });
       if (!filePath) return { success: false };


### PR DESCRIPTION
All six export save dialogs supplied a bare file name, which resolved against the launch directory. Join each existing name to `app.getPath('downloads')` so the suggested destination is the user's Downloads folder. Covers JSON/CSV activity logs, agent database, full audit, configuration, and ZIP exports.

Validation: 45 existing export and IPC tests passed; format:check and build:renderer passed; lint completed with zero errors and 32 existing warnings. Native Windows dialogs and packaged installer behavior were not exercised in this session. The session result is recorded in memory-bank/progress.md.

Closes #332.