### PR TITLE
docs: reconcile remaining development roadmap with shipped work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,58 +1,122 @@
 # AEGIS Roadmap
 
-## Done
+Status checked against `11215d4` on 2026-09-07. Package version: `0.14.1-alpha`;
+locked Electron: `43.4.1`. Changes merged after a release are available in source,
+not automatically in an installed app.
 
-- **#9** IPC event batching — batch IPC events to reduce renderer overhead (append/latest modes, 150-200ms windows)
-- **#11** Ignore .git/node_modules — configurable directory ignore list in file-watcher with UI toggle
-- **#12** EPERM graceful fallback — scanner catches access errors and logs warning instead of crashing
-- Startup perf Phase 1 — deferred file watchers, lazy-loaded modules (400-2200ms saved)
-- Toast/AgentDB/docs color fixes — replaced hardcoded colors with design tokens
+This is the current development queue. Implementation and measurement history
+remain in [progress.md](memory-bank/progress.md). The separately developed frontend
+is user-owned: renderer, Svelte, CSS and design work stay outside this queue until
+integration is requested. Plan IDs below are distinct from GitHub issue numbers.
 
-## Bugs (In Progress)
+## Completed baseline
 
-- **P1.1** 37 hardcoded `rgba(255,255,255)` in 15 Svelte components — replace with `tokens.css` vars
-- **P1.2** Add `eslint-plugin-svelte` (31 components unlinted)
-- **P1.3** Fix hardcoded test counts in README
-- **P1.4** Fix hardcoded test counts in CHANGELOG
+Do not schedule these capabilities as new work:
 
