### PR TITLE
fix(watchers): skip virtual ASAR watch roots

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -745,3 +745,21 @@ rebuild from master plus this fix completed; the same packaged-runtime probe ret
 or lockfile change was needed. Formatting, lint (zero errors, 32 existing warnings) and
 renderer build passed. Rebuild the final 0.14 candidate after this fix merges; the old
 candidate is not releasable despite its green five-context CI.
+
+## Archived watch roots — second packaged smoke finding (2026-09-07)
+
+The next live packaged smoke loaded the rules and reached SQLite `ready`, but chokidar
+rejected its attempts to watch inside `app.asar` with unhandled `reading 'close'` errors.
+The app-directory root and both rule hot-reload watchers pointed into that virtual tree.
+
+`file-watcher.js` now excludes the ASAR app tree from its watch plan and returns no
+hot-reload watcher for embedded rules. Unpacked trees retain both rule watchers; user
+credential/config directories and home env-file watching remain active in either case.
+The registry comments now describe that explicit not-applicable case.
+
+Two archive cases failed before the fix and passed after, including user-root readiness
+and degradation on a real watcher's error. Six affected suites passed (138 passed, 4
+skipped); format, lint, typecheck, counts and renderer build passed. A rebuilt, live
+packaged app then reported three ready user watch groups, `project-dir` absent, SQLite
+`ready`, and no unhandled errors in its captured startup stderr. The final 0.14 candidate
+must include this fix and be rebuilt before release approval.

