### PR TITLE
fix(packaging): include detection rules and runtime icon

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -731,3 +731,17 @@ The config validates against the v17.6.0 schema; local formatting, lint (zero er
 32 existing warnings) and renderer build passed. The notes now include maintenance and
 test PRs, and old released changelog sections stay intact. See RELEASE-VERIFICATION.md.
 This preparation does not authorize merging release PR #287 or publishing a tag.
+
+## Packaged runtime assets — release smoke finding (2026-09-07)
+
+Building release PR #287 at `190036c` exposed a packaging defect: `build.files` omitted
+`rules/` and `assets/icon.png`, although the runtime resolves both under the app root.
+The produced `app.asar` had neither directory. Running the packaged executable in Node
+mode and calling its own loaders returned 0 flat rules, 0 sequence rules and no icon.
+
+The packaging allowlist now includes `rules/**/*` and `assets/icon.png`. A Windows NSIS
+rebuild from master plus this fix completed; the same packaged-runtime probe returned
+73 flat rules, 1 sequence rule, zero sequence errors and an existing icon. No dependency
+or lockfile change was needed. Formatting, lint (zero errors, 32 existing warnings) and
+renderer build passed. Rebuild the final 0.14 candidate after this fix merges; the old
+candidate is not releasable despite its green five-context CI.

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "files": [
       "src/**/*",
       "dist/renderer/**/*",
+      "rules/**/*",
+      "assets/icon.png",
       "package.json"
     ],
     "extraMetadata": {


### PR DESCRIPTION
The Windows package omitted rules/ and assets/icon.png because build.files explicitly included only src, dist/renderer and package.json. Both rule loaders resolve their defaults under the application root, so the packaged app loaded no detection rules even though repository tests passed.

Include rules/**/* and assets/icon.png in the package. The first candidate from release PR #287 (190036c) returned 0 flat rules, 0 sequence rules and a missing icon when its own loaders ran inside the packaged Electron executable. A rebuilt NSIS package with this change returned 73 flat rules, 1 sequence rule, zero sequence errors and an existing icon through the same probe.

Validation: real Windows NSIS build completed; packaged-runtime probe failed before and passed after; renderer build and format:check passed; lint had zero errors and 32 existing warnings. No dependency or lockfile edits. The final release candidate must be rebuilt after this merges.