### PR TITLE
chore: measure Windows watcher startup pauses

### DIFF
--- a/docs/current-state/WINDOWS-STARTUP.md
+++ b/docs/current-state/WINDOWS-STARTUP.md
@@ -1,0 +1,71 @@
+# Windows startup investigation — 2026-09-07
+
+The installed 0.14.0-alpha app has a reproducible source of main-thread pauses:
+chokidar creates thousands of native `fs.watch` subscriptions on that thread.
+This explains measured pauses after the window appears. The longer unresponsive
+episode observed during the installation smoke was not reproduced in full, so its
+cause remains open. No production performance fix has been applied by this investigation.
+
+## Measurements
+
+All numbers are local observations under background desktop load, not startup targets.
+The published Windows executable was profiled with an inspector attached before main
+entry, using disposable profiles and synthetic history. Times below start at the
+instrumented entry and exclude executable launch / debugger attachment. Profiler and
+instrumentation overhead is included. `ready-to-show` is an Electron event, not a
+measurement of visual completeness or keyboard responsiveness.
+
+| Probe | Observation |
+| --- | --- |
+| Isolated packaged audit initialization, 11,000 synthetic records | Synchronous seeding 12 ms; index ready 162 ms; largest heartbeat gap 33 ms |
+| Packaged app, empty profile | `ready-to-show` 464 ms; largest main-thread heartbeat gap 1,119 ms |
+| Packaged app, first index build from 11,000 records | `ready-to-show` 593 ms; largest gap 2,026 ms; individual SQLite batches 31–57 ms |
+| Same packaged profile, existing index | `ready-to-show` 514 ms; largest gap 1,539 ms; 4,812 native `fs.watch` calls taking 2,231 ms cumulatively |
+
+The CPU profile's dominant non-idle stack during the first five seconds was:
+`chokidar._addToNodeFs → _handleFile → _watchWithNodeFs → createFsWatchInstance → fs.watch → FSWatcher.start`.
+An existing index did not remove the pauses. The isolated audit result excludes the
+index as the explanation for these seconds-long pauses at the sampled history size;
+it does not prove history loading is bounded for arbitrarily large logs.
+
+## Reproduce the isolated registration comparison
+
+Run `node scripts/bench-watch-startup.js 3000` after `npm ci`. The script creates its
+own temporary fixture, registers the same files using the application's chokidar
+options (`depth: 2`, no polling, no symlink following), and cleans up afterward. It
+compares registration on the measuring thread with registration in a worker thread.
+The worker is a diagnostic experiment, not an application watcher implementation.
+
+Three successive pairs on Windows / Node 24.11.1:
+
+| Run | Main-thread ready | Main-thread largest gap | Worker ready, including launch | Measuring-thread largest gap with worker |
+| --- | --- | --- | --- | --- |
+| 1 | 1,737 ms | 1,415 ms | 1,416 ms | 19 ms |
+| 2 | 1,501 ms | 1,135 ms | 1,643 ms | 25 ms |
+| 3 | 1,255 ms | 971 ms | 1,431 ms | 16 ms |
+
+Each arm observed 3,031 entries: 3,000 files, 30 subdirectories and the fixture root
+in its parent's watch entry. A count mismatch fails the comparison. The heartbeat
+interval is 10 ms; reported gaps include that interval. Fixture creation and watcher
+shutdown are outside the measurement. Main always runs first, so filesystem-cache
+order is a limitation. The comparison measures responsiveness, not event delivery,
+loss, or faster total setup. It is not a timing gate in CI.
+
+## Next implementation
+
+Move native chokidar registration and watching into a worker, keeping the existing
+root options and observation scope. The main process should still own attribution,
+audit writes, rule evaluation and watch health. Preserve the current root lifecycle:
+registration alone cannot mean `ready`; worker errors and exits must degrade every
+affected root. Reinitialization and shutdown must retire the previous worker and
+reject messages from an older generation.
+
+Before adoption, verify real add/change/unlink delivery, readiness, registration
+failure, crash, close-before-ready and reinitialization. Design a bounded event queue
+with explicit loss reporting before bridging live traffic: moving registration must
+not introduce an unbounded backlog or silently discard observations. Repeat packaged
+startup measurements and existing watch-plan tests after that implementation.
+
+Local diagnostic profiles and raw samples are under `X:/tmp/aegis-startup-20260907/`.
+They stay outside Git. The installed user's profile was not used as a fixture or
+modified by these probes; every profiled app ran with its own `--user-data-dir`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -822,3 +822,24 @@ screen captures were black, so appearance remains visually unverified; navigatio
 content checks used accessibility. The installed app remains open. The next focused
 follow-up is to reproduce and measure the first-launch delay using a disposable profile
 with synthetic retained history. This result does not authorize a new release.
