### PR TITLE
perf: stream audit exports with atomic destination replacement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Explicit user instructions take precedence over anything in AGENTS.md or a skill
 
 ## Project facts
 
-`src/main/` contains 65 main modules: 53 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
+`src/main/` contains 66 main modules: 54 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
 
 A birth time is observed on the pass that stamps it or is `null`; no cache stores one. A snapshot outage freezes sessions and never splits them. For changes touching identity stamping, the audit chain, or the Windows git worktree flow, `memory-bank/ai-mistakes.md` holds the relevant failure history.
 

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **65** = 53 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **66** = 54 top-level + 10 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **50** (plus `src/renderer/App.svelte` → **51** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **16** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 65 CommonJS modules (53 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 66 CommonJS modules (54 top-level + 10 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1116,3 +1116,32 @@ scans and UI work; it is not an application-wide speedup claim. Samples are in
 
 Remaining authorized audit work: streaming/background full exports and baseline
 instance lifecycle. Frontend and releases remain outside this work.
+
+## Session handoff — streamed full audit exports (2026-09-07)
+
+`codex/stream-audit-exports` moves JSON/ZIP exports to asynchronous, backpressured
+file processing. The save dialog precedes journal work. `prepareExport()` flushes
+and captures file byte ranges; the exporter reads only those ranges in 64 KiB
+chunks, yields between chunks and rejects records over 1 MiB. ZIP compression is
+asynchronous with CRC/data descriptors. Existing synchronous `exportAll()` remains
+for direct callers, but neither export IPC handler uses it. Both formats write a
+private temporary file beside the destination and rename only after successful
+read/parse/write/sync/close. Failures clean up the temporary file; overlapping
+exports and replacing source paths are rejected. Crash cleanup of temporary files
+and ZIP64 archives are not implemented. Paginated history is unchanged.
+
+The full suite passed: 2,718 tests, four skips, 153 files. Added malformed/missing/
+truncated/oversize source, recovery, failed replacement, source protection, snapshot
+cutoff, concurrency, event-loop yield, ZIP directory/CRC and IPC cancellation/key
+redaction checks. Format, build, lint, typecheck and counts passed. The new module
+updates the derived inventory to 66 main modules (54 top-level).
+
+On the same artificial 35.95 MiB/100,000-record journal as the audit, JSON finished
+in 312 ms (largest 5 ms timer gap 15.69 ms, sampled RSS increase 17.66 MiB); ZIP in
+468 ms (largest gap 6.38 ms, RSS increase 21.77 MiB). Earlier synchronous ZIP
+preparation blocked a timer for 588 ms and increased RSS by 174.65 MiB. These are
+single local Node samples with different RSS sampling methods, not guarantees.
+Python zipfile independently checked the ZIP CRCs and read all 100,000 records.
+Artifacts are under `X:/tmp/aegis-core-audit-20260907/stream-bench*`.
+
+Remaining authorized audit item: retire completed baseline instance data safely.

--- a/src/main/audit-export-stream.js
+++ b/src/main/audit-export-stream.js
@@ -1,0 +1,118 @@
+/** @file Bounded JSON/ZIP audit exports with atomic destination replacement. @since 0.15.0 */
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const { randomUUID } = require('node:crypto');
+const { setImmediate: yieldTurn } = require('node:timers/promises');
+const { writeZip } = require('./zip-writer');
+
+const CHUNK_BYTES = 64 * 1024;
+const MAX_LINE_BYTES = 1024 * 1024;
+let busy = false;
+
+async function* jsonChunks(files, stats) {
+  yield Buffer.from('[');
+  let output = '';
+  const append = (line) => {
+    if (!line.trim()) return;
+    if (Buffer.byteLength(line) > MAX_LINE_BYTES) throw new Error('record-limit');
+    output += (stats.count++ ? ',\n' : '\n') + JSON.stringify(JSON.parse(line));
+  };
+  for (const file of files) {
+    const handle = await fs.promises.open(file.path, 'r');
+    try {
+      const stat = await handle.stat();
+      if (stat.ino !== file.ino || stat.dev !== file.dev || stat.size < file.size)
+        throw new Error('source-changed');
+      if (!file.size) continue;
+      const input = handle.createReadStream({
+        encoding: 'utf8',
+        highWaterMark: CHUNK_BYTES,
+        end: file.size - 1,
+        autoClose: false,
+      });
+      let pending = '';
+      let bytes = 0;
+      for await (const chunk of input) {
+        bytes += Buffer.byteLength(chunk);
+        pending += chunk;
+        const lines = pending.split('\n');
+        pending = lines.pop();
+        for (const line of lines) {
+          append(line);
+          if (output.length >= CHUNK_BYTES) {
+            yield Buffer.from(output);
+            output = '';
+          }
+        }
+        if (Buffer.byteLength(pending) > MAX_LINE_BYTES) throw new Error('record-limit');
+        // Bound the main-thread parse/CRC work even when the disk is fully cached.
+        await yieldTurn();
+      }
+      if (bytes !== file.size) throw new Error('source-truncated');
+      append(pending);
+      if (output.length >= CHUNK_BYTES) {
+        yield Buffer.from(output);
+        output = '';
+      }
+    } finally {
+      await handle.close();
+    }
+  }
+  yield Buffer.from(output + '\n]\n');
+}
+
+/**
+ * Export the captured byte ranges, never an unbounded live journal tail.
+ * The destination is replaced only after every read, parse, write and close succeeds.
+ * @param {{filePath: string, files: Array<{path: string, size: number, ino: number, dev: number}>,
+ *   zip?: boolean, extraEntries?: Array<{name: string, data: object}>}} options
+ * @returns {Promise<{success: true, path: string, count: number}>}
+ * @since 0.15.0
+ */
+async function writeAuditExport({ filePath, files, zip = false, extraEntries = [] }) {
+  if (busy) throw new Error('An audit export is already running.');
+  const resolved = path.resolve(filePath);
+  const key = (p) =>
+    process.platform === 'win32' ? path.resolve(p).toLowerCase() : path.resolve(p);
+  if (files.some((file) => key(file.path) === key(resolved)))
+    throw new Error('Choose an export destination outside the source journal files.');
+  busy = true;
+  const temporary = path.join(path.dirname(resolved), `.aegis-export-${randomUUID()}.tmp`);
+  let handle;
+  try {
+    handle = await fs.promises.open(temporary, 'wx', 0o600);
+    const stats = { count: 0 };
+    const chunks = jsonChunks(files, stats);
+    const write = async (chunk) => {
+      await handle.writeFile(chunk);
+    };
+    if (zip) {
+      const entries = [{ name: 'audit-log.json', chunks }];
+      for (const entry of extraEntries)
+        entries.push({
+          name: entry.name,
+          chunks: [Buffer.from(JSON.stringify(entry.data, null, 2))],
+        });
+      await writeZip(entries, write);
+    } else {
+      for await (const chunk of chunks) await write(chunk);
+    }
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await fs.promises.rename(temporary, resolved);
+    return { success: true, path: resolved, count: stats.count };
+  } catch {
+    // Neither a parser excerpt nor a filesystem path belongs in the IPC error.
+    throw new Error(
+      'Audit export incomplete: a source is unreadable, invalid or too large, or the destination could not be written.',
+    );
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+    await fs.promises.unlink(temporary).catch(() => {});
+    busy = false;
+  }
+}
+
+module.exports = { writeAuditExport };

--- a/src/main/audit-logger.js
+++ b/src/main/audit-logger.js
@@ -595,6 +595,33 @@ function exportAll() {
 }
 
 /**
+ * Capture the retained journal's byte ranges after flushing, for a streamed export.
+ * Later appends are outside this export; unavailable sources abort it.
+ * @returns {Array<{path: string, size: number, ino: number, dev: number}>}
+ * @since 0.15.0
+ */
+function prepareExport() {
+  flush();
+  if (_buffer.length > 0 || dropTracker.pendingCount() > 0)
+    throw new Error('Audit export incomplete: some events could not be saved to the journal.');
+  try {
+    if (!_logDir) throw new Error('uninitialized');
+    return fs
+      .readdirSync(_logDir)
+      .filter((name) => name.startsWith('aegis-audit-') && name.endsWith('.json'))
+      .sort()
+      .map((name) => {
+        const filePath = path.join(_logDir, name);
+        const stat = fs.statSync(filePath);
+        if (!stat.isFile()) throw new Error('not-a-file');
+        return { path: filePath, size: stat.size, ino: stat.ino, dev: stat.dev };
+      });
+  } catch {
+    throw new Error('Audit export incomplete: the journal files could not be read.');
+  }
+}
+
+/**
  * Stop the flush timer, flush the remaining buffer, then close the index — after the flush,
  * so the last batch reaches the tables; disarmed first, so an open still pending on its
  * `setImmediate` never runs after this.
@@ -795,6 +822,7 @@ module.exports = {
   shutdown,
   getStats,
   exportAll,
+  prepareExport,
   getEntriesBefore,
   verifyChain: hashchain.verifyChain,
   getLogDir: () => _logDir,

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -13,7 +13,7 @@ const analysis = require('./ai-analysis');
 const exporter = require('./exports');
 const audit = require('./audit-logger');
 const { killProcess, suspendProcess, resumeProcess } = require('./platform');
-const zipWriter = require('./zip-writer');
+const { writeAuditExport } = require('./audit-export-stream');
 const { getAllRules, reloadRules } = require('./rule-loader');
 const blocklist = require('./blocklist');
 const logger = require('./logger');
@@ -297,7 +297,6 @@ ${findingsHtml}${recsHtml}
 
   ipcMain.handle('export-full-audit', async () => {
     try {
-      const all = audit.exportAll();
       const defaultName = `aegis-full-audit-${new Date().toISOString().slice(0, 10)}.json`;
       const { filePath } = await dialog.showSaveDialog(deps.getWindow(), {
         title: 'Export Full Audit Log',
@@ -305,8 +304,7 @@ ${findingsHtml}${recsHtml}
         filters: [{ name: 'JSON', extensions: ['json'] }],
       });
       if (!filePath) return { success: false };
-      fs.writeFileSync(filePath, JSON.stringify(all, null, 2));
-      return { success: true, path: filePath, count: all.length };
+      return await writeAuditExport({ filePath, files: audit.prepareExport() });
     } catch (error) {
       logger.error(`IPC export-full-audit failed: ${error.message}`);
       return { success: false, error: error.message };
@@ -379,19 +377,6 @@ ${findingsHtml}${recsHtml}
   // ── Zip export ──
   ipcMain.handle('export-zip', async () => {
     try {
-      const settingsCopy = { ...config.getSettings() };
-      delete settingsCopy.anthropicApiKey;
-      delete settingsCopy._encryptedApiKey;
-      delete settingsCopy.apiKey;
-      const entries = [
-        { name: 'audit-log.json', data: Buffer.from(JSON.stringify(audit.exportAll(), null, 2)) },
-        {
-          name: 'activity-log.json',
-          data: Buffer.from(JSON.stringify(scanner.activityLog.slice(-5000), null, 2)),
-        },
-        { name: 'config.json', data: Buffer.from(JSON.stringify(settingsCopy, null, 2)) },
-      ];
-      const zipBuf = zipWriter.createZip(entries);
       const defaultName = `aegis-export-${new Date().toISOString().slice(0, 10)}.zip`;
       const { filePath } = await dialog.showSaveDialog(deps.getWindow(), {
         title: 'Export All Data (ZIP)',
@@ -399,8 +384,23 @@ ${findingsHtml}${recsHtml}
         filters: [{ name: 'ZIP', extensions: ['zip'] }],
       });
       if (!filePath) return { success: false };
-      fs.writeFileSync(filePath, zipBuf);
-      return { success: true, path: filePath };
+      const settingsCopy = { ...config.getSettings() };
+      delete settingsCopy.anthropicApiKey;
+      delete settingsCopy._encryptedApiKey;
+      delete settingsCopy.apiKey;
+      const extraEntries = [
+        {
+          name: 'activity-log.json',
+          data: scanner.activityLog.slice(-5000),
+        },
+        { name: 'config.json', data: settingsCopy },
+      ];
+      return await writeAuditExport({
+        filePath,
+        files: audit.prepareExport(),
+        zip: true,
+        extraEntries,
+      });
     } catch (error) {
       logger.error(`IPC export-zip failed: ${error.message}`);
       return { success: false, error: error.message };

--- a/src/main/zip-writer.js
+++ b/src/main/zip-writer.js
@@ -7,6 +7,8 @@
 'use strict';
 
 const zlib = require('zlib');
+const { Readable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
 
 // ── CRC-32 lookup table ──
 const CRC_TABLE = new Uint32Array(256);
@@ -109,4 +111,82 @@ function createZip(entries) {
   return Buffer.concat(parts);
 }
 
-module.exports = { createZip };
+/**
+ * Write a ZIP incrementally with asynchronous compression and data descriptors.
+ * Each input and compressed chunk is backpressured by the destination write.
+ * @param {Array<{name: string, chunks: AsyncIterable<Buffer|string>|Iterable<Buffer|string>}>} entries
+ * @param {(chunk: Buffer) => Promise<void>} write
+ * @returns {Promise<void>}
+ * @since 0.15.0
+ */
+async function writeZip(entries, write) {
+  let offset = 0;
+  const centrals = [];
+  const emit = async (chunk) => {
+    if (offset + chunk.length >= 0xffffffff) throw new Error('ZIP64 is required for this export.');
+    await write(chunk);
+    offset += chunk.length;
+  };
+  for (const entry of entries) {
+    const start = offset;
+    const name = Buffer.from(entry.name, 'utf8');
+    if (name.length > 65535 || entries.length > 65535) throw new Error('ZIP limits exceeded.');
+    const local = Buffer.alloc(30 + name.length);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0x808, 6); // UTF-8 + trailing data descriptor
+    local.writeUInt16LE(8, 8);
+    local.writeUInt16LE(name.length, 26);
+    name.copy(local, 30);
+    await emit(local);
+    let crc = 0xffffffff;
+    let size = 0;
+    let compressed = 0;
+    async function* counted() {
+      for await (const value of entry.chunks) {
+        const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+        size += chunk.length;
+        if (size >= 0xffffffff) throw new Error('ZIP64 is required for this export.');
+        for (const byte of chunk) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+        yield chunk;
+      }
+    }
+    await pipeline(Readable.from(counted()), zlib.createDeflateRaw(), async (source) => {
+      for await (const chunk of source) {
+        compressed += chunk.length;
+        await emit(chunk);
+      }
+    });
+    crc = (crc ^ 0xffffffff) >>> 0;
+    const descriptor = Buffer.alloc(16);
+    descriptor.writeUInt32LE(0x08074b50, 0);
+    descriptor.writeUInt32LE(crc, 4);
+    descriptor.writeUInt32LE(compressed, 8);
+    descriptor.writeUInt32LE(size, 12);
+    await emit(descriptor);
+    const central = Buffer.alloc(46 + name.length);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0x808, 8);
+    central.writeUInt16LE(8, 10);
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(compressed, 20);
+    central.writeUInt32LE(size, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE(start, 42);
+    name.copy(central, 46);
+    centrals.push(central);
+  }
+  const directoryOffset = offset;
+  for (const central of centrals) await emit(central);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(offset - directoryOffset, 12);
+  end.writeUInt32LE(directoryOffset, 16);
+  await emit(end);
+}
+
+module.exports = { createZip, writeZip };

--- a/tests/main/audit-export-stream.test.js
+++ b/tests/main/audit-export-stream.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { inflateRawSync } from 'zlib';
+import { writeAuditExport } from '../../src/main/audit-export-stream.js';
+import { createZip } from '../../src/main/zip-writer.js';
+
+describe('streamed audit exports', () => {
+  let root;
+  let destination;
+  const files = () =>
+    fs
+      .readdirSync(root)
+      .filter((name) => name.endsWith('.jsonl'))
+      .map((name) => {
+        const filePath = path.join(root, name);
+        const stat = fs.statSync(filePath);
+        return { path: filePath, size: stat.size, dev: stat.dev, ino: stat.ino };
+      });
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-stream-'));
+    destination = path.join(root, 'export.json');
+    fs.writeFileSync(destination, 'previous export');
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  const write = (text) => fs.writeFileSync(path.join(root, 'audit.jsonl'), text);
+  const noTemporaryFiles = () =>
+    expect(fs.readdirSync(root).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+
+  it('exports bounded source ranges and preserves raw records and unicode', async () => {
+    const rows = [
+      { type: 'file-access', path: 'проект/文件' },
+      { type: 'buffer-overflow-drop', droppedCount: 3 },
+    ];
+    write(rows.map(JSON.stringify).join('\r\n'));
+    const snapshot = files();
+    fs.appendFileSync(snapshot[0].path, '\n{"type":"later"}\n');
+    expect(await writeAuditExport({ filePath: destination, files: snapshot })).toMatchObject({
+      success: true,
+      count: 2,
+    });
+    expect(JSON.parse(fs.readFileSync(destination, 'utf8'))).toEqual(rows);
+    noTemporaryFiles();
+  });
+
+  it.each(['malformed', 'oversize', 'missing', 'truncated'])(
+    'preserves the destination and cleans up after %s input',
+    async (mode) => {
+      write(
+        mode === 'malformed'
+          ? '{"valid":1}\nbroken-secret'
+          : mode === 'oversize'
+            ? JSON.stringify({ text: 'x'.repeat(1024 * 1024) })
+            : '{"valid":1}\n',
+      );
+      const snapshot = files();
+      if (mode === 'missing') fs.unlinkSync(snapshot[0].path);
+      if (mode === 'truncated') fs.truncateSync(snapshot[0].path, 0);
+      await expect(writeAuditExport({ filePath: destination, files: snapshot })).rejects.toThrow(
+        'Audit export incomplete',
+      );
+      expect(fs.readFileSync(destination, 'utf8')).toBe('previous export');
+      noTemporaryFiles();
+      write('{"recovered":true}\n');
+      await expect(
+        writeAuditExport({ filePath: destination, files: files() }),
+      ).resolves.toMatchObject({ count: 1 });
+    },
+  );
+
+  it('rejects replacing a source journal file', async () => {
+    write('{"keep":true}\n');
+    const snapshot = files();
+    await expect(writeAuditExport({ filePath: snapshot[0].path, files: snapshot })).rejects.toThrow(
+      'source journal',
+    );
+    expect(fs.readFileSync(snapshot[0].path, 'utf8')).toBe('{"keep":true}\n');
+  });
+
+  it('preserves the old destination if atomic replacement fails', async () => {
+    write('{"valid":1}\n');
+    vi.spyOn(fs.promises, 'rename').mockRejectedValue(
+      Object.assign(new Error('fixture'), { code: 'EACCES' }),
+    );
+    await expect(writeAuditExport({ filePath: destination, files: files() })).rejects.toThrow(
+      'Audit export incomplete',
+    );
+    expect(fs.readFileSync(destination, 'utf8')).toBe('previous export');
+    noTemporaryFiles();
+  });
+
+  it('creates a ZIP with valid central directory, sizes, CRCs and all three entries', async () => {
+    write('{"type":"first"}\n');
+    await writeAuditExport({
+      filePath: destination,
+      files: files(),
+      zip: true,
+      extraEntries: [
+        { name: 'activity-log.json', data: [{ action: 'fixture' }] },
+        { name: 'config.json', data: { enabled: true } },
+      ],
+    });
+    const zip = fs.readFileSync(destination);
+    const end = zip.length - 22;
+    expect(zip.readUInt32LE(end)).toBe(0x06054b50);
+    expect(zip.readUInt16LE(end + 10)).toBe(3);
+    let offset = zip.readUInt32LE(end + 16);
+    const decoded = {};
+    for (let i = 0; i < 3; i++) {
+      expect(zip.readUInt32LE(offset)).toBe(0x02014b50);
+      const nameLength = zip.readUInt16LE(offset + 28);
+      const name = zip.subarray(offset + 46, offset + 46 + nameLength).toString('utf8');
+      const local = zip.readUInt32LE(offset + 42);
+      const size = zip.readUInt32LE(offset + 20);
+      const begin = local + 30 + zip.readUInt16LE(local + 26);
+      const data = inflateRawSync(zip.subarray(begin, begin + size));
+      expect(data.length).toBe(zip.readUInt32LE(offset + 24));
+      expect(createZip([{ name, data }]).readUInt32LE(14)).toBe(zip.readUInt32LE(offset + 16));
+      expect(zip.readUInt32LE(begin + size)).toBe(0x08074b50);
+      decoded[name] = JSON.parse(data);
+      offset += 46 + nameLength;
+    }
+    expect(offset).toBe(end);
+    expect(decoded).toEqual({
+      'audit-log.json': [{ type: 'first' }],
+      'activity-log.json': [{ action: 'fixture' }],
+      'config.json': { enabled: true },
+    });
+  });
+
+  it('yields while exporting a large journal and rejects overlapping exports', async () => {
+    write((JSON.stringify({ text: 'x'.repeat(200) }) + '\n').repeat(15000));
+    let turns = 0;
+    const timer = setInterval(() => turns++, 1);
+    try {
+      const running = writeAuditExport({ filePath: destination, files: files(), zip: true });
+      await expect(writeAuditExport({ filePath: destination, files: files() })).rejects.toThrow(
+        'already running',
+      );
+      await running;
+      expect(turns).toBeGreaterThan(2);
+    } finally {
+      clearInterval(timer);
+    }
+    noTemporaryFiles();
+  });
+});

--- a/tests/main/audit-export.test.js
+++ b/tests/main/audit-export.test.js
@@ -77,6 +77,7 @@ describe('complete audit exports', () => {
       });
       audit.log('file-access', { agent: 'fixture' });
       expect(() => audit.exportAll()).toThrow('Audit export incomplete');
+      expect(() => audit.prepareExport()).toThrow('Audit export incomplete');
       append.mockRestore();
       const rows = audit.exportAll();
       expect(rows.map((entry) => entry.type)).toEqual([

--- a/tests/main/ipc-handlers.test.js
+++ b/tests/main/ipc-handlers.test.js
@@ -53,6 +53,7 @@ const mockConfig = {
 };
 
 const mockScanner = {
+  activityLog: [],
   scanProcesses: vi.fn(() => Promise.resolve({ agents: [{ agent: 'Claude', pid: 100 }] })),
   agentDb: { agents: [] },
 };
@@ -89,8 +90,10 @@ const mockAudit = {
   })),
   getLogDir: vi.fn(() => '/logs'),
   exportAll: vi.fn(() => []),
+  prepareExport: vi.fn(() => []),
   getEntriesBefore: vi.fn(() => []),
 };
+const mockStreamExport = { writeAuditExport: vi.fn(async () => ({ success: true })) };
 
 const mockLogger = {
   getStats: vi.fn(() => ({
@@ -120,6 +123,7 @@ const baselinesPath = path.resolve(__dirname, '../../src/main/baselines.js');
 const analysisPath = path.resolve(__dirname, '../../src/main/ai-analysis.js');
 const exporterPath = path.resolve(__dirname, '../../src/main/exports.js');
 const auditPath = path.resolve(__dirname, '../../src/main/audit-logger.js');
+const streamExportPath = path.resolve(__dirname, '../../src/main/audit-export-stream.js');
 const loggerPath = path.resolve(__dirname, '../../src/main/logger.js');
 const platformPath = path.resolve(__dirname, '../../src/main/platform/index.js');
 const ipcPath = path.resolve(__dirname, '../../src/main/ipc-handlers.js');
@@ -144,6 +148,7 @@ Module._load = function (request, parent, _isMain) {
       return mockExporter;
     if (resolved === auditPath.replace(/\.js$/, '') || resolved + '.js' === auditPath)
       return mockAudit;
+    if (resolved + '.js' === streamExportPath) return mockStreamExport;
     if (resolved === loggerPath.replace(/\.js$/, '') || resolved + '.js' === loggerPath)
       return mockLogger;
     if (
@@ -200,24 +205,37 @@ describe('ipc-handlers', () => {
   }
 
   it.each(['export-full-audit', 'export-zip'])(
-    '%s reports incomplete history without offering or writing a partial file',
+    '%s reports incomplete history without writing a partial file',
     async (channel) => {
       ipcHandlers.init({ getWindow: () => null });
       ipcHandlers.register();
       mockElectron.dialog.showSaveDialog.mockClear();
+      mockElectron.dialog.showSaveDialog.mockResolvedValue({ filePath: '/fixture/export.json' });
       const write = vi.spyOn(fs, 'writeFileSync');
       const message =
         'Audit export incomplete: a log file could not be read or contains invalid JSON.';
-      mockAudit.exportAll.mockImplementationOnce(() => {
+      mockAudit.prepareExport.mockImplementationOnce(() => {
         throw new Error(message);
       });
       try {
         expect(await getHandler(channel)()).toEqual({ success: false, error: message });
-        expect(mockElectron.dialog.showSaveDialog).not.toHaveBeenCalled();
+        expect(mockElectron.dialog.showSaveDialog).toHaveBeenCalledOnce();
         expect(write).not.toHaveBeenCalled();
       } finally {
         write.mockRestore();
       }
+    },
+  );
+
+  it.each(['export-full-audit', 'export-zip'])(
+    '%s does no journal work after cancellation',
+    async (channel) => {
+      ipcHandlers.init({ getWindow: () => null });
+      ipcHandlers.register();
+      mockElectron.dialog.showSaveDialog.mockResolvedValue({});
+      mockAudit.prepareExport.mockClear();
+      expect(await getHandler(channel)()).toEqual({ success: false });
+      expect(mockAudit.prepareExport).not.toHaveBeenCalled();
     },
   );
 
@@ -242,6 +260,30 @@ describe('ipc-handlers', () => {
         'evil.exe',
       );
       expect(updates[method]).toHaveBeenCalledExactlyOnceWith();
+    }
+  });
+
+  it('streams the ZIP with bounded activity and sanitized settings', async () => {
+    ipcHandlers.init({ getWindow: () => null });
+    ipcHandlers.register();
+    mockElectron.dialog.showSaveDialog.mockResolvedValue({ filePath: '/fixture/export.zip' });
+    mockConfig.getSettings.mockReturnValue({
+      anthropicApiKey: 'fixture',
+      _encryptedApiKey: 'fixture',
+      apiKey: 'fixture',
+      theme: 'dark',
+    });
+    mockScanner.activityLog = Array.from({ length: 5100 }, (_, i) => ({ i }));
+    mockStreamExport.writeAuditExport.mockClear();
+    try {
+      expect(await getHandler('export-zip')()).toEqual({ success: true });
+      const options = mockStreamExport.writeAuditExport.mock.calls[0][0];
+      expect(options.extraEntries[0].data).toHaveLength(5000);
+      expect(options.extraEntries[0].data[0]).toEqual({ i: 100 });
+      expect(options.extraEntries[1]).toEqual({ name: 'config.json', data: { theme: 'dark' } });
+      expect(options.zip).toBe(true);
+    } finally {
+      mockScanner.activityLog = [];
     }
   });
 


### PR DESCRIPTION
Full JSON/ZIP exports previously read, parsed and serialized the entire journal in main, then compressed synchronously before the save dialog. Export now starts after destination selection, captures flushed byte ranges and streams them in bounded chunks with explicit event-loop yields. ZIP compression is asynchronous. A temporary destination is atomically renamed after success; read/parse/write failures preserve existing output and reject incomplete exports.

Tests cover missing, malformed, oversized and truncated sources; captured append boundaries; source/destination protection; cleanup, concurrency and event-loop progress; ZIP sizes/CRCs; cancellation and settings-key redaction. 2,718 tests passed with four skipped, plus format, build, lint, typecheck and counts. Python zipfile independently validated a 100,000-record archive. On the same 35.95 MiB synthetic journal, ZIP took 468 ms with a 6.38 ms largest timer gap and 21.77 MiB sampled RSS increase; the earlier synchronous preparation blocked for 588 ms with 174.65 MiB RSS growth. Single-machine samples, not guaranteed performance.

Journal records over 1 MiB and ZIP64-sized output are rejected. Temporary-file cleanup after a process crash remains future work. No dependencies or renderer code changed.
