### PR TITLE
perf: move evidence file watchers off the main thread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Explicit user instructions take precedence over anything in AGENTS.md or a skill
 
 ## Project facts
 
-`src/main/` contains 59 main modules: 47 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 40 invoke + 9 push = 49 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
+`src/main/` contains 62 main modules: 50 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 40 invoke + 9 push = 49 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
 
 A birth time is observed on the pass that stamps it or is `null`; no cache stores one. A snapshot outage freezes sessions and never splits them. For changes touching identity stamping, the audit chain, or the Windows git worktree flow, `memory-bank/ai-mistakes.md` holds the relevant failure history.
 

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **59** = 47 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **62** = 50 top-level + 10 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/docs/current-state/WINDOWS-STARTUP.md
+++ b/docs/current-state/WINDOWS-STARTUP.md
@@ -4,7 +4,7 @@ The installed 0.14.0-alpha app has a reproducible source of main-thread pauses:
 chokidar creates thousands of native `fs.watch` subscriptions on that thread.
 This explains measured pauses after the window appears. The longer unresponsive
 episode observed during the installation smoke was not reproduced in full, so its
-cause remains open. No production performance fix has been applied by this investigation.
+cause remains open. The implementation below now moves evidence watchers into workers.
 
 ## Measurements
 
@@ -51,20 +51,48 @@ shutdown are outside the measurement. Main always runs first, so filesystem-cach
 order is a limitation. The comparison measures responsiveness, not event delivery,
 loss, or faster total setup. It is not a timing gate in CI.
 
-## Next implementation
+## Implementation — 2026-09-07
 
-Move native chokidar registration and watching into a worker, keeping the existing
-root options and observation scope. The main process should still own attribution,
-audit writes, rule evaluation and watch health. Preserve the current root lifecycle:
-registration alone cannot mean `ready`; worker errors and exits must degrade every
-affected root. Reinitialization and shutdown must retire the previous worker and
-reject messages from an older generation.
+Each applicable evidence watch group now owns a dedicated Node worker. Registration,
+native handles and chokidar run there; paths and event types cross to the main thread,
+which still owns attribution, audit writes, rule evaluation and watch health. Existing
+depth, symlink, polling, initial-event and project-ignore behavior is retained. The small
+development-only rule hot-reload watchers remain local; ASAR rules are not watched.
 
