### PR TITLE
fix: reject incomplete audit exports

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1052,3 +1052,30 @@ detector; no matching agents were found. Evidence is in X:/tmp/aegis-wsl-recover
 No renderer, IPC contract, dependency, system setting or installed-app change was
 made. This addresses reliability in the existing WSL part of issue #8; Docker,
 Podman and multi-distribution coverage remain open. No release was published.
+
+## Session handoff — reject incomplete audit exports (2026-09-07)
+
+The core bug/performance audit is recorded outside Git at
+`X:/tmp/aegis-core-audit-20260907/audit.md`. The user's subsequent "что дальше"
+continues with its first correctness fix on `codex/audit-export-completeness`.
+`audit.exportAll()` now throws if a journal file cannot be read, a nonblank line
+contains invalid JSON, or the initial flush leaves buffered events or a pending
+loss marker. Both existing JSON and ZIP handlers return failure before offering
+a destination or writing an incomplete export. Error text excludes source paths
+and JSON contents. Valid legacy records and persisted loss markers remain raw;
+paginated history still tolerates malformed lines. Export remains synchronous.
+
+Six failure cases went red before the fix and passed afterward. Added coverage
+also checks recovery, marker-only flush failure, unchanged source bytes and both
+IPC error responses. The full suite passed with 2,696 tests and four skips across
+151 files. An isolated Node harness used the real audit logger and IPC handlers
+with a simulated EACCES on the second of two journal files: both exports failed,
+no save dialog opened, and an existing destination remained unchanged. Restoring
+the read allowed both records to export. Evidence is under
+`X:/tmp/aegis-export-fix-cTZqpq`, outside Git.
+
+Next core tasks from the audit: preserve last-observed WSL agents through an
+inconclusive refresh with explicit freshness, evaluate one fresh Windows process
+snapshot per pass, then move full-export preparation off the main event loop.
+The frontend remains user-owned separate work; no renderer, dependency, system
+setting, installed-app or release change is included here.

