### PR TITLE
perf: share fresh Windows process observations across scan stages

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1094,3 +1094,25 @@ freshness metadata. Targeted WSL, health and scan-loop tests passed (115 tests).
 
 Remaining authorized audit work: one Windows process observation per scan,
 background/streaming full exports, and bounded lifecycle of baseline instance data.
+
+## Session handoff — shared Windows process observation (2026-09-07)
+
+`codex/shared-process-observation` requests a fresh Windows process map in the
+scanner and passes that same map to identity enrichment. Healthy named snapshots
+supply population too, avoiding tasklist. Empty/nameless maps retain the tasklist
+population fallback, while even an empty map is passed through so enrichment cannot
+make a second observation. No map or birth time is stored across passes. Direct
+scanner callers and platforms without birth-time support keep the previous path.
+
+Tests cover same-name PID reuse inside the cache TTL, outage/recovery without
+session splits, every configured signature's parity, fallback and scan-loop wiring.
+The umbrella harness now supplies its simulated snapshot at the new observation
+boundary. Full coverage and both mutation gates passed, alongside build, formatting,
+lint, typecheck and counts. Six interleaved native Windows comparisons found 13
+agents in both paths: population plus identity took 388–491 ms on the old path and
+6.4–9.1 ms on the shared path (warm class5 snapshots). This excludes cwd, file/network
+scans and UI work; it is not an application-wide speedup claim. Samples are in
+`X:/tmp/aegis-core-audit-20260907/shared-snapshot-bench.json`.
+
+Remaining authorized audit work: streaming/background full exports and baseline
+instance lifecycle. Frontend and releases remain outside this work.

--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -19,6 +19,7 @@ const { IGNORE_PROCESS_PATTERNS, EDITOR_HOSTS } = require('../shared/constants')
 const sensorHealth = require('./sensor-health');
 const _platform = require('./platform');
 let _listProcesses = _platform.listProcesses;
+let _getParentProcessMap = _platform.getParentProcessMap;
 // Identity-quality inputs, mirrored as overridable locals the same way process-utils.js
 // holds `providesStartTime` — so a test can state a platform's identity story without
 // pretending to be that platform.
