### PR TITLE
perf: retire completed baseline instances after confirmed exits

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1145,3 +1145,33 @@ Python zipfile independently checked the ZIP CRCs and read all 100,000 records.
 Artifacts are under `X:/tmp/aegis-core-audit-20260907/stream-bench*`.
 
 Remaining authorized audit item: retire completed baseline instance data safely.
+
+## Session handoff — retire completed baseline instances (2026-09-07)
+
+`codex/retire-baseline-instances` archives confirmed native process exits into the
+existing ten-record per-agent profile, deletes their detailed live sets and frees
+their anomaly-warning deduplication. The scan loop retires only the exits returned
+by reliable session reconciliation, after the existing grace window. An outage or
+suspend freezes reconciliation and cannot trigger cleanup. Still-active instances
+sharing a key are excluded from retirement.
+
+Baseline recording uses a live-membership predicate (tracked sessions including
+grace, or currently surfaced pid-0 synthetics) to reject late callbacks without an
+ever-growing closed-key list. Shutdown archives only remaining buckets, so repeated
+shutdown/finalization does not double-count. Profile end times include the latest
+observed activity. Synthetic instances still have no native session exit and retain
+their existing shutdown finalization. Token cost totals are untouched.
+
+The full suite passed with 2,723 tests and four skips across 153 files; a subsequent
+additional failed-save/retry test also passed with the whole baseline test file.
+Build, format, lint, both type checks, both mutation gates and counts passed. Tests
+cover 2,000 completed instances leaving zero live buckets and ten profile records,
+selective retirement, warning cleanup, repeated shutdown, grace/outage wiring,
+rejection of late callbacks and save recovery without duplicate profile records.
+Failed saves retain the rolling profile in memory for a later save; crash durability
+of that profile remains limited by the existing persistence mechanism.
+
+All four follow-up items from the core audit are implemented. Earlier completed
+PRs in this batch: #371 WSL freshness, #372 shared Windows observation, #373 streamed
+exports. No release or installed-app update was requested; the separately developed
+frontend remains untouched.

--- a/src/main/anomaly-detector.js
+++ b/src/main/anomaly-detector.js
@@ -221,4 +221,10 @@ function checkDeviations() {
   return warnings;
 }
 
-module.exports = { calculateAnomalyScore, checkDeviations };
+/** Release warning deduplication for confirmed exits.
+ * @param {string[]} instanceIds @returns {void} @since 0.15.0 */
+function forgetInstances(instanceIds) {
+  for (const instanceId of instanceIds) delete deviationWarningsSent[instanceId];
+}
+
+module.exports = { calculateAnomalyScore, checkDeviations, forgetInstances };

--- a/src/main/baselines.js
+++ b/src/main/baselines.js
@@ -40,6 +40,18 @@ const MAX_BASELINE_SESSIONS = 10;
 let baselines = { agents: {} };
 /** @type {Object<string, Object>} Live session buckets, keyed by `instanceId`. */
 const sessionData = {};