--- a/src/main/audit-logger.js
+++ b/src/main/audit-logger.js
@@ -561,11 +561,17 @@ function getStats() {
  * real field set each version wrote, and must receive every line (including
  * `buffer-overflow-drop` markers) so the hash chain can be replayed. Use
  * `normalizeAuditEntry` on the caller side if a uniform shape is wanted.
+ * A failed read, malformed JSON line, or pending flush aborts the export: returning
+ * an earlier subset would make both export IPC handlers report incomplete history
+ * as successfully saved. Errors omit source paths and record contents.
  * @returns {Object[]} Array of all audit log entries, mixed schema versions possible.
+ * @throws {Error} When the complete retained history cannot be exported.
  * @since v0.2.0
  */
 function exportAll() {
   flush();
+  if (_buffer.length > 0 || dropTracker.pendingCount() > 0)
+    throw new Error('Audit export incomplete: some events could not be saved to the journal.');
   const all = [];
   if (!_logDir) return all;
   try {
@@ -576,17 +582,14 @@ function exportAll() {
     for (const f of files) {
       const content = fs.readFileSync(path.join(_logDir, f), 'utf-8');
       for (const line of content.split('\n')) {
-        if (line.trim()) {
-          try {
-            all.push(JSON.parse(line));
-          } catch (_) {
-            /* skip malformed line */
-          }
-        }
+        if (line.trim()) all.push(JSON.parse(line));
       }
     }
-  } catch (err) {
-    console.error('[audit-logger] exportAll failed:', err.message);
+  } catch {
+    // JSON parser and filesystem errors can quote journal contents or local paths.
+    throw new Error(
+      'Audit export incomplete: a log file could not be read or contains invalid JSON.',
+    );
   }
   return all;
 }

--- a/tests/main/audit-export.test.js
+++ b/tests/main/audit-export.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('complete audit exports', () => {
+  let audit;
+  let root;
+  const file = (day) => path.join(audit.getLogDir(), `aegis-audit-${day}.json`);
+  const write = (day, contents) => fs.writeFileSync(file(day), contents);
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-export-'));
+    vi.resetModules();
+    audit = (await import('../../src/main/audit-logger.js')).default;
+    audit.init({ userDataPath: root, loadSqlite: () => null });
+    await audit._awaitIndexForTest();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await audit._awaitIndexForTest();
+    audit.shutdown();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('exports an empty initialized journal', () => {
+    expect(audit.exportAll()).toEqual([]);
+  });
+
+  it('rejects a missing log directory instead of exporting an empty history', () => {
+    fs.rmdirSync(audit.getLogDir());
+    expect(() => audit.exportAll()).toThrow('Audit export incomplete');
+  });
+
+  it('rejects a read failure after an earlier file succeeded, then recovers', () => {
+    write('2026-09-06', '{"type":"first"}\n');
+    write('2026-09-07', '{"type":"second"}\n');
+    write('2026-09-08', '{"type":"third"}\n');
+    const read = fs.readFileSync;
+    const spy = vi.spyOn(fs, 'readFileSync').mockImplementation((p, ...args) => {
+      if (p === file('2026-09-07'))
+        throw Object.assign(new Error('private-fixture-path'), { code: 'EACCES' });
+      return read(p, ...args);
+    });
+    expect(() => audit.exportAll()).toThrow('Audit export incomplete');
+    expect(() => audit.exportAll()).not.toThrow('private-fixture-path');
+    spy.mockRestore();
+    expect(audit.exportAll().map((entry) => entry.type)).toEqual(['first', 'second', 'third']);
+  });
+
+  it('rejects malformed records without changing their source or hiding them from the failure', () => {
+    const contents = '{"type":"first"}\nnot-json-private-fixture\n{"type":"last"}\n';
+    write('2026-09-07', contents);
+    expect(() => audit.exportAll()).toThrow('Audit export incomplete');
+    expect(() => audit.exportAll()).not.toThrow('not-json-private-fixture');
+    expect(fs.readFileSync(file('2026-09-07'), 'utf8')).toBe(contents);
+  });
+
+  it('preserves raw legacy records, loss markers and unknown fields across files', () => {
+    const rows = [
+      { type: 'file-access', details: { pid: 7 }, unknownField: 'keep' },
+      { schemaVersion: 1, type: 'buffer-overflow-drop', droppedCount: 2, seq: 0, hash: 'raw' },
+    ];
+    write('2026-09-06', JSON.stringify(rows[0]) + '\r\n\r\n');
+    write('2026-09-07', JSON.stringify(rows[1]));
+    expect(audit.exportAll()).toEqual(rows);
+  });
+
+  it.each([10, 0])(
+    'rejects failed flushes with buffer cap %i and succeeds after recovery',
+    (cap) => {
+      audit.shutdown();
+      audit.init({ userDataPath: root, bufferCap: cap, loadSqlite: () => null });
+      const append = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {
+        throw Object.assign(new Error('fixture disk full'), { code: 'ENOSPC' });
+      });
+      audit.log('file-access', { agent: 'fixture' });
+      expect(() => audit.exportAll()).toThrow('Audit export incomplete');
+      append.mockRestore();
+      const rows = audit.exportAll();
+      expect(rows.map((entry) => entry.type)).toEqual([
+        cap === 0 ? 'buffer-overflow-drop' : 'file-access',
+      ]);
+      const dayFile = fs.readdirSync(audit.getLogDir()).find((name) => name.endsWith('.json'));
+      expect(audit.verifyChain(path.join(audit.getLogDir(), dayFile)).valid).toBe(true);
+    },
+  );
+});

--- a/tests/main/audit-index-fallback.test.js
+++ b/tests/main/audit-index-fallback.test.js
@@ -88,7 +88,7 @@ describe('audit index history and fallback', () => {
       expect(hashchain.verifyChain(path.join(logDir(), file)).valid).toBe(true);
   });
 
-  it('normalizes v0, skips malformed lines and markers, and preserves the raw export', async () => {
+  it('keeps partial history readable while rejecting a malformed full export', async () => {
     const rows = [
       event(`${today}T08:00:00.000Z`, 'file-access', {
         details: { pid: 42, attribution: 'confirmed' },
@@ -113,7 +113,7 @@ describe('audit index history and fallback', () => {
       status: 'confirmed',
       evidence: null,
     });
-    expect(audit.exportAll()).toEqual(rows.filter((r) => typeof r !== 'string'));
+    expect(() => audit.exportAll()).toThrow('Audit export incomplete');
   });
 
   it('binds type values and shares validation and limits with the JSONL reader', async () => {

--- a/tests/main/ipc-handlers.test.js
+++ b/tests/main/ipc-handlers.test.js
@@ -199,6 +199,28 @@ describe('ipc-handlers', () => {
     return handlers[channel];
   }
 
+  it.each(['export-full-audit', 'export-zip'])(
+    '%s reports incomplete history without offering or writing a partial file',
+    async (channel) => {
+      ipcHandlers.init({ getWindow: () => null });
+      ipcHandlers.register();
+      mockElectron.dialog.showSaveDialog.mockClear();
+      const write = vi.spyOn(fs, 'writeFileSync');
+      const message =
+        'Audit export incomplete: a log file could not be read or contains invalid JSON.';
+      mockAudit.exportAll.mockImplementationOnce(() => {
+        throw new Error(message);
+      });
+      try {
+        expect(await getHandler(channel)()).toEqual({ success: false, error: message });
+        expect(mockElectron.dialog.showSaveDialog).not.toHaveBeenCalled();
+        expect(write).not.toHaveBeenCalled();
+      } finally {
+        write.mockRestore();
+      }
+    },
+  );
+
   it('update operations only accept the owned main frame and never forward caller parameters', () => {
     const frame = {};
     const window = { isDestroyed: () => false, webContents: { mainFrame: frame } };


### PR DESCRIPTION
A failed read midway through the audit journal previously returned the records collected so far, and both JSON and ZIP exports reported success. Malformed lines and failed flushes could also silently omit history.

The audit exporter now rejects unreadable files, malformed JSON and pending events or loss markers after flushing. Existing IPC handlers return failure before opening the save dialog or writing a destination. Errors exclude file paths and record contents. Valid raw records and persisted loss markers are preserved; paginated history remains readable when a line is malformed.

Validation: six failure cases reproduced before the fix; 2,696 tests passed with four skipped across 151 files. Renderer build, format, lint (zero errors; 31 existing warnings), both type checks, both mutation gates, counts and production dependency audit passed. An isolated harness using the real logger and IPC handlers confirmed that a second-file EACCES fails both export formats without touching an existing destination, then exports both records after recovery.

Full-export memory use and synchronous preparation remain separate follow-up work.