--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -20,6 +20,8 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const chokidar = require('chokidar');
+const DEFAULT_APP_DIR = path.join(__dirname, '..', '..');
+let _appDir = DEFAULT_APP_DIR;
 const {
   IGNORE_PATTERNS,
   AGENT_CONFIG_PATHS,
@@ -296,6 +298,7 @@ function noteFileScanSkip(reason) {
 
 /** @internal Override dependencies (for tests). */
 function _setDepsForTest(overrides) {
+  if (overrides.appDir) _appDir = overrides.appDir;
   if (overrides.getFileHandles) _getFileHandles = overrides.getFileHandles;
   if (overrides.getSensitiveHolders) _getSensitiveHolders = overrides.getSensitiveHolders;
   if (overrides.getHotSensitiveHolders) _getHotSensitiveHolders = overrides.getHotSensitiveHolders;
@@ -319,6 +322,7 @@ function _setDepsForTest(overrides) {
 }
 /** @internal Reset debounce state + opt out of the RM path (for tests). */
 function _resetForTest() {
+  _appDir = DEFAULT_APP_DIR;
   watcherDebounce.clear();
   _getSensitiveHolders = undefined; // tests opt into RM explicitly via _setDepsForTest
   _getHotSensitiveHolders = undefined;
@@ -613,7 +617,7 @@ function handleWatcherEvent(action, filePath) {
  */
 async function setupFileWatchers() {
   const homeDir = os.homedir();
-  const projectDir = path.join(__dirname, '..', '..');
+  const projectDir = _appDir;
   // BOTH preflights complete before ANY registration (§1.2). The plan separates
   // intent from outcome: a group may leave it only because a completed probe proved
   // there is nothing to watch — never because a registration threw. Under the old
@@ -634,8 +638,10 @@ async function setupFileWatchers() {
   buildWatchPlan([
     { id: WATCH_GROUP.CREDENTIAL_DIRS, applicable: sensitiveDirs.length > 0 },
     { id: WATCH_GROUP.AGENT_CONFIG_DIRS, applicable: agentConfigDirs.length > 0 },
-    // Unconditional: no preflight can exclude them, so the plan is never empty.
-    { id: WATCH_GROUP.PROJECT_DIR, applicable: true },
+    // ASAR contents are a virtual, read-only tree. fs.watch cannot observe them;
+    // registering them makes chokidar reject while its root may still report ready.
+    { id: WATCH_GROUP.PROJECT_DIR, applicable: path.extname(projectDir) !== '.asar' },
+    // Unconditional, so the plan is never empty even in an archived app.
     { id: WATCH_GROUP.ENV_FILES, applicable: true },
   ]);
   /** @type {string|null} The group whose registration is in flight. */
@@ -1180,9 +1186,11 @@ function pruneKnownHandles(activeAgents) {
  * (function-form `ignored`, not a glob — chokidar issue #773). Shared by the two rule
  * watchers below so they cannot drift apart on their options.
  * @param {string} dir
- * @returns {import('chokidar').FSWatcher}
+ * @returns {import('chokidar').FSWatcher|null} null for rules embedded in ASAR.
  */
 function _watchRuleDir(dir) {
+  // Embedded rules are loaded normally; hot reload applies to unpacked app trees.
+  if (path.extname(_appDir) === '.asar') return null;
   return chokidar.watch(dir, {
     ignored: (filePath) => path.basename(filePath).startsWith('_'),
     persistent: false,
@@ -1210,12 +1218,13 @@ function _isRuleFile(basename) {
  * @param {(channel: string, data: object) => void} sendFn - Function to push events to renderer
  * @param {{sequenceCount: () => number}} deps - `sequenceCount` answers how many sequence
  *   rules the engine currently holds (main.js owns that figure).
- * @returns {import('chokidar').FSWatcher}
+ * @returns {import('chokidar').FSWatcher|null} null for rules embedded in ASAR.
  * @since v0.6.0
  */
 function setupRulesWatcher(sendFn, { sequenceCount }) {
-  const rulesDir = path.join(__dirname, '..', '..', 'rules');
+  const rulesDir = path.join(_appDir, 'rules');
   const rw = _watchRuleDir(rulesDir);
+  if (!rw) return null;
   rw.on('change', (filePath) => {
     const basename = path.basename(filePath);
     if (!_isRuleFile(basename)) return;
@@ -1239,12 +1248,13 @@ function setupRulesWatcher(sendFn, { sequenceCount }) {
  * @param {(channel: string, data: object) => void} sendFn - Function to push events to renderer
  * @param {{reload: () => number}} deps - `reload` re-reads the sequence rules into the engine
  *   and returns how many are loaded now.
- * @returns {import('chokidar').FSWatcher}
+ * @returns {import('chokidar').FSWatcher|null} null for rules embedded in ASAR.
  * @since v0.14.0
  */
 function setupSequenceRulesWatcher(sendFn, { reload }) {
-  const sequencesDir = path.join(__dirname, '..', '..', 'rules', 'sequences');
+  const sequencesDir = path.join(_appDir, 'rules', 'sequences');
   const rw = _watchRuleDir(sequencesDir);
+  if (!rw) return null;
   rw.on('change', (filePath) => {
     const basename = path.basename(filePath);
     if (!_isRuleFile(basename)) return;

--- a/src/main/watch-root-registry.js
+++ b/src/main/watch-root-registry.js
@@ -25,8 +25,8 @@
 const sensorHealth = require('./sensor-health');
 
 /**
- * The four watch-root groups `setupFileWatchers` registers. Two are preflighted,
- * two are unconditional — which is why the plan can never be empty (§1.2).
+ * The four watch-root groups `setupFileWatchers` considers. User directories are
+ * preflighted, the app tree is excluded inside ASAR, and env-files is unconditional.
  * @type {Readonly<Record<string, string>>}
  * @since 0.12.0
  */
@@ -41,7 +41,7 @@ const WATCH_GROUP = Object.freeze({
  * Lifecycle states of one watch root (§1.3).
  *
  * `not-applicable` is the ONLY exclusion from the plan, and it rests on a completed
- * probe — never on a throw. `registration-failed`, `not-attempted` and `errored` are
+ * probe or a known ASAR app tree — never on a throw. `registration-failed`, `not-attempted` and `errored` are
  * all terminal: nothing in this module recreates a watcher object (gap P).
  * @type {Readonly<Record<string, string>>}
  * @since 0.12.0

--- a/tests/main/file-watcher-watch-roots.test.js
+++ b/tests/main/file-watcher-watch-roots.test.js
@@ -174,6 +174,31 @@ describe('chokidar watch-root registry (step B)', () => {
     restoreChokidar();
   });
 
+  it.each([true, false])(
+    'keeps user roots live without watching ASAR (user dirs: %s)',
+    async (present) => {
+      vi.restoreAllMocks();
+      stubPreflight(present);
+      const appDir = path.join(os.tmpdir(), 'resources', 'app.asar');
+      fileWatcher._setDepsForTest({ appDir });
+
+      await fileWatcher.setupFileWatchers();
+      expect(ids(fileWatcher.getWatchPlan())).toEqual(
+        present ? ['credential-dirs', 'agent-config-dirs', 'env-files'] : ['env-files'],
+      );
+      expect(fileWatcher.getWatchPlan().absentGroups).toContain('project-dir');
+      expect(fileWatcher.setupRulesWatcher(vi.fn(), { sequenceCount: () => 1 })).toBeNull();
+      expect(fileWatcher.setupSequenceRulesWatcher(vi.fn(), { reload: vi.fn() })).toBeNull();
+      expect(fakeWatchers).toHaveLength(present ? 3 : 1);
+      expect(fakeWatchers.flatMap((w) => w._paths).some((p) => p.includes('app.asar'))).toBe(false);
+
+      readyAll();
+      expect(fileWatcher.getWatchPlan().state).toBe('HEALTHY');
+      fakeWatchers[0].emit('error', new Error('user root unavailable'));
+      expect(fileWatcher.getWatchPlan().state).toBe('DEGRADED');
+    },
+  );
+
   describe('the plan (§1.2)', () => {
     it('is complete at the first registration, and every root is still only planned', async () => {
       await fileWatcher.setupFileWatchers();


### PR DESCRIPTION
A live packaged app attempted to watch its virtual app.asar directory and embedded rule directories. Chokidar rejected those registrations with unhandled reading-close errors, while the app-root watcher could still report ready.

Exclude the archived app tree from the watch plan and skip the two embedded-rule hot-reload watchers. Rule loading stays active; credential/config directories and home env-file watching remain active. Unpacked app trees keep their app-root and rule watchers. Registry comments describe the explicit not-applicable case.

Validation: two archive cases failed before the fix and passed after, including user-root readiness and degradation on watcher error. Six affected suites passed (138 passed, 4 skipped). Format, lint, typecheck, counts and renderer build passed. A real packaged Electron launch reported three ready user watch groups, project-dir absent, SQLite ready, and no unhandled errors in captured startup stderr. The final 0.14 release candidate must be rebuilt after this fix.