### PR TITLE
feat: add consent-driven signed Windows updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Explicit user instructions take precedence over anything in AGENTS.md or a skill
 
 ## Project facts
 
-`src/main/` contains 62 main modules: 50 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 40 invoke + 9 push = 49 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
+`src/main/` contains 65 main modules: 53 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
 
 A birth time is observed on the pass that stamps it or is `null`; no cache stores one. A snapshot outage freezes sessions and never splits them. For changes touching identity stamping, the audit chain, or the Windows git worktree flow, `memory-bank/ai-mistakes.md` holds the relevant failure history.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 │  └───────────────┬──────────────┘     └──────────────┬───────────────┘  │
 │                  │          preload.js                │                  │
 │                  └─────── (IPC bridge) ───────────────┘                  │
-│              contextBridge API (49 channels: 40 invoke + 9 push)        │
+│              contextBridge API (54 channels: 44 invoke + 10 push)        │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
@@ -304,12 +304,44 @@ caller:
 - `file-watcher.js` — chokidar is cross-platform; only open-handle detection is
   platform-specific
 
+## Application Updates
+
+Installed Windows x64 builds use `electron-updater` 6.8.9 with
+`update-provider.js`, a custom provider for the existing `aegis-v` release tags and
+signed manifests. Automatic checks and downloads default to off. With the saved
+`automaticUpdatesEnabled` preference enabled, the first check runs after 30 seconds
+and subsequent checks run every six hours. Settings also provides manual check and
+download actions; the dashboard links to release notes and installation controls.
+
+The provider requests only public GitHub release metadata and assets for
+`antropos17/Aegis`, without account credentials or monitoring data. It verifies the
+raw manifest's Ed25519 signature against the public key bundled inside app.asar,
+then binds the version, repository, installer size and SHA-256. Installer bytes are
+checked after download and again after native restart confirmation. Stable versions
+stay on the stable channel; alpha versions can advance to alpha or stable. Lower
+versions are never selected. Release notes are untrusted plain text.
+
+`app-updates.js` owns the lifecycle. Four argument-free IPC operations are restricted
+to the application's own top-level renderer; one push carries safe display state.
+No file path, URL or updater options are accepted from the renderer. Closing AEGIS
+does not install an update. Installation uses the per-user NSIS upgrade and requires
+the native Restart/Later confirmation. Existing settings and history are retained
+by the installer configuration; there is no automatic rollback or backup.
+
+The existing SHA-256 manifests work without publishing updater YAML feeds. The NSIS
+build still bundles electron-builder's `app-update.yml` for cache configuration.
+The downloader cannot reuse a SHA-256-only cached file across application restarts,
+so a later session downloads it again. macOS, Linux and development builds expose
+an unsupported state. Published 0.14.1-alpha predates this feature: the first version
+containing the updater must be installed manually.
+
 ## Privacy Architecture
 
 AEGIS is designed with privacy as a core architectural constraint:
 
 - **All data stays local.** Settings, baselines, and audit logs are stored in Electron's userData directory. Nothing leaves the machine unless the user explicitly exports it.