-## Startup Perf Phase 2
+- Codex migration and SQLite audit-index blocks 1–2: index maintenance and paginated
+  reads with JSONL fallback. JSONL remains the source of truth. See
+  [audit-index.md](docs/roadmap/audit-index.md).
+- Sensor Health B1–B8, including suspend/resume gaps and the cross-sensor umbrella
+  suite (PR #329). See [sensor-health-degraded.md](docs/roadmap/sensor-health-degraded.md).
+- Sequence loader, engine, scan taps, hot reload and mutation gate. See
+  [sequence-rules.md](docs/roadmap/sequence-rules.md).
+- Startup work: deferred initialization, evidence watchers in workers and deferred
+  log cleanup. Further performance changes need a measured bottleneck.
+- Signed Windows update checking, download and installer verification (PR #367).
+- Downloads defaults (#332), incomplete-export rejection (#370), WSL observation
+  freshness (#371), shared fresh Windows process observations (#372), streamed
+  JSON/ZIP audit exports (#373), and completed native baseline retirement (#374).
 
-- Defer `cleanOldLogs()` via `setImmediate` in logger.js + audit-logger.js
-- `show: false` BrowserWindow + show on `did-finish-load` in main.js
-- Defer `tray.createTray()` to after `did-finish-load`
-- Lazy-wrap network-monitor agent-db parse (same pattern as process-scanner.js)
-- Defer `baselines.loadBaselines()` to after `createWindow`
+Limits remain: streamed exports reject audit records over 1 MiB and do not implement
+ZIP64; profile persistence retains its existing crash durability limits; WSL on this
+baseline covers the default distribution and `opencode` / `grok` signatures only.
 
-## 20-Feature Plan
+## A — discovery coverage
 
-### UI/UX
-- **#1** Click-to-copy PID — click any PID in the UI to copy it to clipboard
-- **#2** Smart autoscroll Activity Feed — auto-scroll to new events, pause when user scrolls up
-- **#3** Smart truncation for paths — shorten long file paths without breaking layout
-- **#4** Relative + exact time — show "2 min ago" with full timestamp on hover
-- **#5** Threat flash animation — red flash on high-threat detection for visibility
-- **#6** Version display — show app version from package.json in UI corner
-- **#7** Hotkeys — Esc closes panels, Ctrl+F opens search
-- **#8** Open File Location — "Show in Explorer" button next to file paths
+| Block | Remaining work | Dependency and completion evidence |
+| --- | --- | --- |
+| A1 | All running WSL distributions, separate identities, caches and health. | Supplied patch `a408af0` was tested separately and is unmerged. Resolve the running-list / `wsl -d` race: a distribution can stop between the commands and be restarted by the probe. Another list check alone cannot provide an atomic no-start guarantee. |
+| A2 | Derive suitable POSIX signatures from the agent database. | After A1. Verify executable boundaries, Windows-only aliases and misleading argument matches; preserve `opencode` / `grok` coverage. The database's 110 agents / 262 names are not a count of detectable Linux agents or processes. Derive the usable subset. |
+| A3 | Docker and Podman discovery under [#8](https://github.com/antropos17/Aegis/issues/8). | After A2. List running containers through runtime commands, with distinct runtime/container identities and independent freshness/health. No container start or exec for discovery. Command/image metadata is discovery evidence, not proof of every process inside. Direct daemon-socket integration is outside this block. |
+| A4 | Define and implement the missing GPU signal in [#9](https://github.com/antropos17/Aegis/issues/9). | Recon first: current code already reports per-PID NVIDIA VRAM through `nvidia-smi`. Allocation does not measure active inference. Establish signal meaning, supported hardware, cost and unavailable behavior before implementation. |
 
-### Electron
-- **#10** HW acceleration toggle — let users disable GPU acceleration if app lags
+A1 must preserve successful observations from other distributions when one fails.
+Retained observations keep their original time and an explicit stale flag. A WSL
+namespace PID must never become a Windows PID for file/network attribution.
+Discovery alone does not close every requirement of issue #8.
 
-### Logic
-- **#13** HTTP vs HTTPS scoring — score HTTP connections higher threat than HTTPS
-- **#14** Custom User-Agent — identify Aegis in Anthropic API calls
-- **#15** API status indicator — green/red dot showing Anthropic API availability
-- **#16** OOM protection on export — prevent crash when exporting large log files
-- **#17** Zip logs export — one-click ZIP export of all audit logs
+## B — Windows ETW attribution
 
-### Community
-- **#18** Report False Positive — "Not a threat" button for user feedback
-- **#19** Agent Database link — link to agent-database.json from UI
-- **#20** Scan status badge — "Scanning active/paused" indicator in header
+[Issue #12](https://github.com/antropos17/Aegis/issues/12) needs measurements before
+production implementation. [kernel-file-etw.md](docs/recon/kernel-file-etw.md) lists
+**13** hardware-gated questions, including Fast I/O, mapped files, Windows editions
+and Hyper-V as well as filtering, event identity, mapping lifecycle and loss.
+The dependency is those observations, not the absence of a Windows host.
 
-## Architecture Roadmap
+1. **B1:** prepare an isolated C#/TraceEvent measurement harness and procedure.
+   Collect results on target systems that answer each question; distinguish verified
+   results from environment-limited or unresolved coverage. One machine or a mock
+   cannot close all questions.
+2. **B2:** use B1 evidence to choose producer scope, sensor IDs, attribution, loss
+   handling and the relation to population/identity health.
+3. **B3+:** split implementation into sidecar blocks after B2. The existing
+   `sidecar/procsnap` transport and health integration are a precedent. ETW runs in
+   a separate process, not a native addon inside Electron.
 
-- **Phase A:** Ship v0.4.0 — complete bugs + features, auto-updater
-- **Phase B:** scanner to child_process, ring buffers, container detection, GPU monitor, process tree fan-out
-- **Phase C:** ETW/eBPF sensors in a separate sidecar process, never native addons inside the Electron process — strangler pattern, JS/TS core stays; for the Windows ETW sensor C#/TraceEvent is preferred over Rust/ferrisetw (docs/recon/kernel-file-etw.md)
-- **Phase D:** daemon architecture, MCP interception, SIEM export
+## C — existing rules coverage
+
+**C1:** map every requirement of [#73](https://github.com/antropos17/Aegis/issues/73)
+and [#75](https://github.com/antropos17/Aegis/issues/75) to existing tests and report
+covered / partial / absent with evidence. Existing YAML and OpenClaw tests mean
+neither issue should be treated as wholly unimplemented.
+
+**C2:** implement only confirmed gaps. If all requirements are covered, close with
+evidence rather than adding duplicate tests or unrelated detection rules.
+
+## D — platform identity, then sensors
+
+Linux and macOS adapters omit birth time and declare `providesStartTime: false`.
+Their native `<pid>:u` identities cannot distinguish reuse.
+
+- **D1:** Linux birth observations from `/proc`, with verified field parsing,
+  clock-tick conversion, boot-time anchoring and process exit/read race handling.
+  Do not assume the host tick rate without evidence.
+- **D2:** select and verify macOS birth-time collection. Document resolution and
+  residual ambiguity: a one-second timestamp cannot distinguish every rapid reuse.
+- **D3 / D4:** Linux fanotify/eBPF and macOS Endpoint Security follow platform
+  identity work and separate recon documents. Schedule implementation after the
+  Windows ETW track establishes the cost of operating a file sensor sidecar.
+
+An unread birth time stays `null`; never fill it from a cache. An observation outage
+freezes sessions rather than establishing process exits.
+
+## E — longer-term architecture
+
+Browser extension, cross-device correlation, daemon operation, MCP interception and
+SIEM export remain unscoped. Each needs requirements and recon before an estimate.
+Keep them outside the active queue while the first ETW sensor is being established.
+
+## F — maintenance
+
+- **F1:** a scripted audit-index mutation gate may replace documented manual
+  mutations. A local gate and CI wiring are separate scopes: changes under
+  `.github/workflows/` require explicit authorization under `AGENTS.md`.
+- **F2:** dependency PRs #352 / #353 (Vitest and coverage together) and #354 (Vite and
+  plugin compatibility) are separate from functional work. Lockfile regeneration
+  requires explicit authorization.
+- **F3:** release PR #364 is pending preparation, not authorization to publish a
+  release or tag. Leave it outside the development merge cycle.
+
+## Execution order
+
+Block 0 is this roadmap reconciliation, including the stale B8 status correction.
+Next resolve A1's no-start requirement, then A2, C1 and A3. B1 measurement preparation
+and independent D1 / D2 can follow; A4 starts with recon. If A1 cannot yet meet its
+requirement, C1 is an independent next block.
+
+Keep one logical block per branch and PR. A supplied patch is not complete until
+reviewed, verified and merged. Use `AGENTS.md` for the authorized git cycle and
+verification: branch from `origin/master`, stage task files only, run appropriate
+local checks, open the PR, wait for all five required contexts, then merge. Update
+the session handoff after each block. A docs change does not authorize a release or
+changes to protected configuration.

--- a/docs/roadmap/sensor-health-degraded.md
+++ b/docs/roadmap/sensor-health-degraded.md
@@ -1,11 +1,13 @@
 # Block B — Sensor Health / DEGRADED
 
-**Status (as of 2026-08-25):** design document, largely implemented since it was written.
+**Status (as of 2026-09-07):** B1–B8 implemented; this document retains the design and
+the evidence and limitations recorded for each slice.
 **Closed:** B1 (`src/main/sensor-health.js`), B2 (chokidar / handle / Restart Manager), B3
 (process enumeration and the secondary detectors), B4 (network + the ETW schema freeze), B5
 (`src/main/observation-gap.js` — the OS suspend / resume gap), B6 (`stats.appHealth` on the
-existing stats payload) and B7 (footer chip + population-gated empty states). **Open:** B8 (the
-cross-sensor umbrella suite). Per-slice detail is in §10.
+existing stats payload), B7 (footer chip + population-gated empty states), and B8 (the
+cross-sensor umbrella suite, PR #329). No B1–B8 implementation slice remains open.
+Per-slice detail is in §10; the unresolved measurements in §14 remain explicit.
 
 *Correction, 2026-08-23.* Until this edit the header read "the process-scan record and the
 renderer surfacing (B3 remainder, B6–B7) are not built", and every word of it was already false:
@@ -639,6 +641,12 @@ Audit drops remain on **audit** stats path (already honest).
 
 ### B8 — Integration / non-vacuous failure suite
 
+- **Status:** CLOSED, PR #329 (2026-08-25). `tests/main/app-health-umbrella.test.js`
+  drives real sensor leaves through the scan-loop schedulers and the app-health
+  composer. The read-mechanism ownership regression it exposed was subsequently
+  fixed; the Restart Manager bring-up case is now an ordinary passing test.
+  The mutation evidence and follow-up are recorded in `memory-bank/progress.md`
+  under the B8 umbrella and read-mechanism ownership entries.
 - **Closes:** cross-sensor regressions  
 - **Tests:** multi-sensor worst-of global; mutation proofs per critical registration  
 - **Stop:** Block B complete checklist  
@@ -717,14 +725,15 @@ Block B is done when:
 
 ---
 
-## 16. Next executable block
+## 16. Next work
 
-**Implement B8:** the cross-sensor umbrella suite (§10) — a multi-sensor worst-of global driven
-through the real leaves, a mutation proof per critical health registration, and the Block B
-stopping checklist (§15) walked with evidence. B5 landed 2026-08-25 (§10).
+B8 landed in PR #329 on 2026-08-25. Do not implement it again. The current
+development queue is [ROADMAP.md](../../ROADMAP.md); new sensors still need their
+own producer, health and observation contracts. Completing B1–B8 does not establish
+hardware-dependent ETW behavior or resolve every UNKNOWN in §14.
 
-*Refreshed 2026-08-25:* this section pointed at B5 until B5 merged; it now points at B8, the
-last open slice.
+*Refreshed 2026-09-07:* the previous instruction to implement B8 was stale after
+the umbrella suite and its read-mechanism ownership fix merged.
 
 *Refreshed 2026-08-23.* This section said "Implement B1 only … do not start B2+ until B1 is
 merged" for as long as B1 through B4, B6 and B7 were being merged past it. A "next block" line

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1175,3 +1175,35 @@ All four follow-up items from the core audit are implemented. Earlier completed
 PRs in this batch: #371 WSL freshness, #372 shared Windows observation, #373 streamed
 exports. No release or installed-app update was requested; the separately developed
 frontend remains untouched.
+
+## Session handoff — remaining roadmap reconciled (2026-09-07)
+
+Block 0 from the supplied remaining-work plan replaces the obsolete `ROADMAP.md`
+feature list with the current queue, checked against `11215d4`. It records the
+completed baseline, dependencies and completion evidence for discovery, ETW, rules,
+platform identity and maintenance. Renderer/design work remains user-owned.
+The sensor-health roadmap now marks B8 closed with its existing PR #329 and test
+evidence, rather than instructing the next session to implement it again.
+
+A1 is still a supplied patch (`a408af0`), not merged code or an open PR. Its separate
+review ran 2,733 passing tests with four skips, but identified the running-list /
+`wsl -d` race: a distribution can stop between those commands and be restarted by
+the probe. That no-start requirement must be resolved before A1 is merged; a second
+list check alone is not an atomic guarantee. A2 and A3 remain dependent on A1.
+C1, the evidence table for #73/#75, is independent and can proceed meanwhile.
+
+The plan no longer equates the database's 262 process-name entries with usable
+Linux signatures. ETW recon has 13 hardware-gated questions, not nine; their pending
+measurements are distinct from whether a Windows machine is available. Linux and
+macOS birth-time collection need measured resolution and race handling. A scripted
+index mutation gate remains optional follow-up; CI wiring needs separate workflow
+authorization. No source, frontend, dependency, lockfile, workflow or release change
+is part of this documentation block.
+
+The roadmap rewrite also removes its two obsolete single-line exemptions from
+`scripts/counts.js`: `counts:check` correctly rejected them after the old defect
+sentences disappeared. Application source is unchanged.
+
+Local format check, renderer build and lint passed (zero errors, 31 existing
+warnings); `counts:check` passed after removing the two dead exemptions. No new
+tests were added for the documentation and exemption removal.

--- a/scripts/counts.js
+++ b/scripts/counts.js
@@ -853,16 +853,6 @@ const ARCHIVAL_FILES = new Set(ARCHIVAL.map((a) => a.file));
  */
 const SITE_EXEMPTIONS = [
   {
-    file: 'ROADMAP.md',
-    contains: 'hardcoded `rgba(255,255,255)` in 15 Svelte components',
-    why: 'the size of a defect (15 affected components), not the component inventory',
-  },
-  {
-    file: 'ROADMAP.md',
-    contains: '(31 components unlinted)',
-    why: 'the size of a lint gap, not the component inventory',
-  },
-  {
     file: 'README.md',
     contains: '| YAML rulesets, 68 rules, hot-reload, 568 tests |',
     why: 'a release-history table row: it describes v0.7.0-alpha, not the tree',


### PR DESCRIPTION
ROADMAP.md still scheduled shipped startup, health and export work, while the sensor-health design named B8 as the next implementation despite its merge in #329. Replace that obsolete queue with the remaining development tracks and correct the B8 status using existing implementation evidence.

The roadmap distinguishes the supplied, unmerged multi-distro WSL patch from current source, records its unresolved no-start race, and names C1 as independent work. It also corrects the ETW hardware-gated scope and avoids treating every database alias as a usable Linux signature. Frontend ownership and release/workflow authorization boundaries remain explicit.

Remove the two count-check exemptions for deleted roadmap sentences and record the handoff. Application code, dependencies and workflows are unchanged.

Validation: format:check, build:renderer, lint (zero errors; 31 existing warnings), counts:check, git diff --check, targeted counts-script lint, and local document links passed. No new tests are needed for the documentation and obsolete exemption removal; the five required CI contexts must pass before merge.
