### PR TITLE
feat(ui): show navigation keyboard shortcut hints

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1005,3 +1005,20 @@ The first release carrying this feature still needs manual installation. Windows
 x64 is the supported update target; SHA-256-only cached downloads are fetched again
 after an app restart, and automatic rollback/backups are not implemented. The next
 release remains a separate user-authorized step; major dependency PRs stay deferred.
+
+## Session handoff — tab shortcut hints, issue #77 (2026-09-07)
+
+After the user asked to continue development, `codex/tab-shortcut-hints` adds visible
+Ctrl+1 through Ctrl+5 hints beneath the five navigation labels. The current handler
+already supports these combinations; the older issue mentions only four tabs.
+The accessibility shortcut metadata now lists both the existing plain digit and
+Control+digit alternatives. Colors, spacing and the mono font use existing tokens.
+
+Renderer and demo builds, formatting, lint and Svelte checks passed. The Svelte
+autofixer reported no issues; its suggestions concern existing indicator effects.
+The built web preview was inspected at 1280x720 and each Ctrl+1–5 combination selected
+the matching tab. The preview correctly showed NO DATA without the desktop bridge.
+The Vite dev server could not render the existing CommonJS instance-key import, so
+visual verification used the built preview. No keyboard handler or monitoring code
+changed, and no tests were added for this presentation change. Release publication
+and the installed application remain outside this task.

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -56,10 +56,11 @@
       role="tab"
       aria-selected={activeTab === tab.id}
       aria-controls="tabpanel-{tab.id}"
-      aria-keyshortcuts={String(i + 1)}
+      aria-keyshortcuts={`${i + 1} Control+${i + 1}`}
       onclick={() => (activeTab = tab.id)}
     >
       {tab.label}
+      <kbd class="shortcut-hint" aria-hidden="true">Ctrl+{i + 1}</kbd>
     </button>
   {/each}
 </div>
@@ -100,6 +101,10 @@
   }
 
   .tab-pill {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--aegis-space-2);
     position: relative;
     z-index: 1;
     padding: var(--aegis-space-4) var(--aegis-space-9);
@@ -118,6 +123,14 @@
 
   .tab-pill:hover {
     color: var(--md-sys-color-on-surface);
+  }
+
+  .shortcut-hint {
+    color: inherit;
+    font-family: var(--fancy-font-mono);
+    font-size: calc(0.6875rem * var(--aegis-ui-scale));
+    font-weight: 400;
+    line-height: 1.2;
   }
 
   .tab-pill.active {


### PR DESCRIPTION
Display Ctrl+1 through Ctrl+5 below the navigation labels so users can discover the existing shortcuts. The hints use the current spacing, font and color tokens, and tab accessibility metadata now lists both digit and Control+digit shortcuts.

Renderer/demo builds, format, lint and Svelte checks passed. Inspected the built preview at 1280x720 and verified all five keyboard combinations select the matching tab. The keyboard handlers are unchanged; no implementation-mirroring tests were added for this presentation change.

Closes #77.