+
+## Session handoff — startup pause diagnosis (2026-09-07)
+
+The startup investigation reproduced 1.1–2.0 s main-thread heartbeat gaps in the
+published executable, with both empty and synthetic-history profiles. CPU profiling
+points to chokidar's native `fs.watch` registration; an existing-index run created
+4,812 subscriptions with 2.23 s cumulative synchronous registration time. Isolated
+audit initialization for 11,000 synthetic records reached index `ready` in 162 ms.
+The longer installation-smoke episode was not reproduced in full and remains open.
+
+`scripts/bench-watch-startup.js` now provides a disposable 3,000-file registration
+comparison. Three pairs measured 971–1,415 ms gaps on the main thread and 16–25 ms
+with registration in a worker, with identical 3,031-entry watch inventories. This
+prototype measures responsiveness only; it does not replace production watchers.
+See `docs/current-state/WINDOWS-STARTUP.md` for methods, limits and the next change.
+
+Next: move chokidar into a worker while preserving root readiness/error semantics,
+generation isolation, shutdown, and bounded event delivery with explicit loss
+reporting. No production source, dependency, installed app or release was changed
+by this investigation. The local probes used disposable profiles and synthetic
+history. A release of any subsequent fix still requires explicit authorization.

--- a/scripts/bench-watch-startup.js
+++ b/scripts/bench-watch-startup.js
@@ -1,0 +1,154 @@
+/**
+ * @file bench-watch-startup.js
+ * @description Compare main-thread and worker-thread chokidar registration using
+ *   disposable synthetic files. Diagnostic only; no timing threshold or product
+ *   watcher replacement. Run: node scripts/bench-watch-startup.js [file-count].
+ */
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { Worker, isMainThread, parentPort, workerData } = require('node:worker_threads');
+
+/** @param {number} ms @returns {Promise<void>} @since v0.14.0 */
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** @param {string} root @returns {Promise<object>} @since v0.14.0 */
+async function register(root) {
+  const start = performance.now();
+  const watcher = require('chokidar').watch(root, {
+    persistent: true,
+    ignoreInitial: true,
+    usePolling: false,
+    followSymlinks: false,
+    depth: 2,
+  });
+  try {
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('Watcher did not become ready in 30s')),
+        30000,
+      );
+      watcher.once('ready', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+      watcher.once('error', (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+    });
+    return {
+      readyMs: performance.now() - start,
+      watchedEntries: Object.values(watcher.getWatched()).reduce((n, names) => n + names.length, 0),
+      close: () => watcher.close(),
+    };
+  } catch (error) {
+    await watcher.close();
+    throw error;
+  }
+}
+
+/** @param {string} root @returns {Promise<object>} @since v0.14.0 */
+function registerInWorker(root) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(__filename, { workerData: { root } });
+    worker.once('error', reject);
+    worker.once('exit', (code) => reject(new Error(`Worker exited before ready: ${code}`)));
+    worker.once('message', (result) =>
+      resolve({
+        ...result,
+        close: () => worker.terminate(),
+      }),
+    );
+  });
+}
+
+/** @param {string} root @param {boolean} inWorker @returns {Promise<object>} @since v0.14.0 */
+async function measure(root, inWorker) {
+  let last = performance.now();
+  let maxHeartbeatGapMs = 0;
+  let ticks = 0;
+  let registration;
+  const heartbeat = setInterval(() => {
+    const now = performance.now();
+    maxHeartbeatGapMs = Math.max(maxHeartbeatGapMs, now - last);
+    last = now;
+    ticks++;
+  }, 10);
+  try {
+    await sleep(30);
+    const start = performance.now();
+    registration = await (inWorker ? registerInWorker(root) : register(root));
+    const wallReadyMs = performance.now() - start;
+    // Include the heartbeat delayed by the final registration turn; exclude close.
+    await sleep(20);
+    return {
+      mode: inWorker ? 'worker' : 'main',
+      wallReadyMs,
+      registrationMs: registration.readyMs,
+      maxHeartbeatGapMs,
+      ticks,
+      watchedEntries: registration.watchedEntries,
+    };
+  } finally {
+    clearInterval(heartbeat);
+    if (registration) await registration.close();
+  }
+}
+
+/** @returns {Promise<void>} @since v0.14.0 */
+async function main() {
+  const count = Number(process.argv[2] || 3000);
+  if (!Number.isSafeInteger(count) || count < 1 || count > 10000) {
+    throw new Error('file-count must be an integer from 1 to 10000');
+  }
+  const temp = fs.realpathSync(os.tmpdir());
+  const root = fs.mkdtempSync(path.join(temp, 'aegis-watch-startup-'));
+  let failure;
+  try {
+    for (let i = 0; i < count; i++) {
+      const dir = path.join(root, `fixture-${Math.floor(i / 100)}`);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, `config-${i}.json`), '{}');
+    }
+    const direct = await measure(root, false);
+    const worker = await measure(root, true);
+    const expected = count + Math.ceil(count / 100) + 1;
+    if (direct.watchedEntries !== expected || worker.watchedEntries !== expected) {
+      throw new Error('A registration missed fixture entries; timing comparison is invalid');
+    }
+    process.stdout.write(
+      JSON.stringify({ node: process.version, platform: process.platform, count, direct, worker }) +
+        '\n',
+    );
+  } catch (error) {
+    failure = error;
+  }
+  try {
+    const resolved = fs.realpathSync(root);
+    if (
+      path.dirname(resolved) !== temp ||
+      !path.basename(resolved).startsWith('aegis-watch-startup-')
+    ) {
+      throw new Error('Refusing cleanup outside the generated temporary fixture');
+    }
+    fs.rmSync(resolved, { recursive: true });
+  } catch (error) {
+    failure = failure ? new AggregateError([failure, error], 'Probe and cleanup failed') : error;
+  }
+  if (failure) throw failure;
+}
+
+if (isMainThread) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack}\n`);
+    process.exitCode = 1;
+  });
+} else {
+  register(workerData.root).then(({ readyMs, watchedEntries }) => {
+    parentPort.postMessage({ readyMs, watchedEntries });
+  });
+}


### PR DESCRIPTION
Windows startup profiling reproduced main-thread pauses during thousands of chokidar fs.watch registrations, including on a profile whose SQLite index already existed. Add a disposable synthetic-file benchmark comparing registration on the main thread and in a worker, plus the measured results and implementation requirements in the session handoff.

The three 3,000-file comparisons observed equal 3,031-entry watch inventories, with main-thread heartbeat gaps of 971–1,415 ms versus 16–25 ms during the worker experiment. These are local diagnostic observations; the benchmark has no timing threshold. Production watchers are unchanged, and the longer installation-smoke episode remains unexplained in full.

Validation: benchmark at 1, 101 and 3,000 files; invalid count rejected; cleanup and matched inventories checked. Packaged runtime profiling used disposable profiles and synthetic history. Format, renderer build and lint checks completed; the new script passes lint after fixing its cleanup error handling. No dependencies or workflows changed.
