### PR TITLE
fix: recover WSL discovery after availability changes

### DIFF
--- a/docs/roadmap/sensor-health-degraded.md
+++ b/docs/roadmap/sensor-health-degraded.md
@@ -525,12 +525,15 @@ Audit drops remain on **audit** stats path (already honest).
   `ide-extension`: process list unreadable → FAILED; a RUNNING editor whose extensions dir fails
   to read for any reason other than ENOENT/ENOTDIR → DEGRADED (those two stay a definite absence);
   otherwise HEALTHY.
-  `wsl`: non-win32, no `wsl.exe`, or a `wsl.exe` that RAN and reported no distribution →
-  UNSUPPORTED (out of the worst-of — the binary ships in System32 on stock Windows, and holding
-  every such machine DEGRADED would be a warning that is always on); a probe that produced no
-  verdict at all — a timeout kill, a spawn failure — → DEGRADED and, unlike before, **not cached**,
-  so the next 60 s cycle asks again; WSL present but its process list unreadable or empty →
-  DEGRADED; a list that was read → HEALTHY.
+  `wsl`: non-win32, missing `wsl.exe` (ENOENT), or a successful empty distribution list →
+  UNSUPPORTED (out of the worst-of). On Windows, conclusive availability answers expire
+  after 60 s so a later installation/removal is observed without restarting AEGIS. A retry
+  after UNSUPPORTED starts a fresh health record. Any other failed availability probe,
+  including a numeric non-zero exit, → DEGRADED and is **not cached**: an exit status alone
+  cannot establish that no distribution is installed. This also means an unconfigured WSL
+  executable that rejects the command is reported as an inconclusive probe, rather than
+  assumed absent. The next refresh asks again. WSL present but its process list unreadable
+  or empty → DEGRADED; a list that was read → HEALTHY.
   `llm-ollama` / `llm-lmstudio`: one record per PROBE, because the two run concurrently under one
   `Promise.all` and a shared record would let the definite answer overwrite the uncertain one.
   ECONNREFUSED and a completed response that is not this runtime's JSON are definite negatives

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1022,3 +1022,33 @@ The Vite dev server could not render the existing CommonJS instance-key import, 
 visual verification used the built preview. No keyboard handler or monitoring code
 changed, and no tests were added for this presentation change. Release publication
 and the installed application remain outside this task.
+
+## Session handoff — core focus and WSL recovery (2026-09-07)
+
+User direction: work on core functionality and reliability. The frontend is being
+developed separately by the user and will be merged later; do not edit renderer
+components or styles for subsequent core tasks.
+
+`codex/wsl-probe-recovery` fixes the availability gate in the existing WSL detector.
+Previously a missing executable, empty distribution list or any non-zero listing
+exit cached false for the entire application lifetime. Now conclusive availability
+answers expire after 60 seconds and the next background refresh probes again. A
+retry from a confirmed absence starts a fresh health record. Numeric non-zero exits
+are inconclusive and report DEGRADED without caching absence; only ENOENT or a
+successful empty list establish UNSUPPORTED on Windows. Non-Windows remains
+UNSUPPORTED. This changes health reporting on unconfigured WSL installations that
+reject the list command: they now expose the probe failure instead of being assumed
+absent. Existing process enumeration still covers the default distribution only.
+
+Six regression cases failed before the fix and passed afterward: recovery from
+empty/missing availability, removal after a positive cache, an inconclusive retry
+from UNSUPPORTED, and recovery from exit 1 or 4294967295. The full suite passed with
+2,687 tests and four skips across 150 files. Renderer build, format, lint (zero
+errors; 32 existing warnings), type checks, both mutation gates, counts and the
+production audit passed. A standalone Windows process injected one probe failure,
+then used real wsl.exe on the next call: DEGRADED → HEALTHY without resetting the
+detector; no matching agents were found. Evidence is in X:/tmp/aegis-wsl-recovery-*.
+
+No renderer, IPC contract, dependency, system setting or installed-app change was
+made. This addresses reliability in the existing WSL part of issue #8; Docker,
+Podman and multi-distribution coverage remain open. No release was published.