-- **No telemetry.** AEGIS does not phone home. No analytics, no crash reporting, no usage tracking.
+- **No telemetry.** No analytics, no crash reporting, no usage tracking.
+- **Updates are opt-in.** Manual update actions or the saved automatic-update preference contact GitHub for public release files. These requests expose the normal network address to GitHub but do not send monitoring records, settings or API keys.
 - **No cloud sync.** There is no account system, no server, no cloud backend.
 - **AI analysis is opt-in.** Calls to the Anthropic API happen only when the user explicitly clicks "Run AI Threat Analysis." The API key is user-provided and stored locally.
 - **Audit logs are metadata-only.** File paths and agent names are logged. File contents are never read, stored, or transmitted.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Everything below is **planned**, not shipped. AEGIS today is monitor-only (see [
 - [ ] Per-process file attribution (ETW, fanotify) — static recon: [docs/recon/kernel-file-etw.md](docs/recon/kernel-file-etw.md)
 - [ ] Container/VM detection (Docker, WSL)
 - [ ] Browser extension for web-based AI agents
-- [ ] Auto-update mechanism
+- [x] Signed Windows auto-updates (implemented; first release requires a manual install)
 - [x] i18n / localization ([#53](https://github.com/antropos17/Aegis/issues/53))
 
 ## Frequently asked questions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,16 +68,18 @@ AEGIS follows Electron security best practices:
 
 - **Context isolation:** Enabled. The renderer process cannot access Node.js APIs.
 - **Node integration:** Disabled in the renderer.
-- **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (49 channels: 40 invoke + 9 push). No arbitrary IPC.
+- **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (54 channels: 44 invoke + 10 push). No arbitrary IPC.
 - **Content Security Policy:** Strict `default-src 'self'` policy, no external font loading.
 - **No remote content:** The app loads only local files. No external URLs in the renderer.
 - **Input sanitization:** All user-visible strings pass through `escapeHtml()` before DOM insertion. Template literals are used for HTML generation, not `innerHTML` with raw strings.
 - **Single-instance lock:** Only one AEGIS instance runs at a time, preventing IPC interception.
+- **Application updates:** Windows installer metadata requires an Ed25519 signature from the bundled release public key. SHA-256 and byte length are checked after download and again after native installation confirmation. This authenticates release artifacts independently of Windows Authenticode. Update IPC rejects foreign senders and subframes and accepts no paths or URLs. See [update architecture](ARCHITECTURE.md#application-updates) for supported builds and limitations.
 
 ### Privacy Architecture
 
 - **All data stays local.** No telemetry, no cloud sync, no analytics, no tracking.
 - **AI analysis is opt-in.** API calls to Anthropic only happen when the user explicitly clicks "Run AI Threat Analysis." No background API calls.
+- **Update requests are opt-in.** Automatic checks/downloads default to off; manual actions contact public GitHub releases. These requests send no monitoring records, settings or API keys. Installation always requires native confirmation.
 - **Audit logs contain metadata, not content.** File paths and agent names are logged, but file contents are never read or stored.
 - **API key is stored locally** in Electron's userData directory, encrypted via Electron safeStorage (added v0.9.0).
 

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,12 +68,12 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **62** = 50 top-level + 10 `platform/` + 2 `token-adapters/` |
-| Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **47** (plus `src/renderer/App.svelte` → **48** tracked `.svelte` in total) |
-| Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **13** files (4 of them demo-only) |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **65** = 53 top-level + 10 `platform/` + 2 `token-adapters/` |
+| Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **50** (plus `src/renderer/App.svelte` → **51** tracked `.svelte` in total) |
+| Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **16** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |
-| Shared types | `.ts` under `src/shared/types` | **8** |
-| IPC surface | `ipcRenderer.invoke` / `ipcRenderer.on` in `src/main/preload.js` | **40 invoke + 9 push = 49** |
+| Shared types | `.ts` under `src/shared/types` | **9** |
+| IPC surface | `ipcRenderer.invoke` / `ipcRenderer.on` in `src/main/preload.js` | **44 invoke + 10 push = 54** |
 | Attribution evidence codes | `require('./src/main/attribution.js').EVIDENCE_CODES` | **7** |
 
 At audit time these read 46 main modules, 47 components (against 46 documented), 13 stores, 16
@@ -345,7 +345,7 @@ would re-seed the drift. Current state at `d027f0c`:
   (1079 total) across 68 files". That figure was stale when the audit found it and is staler now.
   It is a hand-maintained counter with no gate behind it (`ai-mistakes.md` #24) — the fix is to
   delete it, not to refresh it.
-- **IPC narrative.** 40 invoke + 9 push = 49 bridge endpoints, unchanged. Two of the audit's three
+- **IPC narrative.** 44 invoke + 10 push = 54 bridge endpoints. Two of the audit's three
   unconsumed push channels now have subscribers; `rules:reloaded` does not (F-E11).
 
 ---

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,13 +1,13 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 62 CommonJS modules (50 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 65 CommonJS modules (53 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle
 - scan-loop.js — periodic scan intervals, staggered startup, event dedup
 - ipc-batcher.js — batches high-frequency IPC events (append/latest modes)
 - ipc-handlers.js — all IPC handlers (invoke + listeners)
-- preload.js — IPC bridge (window.aegis via contextBridge, 40 invoke + 9 events = 49 channels)
+- preload.js — IPC bridge (window.aegis via contextBridge, 44 invoke + 10 events = 54 channels)
 - process-scanner.js — AI agent detection (tasklist + pattern matching)
 - process-utils.js — parent chain resolution + editor annotation
 - file-watcher.js — watcher health, main-thread attribution + handle scanning
@@ -31,7 +31,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (src/renderer/) — Svelte 5 + Vite 7
-48 Svelte components, 15 stores, 21 utils, scoped CSS + tokens.css/global.css
+50 Svelte components, 16 stores, 21 utils, scoped CSS + tokens.css/global.css
 
 ### Components (src/renderer/lib/components/)
 - App.svelte — root layout, tab routing, settings modal

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -960,7 +960,7 @@ product task; implementing it has not been authorized by this verification step.
 
 The user's subsequent "давай" authorized implementation. The feature branch
 `codex/signed-auto-update` adds electron-updater 6.8.9, pinned for its custom-provider
-and positional installation contracts. The provider consumes the existing GitHub
+and positional installation contracts ([PR #367](https://github.com/antropos17/Aegis/pull/367)). The provider consumes the existing GitHub
 release API, `aegis-v` tags, Ed25519-signed manifest and SHA-256 installer entries.
 No release workflow changes or new YAML feeds are needed. The NSIS package includes
 the public key and generated app-update.yml cache configuration.
@@ -973,8 +973,9 @@ rechecks the installer bytes afterward, and never happens merely on app quit.
 Update IPC checks the owned webContents and main frame and accepts no operation
 arguments. Opt-out cancels downloading; failures expose fixed error codes.
 
-Local checks passed: renderer build, formatting, lint (zero errors; existing
-warnings), main/renderer TypeScript, Svelte check, coverage suite, both mutation
+Local checks passed: renderer build, formatting, lint (zero errors; 32 existing
+warnings), main/renderer TypeScript, Svelte check, coverage suite (2,682 passed,
+four skipped across 150 files), both mutation
 gates, counts and production dependency audit. Targeted tests cover tampering,
 channel/downgrade selection, consent, cancellation, duplicate actions, failed
 installation, IPC ownership, stale renderer snapshots and literal release notes.
@@ -994,9 +995,10 @@ Evidence, fixture profile, downloaded installer and candidate stay under
 `X:/tmp/aegis-updater-*`. The fixture was quit and its temporary inspector closed.
 The Start Menu shortcut again resolved to the test executable after a candidate
 launch; it was backed up, restored to the installed app and read back. This repeats
-the earlier package-test shortcut issue; its cause remains unestablished. A helper
-cleanup expression also raised a harness-only error before being corrected to use
-process.mainModule.require; the application renderer remained healthy.
+the earlier package-test shortcut issue; its cause remains unestablished. A transient
+Error window appeared during harness cleanup, but its contents were not captured.
+The helper's inspector cleanup was changed to use process.mainModule.require;
+subsequent runtime inspection and the Settings UI check passed.
 
 No release was published and the user's installed 0.14.1-alpha was not upgraded.
 The first release carrying this feature still needs manual installation. Windows

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -955,3 +955,51 @@ the owner-repair script and ACL backups are under
 `X:/tmp/aegis-wsl-owner-repair-20260907`, outside Git. The previous entries' WSL
 degradation is resolved for this machine. Auto-update issue #20 is the next proposed
 product task; implementing it has not been authorized by this verification step.
+
+## Session handoff — signed Windows updates, issue #20 (2026-09-07)
+
+The user's subsequent "давай" authorized implementation. The feature branch
+`codex/signed-auto-update` adds electron-updater 6.8.9, pinned for its custom-provider
+and positional installation contracts. The provider consumes the existing GitHub
+release API, `aegis-v` tags, Ed25519-signed manifest and SHA-256 installer entries.
+No release workflow changes or new YAML feeds are needed. The NSIS package includes
+the public key and generated app-update.yml cache configuration.
+
+Automatic checks/downloads default to off and require a saved boolean preference.
+When enabled, checks start after 30 seconds and repeat every six hours. Settings has
+manual check/download/restart controls and plain-text release notes; the dashboard
+shows available/downloading/ready notices. Installation needs native confirmation,
+rechecks the installer bytes afterward, and never happens merely on app quit.
+Update IPC checks the owned webContents and main frame and accepts no operation
+arguments. Opt-out cancels downloading; failures expose fixed error codes.
+
+Local checks passed: renderer build, formatting, lint (zero errors; existing
+warnings), main/renderer TypeScript, Svelte check, coverage suite, both mutation
+gates, counts and production dependency audit. Targeted tests cover tampering,
+channel/downgrade selection, consent, cancellation, duplicate actions, failed
+installation, IPC ownership, stale renderer snapshots and literal release notes.
+The clean npm ci completed with zero reported vulnerabilities.
+
+A full Windows NSIS candidate was built outside Git. In the packaged Electron
+runtime, the real provider reported the installed version current; an isolated
+updater instance with a simulated older currentVersion then downloaded the actual
+published 0.14.1-alpha installer (104,675,807 bytes) into a disposable cache and
+verified its signed digest. Declining the test confirmation preserved ready state;
+installation was disabled in the harness. The real Settings button separately
+passed through preload/main IPC and visibly reached "You're up to date". The first
+real request exposed GitHub's HTTP 415 for an octet-stream API Accept header; the
+provider now requests GitHub JSON for the release list and has a regression check.
+
+Evidence, fixture profile, downloaded installer and candidate stay under
+`X:/tmp/aegis-updater-*`. The fixture was quit and its temporary inspector closed.
+The Start Menu shortcut again resolved to the test executable after a candidate
+launch; it was backed up, restored to the installed app and read back. This repeats
+the earlier package-test shortcut issue; its cause remains unestablished. A helper
+cleanup expression also raised a harness-only error before being corrected to use
+process.mainModule.require; the application renderer remained healthy.
+
+No release was published and the user's installed 0.14.1-alpha was not upgraded.
+The first release carrying this feature still needs manual installation. Windows
+x64 is the supported update target; SHA-256-only cached downloads are fetched again
+after an app restart, and automatic rollback/backups are not implemented. The next
+release remains a separate user-authorized step; major dependency PRs stay deferred.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "ajv": "^6.14.0",
         "chokidar": "^3.6.0",
-        "js-yaml": "^5.4.1"
+        "electron-updater": "6.8.9",
+        "js-yaml": "^5.4.1",
+        "semver": "^7.7.4"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -3629,7 +3631,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -4076,7 +4077,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4466,6 +4466,44 @@
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/electron-winstaller": {
@@ -5171,7 +5209,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5436,7 +5473,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -5934,7 +5970,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -5964,7 +5999,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -6056,6 +6090,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -6292,7 +6339,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7309,7 +7355,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -7332,7 +7377,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7898,6 +7942,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8145,7 +8195,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
       "deleteAppDataOnUninstall": false
     },
     "files": [
+      "keys/aegis-release-pubkey.pub",
       "src/**/*",
       "dist/renderer/**/*",
       "rules/**/*",
@@ -83,7 +84,14 @@
     ],
     "extraMetadata": {
       "main": "src/main/main.js"
-    }
+    },
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "antropos17",
+        "repo": "Aegis"
+      }
+    ]
   },
   "repository": {
     "type": "git",
@@ -140,7 +148,9 @@
   "dependencies": {
     "ajv": "^6.14.0",
     "chokidar": "^3.6.0",
-    "js-yaml": "^5.4.1"
+    "electron-updater": "6.8.9",
+    "js-yaml": "^5.4.1",
+    "semver": "^7.7.4"
   },
   "overrides": {
     "picomatch@<=2.3.1": "^2.3.2"

--- a/src/main/app-updates.js
+++ b/src/main/app-updates.js
@@ -1,0 +1,155 @@
+/** @file Consent-driven update lifecycle; only verified installers become installable. @since 0.15.0 */
+'use strict';
+const { verifyInstaller } = require('./update-verification');
+
+/** Create an isolated lifecycle with injected Electron boundaries. @param {object} deps @returns {object} @since 0.15.0 */
+function createUpdateManager(deps) {
+  let updater;
+  let selected;
+  let downloadedFile;
+  let cancellation;
+  let timer;
+  let busy = false;
+  let disposed = false;
+  let state = {
+    status: deps.supported ? 'idle' : 'unsupported',
+    version: null,
+    notes: '',
+    progress: 0,
+    error: null,
+  };
+  const verify = deps.verifyInstaller || verifyInstaller;
+  function snapshot() {
+    return { ...state };
+  }
+  function set(patch) {
+    if (disposed) return;
+    state = { ...state, ...patch };
+    deps.onChange?.(snapshot());
+  }
+  function instance() {
+    if (!updater) {
+      updater = deps.createUpdater();
+      updater.autoDownload = false;
+      updater.autoInstallOnAppQuit = false;
+      updater.allowDowngrade = false;
+      updater.disableDifferentialDownload = true;
+      updater.disableWebInstaller = true;
+      updater.logger = null;
+      updater.on('error', () => {
+        // Check/download failures also reject their promises. Installation may fail
+        // asynchronously after quitAndInstall returned, so report that path here.
+        if (state.status === 'installing') {
+          deps.prepareQuit(false);
+          set({ status: 'error', error: 'update-install-failed' });
+        }
+      });
+      updater.on('download-progress', (progress) => {
+        if (state.status === 'downloading')
+          set({ progress: Math.max(0, Math.min(100, Number(progress.percent) || 0)) });
+      });
+    }
+    return updater;
+  }
+  async function check(automatic = false) {
+    if (disposed || !deps.supported || busy || ['ready', 'installing'].includes(state.status))
+      return snapshot();
+    if (automatic && deps.getSettings().automaticUpdatesEnabled !== true) return snapshot();
+    busy = true;
+    selected = null;
+    downloadedFile = null;
+    set({ status: 'checking', error: null, version: null, notes: '', progress: 0 });
+    try {
+      const result = await instance().checkForUpdates();
+      if (disposed) return snapshot();
+      if (!result) throw new Error('update-check-unavailable');
+      cancellation = result.cancellationToken;
+      if (result.isUpdateAvailable) {
+        if (!result.updateInfo.verified) throw new Error('update-unverified');
+        selected = result.updateInfo.verified;
+        set({
+          status: 'available',
+          version: selected.version,
+          notes: result.updateInfo.releaseNotes || '',
+        });
+      } else set({ status: 'up-to-date' });
+    } catch {
+      set({ status: 'error', error: 'update-check-failed' });
+    } finally {
+      busy = false;
+    }
+    if (
+      automatic &&
+      state.status === 'available' &&
+      deps.getSettings().automaticUpdatesEnabled === true
+    )
+      await download();
+    return snapshot();
+  }
+  async function download() {
+    if (disposed || busy || state.status !== 'available' || !selected) return snapshot();
+    busy = true;
+    set({ status: 'downloading', progress: 0, error: null });
+    const timeout = setTimeout(() => cancellation?.cancel(), 15 * 60 * 1000);
+    try {
+      const files = await instance().downloadUpdate(cancellation);
+      if (disposed) return snapshot();
+      if (files.length !== 1 || files[0] !== updater.installerPath)
+        throw new Error('update-file-invalid');
+      await verify(files[0], selected);
+      downloadedFile = files[0];
+      set({ status: 'ready', progress: 100 });
+    } catch {
+      downloadedFile = null;
+      selected = null;
+      set({ status: 'error', error: 'update-download-failed' });
+    } finally {
+      clearTimeout(timeout);
+      busy = false;
+    }
+    return snapshot();
+  }
+  async function install() {
+    if (disposed || busy || state.status !== 'ready' || !selected || !downloadedFile)
+      return snapshot();
+    busy = true;
+    try {
+      if (!(await deps.confirmInstall(state.version))) return snapshot();
+      if (disposed || downloadedFile !== updater.installerPath)
+        throw new Error('update-file-invalid');
+      await verify(downloadedFile, selected);
+      if (disposed) return snapshot();
+      set({ status: 'installing', error: null });
+      deps.prepareQuit();
+      // v6.8.9 positional API: silent installer, then relaunch the application.
+      updater.quitAndInstall(true, true);
+    } catch {
+      if (state.status === 'installing') deps.prepareQuit(false);
+      set({ status: 'error', error: 'update-install-failed' });
+    } finally {
+      busy = false;
+    }
+    return snapshot();
+  }
+  function schedule(delay = 30000) {
+    clearTimeout(timer);
+    if (disposed || !deps.supported || deps.getSettings().automaticUpdatesEnabled !== true) return;
+    timer = setTimeout(async () => {
+      await check(true);
+      schedule(6 * 60 * 60 * 1000);
+    }, delay);
+    timer.unref?.();
+  }
+  function preferencesChanged() {
+    if (deps.getSettings().automaticUpdatesEnabled !== true) cancellation?.cancel();
+    schedule();
+  }
+  function dispose() {
+    disposed = true;
+    clearTimeout(timer);
+    cancellation?.cancel();
+  }
+  return { snapshot, check, download, install, schedule, preferencesChanged, dispose };
+}
+
+module.exports = { createUpdateManager };

--- a/src/main/config-manager.js
+++ b/src/main/config-manager.js
@@ -65,6 +65,7 @@ const DEFAULT_SETTINGS = {
   customSensitivePatterns: [],
   startMinimized: false,
   autoStartWithWindows: false,
+  automaticUpdatesEnabled: false,
   anthropicApiKey: '',
   darkMode: false,
   uiScale: 1,

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -45,6 +45,23 @@ function init(injected) {
 
 /** @returns {void} @since v0.1.0 */
 function register() {
+  // Only the owned top-level renderer may request an update operation. No URLs,
+  // file paths, versions, command arguments or updater options cross this boundary.
+  const updateAction = (event, action) => {
+    const window = deps.getWindow?.();
+    if (
+      !window ||
+      window.isDestroyed() ||
+      event.sender !== window.webContents ||
+      event.senderFrame !== window.webContents.mainFrame
+    )
+      throw new Error('Update request denied');
+    return deps.updates[action]();
+  };
+  ipcMain.handle('updates:status', (event) => updateAction(event, 'snapshot'));
+  ipcMain.handle('updates:check', (event) => updateAction(event, 'check'));
+  ipcMain.handle('updates:download', (event) => updateAction(event, 'download'));
+  ipcMain.handle('updates:install', (event) => updateAction(event, 'install'));
   ipcMain.handle('get-stats', () => deps.getStats());
   ipcMain.handle('get-resource-usage', () => deps.getResourceUsage());
   ipcMain.handle('export-log', async () => {
@@ -84,6 +101,7 @@ function register() {
     }
     config.saveSettings(newSettings);
     config.applySettings();
+    deps.updates?.preferencesChanged();
     return { success: true };
   });
 
@@ -328,6 +346,7 @@ ${findingsHtml}${recsHtml}
       }
       config.saveSettings(raw);
       config.applySettings();
+      deps.updates?.preferencesChanged();
       return { success: true };
     } catch (e) {
       return { success: false, error: e.message };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -42,6 +42,7 @@ const config = require('./config-manager');
 const logger = require('./logger');
 const tray = require('./tray-icon');
 const ipc = require('./ipc-handlers');
+let updates;
 const { createBatcher } = require('./ipc-batcher');
 // Pure domain modules — no I/O, no Electron, no timers — so they cost nothing to load
 // on the fast path to a visible window. `file-access-batching` must be here rather than
@@ -791,6 +792,34 @@ app.whenReady().then(() => {
   logger.init({ userDataPath: userData, isDev: !app.isPackaged });
   logger.info('main', 'App starting', { version: app.getVersion(), platform: process.platform });
   config.loadSettings();
+  updates = require('./app-updates').createUpdateManager({
+    supported: app.isPackaged && process.platform === 'win32' && process.arch === 'x64',
+    getSettings: config.getSettings,
+    onChange: (state) => sendToRenderer('updates:status', state),
+    createUpdater: () => {
+      const { NsisUpdater } = require('electron-updater');
+      const { SignedReleaseProvider } = require('./update-provider');
+      return new NsisUpdater({ provider: 'custom', updateProvider: SignedReleaseProvider });
+    },
+    confirmInstall: async (version) => {
+      if (!mainWindow || mainWindow.isDestroyed()) return false;
+      const { response } = await require('electron').dialog.showMessageBox(mainWindow, {
+        type: 'question',
+        title: 'Update AEGIS',
+        message: `Install AEGIS ${version} and restart?`,
+        detail:
+          'Monitoring will pause while the update is installed. Your settings and history will be kept.',
+        buttons: ['Restart and install', 'Later'],
+        defaultId: 1,
+        cancelId: 1,
+      });
+      return response === 0;
+    },
+    prepareQuit: (value = true) => {
+      isQuitting = value;
+    },
+  });
+  updates.schedule();
   tray.init({
     tray: null,
     currentTrayColor: 'green',
@@ -846,6 +875,7 @@ app.whenReady().then(() => {
     },
   });
   ipc.init({
+    updates,
     getWindow: () => mainWindow,
     getStats,
     getResourceUsage,
@@ -870,6 +900,7 @@ app.whenReady().then(() => {
 });
 
 app.on('before-quit', () => {
+  updates?.dispose();
   if (oomIntervalId) {
     clearInterval(oomIntervalId);
     oomIntervalId = null;

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -17,6 +17,15 @@ contextBridge.exposeInMainWorld('aegis', {
   exportCsv: () => ipcRenderer.invoke('export-csv'),
   generateReport: () => ipcRenderer.invoke('generate-report'),
   getSettings: () => ipcRenderer.invoke('get-settings'),
+  getUpdateStatus: () => ipcRenderer.invoke('updates:status'),
+  checkForUpdates: () => ipcRenderer.invoke('updates:check'),
+  downloadUpdate: () => ipcRenderer.invoke('updates:download'),
+  installUpdate: () => ipcRenderer.invoke('updates:install'),
+  onUpdateStatus: (cb) => {
+    const handler = (_e, data) => cb(data);
+    ipcRenderer.on('updates:status', handler);
+    return () => ipcRenderer.removeListener('updates:status', handler);
+  },
   saveSettings: (s) => ipcRenderer.invoke('save-settings', s),
   analyzeAgent: (name) => ipcRenderer.invoke('analyze-agent', name),
   analyzeSession: () => ipcRenderer.invoke('analyze-session'),

--- a/src/main/settings-validation.js
+++ b/src/main/settings-validation.js
@@ -14,6 +14,7 @@ const SETTINGS_WHITELIST = new Set([
   'customSensitivePatterns',
   'startMinimized',
   'autoStartWithWindows',
+  'automaticUpdatesEnabled',
   'anthropicApiKey',
   'darkMode',
   'uiScale',
@@ -43,6 +44,9 @@ function validateSettings(obj) {
   const unknownKeys = Object.keys(obj).filter((k) => !SETTINGS_WHITELIST.has(k));
   if (unknownKeys.length > 0) {
     return { valid: false, error: `Unknown settings keys: ${unknownKeys.join(', ')}` };
+  }
+  if ('automaticUpdatesEnabled' in obj && typeof obj.automaticUpdatesEnabled !== 'boolean') {
+    return { valid: false, error: 'automaticUpdatesEnabled must be a boolean' };
   }
   if ('scanIntervalSec' in obj) {
     if (typeof obj.scanIntervalSec !== 'number' || obj.scanIntervalSec <= 0) {

--- a/src/main/update-provider.js
+++ b/src/main/update-provider.js
@@ -1,0 +1,128 @@
+/** @file electron-updater provider for AEGIS's existing signed GitHub manifests. @since 0.15.0 */
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const semver = require('semver');
+const { REPOSITORY, releaseVersion, verifyManifest } = require('./update-verification');
+
+const API_URL = `https://api.github.com/repos/${REPOSITORY}/releases?per_page=30`;
+
+/** Read bounded public metadata without credentials or disk writes. @param {string} url @param {number} limit @param {Function} fetcher @returns {Promise<Buffer>} @since 0.15.0 */
+async function fetchBytes(url, limit, fetcher) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const response = await fetcher(url, {
+      signal: controller.signal,
+      credentials: 'omit',
+      cache: 'no-store',
+      headers: {
+        Accept: url === API_URL ? 'application/vnd.github+json' : 'application/octet-stream',
+        'User-Agent': 'AEGIS-updater',
+      },
+    });
+    if (!response.ok || !response.body) throw new Error('update-fetch-failed');
+    const chunks = [];
+    let size = 0;
+    for await (const chunk of response.body) {
+      size += chunk.length;
+      if (size > limit) {
+        controller.abort();
+        throw new Error('update-metadata-too-large');
+      }
+      chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Select the newest complete release in the installed version's channel. @param {unknown} releases @param {string} current @returns {object|null} @since 0.15.0 */
+function selectRelease(releases, current) {
+  if (!Array.isArray(releases) || !semver.valid(current))
+    throw new Error('update-releases-invalid');
+  return (
+    releases
+      .filter((release) => {
+        const version = releaseVersion(release?.tag_name);
+        return (
+          version &&
+          !release.draft &&
+          (semver.prerelease(current) || !semver.prerelease(version)) &&
+          semver.gt(version, current) &&
+          Array.isArray(release.assets) &&
+          ['manifest.json', 'manifest.json.sig'].every((name) =>
+            release.assets.some((a) => a.name === name && a.state === 'uploaded'),
+          )
+        );
+      })
+      .sort((a, b) => semver.rcompare(releaseVersion(a.tag_name), releaseVersion(b.tag_name)))[0] ||
+    null
+  );
+}
+
+/** Build authenticated updater metadata; URLs always stay under the fixed repository. @param {object} options @returns {Promise<object>} @since 0.15.0 */
+async function loadRelease({ current, fetcher, publicKey }) {
+  const releases = JSON.parse(
+    (await fetchBytes(API_URL, 2 * 1024 * 1024, fetcher)).toString('utf8'),
+  );
+  const release = selectRelease(releases, current);
+  if (!release) return { version: current, files: [] };
+  const base = `https://github.com/${REPOSITORY}/releases/download/${release.tag_name}/`;
+  const bytes = await fetchBytes(base + 'manifest.json', 64 * 1024, fetcher);
+  const signatureText = (await fetchBytes(base + 'manifest.json.sig', 256, fetcher))
+    .toString('ascii')
+    .trim();
+  if (!/^[A-Za-z0-9+/]{86}==$/.test(signatureText)) throw new Error('update-signature-invalid');
+  const verified = verifyManifest(
+    bytes,
+    Buffer.from(signatureText, 'base64'),
+    publicKey,
+    release.tag_name,
+  );
+  const assets = release.assets.filter(
+    (a) =>
+      typeof a.name === 'string' && /^[A-Za-z0-9._-]+\.exe$/.test(a.name) && a.state === 'uploaded',
+  );
+  if (assets.length !== 1 || assets[0].size !== verified.bytes)
+    throw new Error('update-asset-invalid');
+  return {
+    version: verified.version,
+    releaseNotes: typeof release.body === 'string' ? release.body.slice(0, 12000) : '',
+    files: [
+      {
+        url: base + encodeURIComponent(assets[0].name),
+        sha2: verified.sha256,
+        size: verified.bytes,
+      },
+    ],
+    verified,
+  };
+}
+
+/** Custom provider contract supported by electron-updater 6.8.9. @since 0.15.0 */
+class SignedReleaseProvider {
+  constructor(options, updater) {
+    this.updater = updater;
+    this.fetcher = options.fetcher || ((...args) => require('electron').net.fetch(...args));
+    this.publicKey =
+      options.publicKey ||
+      fs.readFileSync(path.join(__dirname, '../../keys/aegis-release-pubkey.pub'));
+    this.isUseMultipleRangeRequest = false;
+    this.fileExtraDownloadHeaders = null;
+  }
+  setRequestHeaders() {} // Public releases never need renderer or environment credentials.
+  async getLatestVersion() {
+    return loadRelease({
+      current: this.updater.currentVersion.version,
+      fetcher: this.fetcher,
+      publicKey: this.publicKey,
+    });
+  }
+  resolveFiles(info) {
+    return info.files.map((file) => ({ url: new URL(file.url), info: file }));
+  }
+}
+
+module.exports = { SignedReleaseProvider, loadRelease, selectRelease, fetchBytes };

--- a/src/main/update-verification.js
+++ b/src/main/update-verification.js
@@ -1,0 +1,65 @@
+/** @file Signed release verification used by the Windows updater. @since 0.15.0 */
+'use strict';
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const semver = require('semver');
+
+const REPOSITORY = 'antropos17/Aegis';
+const MAX_INSTALLER_BYTES = 512 * 1024 * 1024;
+
+/** Validate a release tag without accepting paths or arbitrary channels. @param {string} tag @returns {string|null} @since 0.15.0 */
+function releaseVersion(tag) {
+  if (typeof tag !== 'string' || !/^aegis-v\d+\.\d+\.\d+(?:-alpha(?:\.\d+)?)?$/.test(tag))
+    return null;
+  return semver.valid(tag.slice(7));
+}
+
+/** Authenticate raw bytes before trusting their fields. @param {Buffer} bytes @param {Buffer} signature @param {string|Buffer} publicKey @param {string} tag @returns {object} @since 0.15.0 */
+function verifyManifest(bytes, signature, publicKey, tag) {
+  const key = crypto.createPublicKey(publicKey);
+  if (
+    key.asymmetricKeyType !== 'ed25519' ||
+    signature.length !== 64 ||
+    !crypto.verify(null, bytes, key, signature)
+  ) {
+    throw new Error('update-signature-invalid');
+  }
+  const manifest = JSON.parse(bytes.toString('utf8'));
+  const version = releaseVersion(tag);
+  if (
+    !version ||
+    manifest.schema !== 'aegis-release-manifest/v1' ||
+    manifest.repository !== REPOSITORY ||
+    manifest.tag !== tag ||
+    manifest.algorithm !== 'sha256' ||
+    !/^[a-f0-9]{40}$/.test(manifest.commit) ||
+    !Array.isArray(manifest.files)
+  )
+    throw new Error('update-manifest-invalid');
+  const files = manifest.files.filter(
+    (file) => typeof file?.filename === 'string' && file.filename.endsWith('.exe'),
+  );
+  if (files.length !== 1) throw new Error('update-installer-ambiguous');
+  const file = files[0];
+  if (
+    file.filename !== `AEGIS - AI Monitoring & Threat Detection Setup ${version}.exe` ||
+    !/^[a-f0-9]{64}$/.test(file.sha256) ||
+    !Number.isSafeInteger(file.bytes) ||
+    file.bytes <= 0 ||
+    file.bytes > MAX_INSTALLER_BYTES
+  )
+    throw new Error('update-installer-invalid');
+  return { version, tag, sha256: file.sha256, bytes: file.bytes };
+}
+
+/** Recheck downloaded bytes, including cached files, immediately before installing. @param {string} file @param {{sha256:string,bytes:number}} expected @returns {Promise<void>} @since 0.15.0 */
+async function verifyInstaller(file, expected) {
+  const stat = await fs.promises.lstat(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== expected.bytes)
+    throw new Error('update-size-invalid');
+  const hash = crypto.createHash('sha256');
+  for await (const chunk of fs.createReadStream(file)) hash.update(chunk);
+  if (hash.digest('hex') !== expected.sha256) throw new Error('update-hash-invalid');
+}
+
+module.exports = { REPOSITORY, releaseVersion, verifyManifest, verifyInstaller };

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1,5 +1,7 @@
 <script>
   import Header from './lib/components/Header.svelte';
+  import UpdateNotice from './lib/components/UpdateNotice.svelte';
+  import { connectUpdates } from './lib/stores/updates';
   import Footer from './lib/components/Footer.svelte';
   import TabBar from './lib/components/TabBar.svelte';
   import ShieldTab from './lib/components/ShieldTab.svelte';
@@ -42,6 +44,7 @@
   let prevTab = $state('shield');
   let slideDir = $state(1);
   let optionsOpen = $state(false);
+  $effect(() => connectUpdates());
 
   $effect(() => {
     if (activeTab !== prevTab) {
@@ -300,6 +303,11 @@
 </script>
 
 <Header bind:optionsOpen />
+<UpdateNotice
+  onOpen={() => {
+    optionsOpen = true;
+  }}
+/>
 
 <div class="app-shell">
   {#if liveDataUnavailable}

--- a/src/renderer/lib/components/OptionsPanel.svelte
+++ b/src/renderer/lib/components/OptionsPanel.svelte
@@ -9,6 +9,7 @@
   import { isDemoMode } from '../stores/ipc.js';
   import SettingsAppearance from './SettingsAppearance.svelte';
   import SettingsMonitoring from './SettingsMonitoring.svelte';
+  import SettingsUpdates from './SettingsUpdates.svelte';
   import { t } from '../i18n/index.js';
 
   let { open = $bindable(false) } = $props();
@@ -17,6 +18,7 @@
   let localScale = $state($uiScale);
   let scanInterval = $state(10);
   let notifications = $state(true);
+  let automaticUpdatesEnabled = $state(false);
   let apiKey = $state('');
   let customPatterns = $state('');
   let ignoreBuildDirs = $state(true);
@@ -35,6 +37,7 @@
               if (!s) return;
               scanInterval = s.scanIntervalSec ?? 10;
               notifications = s.notificationsEnabled ?? true;
+              automaticUpdatesEnabled = s.automaticUpdatesEnabled === true;
               apiKey = s.anthropicApiKey ?? '';
               customPatterns = (s.customSensitivePatterns || []).join('\n');
               ignoreBuildDirs = s.ignoreCommonBuildDirs !== false;
@@ -78,6 +81,7 @@
         uiScale: localScale,
         scanIntervalSec: scanInterval,
         notificationsEnabled: notifications,
+        automaticUpdatesEnabled,
         anthropicApiKey: apiKey.trim(),
         customSensitivePatterns: patterns,
         ignoreCommonBuildDirs: ignoreBuildDirs,
@@ -131,6 +135,8 @@
         bind:ignoreBuildDirs
         bind:ignoredDirectories
       />
+
+      <SettingsUpdates bind:automaticUpdatesEnabled />
 
       <div class="config-actions">
         <button

--- a/src/renderer/lib/components/SettingsUpdates.svelte
+++ b/src/renderer/lib/components/SettingsUpdates.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import { updateStatus, updateAction } from '../stores/updates';
+  let { automaticUpdatesEnabled = $bindable(false) }: { automaticUpdatesEnabled?: boolean } =
+    $props();
+  const supported = $derived(
+    $updateStatus.status !== 'unsupported' && !!window.aegis?.checkForUpdates,
+  );
+  const busy = $derived(['checking', 'downloading', 'installing'].includes($updateStatus.status));
+</script>
+
+<section aria-labelledby="updates-title" class="updates">
+  <h3 id="updates-title">Updates</h3>
+  <label class="consent">
+    <input type="checkbox" bind:checked={automaticUpdatesEnabled} disabled={!supported} />
+    Check and download updates automatically
+  </label>
+  <p class="hint">
+    After you save, AEGIS can contact GitHub on startup and every six hours. Restarting to install
+    always requires your confirmation.
+  </p>
+  {#if !supported}
+    <p>Updates are available in the installed Windows x64 app.</p>
+  {:else}
+    <p role="status">
+      {#if $updateStatus.status === 'checking'}Checking for updates…
+      {:else if $updateStatus.status === 'up-to-date'}You’re up to date.
+      {:else if $updateStatus.status === 'available'}Version {$updateStatus.version} is available.
+      {:else if $updateStatus.status === 'downloading'}Downloading — {Math.round(
+          $updateStatus.progress,
+        )}%
+      {:else if $updateStatus.status === 'ready'}Version {$updateStatus.version} is verified and ready.
+      {:else if $updateStatus.status === 'installing'}Restarting to install…
+      {:else if $updateStatus.status === 'error'}The update could not be completed or verified.
+        Check your connection and try again.
+      {:else}Check manually, or enable automatic checks above.{/if}
+    </p>
+    {#if $updateStatus.notes}
+      <details>
+        <summary>What’s new in {$updateStatus.version}</summary>
+        <pre>{$updateStatus.notes}</pre>
+      </details>
+    {/if}
+    <div class="actions">
+      <button
+        disabled={busy || $updateStatus.status === 'ready'}
+        onclick={() => updateAction('check')}>Check for updates</button
+      >
+      {#if $updateStatus.status === 'available'}
+        <button onclick={() => updateAction('download')}>Download update</button>
+      {:else if $updateStatus.status === 'ready'}
+        <button onclick={() => updateAction('install')}>Restart and install</button>
+      {/if}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .updates {
+    display: flex;
+    flex-direction: column;
+    gap: var(--aegis-space-3);
+    border-top: var(--glass-border);
+    padding-top: var(--aegis-space-5);
+  }
+  h3,
+  p {
+    margin: 0;
+  }
+  h3 {
+    font-size: inherit;
+  }
+  .consent {
+    display: flex;
+    align-items: center;
+    gap: var(--aegis-space-3);
+  }
+  .hint {
+    color: var(--md-sys-color-on-surface-variant);
+    font-size: var(--md-sys-typescale-body-small-size, 0.875rem);
+  }
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--aegis-space-3);
+  }
+  button {
+    font: inherit;
+    color: var(--md-sys-color-on-surface);
+    background: var(--md-sys-color-surface-container);
+    border: var(--glass-border);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--aegis-space-2) var(--aegis-space-4);
+    cursor: pointer;
+  }
+  button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  button:focus-visible,
+  input:focus-visible,
+  summary:focus-visible {
+    outline: 2px solid var(--md-sys-color-primary);
+    outline-offset: 2px;
+  }
+  pre {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font: inherit;
+    max-height: 180px;
+    overflow-y: auto;
+  }
+</style>

--- a/src/renderer/lib/components/UpdateNotice.svelte
+++ b/src/renderer/lib/components/UpdateNotice.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { updateStatus } from '../stores/updates';
+  let { onOpen }: { onOpen: () => void } = $props();
+</script>
+
+{#if ['available', 'downloading', 'ready'].includes($updateStatus.status)}
+  <aside class="update-notice" aria-label="Application update">
+    <span role="status">
+      {#if $updateStatus.status === 'ready'}
+        AEGIS {$updateStatus.version} is ready to install.
+      {:else if $updateStatus.status === 'downloading'}
+        Downloading AEGIS {$updateStatus.version} — {Math.round($updateStatus.progress)}%
+      {:else}
+        AEGIS {$updateStatus.version} is available.
+      {/if}
+    </span>
+    <button onclick={onOpen}>Review update</button>
+  </aside>
+{/if}
+
+<style>
+  .update-notice {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: var(--aegis-space-4);
+    padding: var(--aegis-space-3);
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-surface);
+  }
+  button {
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid var(--md-sys-color-primary);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--aegis-space-2) var(--aegis-space-4);
+    cursor: pointer;
+  }
+  button:focus-visible {
+    outline: 2px solid var(--md-sys-color-primary);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/renderer/lib/stores/ipc.ts
+++ b/src/renderer/lib/stores/ipc.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 import { writable, derived } from 'svelte/store';
 import type { Readable, Writable } from 'svelte/store';
+import type { UpdateStatus } from '../../../shared/types/ipc';
 import { isDemoPayload } from './demo-provenance.js';
 import { appendWithRetention, fileEventRetain, EVENTS_CAPACITY } from './events-retention.js';
 import type {
@@ -133,6 +134,11 @@ interface AgentResourceRecord {
 
 /** Minimal type for the window.aegis IPC bridge exposed by preload.js */
 interface AegisIpcBridge {
+  getUpdateStatus(): Promise<UpdateStatus>;
+  checkForUpdates(): Promise<UpdateStatus>;
+  downloadUpdate(): Promise<UpdateStatus>;
+  installUpdate(): Promise<UpdateStatus>;
+  onUpdateStatus(cb: (status: UpdateStatus) => void): () => void;
   onScanBatch(cb: (data: ScanBatchData) => void): void;
   onFileAccess(cb: (data: FileEvent | FileEvent[]) => void): void;
   onStatsUpdate(cb: (data: Record<string, unknown>) => void): void;

--- a/src/renderer/lib/stores/updates.ts
+++ b/src/renderer/lib/stores/updates.ts
@@ -1,0 +1,49 @@
+import { writable } from 'svelte/store';
+import type { UpdateStatus } from '../../../shared/types/ipc';
+
+export const updateStatus = writable<UpdateStatus>({
+  status: 'idle',
+  version: null,
+  notes: '',
+  progress: 0,
+  error: null,
+});
+
+/** Subscribe before requesting a snapshot, preserving any newer push. @returns cleanup @since 0.15.0 */
+export function connectUpdates(): () => void {
+  const api = window.aegis;
+  if (!api?.getUpdateStatus || !api.onUpdateStatus) return () => {};
+  let active = true;
+  let receivedPush = false;
+  const unsubscribe = api.onUpdateStatus((status) => {
+    receivedPush = true;
+    if (active) updateStatus.set(status);
+  });
+  void api
+    .getUpdateStatus()
+    .then((status) => {
+      if (active && !receivedPush) updateStatus.set(status);
+    })
+    .catch(() => {});
+  return () => {
+    active = false;
+    unsubscribe();
+  };
+}
+
+/** Invoke a fixed bridge operation; event pushes own state ordering. @param action @returns completion @since 0.15.0 */
+export async function updateAction(action: 'check' | 'download' | 'install'): Promise<void> {
+  try {
+    const api = window.aegis;
+    if (!api) return;
+    if (action === 'check') await api.checkForUpdates();
+    else if (action === 'download') await api.downloadUpdate();
+    else await api.installUpdate();
+  } catch {
+    updateStatus.update((status) => ({
+      ...status,
+      status: 'error',
+      error: 'update-request-failed',
+    }));
+  }
+}

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -6,6 +6,10 @@
 
 /** IPC invoke channel names (renderer -> main, request-response) */
 export type IpcInvokeChannel =
+  | 'updates:status'
+  | 'updates:check'
+  | 'updates:download'
+  | 'updates:install'
   | 'get-stats'
   | 'get-resource-usage'
   | 'export-log'
@@ -50,6 +54,7 @@ export type IpcInvokeChannel =
  * rather than as proof the channel does not exist.
  */
 export type IpcEventChannel =
+  | 'updates:status'
   | 'file-access'
   | 'stats-update'
   | 'network-update'
@@ -73,4 +78,22 @@ export interface IpcResult {
   readonly error?: string;
   readonly path?: string;
   readonly count?: number;
+}
+
+/** Public updater state. Executable paths and network options never reach the renderer. */
+export interface UpdateStatus {
+  readonly status:
+    | 'idle'
+    | 'unsupported'
+    | 'checking'
+    | 'up-to-date'
+    | 'available'
+    | 'downloading'
+    | 'ready'
+    | 'installing'
+    | 'error';
+  readonly version: string | null;
+  readonly notes: string;
+  readonly progress: number;
+  readonly error: string | null;
 }

--- a/tests/main/app-updates.test.js
+++ b/tests/main/app-updates.test.js
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import updates from '../../src/main/app-updates.js';
+
+const roots = [];
+const managers = [];
+afterEach(() => {
+  managers.splice(0).forEach((m) => m.dispose());
+  roots.splice(0).forEach((root) => fs.rmSync(root, { recursive: true, force: true }));
+  vi.useRealTimers();
+});
+function setup(overrides = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-updater-'));
+  roots.push(root);
+  const file = path.join(root, 'setup.exe');
+  const data = Buffer.from('verified fixture');
+  fs.writeFileSync(file, data);
+  const verified = {
+    version: '0.15.0-alpha',
+    sha256: crypto.createHash('sha256').update(data).digest('hex'),
+    bytes: data.length,
+  };
+  const cancel = vi.fn();
+  const updater = new EventEmitter();
+  updater.installerPath = file;
+  updater.checkForUpdates = vi.fn(async () => ({
+    isUpdateAvailable: true,
+    updateInfo: { verified, releaseNotes: 'Notes' },
+    cancellationToken: { cancel },
+  }));
+  updater.downloadUpdate = vi.fn(async () => [file]);
+  updater.quitAndInstall = vi.fn();
+  const settings = { automaticUpdatesEnabled: false };
+  const deps = {
+    supported: true,
+    createUpdater: vi.fn(() => updater),
+    getSettings: () => settings,
+    onChange: vi.fn(),
+    confirmInstall: vi.fn(async () => true),
+    prepareQuit: vi.fn(),
+    ...overrides,
+  };
+  const manager = updates.createUpdateManager(deps);
+  managers.push(manager);
+  return { manager, updater, deps, settings, file, cancel };
+}
+describe('update consent and installation', () => {
+  it.each([false, undefined, 'true'])(
+    'does not check automatically without boolean consent (%s)',
+    async (enabled) => {
+      vi.useFakeTimers();
+      const { manager, updater, settings } = setup();
+      settings.automaticUpdatesEnabled = enabled;
+      manager.schedule();
+      await vi.advanceTimersByTimeAsync(31000);
+      await manager.check(true);
+      expect(updater.checkForUpdates).not.toHaveBeenCalled();
+    },
+  );
+  it('does nothing on unsupported builds', async () => {
+    const { manager, deps } = setup({ supported: false });
+    await manager.check();
+    await manager.download();
+    await manager.install();
+    expect(manager.snapshot().status).toBe('unsupported');
+    expect(deps.createUpdater).not.toHaveBeenCalled();
+  });
+  it('checks after 30 seconds and six hours, then stops scheduling on opt-out', async () => {
+    vi.useFakeTimers();
+    const { manager, updater, settings } = setup();
+    settings.automaticUpdatesEnabled = true;
+    updater.checkForUpdates.mockResolvedValue({ isUpdateAvailable: false });
+    manager.schedule();
+    await vi.advanceTimersByTimeAsync(29999);
+    expect(updater.checkForUpdates).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(updater.checkForUpdates).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(2);
+    settings.automaticUpdatesEnabled = false;
+    manager.preferencesChanged();
+    await vi.advanceTimersByTimeAsync(7 * 60 * 60 * 1000);
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+  it('manual checking does not download; startup opt-in downloads but never installs', async () => {
+    const { manager, updater, settings } = setup();
+    await manager.check();
+    expect(updater.downloadUpdate).not.toHaveBeenCalled();
+    settings.automaticUpdatesEnabled = true;
+    await manager.check(true);
+    expect(manager.snapshot().status).toBe('ready');
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+    expect(updater.autoInstallOnAppQuit).toBe(false);
+    expect(updater.autoDownload).toBe(false);
+  });
+  it('requires a verified download and native confirmation before restart', async () => {
+    const { manager, updater, deps } = setup();
+    await manager.install();
+    expect(deps.confirmInstall).not.toHaveBeenCalled();
+    await manager.check();
+    await manager.download();
+    deps.confirmInstall.mockResolvedValueOnce(false);
+    await manager.install();
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+    expect(manager.snapshot().status).toBe('ready');
+    await manager.install();
+    expect(updater.quitAndInstall).toHaveBeenCalledExactlyOnceWith(true, true);
+    expect(deps.prepareQuit).toHaveBeenCalledOnce();
+  });
+  it('rejects a corrupt downloaded file and never offers installation', async () => {
+    const { manager, updater, file } = setup();
+    await manager.check();
+    fs.writeFileSync(file, 'tampered');
+    await manager.download();
+    await manager.install();
+    expect(manager.snapshot().status).toBe('error');
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+    expect(JSON.stringify(manager.snapshot())).not.toContain(file);
+  });
+  it('rechecks the installer after confirmation to catch cached-file replacement', async () => {
+    const { manager, updater, deps, file } = setup();
+    await manager.check();
+    await manager.download();
+    deps.confirmInstall.mockImplementation(async () => {
+      fs.writeFileSync(file, 'tampered');
+      return true;
+    });
+    await manager.install();
+    expect(manager.snapshot().status).toBe('error');
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+  });
+  it('coalesces concurrent checks and installations', async () => {
+    const { manager, updater, deps } = setup();
+    let resolve;
+    updater.checkForUpdates.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolve = r;
+        }),
+    );
+    const first = manager.check();
+    await manager.check();
+    expect(updater.checkForUpdates).toHaveBeenCalledOnce();
+    resolve({ isUpdateAvailable: false });
+    await first;
+    await manager.check();
+    await manager.download();
+    let confirm;
+    deps.confirmInstall.mockImplementation(
+      () =>
+        new Promise((r) => {
+          confirm = r;
+        }),
+    );
+    const install = manager.install();
+    await manager.install();
+    confirm(true);
+    await install;
+    expect(updater.quitAndInstall).toHaveBeenCalledOnce();
+  });
+  it('retries after network failure without exposing the raw error', async () => {
+    const { manager, updater } = setup();
+    updater.checkForUpdates.mockRejectedValueOnce(new Error('secret path /private'));
+    await manager.check();
+    expect(manager.snapshot().error).toBe('update-check-failed');
+    await manager.check();
+    expect(manager.snapshot().status).toBe('available');
+  });
+  it('stops automatic downloading if consent is withdrawn during checking', async () => {
+    const { manager, updater, settings } = setup();
+    settings.automaticUpdatesEnabled = true;
+    const original = updater.checkForUpdates.getMockImplementation();
+    updater.checkForUpdates.mockImplementation(async () => {
+      settings.automaticUpdatesEnabled = false;
+      return original();
+    });
+    await manager.check(true);
+    expect(updater.downloadUpdate).not.toHaveBeenCalled();
+  });
+  it('cancels download on opt-out and ignores late state after disposal', async () => {
+    const { manager, updater, cancel, deps } = setup();
+    await manager.check();
+    let resolve;
+    updater.downloadUpdate.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolve = r;
+        }),
+    );
+    const downloading = manager.download();
+    manager.preferencesChanged();
+    expect(cancel).toHaveBeenCalled();
+    manager.dispose();
+    deps.onChange.mockClear();
+    resolve([updater.installerPath]);
+    await downloading;
+    expect(deps.onChange).not.toHaveBeenCalled();
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+  });
+  it('recovers the quit flag if launching the installer throws', async () => {
+    const { manager, updater, deps } = setup();
+    await manager.check();
+    await manager.download();
+    updater.quitAndInstall.mockImplementation(() => {
+      throw new Error('launch failed');
+    });
+    await manager.install();
+    expect(manager.snapshot().error).toBe('update-install-failed');
+    expect(deps.prepareQuit).toHaveBeenLastCalledWith(false);
+  });
+  it('reports asynchronous installer launch failure', async () => {
+    const { manager, updater, deps } = setup();
+    await manager.check();
+    await manager.download();
+    await manager.install();
+    updater.emit('error', new Error('private details'));
+    expect(manager.snapshot().error).toBe('update-install-failed');
+    expect(deps.prepareQuit).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/tests/main/ipc-handlers.test.js
+++ b/tests/main/ipc-handlers.test.js
@@ -199,6 +199,30 @@ describe('ipc-handlers', () => {
     return handlers[channel];
   }
 
+  it('update operations only accept the owned main frame and never forward caller parameters', () => {
+    const frame = {};
+    const window = { isDestroyed: () => false, webContents: { mainFrame: frame } };
+    const updates = { snapshot: vi.fn(), check: vi.fn(), download: vi.fn(), install: vi.fn() };
+    ipcHandlers.init({ getWindow: () => window, updates });
+    ipcHandlers.register();
+    for (const [channel, method] of [
+      ['status', 'snapshot'],
+      ['check', 'check'],
+      ['download', 'download'],
+      ['install', 'install'],
+    ]) {
+      const handler = getHandler(`updates:${channel}`);
+      expect(() => handler({ sender: {}, senderFrame: frame })).toThrow('denied');
+      expect(() => handler({ sender: window.webContents, senderFrame: {} })).toThrow('denied');
+      handler(
+        { sender: window.webContents, senderFrame: frame },
+        'https://attacker.invalid',
+        'evil.exe',
+      );
+      expect(updates[method]).toHaveBeenCalledExactlyOnceWith();
+    }
+  });
+
   it('init stores injected deps', () => {
     ipcHandlers.init({
       getWindow: () => null,

--- a/tests/main/settings-validation.test.js
+++ b/tests/main/settings-validation.test.js
@@ -31,6 +31,11 @@ afterAll(() => {
 const { validateSettings } = require(settingsValidationPath);
 
 describe('settings-validation — validateSettings reject branches', () => {
+  it('accepts explicit boolean update consent and rejects truthy strings', () => {
+    expect(validateSettings({ automaticUpdatesEnabled: true }).valid).toBe(true);
+    expect(validateSettings({ automaticUpdatesEnabled: false }).valid).toBe(true);
+    expect(validateSettings({ automaticUpdatesEnabled: 'true' }).valid).toBe(false);
+  });
   it('rejects null (not a plain object)', () => {
     expect(validateSettings(null)).toEqual({
       valid: false,

--- a/tests/main/update-verification.test.js
+++ b/tests/main/update-verification.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import verification from '../../src/main/update-verification.js';
+import provider from '../../src/main/update-provider.js';
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+const pem = publicKey.export({ type: 'spki', format: 'pem' });
+const tag = 'aegis-v0.15.0-alpha';
+const data = Buffer.from('synthetic installer');
+const digest = crypto.createHash('sha256').update(data).digest('hex');
+const fixture = (overrides = {}) => ({
+  schema: 'aegis-release-manifest/v1',
+  repository: 'antropos17/Aegis',
+  tag,
+  commit: 'a'.repeat(40),
+  algorithm: 'sha256',
+  files: [
+    {
+      filename: 'AEGIS - AI Monitoring & Threat Detection Setup 0.15.0-alpha.exe',
+      sha256: digest,
+      bytes: data.length,
+    },
+  ],
+  ...overrides,
+});
+const signed = (manifest) => {
+  const bytes = Buffer.from(JSON.stringify(manifest));
+  return { bytes, signature: crypto.sign(null, bytes, privateKey) };
+};
+let temp;
+afterEach(() => {
+  if (temp) fs.rmSync(temp, { recursive: true, force: true });
+  temp = null;
+});
+
+describe('signed update boundary', () => {
+  it('accepts the signed installer and rejects changed manifest bytes', () => {
+    const { bytes, signature } = signed(fixture());
+    expect(verification.verifyManifest(bytes, signature, pem, tag)).toMatchObject({
+      version: '0.15.0-alpha',
+      sha256: digest,
+      bytes: data.length,
+    });
+    expect(() =>
+      verification.verifyManifest(Buffer.concat([bytes, Buffer.from(' ')]), signature, pem, tag),
+    ).toThrow();
+  });
+  it('rejects a signature from another key', () => {
+    const { bytes, signature } = signed(fixture());
+    const other = crypto
+      .generateKeyPairSync('ed25519')
+      .publicKey.export({ type: 'spki', format: 'pem' });
+    expect(() => verification.verifyManifest(bytes, signature, other, tag)).toThrow();
+  });
+  it.each([
+    { repository: 'attacker/Aegis' },
+    { tag: 'aegis-v0.99.0-alpha' },
+    { algorithm: 'sha1' },
+    { commit: '../bad' },
+    { files: [] },
+    { files: [...fixture().files, ...fixture().files] },
+    { files: [{ ...fixture().files[0], filename: '../setup.exe' }] },
+    { files: [{ ...fixture().files[0], bytes: 1024 ** 3 }] },
+  ])('rejects even correctly signed invalid metadata: %j', (overrides) => {
+    const { bytes, signature } = signed(fixture(overrides));
+    expect(() => verification.verifyManifest(bytes, signature, pem, tag)).toThrow();
+  });
+  it('checks installer size and hash from the actual file', async () => {
+    temp = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-update-'));
+    const file = path.join(temp, 'setup.exe');
+    fs.writeFileSync(file, data);
+    await expect(
+      verification.verifyInstaller(file, { sha256: digest, bytes: data.length }),
+    ).resolves.toBeUndefined();
+    fs.writeFileSync(file, Buffer.alloc(data.length, 1));
+    await expect(
+      verification.verifyInstaller(file, { sha256: digest, bytes: data.length }),
+    ).rejects.toThrow('hash');
+    await expect(verification.verifyInstaller(file, { sha256: digest, bytes: 1 })).rejects.toThrow(
+      'size',
+    );
+  });
+  it('rejects non-file installer targets', async () => {
+    temp = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-update-link-'));
+    const directory = path.join(temp, 'directory');
+    fs.mkdirSync(directory);
+    await expect(
+      verification.verifyInstaller(directory, { sha256: digest, bytes: 0 }),
+    ).rejects.toThrow('size');
+  });
+});
+
+const release = (version = '0.15.0-alpha') => ({
+  tag_name: `aegis-v${version}`,
+  draft: false,
+  body: '<script>untrusted notes</script>',
+  assets: [
+    { name: 'manifest.json', state: 'uploaded' },
+    { name: 'manifest.json.sig', state: 'uploaded' },
+    {
+      name: 'AEGIS.Setup.exe',
+      state: 'uploaded',
+      size: data.length,
+      browser_download_url: 'https://attacker.invalid/setup.exe',
+    },
+  ],
+});
+describe('signed release provider', () => {
+  it('uses the newest complete allowed version, never downgrades or crosses stable into alpha', () => {
+    const releases = [
+      release('0.14.0-alpha'),
+      release('0.15.0-alpha'),
+      release('0.16.0-alpha'),
+      { ...release('0.17.0-alpha'), assets: [] },
+    ];
+    expect(provider.selectRelease(releases, '0.14.1-alpha').tag_name).toBe('aegis-v0.16.0-alpha');
+    expect(provider.selectRelease(releases, '0.20.0-alpha')).toBeNull();
+    expect(provider.selectRelease(releases, '0.14.1')).toBeNull();
+    expect(provider.selectRelease([release('0.16.0')], '0.15.0-alpha').tag_name).toBe(
+      'aegis-v0.16.0',
+    );
+  });
+  it('authenticates the manifest and constructs a fixed-repository URL despite a supplied external URL', async () => {
+    const { bytes, signature } = signed(fixture());
+    const calls = [];
+    const fetcher = async (url, options) => {
+      calls.push({ url, options });
+      return new Response(
+        url.includes('api.github')
+          ? JSON.stringify([release()])
+          : url.endsWith('.sig')
+            ? signature.toString('base64')
+            : bytes,
+      );
+    };
+    const info = await provider.loadRelease({ current: '0.14.1-alpha', fetcher, publicKey: pem });
+    expect(info.files[0]).toMatchObject({
+      url: `https://github.com/antropos17/Aegis/releases/download/${tag}/AEGIS.Setup.exe`,
+      sha2: digest,
+    });
+    expect(info.releaseNotes).toBe('<script>untrusted notes</script>');
+    expect(calls.every((c) => c.options.credentials === 'omit')).toBe(true);
+    expect(calls[0].options.headers.Accept).toBe('application/vnd.github+json');
+    expect(
+      calls.slice(1).every((c) => c.options.headers.Accept === 'application/octet-stream'),
+    ).toBe(true);
+  });
+  it('refuses a release with a forged manifest signature', async () => {
+    const { bytes } = signed(fixture());
+    const fetcher = async (url) =>
+      new Response(
+        url.includes('api.github')
+          ? JSON.stringify([release()])
+          : url.endsWith('.sig')
+            ? Buffer.alloc(64).toString('base64')
+            : bytes,
+      );
+    await expect(
+      provider.loadRelease({ current: '0.14.1-alpha', fetcher, publicKey: pem }),
+    ).rejects.toThrow('signature');
+  });
+  it('bounds metadata responses and refuses HTTP errors', async () => {
+    await expect(
+      provider.fetchBytes('https://example.invalid', 4, async () => new Response('12345')),
+    ).rejects.toThrow('too-large');
+    await expect(
+      provider.fetchBytes(
+        'https://example.invalid',
+        4,
+        async () => new Response('', { status: 403 }),
+      ),
+    ).rejects.toThrow('fetch-failed');
+  });
+});

--- a/tests/renderer/components/SettingsUpdates.test.ts
+++ b/tests/renderer/components/SettingsUpdates.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import SettingsUpdates from '../../../src/renderer/lib/components/SettingsUpdates.svelte';
+import UpdateNotice from '../../../src/renderer/lib/components/UpdateNotice.svelte';
+import { updateStatus } from '../../../src/renderer/lib/stores/updates';
+
+afterEach(() => {
+  cleanup();
+  delete window.aegis;
+});
+
+describe('update controls', () => {
+  it('renders release notes as text and separates downloading from installation', async () => {
+    // Deliberately narrow bridge: this panel must not require unrelated privileges.
+    Object.defineProperty(window, 'aegis', {
+      configurable: true,
+      value: {
+        checkForUpdates: vi.fn(),
+        downloadUpdate: vi.fn(),
+        installUpdate: vi.fn(),
+      },
+    });
+    updateStatus.set({
+      status: 'available',
+      version: '0.15.0-alpha',
+      notes: '<img src=x onerror=alert(1)>',
+      progress: 0,
+      error: null,
+    });
+    const { container } = render(SettingsUpdates);
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('pre')?.textContent).toContain('<img');
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    await fireEvent.click(screen.getByRole('button', { name: 'Download update' }));
+    expect(window.aegis?.downloadUpdate).toHaveBeenCalledOnce();
+    expect(window.aegis?.installUpdate).not.toHaveBeenCalled();
+    updateStatus.update((s) => ({ ...s, status: 'downloading', progress: 50 }));
+    await tick();
+    expect(screen.getByRole('button', { name: 'Check for updates' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Restart and install' })).toBeNull();
+    updateStatus.update((s) => ({ ...s, status: 'ready', progress: 100 }));
+    await tick();
+    await fireEvent.click(screen.getByRole('button', { name: 'Restart and install' }));
+    expect(window.aegis?.installUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('routes the dashboard notice to review and hides it when no update exists', async () => {
+    updateStatus.set({
+      status: 'ready',
+      version: '0.15.0-alpha',
+      notes: '',
+      progress: 100,
+      error: null,
+    });
+    const onOpen = vi.fn();
+    render(UpdateNotice, { props: { onOpen } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Review update' }));
+    expect(onOpen).toHaveBeenCalledOnce();
+    updateStatus.update((s) => ({ ...s, status: 'up-to-date' }));
+    await tick();
+    expect(screen.queryByRole('button', { name: 'Review update' })).toBeNull();
+  });
+});

--- a/tests/renderer/updates.test.js
+++ b/tests/renderer/updates.test.js
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { connectUpdates, updateStatus, updateAction } from '../../src/renderer/lib/stores/updates';
+
+afterEach(() => {
+  delete window.aegis;
+});
+const status = (state) => ({
+  status: state,
+  version: '0.15.0-alpha',
+  notes: '',
+  progress: 0,
+  error: null,
+});
+describe('update state bridge', () => {
+  it('does not overwrite a newer push with a delayed initial snapshot', async () => {
+    let resolve;
+    let push;
+    const unsubscribe = vi.fn();
+    window.aegis = {
+      getUpdateStatus: () =>
+        new Promise((r) => {
+          resolve = r;
+        }),
+      onUpdateStatus: (cb) => {
+        push = cb;
+        return unsubscribe;
+      },
+    };
+    const stop = connectUpdates();
+    push(status('ready'));
+    resolve(status('idle'));
+    await Promise.resolve();
+    expect(get(updateStatus).status).toBe('ready');
+    stop();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    push(status('error'));
+    expect(get(updateStatus).status).toBe('ready');
+  });
+  it('only requests the action the user selected and passes no download paths', async () => {
+    window.aegis = { checkForUpdates: vi.fn(), downloadUpdate: vi.fn(), installUpdate: vi.fn() };
+    await updateAction('check');
+    expect(window.aegis.checkForUpdates).toHaveBeenCalledExactlyOnceWith();
+    expect(window.aegis.downloadUpdate).not.toHaveBeenCalled();
+    expect(window.aegis.installUpdate).not.toHaveBeenCalled();
+  });
+  it('keeps raw IPC exception text out of the displayed status', async () => {
+    window.aegis = { installUpdate: vi.fn().mockRejectedValue(new Error('/private/local/path')) };
+    await updateAction('install');
+    expect(get(updateStatus).error).toBe('update-request-failed');
+  });
+});


### PR DESCRIPTION
AEGIS currently requires a manual reinstall for every release. This adds opt-in Windows x64 update checks and downloads, a dashboard notice, and Settings controls for checking, reviewing release notes, downloading and restarting to install. Automatic checks default to off; enabling the saved preference checks after 30 seconds and every six hours. Installation always requires native confirmation.

The pinned electron-updater 6.8.9 custom provider supports the existing `aegis-v` tags and signed release manifests. It verifies Ed25519 metadata with the bundled public key and checks the installer's signed SHA-256 and byte length after download and again after confirmation. Four argument-free IPC actions reject foreign windows and subframes. Public GitHub requests carry no account credentials or monitoring records. Existing release workflows are unchanged.

Validation: clean npm ci; all ten CI verification commands passed locally (2,682 tests passed, four platform skips; lint has 32 existing warnings and zero errors). A full Windows NSIS package was built. In packaged Electron, the real provider downloaded and verified the published 104,675,807-byte installer using a simulated older installed version and a disposable cache. The actual Settings button passed through preload/main IPC to the up-to-date result. Tampering, cancellation, consent, scheduling, duplicate actions, installer failure and literal release-note rendering have regression coverage.

The smoke test did not execute the installer or upgrade the user's app. The first release containing this feature still needs a manual install. Updates currently support Windows x64; SHA-256-only downloads are fetched again after an application restart. No rollback or automatic backup is added. No release is published by this PR.

Closes #20.
