### PR TITLE
fix: retain stale WSL observations through discovery outages

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1079,3 +1079,18 @@ inconclusive refresh with explicit freshness, evaluate one fresh Windows process
 snapshot per pass, then move full-export preparation off the main event loop.
 The frontend remains user-owned separate work; no renderer, dependency, system
 setting, installed-app or release change is included here.
+
+## Session handoff — retain WSL observations during outages (2026-09-07)
+
+The user authorized all remaining core audit items. `codex/wsl-retain-observations`
+keeps the last successfully discovered WSL agents when enumeration is inconclusive.
+Published copies carry `discoveryObservation: { observedAt, stale }`; an overdue
+refresh or degraded sensor sets stale without advancing the observed timestamp.
+Successful enumeration replaces the cache, including a confirmed empty fleet;
+confirmed distro absence clears it. Copying records prevents enrichment or consumers
+from mutating the detector cache. The existing health channel still reports outages.
+No renderer work is included; the separate frontend can consume the new optional
+freshness metadata. Targeted WSL, health and scan-loop tests passed (115 tests).
+
+Remaining authorized audit work: one Windows process observation per scan,
+background/streaming full exports, and bounded lifecycle of baseline instance data.

--- a/src/main/wsl-detector.js
+++ b/src/main/wsl-detector.js
@@ -100,6 +100,7 @@ function _resetForTest() {
   _availabilityCheckedAt = null;
   _cache = [];
   _lastRefresh = 0;
+  _lastObservedAt = null;
   _refreshing = false;
   _health = createInitialHealth();
 }
@@ -134,6 +135,7 @@ let _availabilityCheckedAt = null;
 /** @type {Array<Object>} Last detected synthetic agents */
 let _cache = [];
 let _lastRefresh = 0;
+let _lastObservedAt = null;
 let _refreshing = false;
 
 // ═══ INTERNAL ═══
@@ -306,7 +308,13 @@ function getCachedWslAgents() {
     _refreshing = true;
     detectWslAgents()
       .then((agents) => {
-        _cache = agents;
+        if (_health.state === sensorHealth.SENSOR_HEALTH_STATE.HEALTHY) {
+          _cache = agents;
+          _lastObservedAt = _health.lastSuccessAt;
+        } else if (_health.state === sensorHealth.SENSOR_HEALTH_STATE.UNSUPPORTED) {
+          _cache = [];
+          _lastObservedAt = null;
+        }
       })
       .catch((err) => {
         // `detectWslAgents` writes its own record on every path it can reach, so an
@@ -324,7 +332,18 @@ function getCachedWslAgents() {
         _refreshing = false;
       });
   }
-  return _cache;
+  // An unread list cannot establish an exit. Publish the last observation with
+  // its original time, explicitly stale during an outage or an overdue refresh.
+  // Copies keep scan enrichment from mutating the detector's observation cache.
+  const stale =
+    _health.state !== sensorHealth.SENSOR_HEALTH_STATE.HEALTHY ||
+    _lastObservedAt === null ||
+    now < _lastObservedAt ||
+    now - _lastObservedAt > REFRESH_TTL_MS;
+  return _cache.map((agent) => ({
+    ...agent,
+    discoveryObservation: { observedAt: _lastObservedAt, stale },
+  }));
 }
 
 module.exports = {

--- a/src/shared/types/process.ts
+++ b/src/shared/types/process.ts
@@ -67,6 +67,8 @@ export interface DetectedAgent {
   readonly pid: number;
   readonly status: 'running';
   readonly category: string;
+  /** Last successful external discovery; stale observations do not establish current liveness. */
+  readonly discoveryObservation?: { readonly observedAt: number | null; readonly stale: boolean };
   readonly parentEditor?: string | null;
   readonly cwd?: string | null;
   readonly projectName?: string | null;

--- a/tests/main/wsl-detector.test.js
+++ b/tests/main/wsl-detector.test.js
@@ -243,6 +243,73 @@ describe('wsl-detector', () => {
   });
 
   describe('getCachedWslAgents()', () => {
+    it.each(['ps-error', 'empty-ps', 'probe-error'])(
+      'retains a dated stale observation after %s and replaces it on recovery',
+      async (failure) => {
+        const clock = vi.spyOn(Date, 'now').mockReturnValue(1000);
+        let phase = 'healthy';
+        detector._setDepsForTest({
+          platform: 'win32',
+          execFile: (_cmd, args, _opts, cb) => {
+            const listing = args.join(' ') === LIST_KEY;
+            if (
+              phase === 'failed' &&
+              (listing ? failure === 'probe-error' : failure === 'ps-error')
+            )
+              return cb(Object.assign(new Error('fixture failure'), { code: 1 }), '');
+            if (listing) return cb(null, 'Ubuntu');
+            cb(null, phase === 'empty' ? '1 /sbin/init' : phase === 'failed' ? '' : '42 opencode');
+          },
+        });
+        detector.getCachedWslAgents();
+        await new Promise(setImmediate);
+        const first = detector.getCachedWslAgents();
+        expect(first[0].discoveryObservation).toEqual({ observedAt: 1000, stale: false });
+        first[0].agent = 'consumer mutation';
+        phase = 'failed';
+        clock.mockReturnValue(61001);
+        expect(detector.getCachedWslAgents()[0].discoveryObservation.stale).toBe(true);
+        await new Promise(setImmediate);
+        expect(detector.getCachedWslAgents()).toMatchObject([
+          { agent: 'opencode', discoveryObservation: { observedAt: 1000, stale: true } },
+        ]);
+        expect(detector.getWslSensorHealth().state).toBe('DEGRADED');
+        phase = 'healthy';
+        clock.mockReturnValue(121002);
+        detector.getCachedWslAgents();
+        await new Promise(setImmediate);
+        expect(detector.getCachedWslAgents()[0].discoveryObservation).toEqual({
+          observedAt: 121002,
+          stale: false,
+        });
+        phase = 'empty';
+        clock.mockReturnValue(181003);
+        detector.getCachedWslAgents();
+        await new Promise(setImmediate);
+        expect(detector.getCachedWslAgents()).toEqual([]);
+        expect(detector.getWslSensorHealth().state).toBe('HEALTHY');
+      },
+    );
+
+    it('clears a cached agent when distro absence is confirmed', async () => {
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(1000);
+      let installed = true;
+      detector._setDepsForTest({
+        platform: 'win32',
+        execFile: (_cmd, args, _opts, cb) =>
+          cb(null, args.join(' ') === LIST_KEY ? (installed ? 'Ubuntu' : '') : '42 opencode'),
+      });
+      detector.getCachedWslAgents();
+      await new Promise(setImmediate);
+      expect(detector.getCachedWslAgents()).toHaveLength(1);
+      installed = false;
+      clock.mockReturnValue(61001);
+      detector.getCachedWslAgents();
+      await new Promise(setImmediate);
+      expect(detector.getCachedWslAgents()).toEqual([]);
+      expect(detector.getWslSensorHealth().state).toBe('UNSUPPORTED');
+    });
+
     it('returns [] immediately, then caches after the background refresh', async () => {
       detector._setDepsForTest({
         platform: 'win32',


### PR DESCRIPTION
An inconclusive WSL refresh previously replaced known agents with an empty list. Retain the last successful observation during failures and publish optional discoveryObservation timestamps/staleness on copies. Confirmed absence still clears the cache, and recovery replaces it with fresh results.

Validation: 115 targeted WSL, detector-health and scan-loop tests passed, plus format, renderer build, lint and typecheck. Regression cases cover process/probe failures, empty ps output, recovery, confirmed absence and consumer mutation. No renderer changes.