+let isInstanceActive = null;
+
+/**
+ * Gate live recording on the scan loop's current sessions, including exit grace.
+ * This rejects late callbacks without accumulating a tombstone for every old PID.
+ * @param {{isInstanceActive?: (instanceId: string) => boolean}} [deps]
+ * @returns {void}
+ * @since 0.15.0
+ */
+function init(deps = {}) {
+  isInstanceActive = deps.isInstanceActive || null;
+}
 
 /** @returns {void} @since v0.1.0 */
 function loadBaselines() {
@@ -92,6 +104,7 @@ function saveBaselines() {
  */
 function ensureSessionData(instanceId, agentName) {
   if (!instanceId) return null;
+  if (isInstanceActive && !isInstanceActive(instanceId)) return null;
   if (!sessionData[instanceId]) {
     sessionData[instanceId] = {
       agentName,
@@ -115,6 +128,7 @@ function ensureSessionData(instanceId, agentName) {
 function recordFileAccess(instanceId, agentName, filePath, isSensitive, reason) {
   const sd = ensureSessionData(instanceId, agentName);
   if (!sd) return;
+  sd.lastActivityAt = Date.now();
   sd.files.add(filePath);
   if (isSensitive) {
     sd.sensitiveCount++;
@@ -131,6 +145,7 @@ function recordFileAccess(instanceId, agentName, filePath, isSensitive, reason) 
 function recordNetworkEndpoint(instanceId, agentName, ip, port) {
   const sd = ensureSessionData(instanceId, agentName);
   if (!sd) return;
+  sd.lastActivityAt = Date.now();
   sd.endpoints.add(`${ip}:${port}`);
 }
 
@@ -162,30 +177,19 @@ function recomputeAverages(agentBaseline) {
 }
 
 /**
- * Persist every live bucket into its agent's cross-session profile.
- *
- * ONE RECORD PER INSTANCE, not per launch. The unit of a persisted session must be
- * the unit of the live bucket it is compared against: `scoring-utils.js` divides
- * `sd.files.size` (now one instance's activity) by `averages.filesPerSession` (the
- * mean of `sessions[].totalFiles`), and `anomaly-detector.js` fires at 3x that
- * ratio. Merging the buckets back by name here would leave per-instance activity
- * measured against launch-sized averages, and every instance would read as
- * permanently quiet. `sessionCount` therefore now grows by N per launch, where N is
- * the number of same-named instances that were active.
- *
- * TRANSITION, and it is not a bug: records written before this change are
- * launch-sized (all same-named instances merged into one). While they are still in
- * the window, `averages` is inflated and the deviation detector UNDER-fires. With k
- * old records left of MAX_BASELINE_SESSIONS (10), the effective trigger is
- * 3 * (k*N + (10-k)) / 10 times an instance's own typical volume instead of 3x — for
- * N=2 that is 6x immediately after the migration, decaying linearly to 3x. The last
- * old record leaves after 10 new ones, i.e. ceil(10/N) launches: 10 launches at
- * N=1, 5 at N=2, 4 at N=3. Self-correcting; no migration of the file is needed and
- * none is done.
- * @returns {void} @since v0.1.0
+ * Persist confirmed exits as one profile record per instance and release their
+ * detailed live sets. Profiles retain the last ten records per agent name. Older
+ * launch-sized records naturally leave that window as instances finish.
+ * Already-retired keys are ignored, so a repeated shutdown cannot duplicate them.
+ * @param {Array<{instanceId: string, lastSeen?: number}>} instances
+ * @returns {void}
+ * @since 0.15.0
  */
-function finalizeSession() {
-  for (const sd of Object.values(sessionData)) {
+function finalizeInstances(instances) {
+  for (const { instanceId, lastSeen } of instances) {
+    const sd = sessionData[instanceId];
+    if (!sd) continue;
+    delete sessionData[instanceId];
     if (sd.files.size === 0 && sd.sensitiveCount === 0 && sd.endpoints.size === 0) continue;
     // The bucket is instance-keyed; the profile is name-keyed. A bucket with no
     // name has nowhere to land — it is dropped rather than filed under a guess.
@@ -209,7 +213,7 @@ function finalizeSession() {
     ab.sessionCount++;
     ab.sessions.push({
       startTime: sd.startTime,
-      endTime: Date.now(),
+      endTime: Math.max(sd.startTime, sd.lastActivityAt || 0, lastSeen ?? Date.now()),
       totalFiles: sd.files.size,
       sensitiveFiles: sd.sensitiveCount,
       directories: [...sd.directories],
@@ -224,6 +228,12 @@ function finalizeSession() {
   saveBaselines();
 }
 
+/** Persist and release remaining instances at shutdown; repeated calls add no duplicates.
+ * @returns {void} @since v0.1.0 */
+function finalizeSession() {
+  finalizeInstances(Object.keys(sessionData).map((instanceId) => ({ instanceId })));
+}
+
 /** @returns {Object} @since v0.1.0 */ function getBaselines() {
   return baselines;
 }
@@ -232,6 +242,8 @@ function finalizeSession() {
 }
 
 module.exports = {
+  init,
+  finalizeInstances,
   loadBaselines,
   ensureSessionData,
   recordFileAccess,

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -478,6 +478,13 @@ async function doProcessScan() {
     // observation uncredited.
     const observed = reliable && !identityDegraded && !gapStraddled;
     if (observed && deps.observationGap) deps.observationGap.noteObserved(Date.now());
+    // Reconcile alone decides exits. Outages/suspend produce none, so no baseline
+    // is retired without reliable evidence. Persist once for the whole exit batch.
+    const retired = exited.filter((session) => !sessionTracker.hasInstance(session.instanceId));
+    if (retired.length > 0) {
+      deps.baselines?.finalizeInstances?.(retired);
+      anomaly.forgetInstances?.(retired.map((session) => session.instanceId));
+    }
     for (const s of entered) {
       audit.log('agent-enter', {
         agent: s.agent,
@@ -893,6 +900,13 @@ function staggeredStartup(intervalMs, paused) {
 /** @param {Object} injected @since v0.3.0 */
 function init(injected) {
   deps = injected;
+  deps.baselines?.init?.({
+    isInstanceActive: (instanceId) =>
+      sessionTracker.hasInstance(instanceId) ||
+      (deps.getLatestAgents?.() || []).some(
+        (agent) => agent.pid <= 0 && agent.instanceId === instanceId,
+      ),
+  });
 }
 
 /** @returns {{ollama: {running:boolean,models:string[]}, lmstudio: {running:boolean,models:string[]}}} */

--- a/src/main/session-tracker.js
+++ b/src/main/session-tracker.js
@@ -232,6 +232,13 @@ function activeCount() {
   return activeSessions.size;
 }
 
+/** Whether an instance is still active, including the reliable-miss grace window.
+ * @param {string} instanceId @returns {boolean} @since 0.15.0 */
+function hasInstance(instanceId) {
+  for (const session of activeSessions.values()) if (session.instanceId === instanceId) return true;
+  return false;
+}
+
 /** @internal Reset module state (for tests). @returns {void} */
 function _resetForTest() {
   activeSessions.clear();
@@ -240,6 +247,7 @@ function _resetForTest() {
 module.exports = {
   reconcile,
   activeCount,
+  hasInstance,
   sessionKey,
   DEFAULT_EXIT_GRACE,
   _resetForTest,

--- a/tests/main/anomaly-detector.test.js
+++ b/tests/main/anomaly-detector.test.js
@@ -68,6 +68,14 @@ describe('anomaly-detector', () => {
   }
 
   describe('calculateAnomalyScore', () => {
+    it('releases warning deduplication for a retired instance', () => {
+      setupAgent('Fixture', { files: new Set(Array.from({ length: 10 }, (_, i) => `f${i}`)) }, {});
+      const id = Object.keys(bl.getSessionData())[0];
+      expect(anomaly.checkDeviations().some((warning) => warning.type === 'files')).toBe(true);
+      expect(anomaly.checkDeviations()).toEqual([]);
+      anomaly.forgetInstances([id]);
+      expect(anomaly.checkDeviations().some((warning) => warning.type === 'files')).toBe(true);
+    });
     it('returns result with score 0 when no session data exists', () => {
       const result = anomaly.calculateAnomalyScore('Unknown');
       expect(result.score).toBe(0);

--- a/tests/main/baselines.test.js
+++ b/tests/main/baselines.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -12,6 +12,7 @@ describe('baselines', () => {
   let tmpDir;
 
   beforeEach(() => {
+    baselines.init();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-baselines-test-'));
     baselines._setBaselinesPathForTest(path.join(tmpDir, 'baselines.json'));
 
@@ -144,6 +145,64 @@ describe('baselines', () => {
     baselines.finalizeSession();
     const bl = baselines.getBaselines();
     expect(bl.agents['Idle']).toBeUndefined();
+  });
+
+  it('retires only the exited instance and does not count it again at shutdown', () => {
+    baselines.recordFileAccess(CLAUDE_A, 'Claude', '/a/file.js', false);
+    baselines.recordFileAccess(CLAUDE_B, 'Claude', '/b/file.js', false);
+    baselines.finalizeInstances([{ instanceId: CLAUDE_A, lastSeen: 1 }]);
+    expect(Object.keys(baselines.getSessionData())).toEqual([CLAUDE_B]);
+    const first = baselines.getBaselines().agents.Claude.sessions[0];
+    expect(first.endTime).toBeGreaterThanOrEqual(first.startTime);
+    baselines.finalizeInstances([{ instanceId: CLAUDE_A }]);
+    baselines.finalizeSession();
+    baselines.finalizeSession();
+    expect(baselines.getBaselines().agents.Claude.sessionCount).toBe(2);
+    expect(baselines.getSessionData()).toEqual({});
+  });
+
+  it('uses live membership to reject late callbacks without retaining closed keys', () => {
+    const live = new Set([CLAUDE_A]);
+    baselines.init({ isInstanceActive: (key) => live.has(key) });
+    baselines.recordFileAccess(CLAUDE_A, 'Claude', '/first.js', false);
+    live.clear();
+    baselines.finalizeInstances([{ instanceId: CLAUDE_A }]);
+    baselines.recordFileAccess(CLAUDE_A, 'Claude', '/late.js', true);
+    baselines.recordNetworkEndpoint(CLAUDE_A, 'Claude', '1.2.3.4', 443);
+    expect(baselines.getSessionData()).toEqual({});
+    live.add(CLAUDE_B);
+    baselines.recordFileAccess(CLAUDE_B, 'Claude', '/new.js', false);
+    expect(Object.keys(baselines.getSessionData())).toEqual([CLAUDE_B]);
+    expect(baselines.getBaselines().agents.Claude.sessionCount).toBe(1);
+    baselines.init();
+  });
+
+  it('releases thousands of completed buckets while retaining only ten profile sessions', () => {
+    const exits = Array.from({ length: 2000 }, (_, i) => ({ instanceId: `fixture:${i}` }));
+    for (const { instanceId } of exits)
+      baselines.recordFileAccess(instanceId, 'Claude', '/fixture/shared.js', false);
+    baselines.finalizeInstances(exits);
+    expect(baselines.getSessionData()).toEqual({});
+    expect(baselines.getBaselines().agents.Claude.sessionCount).toBe(2000);
+    expect(baselines.getBaselines().agents.Claude.sessions).toHaveLength(10);
+  });
+
+  it('keeps the completed profile in memory after a failed save and retries without double counting', () => {
+    baselines.recordFileAccess(CLAUDE_A, 'Claude', '/fixture/file.js', false);
+    const write = vi.spyOn(fs, 'writeFileSync').mockImplementationOnce(() => {
+      throw Object.assign(new Error('fixture full disk'), { code: 'ENOSPC' });
+    });
+    try {
+      baselines.finalizeInstances([{ instanceId: CLAUDE_A }]);
+      expect(baselines.getBaselines().agents.Claude.sessionCount).toBe(1);
+      expect(baselines.getSessionData()).toEqual({});
+      baselines.finalizeSession();
+      const saved = JSON.parse(fs.readFileSync(path.join(tmpDir, 'baselines.json'), 'utf8'));
+      expect(saved.agents.Claude.sessionCount).toBe(1);
+      expect(saved.agents.Claude.sessions[0].totalFiles).toBe(1);
+    } finally {
+      write.mockRestore();
+    }
   });
 
   it('finalizeSession() files instance buckets under the agent NAME, one record each', () => {

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -945,6 +945,39 @@ describe('scan-loop', () => {
   // ── cwd annotation forceRefresh wiring ──
 
   describe('annotateWorkingDirs forceRefresh wiring', () => {
+    it('retires baseline data only after reliable exit grace, and rejects late native records', async () => {
+      const sessions = require_('../../src/main/session-tracker.js');
+      sessions._resetForTest();
+      const agent = { agent: 'Fixture', process: 'fixture.exe', pid: 300, instanceId: '300:1000' };
+      const finalizeInstances = vi.fn();
+      const forgetInstances = vi.fn();
+      const initialize = vi.fn();
+      const scan = vi.fn().mockResolvedValue({ agents: [agent], reliable: true });
+      const d = makeDeps({ scanner: { scanProcesses: scan } });
+      d.baselines = { ...d.baselines, init: initialize, finalizeInstances };
+      d.anomaly.forgetInstances = forgetInstances;
+      scanLoop.init(d);
+      const valid = initialize.mock.calls[0][0].isInstanceActive;
+      scanLoop.startScanIntervals(5000);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(valid(agent.instanceId)).toBe(true);
+      scan.mockResolvedValue({ agents: [], reliable: false });
+      await vi.advanceTimersByTimeAsync(20000);
+      expect(finalizeInstances).not.toHaveBeenCalled();
+      expect(valid(agent.instanceId)).toBe(true);
+      scan.mockResolvedValue({ agents: [], reliable: true });
+      for (let i = 1; i < sessions.DEFAULT_EXIT_GRACE; i++) {
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(finalizeInstances).not.toHaveBeenCalled();
+      }
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(finalizeInstances).toHaveBeenCalledOnce();
+      expect(finalizeInstances.mock.calls[0][0][0].instanceId).toBe(agent.instanceId);
+      expect(forgetInstances).toHaveBeenCalledWith([agent.instanceId]);
+      expect(valid(agent.instanceId)).toBe(false);
+      sessions._resetForTest();
+    });
+
     /** @param {boolean} changed @returns {Promise<Object>} the procUtil mock after one scan */
     async function scanWithChanged(changed, processMap) {
       const mockDeps = makeDeps({


### PR DESCRIPTION
Completed native process instances previously kept their detailed baseline sets and warning deduplication until AEGIS quit, and every anomaly pass continued visiting them. Confirmed session exits now archive their profile once, release those sets and clear warning deduplication. Recording checks current session membership, including exit grace, so late callbacks cannot recreate retired native buckets. Outages and suspend retain the existing frozen-session behavior.

Shutdown only archives remaining instances; repeated finalization does not duplicate profile records. Failed persistence leaves the rolling profile in memory for a later save. Synthetic pid-0 agents retain their existing shutdown lifecycle, and accumulated token costs are unchanged.

Validation: 2,723 tests passed with four skipped, followed by an additional passing failed-save/retry test. Build, formatting, lint, both type checks, both mutation gates and counts passed. Tests cover selective retirement, a 2,000-instance batch retaining zero live buckets and ten profile sessions, warning cleanup, late callbacks, shutdown idempotence, save recovery and scan-loop grace/outage wiring.