@@ -192,6 +193,7 @@ function noteProcessScanHardFailure(err) {
 /** @internal Override platform functions (for tests). */
 function _setPlatformForTest(overrides) {
   if (overrides.listProcesses) _listProcesses = overrides.listProcesses;
+  if (overrides.getParentProcessMap) _getParentProcessMap = overrides.getParentProcessMap;
   if (typeof overrides.providesStartTime === 'boolean') {
     _providesStartTime = overrides.providesStartTime;
   }
@@ -204,6 +206,7 @@ function _resetForTest() {
   _processHealth = sensorHealth.createSensorHealth(PROCESS_SENSOR_ID);
   _providesStartTime = _platform.providesStartTime === true;
   _getSnapshotHealth = null;
+  _getParentProcessMap = _platform.getParentProcessMap;
 }
 
 let _agentDb = null;
@@ -246,12 +249,15 @@ function init(deps) {
  * Scan running processes via tasklist and match against AI_AGENTS.
  * Editor hosts (VS Code etc.) are skipped themselves, but their child
  * processes are scanned — matched children get parentEditor set.
- * @returns {Promise<{agents: Array, changed: boolean, reliable: boolean}>}
+ * @param {{sharedObservation?: boolean}} [opts] - request one fresh Windows map
+ *   for both population and identity; the returned map belongs to this pass only.
+ * @returns {Promise<{agents: Array, changed: boolean, reliable: boolean, processMap?: Map}>}
  * @since v0.2.0
  */
-async function scanProcesses() {
+async function scanProcesses(opts = {}) {
   _ensureAgentDb();
   let processes;
+  let processMap;
   // A scan is "reliable" only when the process list was actually enumerated.
   // A permission-denied scan returns an empty list that must NOT be read as
   // "all agents exited" — the session tracker uses this flag to ignore it.
@@ -261,7 +267,17 @@ async function scanProcesses() {
   let reliable = true;
   const now = Date.now();
   try {
-    processes = await _listProcesses();
+    if (_providesStartTime && opts.sharedObservation === true) {
+      processMap = await _getParentProcessMap();
+      const rows = [...processMap].map(([pid, info]) => ({ pid, name: info.name }));
+      // An empty or nameless map cannot establish the population. Keep tasklist
+      // as the reserve population source, but carry even the empty observation to
+      // enrichment so it cannot silently retry and change this pass's evidence.
+      processes =
+        rows.length > 0 && rows.every((row) => typeof row.name === 'string' && row.name.length > 0)
+          ? rows
+          : await _listProcesses();
+    } else processes = await _listProcesses();
     permissionDeniedScans = 0;
   } catch (err) {
     const code = err.code || '';
@@ -354,7 +370,12 @@ async function scanProcesses() {
   if (reliable) {
     _processHealth = sensorHealth.markHealthy(_processHealth, now);
   }
-  return { agents: unique, changed, reliable };
+  return {
+    agents: unique,
+    changed,
+    reliable,
+    ...(processMap instanceof Map ? { processMap } : {}),
+  };
 }
 
 module.exports = {

--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -301,11 +301,12 @@ async function getParentChains(pids, opts = {}) {
  * @param {Array} agents
  * @param {boolean} forceRefresh - rebuild every chain from this map regardless of
  *   what the cache holds.
+ * @param {Map} [observedMap] - fresh population observation from this same scan.
  * @returns {Promise<void>}
  * @since v0.12.0
  */
-async function _stampFromFreshBirthTimes(agents, forceRefresh) {
-  const procMap = await _getParentProcessMap();
+async function _stampFromFreshBirthTimes(agents, forceRefresh, observedMap) {
+  const procMap = observedMap instanceof Map ? observedMap : await _getParentProcessMap();
   const now = Date.now();
   _pruneStale(parentChainCache, PARENT_CHAIN_TTL, now);
 
@@ -431,13 +432,14 @@ async function _stampFromCachedChains(agents, forceRefresh) {
  * @param {boolean} [opts.forceRefresh=false] - rebuild every parent chain from the
  *   observed map instead of trusting cached entries. The identity stamp no longer
  *   depends on it: the birth time is re-observed on every pass either way.
+ * @param {Map} [opts.processMap] - this pass's population observation, never a cached map.
  * @returns {Promise<void>}
  * @since v0.1.0
  */
 async function enrichWithParentChains(agents, opts = {}) {
   if (agents.length === 0) return;
   const forceRefresh = opts.forceRefresh === true;
-  if (_providesStartTime) await _stampFromFreshBirthTimes(agents, forceRefresh);
+  if (_providesStartTime) await _stampFromFreshBirthTimes(agents, forceRefresh, opts.processMap);
   else await _stampFromCachedChains(agents, forceRefresh);
   for (const a of agents) {
     const identity = identify(a);

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -409,7 +409,7 @@ async function doProcessScan() {
     const gapBefore = deps.observationGap ? deps.observationGap.snapshot() : null;
     let result;
     try {
-      result = await scanner.scanProcesses();
+      result = await scanner.scanProcesses({ sharedObservation: true });
     } catch (err) {
       // B-S02: hard failure — a non-EPERM rethrow from scanProcesses (the EPERM path
       // marks FAILED inside the scanner and returns normally, so it never lands here).
@@ -428,24 +428,13 @@ async function doProcessScan() {
     // process's session. That ordering is the correctness boundary: the fresh
     // identity observation MUST finish before sessionTracker.reconcile below.
     //
-    // Freshness does NOT come from `forceRefresh`. On win32 every non-empty pass
-    // observes the birth time from one new process map (process-utils.js
-    // `_stampFromFreshBirthTimes`) and stamps that observed value, cached or not;
-    // `forceRefresh` now only decides whether the parent CHAIN is re-walked from
-    // that already-fetched map instead of served from the cache entry, so it adds
-    // no provider call of its own.
-    //
-    // It is not free. `scanner.scanProcesses` enumerates with `tasklist`, and
-    // `getParentProcessMap` has no other caller on this tick, so a fully cached
-    // Windows pass now pays one process-map observation it previously skipped. That
-    // observation is the snapshot sidecar's `snap` request; the `cim-parent`
-    // PowerShell observation is the EMERGENCY FALLBACK behind it, not the per-tick
-    // cost (platform/process-snapshot.js). Measured in
-    // docs/bench/generation-v2-2026-08-12.md, one machine / one sample / 519
-    // processes: sidecar warm p50 9.1 ms, p95 11.3 ms; cold spawn+handshake p50
-    // 67.3 ms; that run's CIM arm p50 1747.6 ms, p95 1873.6 ms, max 2144.0 ms.
-    // Samples, not guaranteed runtimes.
-    await procUtil.enrichWithParentChains(agents, { forceRefresh: result.changed === true });
+    // Windows population and identity consume the same fresh observation. The map
+    // is local to this pass, including an empty failed observation; no birth time
+    // is taken from a cache and enrichment must not make a second provider call.
+    await procUtil.enrichWithParentChains(agents, {
+      forceRefresh: result.changed === true,
+      ...(result.processMap instanceof Map ? { processMap: result.processMap } : {}),
+    });
     // The second half of the straddle witness — after the identity stamp, so a sleep
     // inside `enrichWithParentChains` is caught as well as one inside the enumeration.
     const gapStraddled =

--- a/tests/main/helpers/health-umbrella-harness.js
+++ b/tests/main/helpers/health-umbrella-harness.js
@@ -503,7 +503,14 @@ export function createHarness(shims, opts = {}) {
   function installSnapshotLeaf(state, detail = null) {
     let current = leafRecord('proc-snapshot', state, detail);
     const read = () => current;
-    scanner._setPlatformForTest({ providesStartTime: true, getSnapshotHealth: read });
+    scanner._setPlatformForTest({
+      providesStartTime: true,
+      getSnapshotHealth: read,
+      getParentProcessMap: async () =>
+        current.state === 'FAILED'
+          ? new Map()
+          : new Map((await listProcesses()).map((row) => [row.pid, { name: row.name, ppid: 0 }])),
+    });
     fakePlatform.getSnapshotHealth = read;
     return (next, nextDetail = null) => {
       current = leafRecord('proc-snapshot', next, nextDetail);

--- a/tests/main/process-observation.test.js
+++ b/tests/main/process-observation.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import scanner from '../../src/main/process-scanner.js';
+import utils from '../../src/main/process-utils.js';
+import sessions from '../../src/main/session-tracker.js';
+
+describe('shared Windows process observation', () => {
+  let observe;
+  let list;
+  let extraObserve;
+  const map = (birth, parent = 'code.exe') =>
+    new Map([
+      [100, { name: 'claude.exe', ppid: 200, startTime: birth }],
+      [200, { name: parent, ppid: 0, startTime: 1 }],
+    ]);
+
+  beforeEach(() => {
+    scanner._resetForTest();
+    utils._resetForTest();
+    sessions._resetForTest();
+    observe = vi.fn();
+    list = vi.fn().mockResolvedValue([{ pid: 100, name: 'claude.exe' }]);
+    extraObserve = vi.fn(() => {
+      throw new Error('unexpected second observation');
+    });
+    scanner._setPlatformForTest({
+      providesStartTime: true,
+      getParentProcessMap: observe,
+      listProcesses: list,
+    });
+    utils._setPlatformForTest({ providesStartTime: true, getParentProcessMap: extraObserve });
+  });
+
+  afterEach(() => {
+    scanner._resetForTest();
+    utils._resetForTest();
+    sessions._resetForTest();
+  });
+
+  async function pass() {
+    const result = await scanner.scanProcesses({ sharedObservation: true });
+    await utils.enrichWithParentChains(result.agents, {
+      forceRefresh: result.changed,
+      processMap: result.processMap,
+    });
+    return result;
+  }
+
+  it('observes each pass once and detects same-name PID reuse inside the cache TTL', async () => {
+    observe.mockResolvedValueOnce(map(1000)).mockResolvedValueOnce(map(2000, 'fixture-editor.exe'));
+    const first = await pass();
+    const second = await pass();
+    expect(first.agents[0]).toMatchObject({ instanceId: '100:1000', parentChain: ['code.exe'] });
+    expect(second.changed).toBe(false);
+    expect(second.agents[0]).toMatchObject({
+      instanceId: '100:2000',
+      parentChain: ['fixture-editor.exe'],
+    });
+    expect(observe).toHaveBeenCalledTimes(2);
+    expect(list).not.toHaveBeenCalled();
+    expect(extraObserve).not.toHaveBeenCalled();
+  });
+
+  it('retains tasklist fallback and freezes identity through a failed observation', async () => {
+    let health = 'HEALTHY';
+    scanner._setPlatformForTest({ getSnapshotHealth: () => ({ state: health }) });
+    observe
+      .mockResolvedValueOnce(map(1000))
+      .mockResolvedValueOnce(new Map())
+      .mockResolvedValueOnce(map(1000));
+    const first = await pass();
+    expect(sessions.reconcile(first.agents).entered).toHaveLength(1);
+    health = 'FAILED';
+    const outage = await pass();
+    expect(outage.reliable).toBe(true);
+    expect(outage.agents[0].startTime).toBeNull();
+    expect(scanner.isIdentityDegraded()).toBe(true);
+    expect(
+      sessions.reconcile(outage.agents, { identityDegraded: scanner.isIdentityDegraded() }),
+    ).toEqual({ entered: [], exited: [] });
+    health = 'HEALTHY';
+    const recovered = await pass();
+    expect(sessions.reconcile(recovered.agents)).toEqual({ entered: [], exited: [] });
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(observe).toHaveBeenCalledTimes(3);
+    expect(extraObserve).not.toHaveBeenCalled();
+  });
+
+  it('uses the ordinary list on a platform without birth-time observations', async () => {
+    scanner._setPlatformForTest({ providesStartTime: false });
+    const result = await scanner.scanProcesses({ sharedObservation: true });
+    expect(result.agents).toHaveLength(1);
+    expect(result.processMap).toBeUndefined();
+    expect(observe).not.toHaveBeenCalled();
+  });
+
+  it('does not interpret nameless snapshots as an empty agent fleet', async () => {
+    observe.mockResolvedValue(new Map([[100, { name: '', startTime: 1000 }]]));
+    expect((await pass()).agents).toHaveLength(1);
+    expect(list).toHaveBeenCalledOnce();
+  });
+
+  it('matches the legacy path for every configured process-name signature', async () => {
+    const rows = scanner.AI_AGENTS.flatMap((agent) => agent.patterns).map((name, i) => ({
+      name,
+      pid: i + 1,
+    }));
+    list.mockResolvedValue(rows);
+    observe.mockResolvedValue(
+      new Map(rows.map(({ pid, name }) => [pid, { name, ppid: 0, startTime: 1000 }])),
+    );
+    const legacy = await scanner.scanProcesses();
+    const shared = await scanner.scanProcesses({ sharedObservation: true });
+    expect(shared.agents).toEqual(legacy.agents);
+    expect(shared.changed).toBe(false);
+    expect(list).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/main/scan-loop-provider-health.test.js
+++ b/tests/main/scan-loop-provider-health.test.js
@@ -102,7 +102,7 @@ describe('scan-loop provider-health ownership (Stage-1 step A)', () => {
     scanner = require_('../../src/main/process-scanner.js');
     listProcesses = vi.fn().mockResolvedValue([{ name: 'chrome', pid: 1 }]);
     scanner._resetForTest();
-    scanner._setPlatformForTest({ listProcesses });
+    scanner._setPlatformForTest({ listProcesses, providesStartTime: false });
     scanner.init({ trackSeenAgent: vi.fn() });
     scanner.peakAgents = 0;
 

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -946,12 +946,12 @@ describe('scan-loop', () => {
 
   describe('annotateWorkingDirs forceRefresh wiring', () => {
     /** @param {boolean} changed @returns {Promise<Object>} the procUtil mock after one scan */
-    async function scanWithChanged(changed) {
+    async function scanWithChanged(changed, processMap) {
       const mockDeps = makeDeps({
         scanner: {
           scanProcesses: vi
             .fn()
-            .mockResolvedValue({ agents: [{ agent: 'Cursor', pid: 300 }], changed }),
+            .mockResolvedValue({ agents: [{ agent: 'Cursor', pid: 300 }], changed, processMap }),
         },
       });
       scanLoop.init(mockDeps);
@@ -969,6 +969,12 @@ describe('scan-loop', () => {
       expect(procUtil.enrichWithParentChains).toHaveBeenCalledWith(expect.any(Array), {
         forceRefresh: true,
       });
+    });
+
+    it('passes the exact population observation through to identity enrichment', async () => {
+      const processMap = new Map([[300, { name: 'cursor.exe', startTime: 1000 }]]);
+      const procUtil = await scanWithChanged(false, processMap);
+      expect(procUtil.enrichWithParentChains.mock.calls[0][1].processMap).toBe(processMap);
     });
 
     it('passes forceRefresh false on an unchanged pid set, so the cache still serves', async () => {


### PR DESCRIPTION
Windows process scans previously enumerated with tasklist and then fetched a separate fresh process map for identity. The scan loop now uses one fresh map for both population and enrichment. Empty or nameless snapshots retain tasklist as a population fallback; the failed observation still reaches enrichment, preventing a second read or cached birth time from replacing it. Other platforms and direct scanner callers retain their existing path.

Validation: 2,706 tests passed, four skipped; build, format, lint, typecheck, counts and both mutation gates passed. Added full-signature parity, same-name PID reuse, observation forwarding and outage/recovery checks. Six interleaved Windows comparisons found 13 agents in each path: enumeration plus identity took 388–491 ms before and 6.4–9.1 ms with shared warm class5 observations. These figures exclude cwd, network/file scans and UI work.