-Before adoption, verify real add/change/unlink delivery, readiness, registration
-failure, crash, close-before-ready and reinitialization. Design a bounded event queue
-with explicit loss reporting before bridging live traffic: moving registration must
-not introduce an unbounded backlog or silently discard observations. Repeat packaged
-startup measurements and existing watch-plan tests after that implementation.
+Each worker has at most 512 pending events with a 1 MiB UTF-8 path/envelope budget,
+plus one unacknowledged batch of at most 32 events (also at most 1 MiB). Native watcher
+internals and JavaScript object overhead are outside these bridge bounds. The main
+thread acknowledges after handling a batch. Overflow drops newest events and sends a
+cumulative count separately from event capacity; the client converts it to loss deltas.
+`fs-chokidar.lossCount` increases and the affected root remains errored after subsequent
+ready/events. Provider errors and unexpected worker exits also degrade the root. Only
+fixed error codes cross the bridge; no file contents or arbitrary error strings do.
+
+Closing invalidates callbacks immediately, then terminates the dedicated worker and
+its native handles. Reinitialization closes prior workers and guards callback/preflight
+continuations by generation. Shutdown invalidates delivery before closing the audit log.
+Intentional close cancels queued delivery; it does not drain observations past shutdown.
+
+Validation covers real worker add/change/unlink delivery, startup suppression, literal
+project ignore names, registration failure, error/exit reporting, close-before-ready,
+reinitialization races, count/byte queue bounds and sticky health loss. The existing
+watch-plan and application health suites pass. Full coverage: 2,644 passed, 4 skipped
+across 146 files; both typechecks, lint, renderer build and both mutation gates pass.
+
+A rebuilt Windows package loaded workers from ASAR and reached three healthy evidence
+watch groups, zero chokidar loss, and SQLite `ready`. A repeat on the synthetic-history
+profile recorded `ready-to-show` at 419 ms and a largest main-thread heartbeat gap of
+115 ms, compared with 514 ms / 1,539 ms on the earlier existing-index sample. Instrumented
+main-thread `fs.watch` calls fell from 4,812 to zero. These are individual local samples,
+not a platform-wide speed guarantee or proof of the original long episode's cause.
+For the profiled worker run, the harness cleared inherited worker `execArgv`: otherwise
+the parent's `--inspect-brk` kept workers paused. This adjustment is only in the local
+profiling harness. Normal packaged worker readiness was also checked without the
+debugger in Electron's Node mode. A final normal packaged launch (no startup debugger
+flags; diagnostics attached afterward) also reached three ready groups, delivered
+13 agent-config callbacks, recorded zero chokidar loss and had a ready SQLite index.
+It exited cleanly. This change has not been released or installed over the user's
+published 0.14.0-alpha application.
 
 Local diagnostic profiles and raw samples are under `X:/tmp/aegis-startup-20260907/`.
 They stay outside Git. The installed user's profile was not used as a fixture or

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 59 CommonJS modules (47 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 62 CommonJS modules (50 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle
@@ -10,7 +10,9 @@ Core modules:
 - preload.js — IPC bridge (window.aegis via contextBridge, 40 invoke + 9 events = 49 channels)
 - process-scanner.js — AI agent detection (tasklist + pattern matching)
 - process-utils.js — parent chain resolution + editor annotation
-- file-watcher.js — chokidar watchers + handle scanning
+- file-watcher.js — watcher health, main-thread attribution + handle scanning
+- watch-worker-client.js / watch-worker-thread.js — dedicated chokidar worker per evidence watch group; close invalidates delivery before termination
+- watch-event-queue.js — bounded, acknowledged worker delivery; counted drop-newest overflow reaches sensor health
 - network-monitor.js — TCP scanning + DNS + domain classification
 - rule-loader.js — YAML rule loading + categoryIndex (Map<category, rules[]>) exposed via getRulesByCategory(); built and tested, but no production caller consumes it yet (C-16)
 - config-manager.js — settings persistence + permissions

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -843,3 +843,28 @@ generation isolation, shutdown, and bounded event delivery with explicit loss
 reporting. No production source, dependency, installed app or release was changed
 by this investigation. The local probes used disposable profiles and synthetic
 history. A release of any subsequent fix still requires explicit authorization.
+
+## Session handoff — evidence watchers moved to workers (2026-09-07)
+
+The four possible evidence watch groups now use dedicated chokidar workers, with
+the packaged app retaining its three applicable groups. Main still owns attribution,
+audit and health. A generation guard excludes callbacks and preflight continuations
+from retired setups; close invalidates delivery before terminating native handles,
+and main shutdown closes the bridge before the audit logger.
+
+The bridge allows one 32-event batch in flight plus 512 pending events; both the
+pending queue and any batch are bounded to 1 MiB of UTF-8 path/envelope accounting.
+Overflow drops newest events, reports cumulative loss, increments the existing
+fs-chokidar lossCount and leaves the root degraded. Provider failures and unexpected
+worker exits report fixed error codes. Intentional close cancels remaining delivery.
+
+Full suite: 2,644 passed / 4 skipped across 146 files. Real filesystem worker tests
+exercise create/change/delete, ignore behavior, registration failure and restart;
+queue/client tests cover bounds, acknowledgements, loss and late callbacks. Typechecks,
+lint (32 existing warnings), build, counts and both mutation gates passed. A rebuilt
+Windows ASAR package reached healthy watch groups and SQLite ready. A normal packaged
+launch delivered 13 config callbacks with zero loss and then exited cleanly. The repeated local
+profile measured a 115 ms maximum main-thread gap (earlier existing-index run: 1,539 ms)
+and zero main-thread fs.watch calls. See docs/current-state/WINDOWS-STARTUP.md for the
+profiling method, debugger adjustment and limitations. The installed release remains
+unchanged; publishing this fix still needs explicit release authorization.

--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -20,6 +20,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const chokidar = require('chokidar');
+const watchWorker = require('./watch-worker-client');
 const DEFAULT_APP_DIR = path.join(__dirname, '..', '..');
 let _appDir = DEFAULT_APP_DIR;
 const {
@@ -322,6 +323,7 @@ function _setDepsForTest(overrides) {
 }
 /** @internal Reset debounce state + opt out of the RM path (for tests). */
 function _resetForTest() {
+  closeFileWatchers().catch(() => {});
   _appDir = DEFAULT_APP_DIR;
   watcherDebounce.clear();
   _getSensitiveHolders = undefined; // tests opt into RM explicitly via _setDepsForTest
@@ -345,6 +347,24 @@ function _resetForTest() {
 
 const watcherDebounce = new Map();
 let _state = null;
+let _watchGeneration = 0;
+let _ownedWatchers = [];
+
+/** Stop delivery immediately, then release this lifetime's workers. @returns {Promise<void>} @since v0.14.0 */
+async function closeFileWatchers() {
+  _watchGeneration++;
+  // A retired watch lifetime cannot continue advertising coverage while the next
+  // setup is awaiting preflight or while native handles are being terminated.
+  _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.createSensorHealth(FS_SENSOR.CHOKIDAR);
+  resetWatchPlan();
+  const previous = _ownedWatchers;
+  _ownedWatchers = [];
+  for (const w of previous) {
+    const index = _state?.watchers.indexOf(w) ?? -1;
+    if (index >= 0) _state.watchers.splice(index, 1);
+  }
+  await Promise.all(previous.map((w) => w.close()));
+}
 
 /**
  * @param {Object} state - shared state refs (getCustomRules, getLatestAgents, getLatestAiAgents, isMonitoringPaused, activityLog, knownHandles, watchers, recordFileAccess, onFileEvent, isOtherPanelExpanded)
@@ -470,7 +490,7 @@ function applyWatchPlaneHealth(now) {
       detail: 'no-live-watcher',
     });
   } else if (state === sensorHealth.SENSOR_HEALTH_STATE.DEGRADED) {
-    // No lossCount: chokidar exposes no quantitative lost-event counter.
+    // Native errors have no lost-event count; worker queue loss is recorded separately.
     _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.markDegraded(rec, now, {
       error: unavailableRootSummary(),
       detail: 'watch-roots-unavailable',
@@ -483,20 +503,24 @@ function applyWatchPlaneHealth(now) {
 /**
  * @param {object} watcher - the FSWatcher this binding belongs to
  * @param {string} rootId - the watch group it was registered for
+ * @param {number} generation - watch lifetime that owns these callbacks
  * @returns {void}
  */
-function bindWatcherEvents(watcher, rootId) {
+function bindWatcherEvents(watcher, rootId, generation) {
   // noteRootDelivery lives HERE, not in handleWatcherEvent: the handler is exported
   // and called directly with no root context by the attribution/ignore suites.
   watcher.on('add', (p) => {
+    if (generation !== _watchGeneration) return;
     noteRootDelivery(rootId);
     handleWatcherEvent('created', p);
   });
   watcher.on('change', (p) => {
+    if (generation !== _watchGeneration) return;
     noteRootDelivery(rootId);
     handleWatcherEvent('modified', p);
   });
   watcher.on('unlink', (p) => {
+    if (generation !== _watchGeneration) return;
     noteRootDelivery(rootId);
     handleWatcherEvent('deleted', p);
   });
@@ -506,13 +530,25 @@ function bindWatcherEvents(watcher, rootId) {
   // and only on a real transition — W is derived over the plan, so re-deriving it for
   // an event that named no planned root would read an empty plan and throw.
   watcher.on('error', (err) => {
+    if (generation !== _watchGeneration) return;
     if (markRootErrored(rootId, healthErrorMessage(err))) applyWatchPlaneHealth(Date.now());
   });
   // ready = successful initialization of this FSWatcher instance — that one root. A
   // `ready` on a root already `errored` moves nothing (§1.4 — terminal), so it writes
   // no record either.
   watcher.on('ready', () => {
+    if (generation !== _watchGeneration) return;
     if (markRootReady(rootId)) applyWatchPlaneHealth(Date.now());
+  });
+  watcher.on('loss', (amount) => {
+    if (generation !== _watchGeneration) return;
+    _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.addLoss(
+      _fsHealth[FS_SENSOR.CHOKIDAR],
+      amount,
+      Date.now(),
+      { detail: 'watch-worker-overflow' },
+    );
+    if (markRootErrored(rootId, 'watch-worker-overflow')) applyWatchPlaneHealth(Date.now());
   });
 }
 
@@ -616,6 +652,10 @@ function handleWatcherEvent(action, filePath) {
  * @since v0.1.0
  */
 async function setupFileWatchers() {
+  const closing = closeFileWatchers();
+  const generation = _watchGeneration;
+  await closing;
+  if (generation !== _watchGeneration) return;
   const homeDir = os.homedir();
   const projectDir = _appDir;
   // BOTH preflights complete before ANY registration (§1.2). The plan separates
@@ -632,6 +672,7 @@ async function setupFileWatchers() {
   const agentConfigDirs = await filterExistingDirs(
     AGENT_CONFIG_PATHS.filter((d) => !sensitiveDirNames.has(d)).map((d) => path.join(homeDir, d)),
   );
+  if (generation !== _watchGeneration) return;
   // Reinit chokidar health lifetime when production recreates the watcher set — and
   // the plan with it, since the plan is what writes into that record.
   _fsHealth[FS_SENSOR.CHOKIDAR] = sensorHealth.createSensorHealth(FS_SENSOR.CHOKIDAR);
@@ -648,13 +689,17 @@ async function setupFileWatchers() {
   let attempted = null;
   try {
     const config = _state.getSettings ? _state.getSettings() : {};
-    const dirFilter = getIgnoredDirFilter(config);
+    const customDirs = Array.isArray(config.ignoredDirectories) ? config.ignoredDirectories : [];
+    const ignoredDirectories =
+      config.ignoreCommonBuildDirs === false
+        ? customDirs
+        : [...DEFAULT_IGNORED_DIRS, ...customDirs];
     /** Registration order IS plan order — `not-attempted` is read off plan position. */
     const registrations = [
       [
         WATCH_GROUP.CREDENTIAL_DIRS,
         () =>
-          chokidar.watch(sensitiveDirs, {
+          watchWorker.watch(sensitiveDirs, {
             persistent: true,
             ignoreInitial: true,
             usePolling: false,
@@ -665,7 +710,7 @@ async function setupFileWatchers() {
       [
         WATCH_GROUP.AGENT_CONFIG_DIRS,
         () =>
-          chokidar.watch(agentConfigDirs, {
+          watchWorker.watch(agentConfigDirs, {
             persistent: true,
             ignoreInitial: true,
             usePolling: false,
@@ -676,10 +721,11 @@ async function setupFileWatchers() {
       [
         WATCH_GROUP.PROJECT_DIR,
         () =>
-          chokidar.watch(projectDir, {
+          watchWorker.watch(projectDir, {
             persistent: true,
             ignoreInitial: true,
-            ignored: (filePath) => dirFilter(filePath) || /package-lock\.json$/.test(filePath),
+            ignoredDirectories,
+            ignorePackageLock: true,
             usePolling: false,
             followSymlinks: false,
             depth: 5,
@@ -688,7 +734,7 @@ async function setupFileWatchers() {
       [
         WATCH_GROUP.ENV_FILES,
         () =>
-          chokidar.watch(path.join(homeDir, '.env*'), {
+          watchWorker.watch(path.join(homeDir, '.env*'), {
             persistent: true,
             ignoreInitial: true,
             depth: 0,
@@ -702,7 +748,8 @@ async function setupFileWatchers() {
       attempted = id;
       const w = register();
       markRootRegistered(id, w);
-      bindWatcherEvents(w, id);
+      bindWatcherEvents(w, id, generation);
+      _ownedWatchers.push(w);
       _state.watchers.push(w);
     }
   } catch (err) {
@@ -1265,6 +1312,7 @@ function setupSequenceRulesWatcher(sendFn, { reload }) {
 }
 
 module.exports = {
+  closeFileWatchers,
   init,
   setupFileWatchers,
   setupRulesWatcher,

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -875,6 +875,9 @@ app.on('before-quit', () => {
     oomIntervalId = null;
   }
   globalShortcut.unregisterAll();
+  // Invalidate worker delivery before audit shutdown. Electron cannot await the
+  // final process teardown; each proxy also handles its termination promise.
+  if (watcher?.closeFileWatchers) watcher.closeFileWatchers().catch(() => {});
   logger.info('main', 'App quitting');
   if (audit) audit.shutdown();
   if (baselines) baselines.finalizeSession();

--- a/src/main/watch-event-queue.js
+++ b/src/main/watch-event-queue.js
@@ -1,0 +1,75 @@
+/**
+ * @file watch-event-queue.js
+ * @description Bounded, acknowledged worker-to-main delivery. At most one batch
+ *   is in the MessagePort and one bounded queue is waiting. Drop-newest overflow
+ *   is counted; ready/error/loss state does not compete with file events for space.
+ */
+'use strict';
+
+/** @param {Function} send @param {object} [limits] @returns {object} @since v0.14.0 */
+function createQueue(send, { maxEvents = 512, maxBytes = 1024 * 1024, batchSize = 32 } = {}) {
+  const pending = [];
+  let bytes = 0;
+  let dropped = 0;
+  let ready = false;
+  let error = null;
+  let dirty = false;
+  let inFlight = 0;
+  let seq = 0;
+  let scheduled = false;
+  let closed = false;
+
+  const pump = () => {
+    scheduled = false;
+    if (closed || inFlight || (!pending.length && !dirty)) return;
+    const batch = pending.splice(0, batchSize);
+    for (const event of batch) bytes -= event.bytes;
+    dirty = false;
+    inFlight = ++seq;
+    send({ seq, events: batch.map(({ type, path }) => ({ type, path })), ready, error, dropped });
+  };
+  const schedule = () => {
+    if (closed || scheduled || inFlight) return;
+    scheduled = true;
+    setImmediate(pump);
+  };
+  return {
+    event(type, path) {
+      if (closed) return;
+      const size = Buffer.byteLength(path, 'utf8') + 32;
+      if (pending.length >= maxEvents || bytes + size > maxBytes) {
+        dropped++;
+        dirty = true;
+      } else {
+        pending.push({ type, path, bytes: size });
+        bytes += size;
+      }
+      schedule();
+    },
+    ready() {
+      if (closed || ready) return;
+      ready = true;
+      dirty = true;
+      schedule();
+    },
+    error() {
+      if (closed || error) return;
+      // No paths, watched content or arbitrary provider error text crosses here.
+      error = 'watch-worker-provider-error';
+      dirty = true;
+      schedule();
+    },
+    ack(value) {
+      if (!inFlight || value !== inFlight) return;
+      inFlight = 0;
+      schedule();
+    },
+    close() {
+      closed = true;
+      pending.length = 0;
+      bytes = 0;
+    },
+  };
+}
+
+module.exports = { createQueue };

--- a/src/main/watch-worker-client.js
+++ b/src/main/watch-worker-client.js
@@ -1,0 +1,75 @@
+/**
+ * @file watch-worker-client.js
+ * @description EventEmitter watcher proxy. Each root has a dedicated worker and
+ *   at most one acknowledged batch in flight. Close invalidates delivery before
+ *   terminating the worker, so late callbacks cannot enter a new watch lifetime.
+ */
+'use strict';
+
+const { EventEmitter } = require('node:events');
+const { Worker } = require('node:worker_threads');
+const path = require('node:path');
+
+/**
+ * @param {string|string[]} paths
+ * @param {object} options - Serializable chokidar options plus project ignore descriptors.
+ * @param {object} [deps] - Worker constructor seam for lifecycle tests.
+ * @returns {EventEmitter & {close: Function}}
+ * @since v0.14.0
+ */
+function watch(paths, options, { WorkerClass = Worker } = {}) {
+  const emitter = new EventEmitter();
+  const worker = new WorkerClass(path.join(__dirname, 'watch-worker-thread.js'), {
+    workerData: { paths, options },
+  });
+  let closed = false;
+  let failed = false;
+  let ready = false;
+  let dropped = 0;
+  let sequence = 0;
+  let closing;
+  const fail = (reason) => {
+    if (closed || failed) return;
+    failed = true;
+    emitter.emit('error', new Error(reason));
+  };
+  worker.on('error', () => fail('watch-worker-crashed'));
+  worker.on('exit', () => fail('watch-worker-exited'));
+  worker.on('message', (batch) => {
+    if (closed || batch.seq <= sequence) return;
+    sequence = batch.seq;
+    try {
+      if (batch.dropped > dropped) {
+        const delta = batch.dropped - dropped;
+        dropped = batch.dropped;
+        emitter.emit('loss', delta);
+      }
+      if (closed) return;
+      if (batch.error) fail(batch.error);
+      if (closed) return;
+      if (batch.ready && !ready) {
+        ready = true;
+        emitter.emit('ready');
+      }
+      for (const event of batch.events) {
+        if (closed) break;
+        emitter.emit(event.type, event.path);
+      }
+    } finally {
+      if (!closed) worker.postMessage({ type: 'ack', seq: batch.seq });
+    }
+  });
+  emitter.close = () => {
+    if (!closed) {
+      closed = true;
+      // Termination failure is returned to an awaiting caller, and handled here
+      // as well because Electron's final quit callback cannot await promises.
+      closing = worker.terminate();
+      closing.catch(() => {});
+    }
+    return closing;
+  };
+  return emitter;
+}
+
+module.exports = { watch };

--- a/src/main/watch-worker-thread.js
+++ b/src/main/watch-worker-thread.js
@@ -1,0 +1,37 @@
+/** @file watch-worker-thread.js @description Native chokidar ownership outside Electron's main thread. */
+'use strict';
+
+const { parentPort, workerData } = require('node:worker_threads');
+const chokidar = require('chokidar');
+const { createQueue } = require('./watch-event-queue');
+
+if (parentPort) {
+  const queue = createQueue((batch) => parentPort.postMessage(batch));
+  const { ignoredDirectories, ignorePackageLock, ...options } = workerData.options;
+  if (ignoredDirectories || ignorePackageLock) {
+    options.ignored = (filePath) =>
+      (ignorePackageLock && /package-lock\.json$/.test(filePath)) ||
+      (ignoredDirectories || []).some(
+        (dir) =>
+          filePath.includes('/' + dir + '/') ||
+          filePath.includes('\\' + dir + '\\') ||
+          filePath.endsWith('/' + dir) ||
+          filePath.endsWith('\\' + dir),
+      );
+  }
+  try {
+    const watcher = chokidar.watch(workerData.paths, options);
+    for (const type of ['add', 'change', 'unlink']) {
+      watcher.on(type, (path) => queue.event(type, path));
+    }
+    watcher.on('ready', () => queue.ready());
+    watcher.on('error', () => queue.error());
+    parentPort.on('message', (message) => {
+      if (message?.type === 'ack') queue.ack(message.seq);
+    });
+    // The client terminates this dedicated worker on close. Node disposes all
+    // worker-owned native handles, including a registration still in progress.
+  } catch (_) {
+    queue.error();
+  }
+}

--- a/tests/main/file-watcher-subscription.test.js
+++ b/tests/main/file-watcher-subscription.test.js
@@ -44,7 +44,7 @@ function installChokidarMock() {
   });
 
   Module._load = function (request, parent, isMain) {
-    if (request === 'chokidar') {
+    if (request === 'chokidar' || request === './watch-worker-client') {
       return { watch: watchMock };
     }
     return originalLoad.apply(this, arguments);

--- a/tests/main/file-watcher-watch-roots.test.js
+++ b/tests/main/file-watcher-watch-roots.test.js
@@ -71,7 +71,7 @@ function installChokidarMock({ failOnCall = null } = {}) {
   });
 
   Module._load = function (request) {
-    if (request === 'chokidar') return { watch: watchMock };
+    if (request === 'chokidar' || request === './watch-worker-client') return { watch: watchMock };
     return originalLoad.apply(this, arguments);
   };
 }
@@ -444,5 +444,66 @@ describe('chokidar watch-root registry (step B)', () => {
       }
     }
     expect(state.watchers).toEqual(fakeWatchers);
+  });
+
+  it('keeps counted worker loss visible after subsequent ready and event callbacks', async () => {
+    await fileWatcher.setupFileWatchers();
+    readyAll();
+    fakeWatchers[0].emit('loss', 7);
+    fakeWatchers[0].emit('ready');
+    fakeWatchers[0].emit('change', samplePath('after-overflow.js'));
+    fakeWatchers[0].emit('loss', 2);
+    expect(fileWatcher.getFileSensorHealth()['fs-chokidar']).toMatchObject({
+      state: 'DEGRADED',
+      lossCount: 9,
+    });
+    expect(root(fileWatcher.getWatchPlan(), 'credential-dirs')).toMatchObject({
+      state: 'errored',
+      lastError: 'watch-worker-overflow',
+      deliveredCount: 1,
+    });
+  });
+
+  it('retires old watchers on reinit and ignores their late callbacks', async () => {
+    await fileWatcher.setupFileWatchers();
+    const old = [...fakeWatchers];
+    await fileWatcher.setupFileWatchers();
+    expect(state.watchers).toHaveLength(4);
+    for (const w of old) {
+      expect(w.close).toHaveBeenCalledTimes(1);
+      w.emit('ready');
+      w.emit('error', new Error('late'));
+      w.emit('loss', 10);
+      w.emit('add', samplePath('old-generation.js'));
+    }
+    expect(state.activityLog).toHaveLength(0);
+    expect(fileWatcher.getFileSensorHealth()['fs-chokidar']).toMatchObject({
+      state: 'STARTING',
+      lossCount: 0,
+    });
+    for (const w of state.watchers) w.emit('ready');
+    state.watchers[0].emit('add', samplePath('new-generation.js'));
+    expect(state.activityLog).toHaveLength(1);
+    expect(fileWatcher.getFileSensorHealth()['fs-chokidar'].state).toBe('HEALTHY');
+  });
+
+  it('does not register a superseded setup or a setup closed while yielding', async () => {
+    await Promise.all([fileWatcher.setupFileWatchers(), fileWatcher.setupFileWatchers()]);
+    expect(fakeWatchers).toHaveLength(4);
+    const pending = fileWatcher.setupFileWatchers();
+    await fileWatcher.closeFileWatchers();
+    await pending;
+    expect(fakeWatchers).toHaveLength(4);
+    expect(state.watchers).toEqual([]);
+  });
+
+  it('withdraws the previous coverage claim immediately when closing begins', async () => {
+    await fileWatcher.setupFileWatchers();
+    readyAll();
+    expect(fileWatcher.getWatchPlan().state).toBe('HEALTHY');
+    const closing = fileWatcher.closeFileWatchers();
+    expect(fileWatcher.getWatchPlan()).toMatchObject({ state: 'STARTING', liveWatcherCount: 0 });
+    expect(fileWatcher.getFileSensorHealth()['fs-chokidar'].state).toBe('STARTING');
+    await closing;
   });
 });

--- a/tests/main/helpers/health-umbrella-harness.js
+++ b/tests/main/helpers/health-umbrella-harness.js
@@ -157,7 +157,7 @@ export function installShims() {
 
   Module._load = function (request, parent) {
     if (request === 'electron') return fakeElectron;
-    if (request === 'chokidar') return { watch: watchMock };
+    if (request === 'chokidar' || request === './watch-worker-client') return { watch: watchMock };
     if (request === './platform' && wantsFakePlatform(parent)) return fakePlatform;
     return originalLoad.apply(this, arguments);
   };

--- a/tests/main/watch-event-queue.test.js
+++ b/tests/main/watch-event-queue.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { createQueue } from '../../src/main/watch-event-queue.js';
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('worker event backpressure', () => {
+  it('holds one message in flight, bounds pending events and reports every rejected event', async () => {
+    const sent = [];
+    const q = createQueue((batch) => sent.push(batch), { maxEvents: 4, batchSize: 2 });
+    q.event('add', 'first');
+    await tick();
+    for (let i = 0; i < 1000; i++) q.event('change', `file-${i}`);
+    q.ready();
+    q.error();
+    await tick();
+    expect(sent).toHaveLength(1);
+    q.ack(999); // A stray acknowledgement cannot release the gate.
+    await tick();
+    expect(sent).toHaveLength(1);
+    q.ack(sent[0].seq);
+    await tick();
+    expect(sent[1]).toMatchObject({
+      ready: true,
+      error: 'watch-worker-provider-error',
+      dropped: 996,
+    });
+    expect(sent[1].events.map((e) => e.path)).toEqual(['file-0', 'file-1']);
+    q.ack(sent[1].seq);
+    await tick();
+    expect(sent[2].events.map((e) => e.path)).toEqual(['file-2', 'file-3']);
+    q.ack(sent[2].seq);
+    await tick();
+    expect(sent).toHaveLength(3);
+    q.close();
+  });
+
+  it('bounds path bytes even below the event cap, without losing control state', async () => {
+    const sent = [];
+    const q = createQueue((batch) => sent.push(batch), { maxBytes: 100 });
+    q.event('add', 'é'.repeat(40)); // 80 bytes plus envelope exceeds the budget.
+    q.event('unlink', 'kept');
+    q.ready();
+    await tick();
+    expect(sent[0]).toMatchObject({
+      dropped: 1,
+      ready: true,
+      events: [{ type: 'unlink', path: 'kept' }],
+    });
+    q.close();
+  });
+
+  it('cancels scheduled and queued delivery on close', async () => {
+    const sent = [];
+    const q = createQueue((batch) => sent.push(batch));
+    q.event('add', 'discarded-on-stop');
+    q.close();
+    q.ready();
+    q.error();
+    q.event('change', 'late');
+    await tick();
+    expect(sent).toEqual([]);
+  });
+});

--- a/tests/main/watch-worker-client.test.js
+++ b/tests/main/watch-worker-client.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { watch } from '../../src/main/watch-worker-client.js';
+
+class FakeWorker extends EventEmitter {
+  static instances = [];
+  constructor() {
+    super();
+    FakeWorker.instances.push(this);
+    this.postMessage = vi.fn();
+    this.terminate = vi.fn(() => Promise.resolve(0));
+  }
+}
+function create() {
+  const proxy = watch('/fixture', {}, { WorkerClass: FakeWorker });
+  return { proxy, worker: FakeWorker.instances.at(-1) };
+}
+const batch = (seq, extra = {}) => ({
+  seq,
+  events: [],
+  dropped: 0,
+  ready: false,
+  error: null,
+  ...extra,
+});
+
+describe('worker watcher lifetime', () => {
+  it('delivers ordered events, ready once and loss deltas before acknowledging', () => {
+    const { proxy, worker } = create();
+    const observed = [];
+    proxy.on('ready', () => observed.push('ready'));
+    proxy.on('loss', (n) => observed.push(`loss:${n}`));
+    proxy.on('change', (p) => {
+      expect(worker.postMessage).not.toHaveBeenCalled();
+      observed.push(p);
+    });
+    worker.emit(
+      'message',
+      batch(1, { ready: true, dropped: 5, events: [{ type: 'change', path: 'one' }] }),
+    );
+    worker.emit('message', batch(2, { ready: true, dropped: 7 }));
+    worker.emit('message', batch(2, { dropped: 7 }));
+    expect(observed).toEqual(['loss:5', 'ready', 'one', 'loss:2']);
+    expect(worker.postMessage.mock.calls).toEqual([
+      [{ type: 'ack', seq: 1 }],
+      [{ type: 'ack', seq: 2 }],
+    ]);
+  });
+
+  it.each(['error', 'exit'])(
+    'reports unexpected worker %s once and never forwards error contents',
+    (event) => {
+      const { proxy, worker } = create();
+      const errors = [];
+      proxy.on('error', (e) => errors.push(e.message));
+      worker.emit(event, new Error('synthetic-private-path-or-content'));
+      worker.emit('exit', 1);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatch(/^watch-worker-(crashed|exited)$/);
+    },
+  );
+
+  it('invalidates late messages and errors before termination, including close-before-ready', async () => {
+    const { proxy, worker } = create();
+    const seen = vi.fn();
+    for (const event of ['ready', 'error', 'loss', 'add']) proxy.on(event, seen);
+    await proxy.close();
+    worker.emit(
+      'message',
+      batch(1, { ready: true, dropped: 2, events: [{ type: 'add', path: 'late' }] }),
+    );
+    worker.emit('error', new Error('late'));
+    worker.emit('exit', 0);
+    await proxy.close();
+    expect(seen).not.toHaveBeenCalled();
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(worker.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('stops a batch when a consumer closes its watcher', () => {
+    const { proxy, worker } = create();
+    const seen = [];
+    proxy.on('add', (p) => {
+      seen.push(p);
+      proxy.close();
+    });
+    worker.emit(
+      'message',
+      batch(1, {
+        events: [
+          { type: 'add', path: 'one' },
+          { type: 'add', path: 'two' },
+        ],
+      }),
+    );
+    expect(seen).toEqual(['one']);
+    expect(worker.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('propagates synchronous construction failure to the root registrar', () => {
+    expect(() =>
+      watch(
+        '/fixture',
+        {},
+        {
+          WorkerClass: class {
+            constructor() {
+              throw new Error('no-worker');
+            }
+          },
+        },
+      ),
+    ).toThrow('no-worker');
+  });
+});

--- a/tests/main/watch-worker-integration.test.js
+++ b/tests/main/watch-worker-integration.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { watch } from '../../src/main/watch-worker-client.js';
+
+const roots = [];
+const watchers = [];
+afterEach(async () => {
+  await Promise.all(watchers.splice(0).map((w) => w.close()));
+  for (const root of roots.splice(0)) {
+    const resolved = await fs.realpath(root);
+    expect(path.dirname(resolved)).toBe(await fs.realpath(os.tmpdir()));
+    expect(path.basename(resolved)).toMatch(/^aegis-worker-test-/);
+    await fs.rm(resolved, { recursive: true });
+  }
+});
+function waitFor(watcher, type, expected) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out: ${type}`));
+    }, 10000);
+    const handler = (value) => {
+      if (expected && value !== expected) return;
+      cleanup();
+      resolve(value);
+    };
+    const error = (err) => {
+      cleanup();
+      reject(err);
+    };
+    function cleanup() {
+      clearTimeout(timer);
+      watcher.off(type, handler);
+      watcher.off('error', error);
+    }
+    watcher.on(type, handler);
+    watcher.on('error', error);
+  });
+}
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'aegis-worker-test-'));
+  roots.push(root);
+  return root;
+}
+function start(root, extra = {}) {
+  const w = watch(root, {
+    persistent: true,
+    ignoreInitial: true,
+    usePolling: false,
+    followSymlinks: false,
+    depth: 2,
+    ...extra,
+  });
+  watchers.push(w);
+  return w;
+}
+
+describe('real worker filesystem delivery', () => {
+  it('reports a native registration exception without claiming ready', async () => {
+    const w = start(42);
+    let ready = false;
+    w.on('ready', () => {
+      ready = true;
+    });
+    const error = await new Promise((resolve) => w.once('error', resolve));
+    expect(error.message).toBe('watch-worker-provider-error');
+    expect(ready).toBe(false);
+  });
+  it('delivers add/change/unlink in order and ignores pre-existing files at startup', async () => {
+    const root = await fixture();
+    await fs.writeFile(path.join(root, 'existing.txt'), 'fixture');
+    const w = start(root);
+    const seen = [];
+    for (const type of ['add', 'change', 'unlink']) w.on(type, (p) => seen.push([type, p]));
+    await waitFor(w, 'ready');
+    expect(seen).toEqual([]);
+    const target = path.join(root, 'new.txt');
+    let received = waitFor(w, 'add', target);
+    await fs.writeFile(target, 'one');
+    await received;
+    received = waitFor(w, 'change', target);
+    await fs.appendFile(target, 'two');
+    await received;
+    received = waitFor(w, 'unlink', target);
+    await fs.unlink(target);
+    await received;
+    expect(seen.map(([type]) => type)).toEqual(['add', 'change', 'unlink']);
+  });
+
+  it('materializes project ignore descriptors in the worker without treating names as globs', async () => {
+    const root = await fixture();
+    const ignored = path.join(root, 'build[custom]');
+    await fs.mkdir(ignored);
+    const w = start(root, { ignoredDirectories: ['build[custom]'], ignorePackageLock: true });
+    const added = [];
+    w.on('add', (p) => added.push(p));
+    await waitFor(w, 'ready');
+    await fs.writeFile(path.join(ignored, 'ignored.js'), '{}');
+    await fs.writeFile(path.join(root, 'package-lock.json'), '{}');
+    const target = path.join(root, 'visible.js');
+    const received = waitFor(w, 'add', target);
+    await fs.writeFile(target, '{}');
+    await received;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(added).toEqual([target]);
+  });
+
+  it('can close a real worker during registration and start a fresh lifetime', async () => {
+    const root = await fixture();
+    const first = start(root);
+    await first.close();
+    const second = start(root);
+    await waitFor(second, 'ready');
+    const target = path.join(root, 'fresh.txt');
+    const received = waitFor(second, 'add', target);
+    await fs.writeFile(target, 'fixture');
+    await received;
+  });
+});


### PR DESCRIPTION
Starting AEGIS on a Windows home with thousands of agent files synchronously registered chokidar handles on the main thread and stalled it. Evidence watch groups now own dedicated workers; the main thread retains attribution, audit writes and sensor health. A repeated packaged profile reduced the largest main-thread heartbeat gap from 1,539 ms to 115 ms, with zero main-thread fs.watch registrations. These are individual local samples.

Delivery is bounded to one 32-event batch in flight plus 512 pending events, with 1 MiB path/envelope accounting per queue or batch. Drop-newest overflow increments sensor loss and degrades the root; provider failures and unexpected worker exits also remain visible. Ready alone cannot erase errors. Reinitialization and close invalidate older callbacks before terminating workers, and shutdown stops delivery before closing the audit logger. Existing observation scope and project ignore behavior are retained.

Validation: 2,644 tests passed, 4 skipped across 146 files; both typechecks, formatting, lint, renderer build, counts and both mutation gates passed. Real filesystem tests cover delivery, ignore behavior, failure and restart; queue/client tests cover backpressure, loss, crashes and close races. The final Windows ASAR build started normally, reached three healthy watch groups and SQLite ready, delivered callbacks without loss, and exited cleanly. Method and limits are recorded in docs/current-state/WINDOWS-STARTUP.md.

No dependency, renderer IPC, workflow or release changes. The published installed version is unchanged.