--- a/src/main/wsl-detector.js
+++ b/src/main/wsl-detector.js
@@ -48,8 +48,8 @@ function createInitialHealth() {
 }
 
 /**
- * Persistent health for WSL enumeration. Lifetime = module lifetime; reset only by
- * {@link _resetForTest}, never recreated per refresh.
+ * Persistent health for WSL enumeration. Ordinary failures preserve the record;
+ * reprobing after confirmed absence starts a new record so UNSUPPORTED can recover.
  * @type {import('./sensor-health').SensorHealth}
  */
 let _health = createInitialHealth();
@@ -78,17 +78,6 @@ function errorCode(err) {
 }
 
 /**
- * Whether the binary RAN and reported a condition, as opposed to never producing a
- * verdict. A numeric `code` is an exit status; a string `code` (ENOENT, EACCES) or
- * none at all (a timeout kill) means the spawn itself failed.
- * @param {unknown} err
- * @returns {boolean}
- */
-function ranButFailed(err) {
-  return typeof (err && /** @type {{code?: unknown}} */ (err).code) === 'number';
-}
-
-/**
  * @internal Override dependencies (for tests).
  * @param {{ execFile?: Function, platform?: string }} overrides
  */
@@ -108,6 +97,7 @@ function _resetForTest() {
   _execFile = execFile;
   _getPlatform = () => process.platform;
   _wslAvailable = null;
+  _availabilityCheckedAt = null;
   _cache = [];
   _lastRefresh = 0;
   _refreshing = false;
@@ -137,8 +127,10 @@ const WSL_SIGNATURES = [
 /** @type {number} How long an enumeration stays fresh (ms) — WSL spawn is heavy */
 const REFRESH_TTL_MS = 60000;
 
-/** @type {boolean|null} Cached WSL availability (null = not yet probed) */
+/** @type {boolean|null} Cached WSL availability (null = no conclusive cached answer) */
 let _wslAvailable = null;
+/** @type {number|null} Time of the last conclusive availability probe. */
+let _availabilityCheckedAt = null;
 /** @type {Array<Object>} Last detected synthetic agents */
 let _cache = [];
 let _lastRefresh = 0;
@@ -207,7 +199,8 @@ function parsePsOutput(stdout) {
 // ═══ PUBLIC API ═══
 
 /**
- * Whether WSL is installed with at least one distro. Cached after first probe.
+ * Whether WSL is installed with at least one distro. Conclusive answers expire
+ * after one minute so installation, removal and recovery need no app restart.
  * `wsl.exe -l -q` emits UTF-16LE; decoded as UTF-8 it interleaves a null byte
  * between characters, so we strip null bytes before the emptiness check (we only
  * need existence, not exact distro names).
@@ -215,27 +208,29 @@ function parsePsOutput(stdout) {
  * @since v0.11.0-alpha
  */
 async function isWslAvailable() {
-  if (_wslAvailable !== null) return _wslAvailable;
   if (_getPlatform() !== 'win32') {
-    _wslAvailable = false;
     return false;
   }
+  const age = _availabilityCheckedAt === null ? null : Date.now() - _availabilityCheckedAt;
+  if (_wslAvailable !== null && age !== null && age >= 0 && age < REFRESH_TTL_MS)
+    return _wslAvailable;
+  _wslAvailable = null;
+  // Availability can change on Windows. Re-enter the health state machine when
+  // probing again after a previously confirmed absence (UNSUPPORTED is terminal).
+  if (_health.state === sensorHealth.SENSOR_HEALTH_STATE.UNSUPPORTED)
+    _health = createInitialHealth();
   const { ok, stdout, err } = await run('wsl.exe', ['-l', '-q']);
   if (!ok) {
-    if (errorCode(err) === 'ENOENT' || ranButFailed(err)) {
-      // Two DEFINITE answers, one state. ENOENT: no `wsl.exe` on this machine at all.
-      // A numeric exit status: `wsl.exe` ran and refused, and on `-l -q` that is "no
-      // installed distributions" — the stock Windows shape, since the binary ships in
-      // System32 whether or not WSL was ever set up. Nothing exists to enumerate BY
-      // DESIGN, so the leaf is UNSUPPORTED and leaves the worst-of, rather than holding
-      // the whole app DEGRADED over a condition that is not a fault.
+    if (errorCode(err) === 'ENOENT') {
+      // Missing executable is a definite absence for this probe, not forever.
       _wslAvailable = false;
+      _availabilityCheckedAt = Date.now();
       _health = sensorHealth.markUnsupported(_health, Date.now(), {
-        detail: errorCode(err) === 'ENOENT' ? 'wsl-not-installed' : 'wsl-no-distro',
+        detail: 'wsl-not-installed',
       });
       return false;
     }
-    // The spawn produced no verdict: a timeout kill, EACCES, EAGAIN. NOT cached — a
+    // Non-zero exits, timeouts and access errors do not establish absence. NOT cached — a
     // cached `false` is what turned one bad probe into a blind spot for the rest of the
     // process life, and the 60s refresh will ask again. DEGRADED, because for as long
     // as this lasts a WSL-hosted agent would be missing from the fleet unannounced.
@@ -247,9 +242,9 @@ async function isWslAvailable() {
   }
   const hasDistro = stdout.split(NUL_CHAR).join('').trim().length > 0;
   _wslAvailable = hasDistro;
+  _availabilityCheckedAt = Date.now();
   if (!hasDistro) {
-    // `wsl.exe` answered with an empty list: installed, no distro. Definite, permanent
-    // for this process life, and not a fault.
+    // A successful empty list confirms no distro at this probe, until its TTL expires.
     _health = sensorHealth.markUnsupported(_health, Date.now(), { detail: 'wsl-no-distro' });
   }
   // A distro exists: availability is not the observation this sensor names, so no

--- a/tests/main/detector-health.test.js
+++ b/tests/main/detector-health.test.js
@@ -260,7 +260,7 @@ describe('wsl sensor health (B-S12)', () => {
     });
     expect(await wsl.detectWslAgents()).toEqual([]);
     expect(await wsl.detectWslAgents()).toEqual([]);
-    // A definite, permanent answer: asked once, not once per cycle.
+    // Repeated calls within the availability TTL reuse the definite answer.
     expect(calls.filter((k) => k === LIST_KEY)).toHaveLength(1);
     const h = wsl.getWslSensorHealth();
     expect(h.state).toBe(S.UNSUPPORTED);
@@ -268,19 +268,23 @@ describe('wsl sensor health (B-S12)', () => {
     expect(h.consecutiveFailures).toBe(0);
   });
 
-  it('wsl.exe that RAN and exited non-zero is UNSUPPORTED (no distro), not degraded', async () => {
-    // The stock Windows shape: the binary ships in System32 whether or not WSL was set
-    // up, and answers `-l -q` with a non-zero exit. Reading that as degradation would
-    // hold every such machine permanently DEGRADED.
-    wsl._setDepsForTest({
-      platform: 'win32',
-      execFile: mockExec({ [LIST_KEY]: { code: 1 } }),
-    });
-    expect(await wsl.detectWslAgents()).toEqual([]);
-    const h = wsl.getWslSensorHealth();
-    expect(h.state).toBe(S.UNSUPPORTED);
-    expect(h.detail).toBe('wsl-no-distro');
-  });
+  it.each([1, 4294967295])(
+    'a numeric exit %s is an inconclusive probe and can recover',
+    async (code) => {
+      const responses = { [LIST_KEY]: { code }, [PS_KEY]: { stdout: '42 opencode' } };
+      wsl._setDepsForTest({
+        platform: 'win32',
+        execFile: mockExec(responses),
+      });
+      expect(await wsl.detectWslAgents()).toEqual([]);
+      const h = wsl.getWslSensorHealth();
+      expect(h.state).toBe(S.DEGRADED);
+      expect(h.lastError).toBe(`wsl-probe-failed:exit${code}`);
+      responses[LIST_KEY] = { stdout: 'Ubuntu\n' };
+      expect(await wsl.detectWslAgents()).toMatchObject([{ agent: 'opencode', pid: 0 }]);
+      expect(wsl.getWslSensorHealth().state).toBe(S.HEALTHY);
+    },
+  );
 
   it('an empty distro list is UNSUPPORTED (no distro)', async () => {
     wsl._setDepsForTest({

--- a/tests/main/wsl-detector.test.js
+++ b/tests/main/wsl-detector.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import detector from '../../src/main/wsl-detector.js';
 
 /**
@@ -28,6 +28,7 @@ const LIST_KEY = '-l -q';
 
 afterEach(() => {
   detector._resetForTest();
+  vi.restoreAllMocks();
 });
 
 describe('wsl-detector', () => {
@@ -80,6 +81,67 @@ describe('wsl-detector', () => {
   });
 
   describe('isWslAvailable()', () => {
+    it.each(['empty', 'ENOENT'])(
+      'rechecks cached absence (%s) and resumes detection after one minute',
+      async (absence) => {
+        const clock = vi.spyOn(Date, 'now').mockReturnValue(1000);
+        let available = false;
+        const execFile = vi.fn((_cmd, args, _opts, cb) => {
+          if (args.join(' ') === LIST_KEY) {
+            if (available) return cb(null, 'Ubuntu\n');
+            if (absence === 'ENOENT')
+              return cb(Object.assign(new Error('missing'), { code: 'ENOENT' }), '');
+            return cb(null, '');
+          }
+          cb(null, '42 opencode serve');
+        });
+        detector._setDepsForTest({ platform: 'win32', execFile });
+        expect(await detector.detectWslAgents()).toEqual([]);
+        expect(detector.getWslSensorHealth().state).toBe('UNSUPPORTED');
+        available = true;
+        clock.mockReturnValue(60999);
+        expect(await detector.detectWslAgents()).toEqual([]);
+        expect(execFile).toHaveBeenCalledOnce();
+        clock.mockReturnValue(61000);
+        expect(await detector.detectWslAgents()).toMatchObject([{ agent: 'opencode', pid: 0 }]);
+        expect(detector.getWslSensorHealth().state).toBe('HEALTHY');
+        expect(execFile).toHaveBeenCalledTimes(3);
+      },
+    );
+
+    it('rechecks a previously available distribution and does not run ps after removal', async () => {
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(1000);
+      let listed = 'Ubuntu\n';
+      const execFile = vi.fn((_cmd, _args, _opts, cb) => cb(null, listed));
+      detector._setDepsForTest({ platform: 'win32', execFile });
+      expect(await detector.isWslAvailable()).toBe(true);
+      listed = '';
+      clock.mockReturnValue(61000);
+      expect(await detector.detectWslAgents()).toEqual([]);
+      expect(detector.getWslSensorHealth().state).toBe('UNSUPPORTED');
+      expect(execFile.mock.calls.map((call) => call[1])).toEqual([
+        ['-l', '-q'],
+        ['-l', '-q'],
+      ]);
+    });
+
+    it('reports an inconclusive retry after cached absence as degraded', async () => {
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(1000);
+      const execFile = vi.fn((_cmd, _args, _opts, cb) => cb(null, ''));
+      detector._setDepsForTest({ platform: 'win32', execFile });
+      await detector.isWslAvailable();
+      execFile.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(Object.assign(new Error('private distro path'), { killed: true }), ''),
+      );
+      clock.mockReturnValue(61000);
+      expect(await detector.isWslAvailable()).toBe(false);
+      expect(detector.getWslSensorHealth()).toMatchObject({
+        state: 'DEGRADED',
+        lastError: 'wsl-probe-failed:timeout',
+      });
+      expect(JSON.stringify(detector.getWslSensorHealth())).not.toContain('private');
+    });
+
     it('returns false on non-win32 platforms', async () => {
       detector._setDepsForTest({ platform: 'linux', execFile: mockExec({}) });
       expect(await detector.isWslAvailable()).toBe(false);


### PR DESCRIPTION
If WSL was missing or its initial listing command exited non-zero, AEGIS cached unavailability until the application restarted. Conclusive availability now expires after 60 seconds, so subsequent background refreshes detect installation, removal and recovery. Numeric non-zero exits report an inconclusive DEGRADED probe and are retried; ENOENT and a successful empty list establish absence. Retrying after UNSUPPORTED creates a fresh health record.

Six regression cases failed on the previous implementation and passed with this fix. Full coverage suite: 2,687 passed, four skipped on Windows. All ten local CI checks passed (lint: zero errors, 32 existing warnings; production audit: zero vulnerabilities). A standalone Windows smoke injected one listing failure and then used real wsl.exe, recovering DEGRADED → HEALTHY without resetting the detector.

This deliberately reports failed listing on an unconfigured WSL executable as inconclusive rather than inferring absence from its exit code. The existing default-distribution enumeration remains unchanged. No renderer, IPC, dependency or system configuration changes. Related to #8; Docker, Podman and multiple-distribution coverage remain open.
