### PR TITLE
fix(release): generate changelog from merged pull requests

### DIFF
--- a/docs/RELEASE-VERIFICATION.md
+++ b/docs/RELEASE-VERIFICATION.md
@@ -127,6 +127,23 @@ that was renamed on upload *and* altered afterwards shows up as exactly that pai
 In every one of those cases, do not run the installer. Re-download from the Release page
 and check again; if it still fails, open an issue with the output.
 
+## Release notes
+
+`release-please-config.json` uses `changelog-type: github`: GitHub generates the
+notes from merged pull requests between release tags. The default commit-based
+builder listed both a feature commit and its conventional merge commit, producing
+duplicate entries with this repository's merge-only workflow.
+
+New release sections use GitHub's PR list, contributor credits and comparison link.
+They include maintenance and test PRs too; the former commit-type sections and hidden
+types no longer apply. Existing released sections of `CHANGELOG.md` are preserved.
+Conventional commits still determine the version bump. Review the generated notes
+on the final release PR head before approving CI or publishing.
+
+This is the built-in
+[GitHub changelog builder](https://github.com/googleapis/release-please/blob/v17.6.0/docs/customizing.md#changelog-types),
+not a custom post-processing step.
+
 ## How the signature is produced
 
 `.github/workflows/release-build.yml` runs on every published Release and on the

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -716,3 +716,18 @@ of the launch directory. Local verification: 45 existing export/IPC tests passed
 `format:check` and `build:renderer` passed, and lint reported zero errors (32 warnings).
 The native Windows dialog and a packaged installer were not exercised in this session.
 Audit-index blocks 1–2 remain complete; no further product task has been selected.
+
+## Release 0.14 preparation — PR queue and changelog (2026-09-07)
+
+PRs #340 and #341 merged the audit-format and demo-command corrections after updating
+each branch and passing all five required CI contexts. Superseded PR #339 and issue #281
+are closed. PR #338 added weekly Dependabot updates with minor/patch grouping; its five
+contexts passed and issue #268 closed. Master after these merges is `1ee871d`.
+
+The release notes now select release-please's built-in `github` changelog builder to
+avoid counting both a conventional commit and its merge commit. A generate-notes preview
+from `aegis-v0.13.0-alpha` to `1ee871d` produced 60 PR entries with 60 distinct PR numbers.
+The config validates against the v17.6.0 schema; local formatting, lint (zero errors,
+32 existing warnings) and renderer build passed. The notes now include maintenance and
+test PRs, and old released changelog sections stay intact. See RELEASE-VERIFICATION.md.
+This preparation does not authorize merging release PR #287 or publishing a tag.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,15 +3,7 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance" },
-        { "type": "refactor", "section": "Code Refactoring" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "chore", "section": "Maintenance", "hidden": true },
-        { "type": "test", "section": "Tests", "hidden": true }
-      ],
+      "changelog-type": "github",
       "bump-minor-pre-major": true,
       "prerelease": true,
       "prerelease-type": "alpha",


### PR DESCRIPTION
Release-please's default changelog includes both conventional feature commits and their merge commits in this merge-only repository. Select the built-in GitHub changelog builder so release sections list merged pull requests once.

This changes the notes format to GitHub's PR list, contributor credits and comparison link, including maintenance and test PRs. Existing released CHANGELOG sections remain intact; conventional commits still determine version bumps. Remove the commit-type sections that the GitHub builder does not use and document the release review process.

Validation: generate-notes preview from aegis-v0.13.0-alpha to 1ee871d produced 60 PR entries and 60 unique PR numbers; config validates against release-please v17.6.0's schema; format:check and build:renderer passed; lint completed with zero errors and 32 existing warnings. No dependency or workflow edits. Release PR #287 remains separate from this change.