### PR TITLE
test: cover YAML failure boundaries and OpenClaw detection

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,13 +65,12 @@ The dependency is those observations, not the absence of a Windows host.
 
 ## C — existing rules coverage
 
-**C1:** map every requirement of [#73](https://github.com/antropos17/Aegis/issues/73)
-and [#75](https://github.com/antropos17/Aegis/issues/75) to existing tests and report
-covered / partial / absent with evidence. Existing YAML and OpenClaw tests mean
-neither issue should be treated as wholly unimplemented.
-
-**C2:** implement only confirmed gaps. If all requirements are covered, close with
-evidence rather than adding duplicate tests or unrelated detection rules.
+**C1 / C2 implemented:** [rules-coverage.md](docs/roadmap/rules-coverage.md) maps
+[#73](https://github.com/antropos17/Aegis/issues/73) and
+[#75](https://github.com/antropos17/Aegis/issues/75) to the previous coverage and the
+new regression cases. The gaps were in YAML failure boundaries and independent
+OpenClaw expectations. Tests now exercise these contracts without changing
+production rules or matching behavior; five deliberate mutations were caught.
 
 ## D — platform identity, then sensors
 
@@ -110,9 +109,10 @@ Keep them outside the active queue while the first ETW sensor is being establish
 ## Execution order
 
 Block 0 is this roadmap reconciliation, including the stale B8 status correction.
-Next resolve A1's no-start requirement, then A2, C1 and A3. B1 measurement preparation
-and independent D1 / D2 can follow; A4 starts with recon. If A1 cannot yet meet its
-requirement, C1 is an independent next block.
+Next resolve A1's no-start requirement, then A2 and A3. C1/C2 are implemented with
+evidence linked above. B1 measurement preparation and independent D1 / D2 can
+follow; A4 starts with recon. If A1 cannot yet meet its requirement, D1 is an
+independent next block.
 
 Keep one logical block per branch and PR. A supplied patch is not complete until
 reviewed, verified and merged. Use `AGENTS.md` for the authorized git cycle and

--- a/docs/roadmap/rules-coverage.md
+++ b/docs/roadmap/rules-coverage.md
@@ -1,0 +1,75 @@
+# Rules coverage — C1 evidence and C2 scope
+
+Checked against `8183226` on 2026-09-07. The relevant existing suites ran together:
+72 tests passed across `rule-loader`, `rule-loader-yaml-parity`, `process-scanner`
+and `process-observation`. Passing those suites does not establish the missing
+requirements below.
+
+The bodies of [#73](https://github.com/antropos17/Aegis/issues/73) and
+[#75](https://github.com/antropos17/Aegis/issues/75) contain damaged inline code and
+embedded historical command output. Required fields are taken from the production
+`rules/_schema.json`; OpenClaw identifiers are taken from its database entry and
+the production YAML. This reconstruction does not invent additional product rules.
+
+## C1 — coverage before this change
+
+| Issue requirement | Existing evidence | Verdict / gap |
+| --- | --- | --- |
+| #73 malformed YAML syntax / indentation | `tests/main/rule-loader.test.js`, “invalid YAML”, uses `tests/fixtures/rules/invalid-test.yaml`. That fixture is syntactically valid YAML with an invalid ID. | Absent for syntax errors; the schema-invalid case is covered. |
+| #73 missing required fields | The fixture has all required fields; “each rule has required fields” checks accepted rules only. | Absent for rejection of omitted fields. |
+| #73 empty YAML files | “empty directory” passes a nonexistent directory; no empty file is parsed. | Absent. |
+| #73 duplicate IDs, warning and skip | “warns on duplicate and keeps first occurrence” explicitly uses no duplicates and asserts zero warnings. | Absent for actual duplicates; the no-false-warning case is covered. |
+| #73 schema validation rejection | The invalid-ID fixture is excluded and an `Invalid ruleset` warning is asserted. | Partial: add isolated omission cases for the production schema's required fields. |
+| #73 mixed valid and invalid rules in one file | Separate valid and invalid fixture files are loaded together. | Absent within one file. Schema validation is document-wide; a schema-invalid member rejects the document. A schema-valid member with an invalid regex is skipped individually during compilation. Test both boundaries. |
+| #75 OpenClaw entry and aliases | `src/shared/agent-database.json` has `openclaw`, `moltbot`, `clawdbot`, `molty`. Generic scanner parity takes inputs from that same mutable database. | Partial: parity checks two scanner paths agree; it cannot detect a deleted alias or a consistently wrong owner. Pin the aliases and expected owner independently. |
+| #75 OpenClaw and legacy configuration paths | `rules/ai-config.yaml` has AI013 (`.openclaw`), AI034 (`.moltbot`) and AI035 (`.openclaw/config.yaml`). YAML parity preserves their IDs and pattern bytes. | Partial: no dedicated positive/negative path assertions for these rules. |
+| #75 known port 18789 | Present in the OpenClaw database entry. | Absent as an independent test assertion. |
+| #75 legacy aliases resolve to OpenClaw | Generic scanner parity compares legacy and shared process-observation paths. | Partial: neither path is asserted against an independent OpenClaw result for each alias. |
+
+Relevant implementation: [rule-loader.js](../../src/main/rule-loader.js),
+[production schema](../../rules/_schema.json),
+[agent database](../../src/shared/agent-database.json),
+[AI configuration rules](../../rules/ai-config.yaml).
+
+## C2 — bounded implementation
+
+Add disposable-fixture tests for syntax failures, empty documents, missing required
+fields, real duplicate IDs and the two mixed-rule failure boundaries. Assert that
+a bad file does not discard a valid sibling file, that duplicates preserve the
+first rule, and that category lookup reflects only accepted rules. Rename the
+existing no-duplicate test to describe what it actually proves.
+
+Add independent OpenClaw metadata assertions, real scanner calls for each pinned
+alias, and Windows/POSIX configuration-path cases using the production rule loader.
+Do not change production rules, matching behavior, agent metadata or the renderer
+merely to increase test coverage.
+
+## C2 — implementation and evidence
+
+[rule-loader-edge-cases.test.js](../../tests/main/rule-loader-edge-cases.test.js)
+adds 17 cases covering the #73 gaps above, using disposable files and the production
+schema. Empty input must warn and preserve a valid sibling whether the parser or
+schema rejects it. The existing no-duplicate test now names that narrower behavior.
+
+[openclaw-detection.test.js](../../tests/main/openclaw-detection.test.js) adds nine
+cases covering the #75 gaps: independent entry/alias/port/config metadata,
+one real scanner call for each pinned alias, lookalike executable rejection, and
+three production path rules with Windows/POSIX positive and negative examples.
+This verifies discovery contracts, not a live Gateway installation or network probe.
+
+The six affected suites passed together: 98 tests. Five deliberate mutations were
+applied individually in an isolated checkout; every original file was restored
+byte-for-byte after its run:
+
+| Mutation | New tests that failed |
+| --- | ---: |
+| Bypass duplicate-ID skip | 1 |
+| Bypass document schema validation | 10 |
+| Remove the `molty` alias | 2 |
+| Change the Gateway port from 18789 | 1 |
+| Replace the AI013 path pattern with a nonmatching pattern | 1 |
+
+Local mutation reports are in `X:/tmp/aegis-rule-coverage-mutations-20260907/`;
+they contain disposable fixture results, not user data. No production source,
+database entry or rule is changed by C2. Issues #73/#75 can close when this change
+passes the required checks and merges.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1207,3 +1207,34 @@ sentences disappeared. Application source is unchanged.
 Local format check, renderer build and lint passed (zero errors, 31 existing
 warnings); `counts:check` passed after removing the two dead exemptions. No new
 tests were added for the documentation and exemption removal.
+
+## Session handoff — rules coverage C1/C2 (2026-09-07)
+
+`docs/roadmap/rules-coverage.md` maps every readable requirement in #73/#75 to
+existing tests on `8183226`. The old duplicate-ID test used no duplicates; the
+empty-directory test used no YAML file; the invalid fixture tested schema rejection
+with valid YAML syntax. Generic database/scanner parity could not catch an alias
+deleted from both its inputs and its expectations. The issues were not already
+fully covered.
+
+C2 adds 17 disposable-fixture cases for YAML syntax/empty input, each required
+schema field, actual duplicate IDs, whole-document schema rejection and per-rule
+regex rejection. Nine OpenClaw cases independently pin aliases, ownership, port and
+config metadata, call the real scanner for all four aliases, and match production
+rules against Windows/POSIX config paths and lookalikes. The misleading duplicate
+test title is corrected. Six affected suites passed together (98 tests).
+
+Five isolated mutations were caught: duplicate skip removed (1 failed test), schema
+validation bypassed (10), `molty` alias removed (2), Gateway port changed (1), and
+AI013 pattern replaced (1). Each original file was restored byte-for-byte; artifacts
+are under `X:/tmp/aegis-rule-coverage-mutations-20260907/`. Production code, YAML,
+agent metadata, renderer, dependencies and workflows are unchanged. The roadmap
+records the implemented C1/C2 scope. A1's no-start race remains unresolved; D1 is an
+independent next block if A1 is not yet implementable under that constraint.
+
+Full coverage passed: 2,750 tests, four skips, 155 files. The first concurrent run
+hit the existing five-second timeout in `actor-secret-hold.test.js`; its isolated
+rerun and the subsequent full coverage run passed without changing code or timeout.
+Format, build, lint (zero errors, 31 existing warnings), both type checks, both
+mutation gates, counts and the production dependency audit also passed. Local
+document links were verified. Closure of #73/#75 is attached to the test PR merge.

--- a/tests/main/openclaw-detection.test.js
+++ b/tests/main/openclaw-detection.test.js
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import path from 'path';
+import database from '../../src/shared/agent-database.json';
+import scanner from '../../src/main/process-scanner.js';
+import ruleLoader from '../../src/main/rule-loader.js';
+
+const RULES_DIR = path.resolve(__dirname, '../../rules');
+// Independent expectations: deleting an alias from the database must fail a test.
+const ALIASES = ['openclaw', 'moltbot', 'clawdbot', 'molty'];
+
+describe('OpenClaw detection contract (#75)', () => {
+  beforeEach(() => {
+    scanner._resetForTest();
+  });
+
+  afterEach(() => {
+    scanner._resetForTest();
+  });
+
+  it('keeps the canonical entry, legacy aliases, gateway port and config paths together', () => {
+    const entries = database.agents.filter((a) => a.id === 'openclaw');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      displayName: 'OpenClaw',
+      names: expect.arrayContaining(ALIASES),
+      knownPorts: expect.arrayContaining([18789]),
+      configPaths: expect.arrayContaining(['~/.openclaw/', '~/.openclaw/config', '~/.moltbot/']),
+    });
+    for (const alias of ALIASES) {
+      expect(database.agents.filter((a) => a.names.includes(alias)).map((a) => a.id)).toEqual([
+        'openclaw',
+      ]);
+    }
+  });
+
+  it.each(ALIASES)('resolves the %s process alias to OpenClaw', async (name) => {
+    scanner._setPlatformForTest({
+      providesStartTime: false,
+      listProcesses: async () => [{ name, pid: 4242 }],
+    });
+    const result = await scanner.scanProcesses();
+    expect(result.reliable).toBe(true);
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0]).toMatchObject({ agent: 'OpenClaw', pid: 4242 });
+  });
+
+  it('does not classify lookalike executable names as OpenClaw', async () => {
+    scanner._setPlatformForTest({
+      providesStartTime: false,
+      listProcesses: async () => [
+        { name: 'notopenclaw', pid: 4242 },
+        { name: 'moltbot-helper', pid: 4243 },
+      ],
+    });
+    expect((await scanner.scanProcesses()).agents).toEqual([]);
+  });
+
+  it.each([
+    ['AI013', '.openclaw', 'settings.json', 'AI agent config — OpenClaw'],
+    ['AI034', '.moltbot', 'settings.json', 'AI agent config — OpenClaw (legacy Moltbot)'],
+    ['AI035', '.openclaw', 'config.yaml', 'AI agent config — OpenClaw'],
+  ])(
+    '%s matches Windows/POSIX config paths without matching sibling directories',
+    (id, dir, file, reason) => {
+      const loaded = ruleLoader.reloadRules(RULES_DIR).get(id);
+      expect(loaded).toBeDefined();
+      expect(loaded.reason).toBe(reason);
+      for (const separator of ['/', '\\']) {
+        const prefix = separator === '/' ? '/home/test' : 'C:\\Users\\test';
+        expect(loaded.pattern.test([prefix, dir, file].join(separator))).toBe(true);
+        expect(loaded.pattern.test([prefix, `${dir}-backup`, file].join(separator))).toBe(false);
+      }
+      if (id === 'AI035') {
+        expect(loaded.pattern.test('/home/test/.openclaw/config.yaml.bak')).toBe(false);
+        expect(loaded.pattern.test('C:\\Users\\test\\.openclaw\\other.yaml')).toBe(false);
+      }
+    },
+  );
+});

--- a/tests/main/rule-loader-edge-cases.test.js
+++ b/tests/main/rule-loader-edge-cases.test.js
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { dump } from 'js-yaml';
+import ruleLoader from '../../src/main/rule-loader.js';
+
+// The loader calls the CommonJS export, not the ESM interop wrapper.
+const logger = require('../../src/main/logger.js');
+const SCHEMA = path.resolve(__dirname, '../../rules/_schema.json');
+
+function rule(id, overrides = {}) {
+  return {
+    id,
+    name: `Fixture ${id}`,
+    pattern: `${id}$`,
+    reason: 'Disposable fixture',
+    category: 'secrets',
+    ...overrides,
+  };
+}
+
+function document(rules) {
+  return { version: 1, category: 'secrets', description: 'Disposable fixture', rules };
+}
+
+describe('rule-loader — YAML failure boundaries (#73)', () => {
+  let directory;
+  let warnings;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-yaml-cases-'));
+    fs.copyFileSync(SCHEMA, path.join(directory, '_schema.json'));
+    warnings = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    // Every rejection case must leave this unrelated, valid file usable.
+    write('control.yaml', document([rule('TS900')]));
+  });
+
+  afterEach(() => {
+    if (directory) {
+      ruleLoader.reloadRules(path.join(directory, 'absent'));
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  function write(name, contents) {
+    fs.writeFileSync(
+      path.join(directory, name),
+      typeof contents === 'string' ? contents : dump(contents),
+      'utf8',
+    );
+  }
+
+  function expectRejected(message) {
+    const loaded = ruleLoader.reloadRules(directory);
+    expect([...loaded.keys()]).toEqual(['TS900']);
+    expect(ruleLoader.getRulesByCategory('secrets', directory).map((r) => r.id)).toEqual(['TS900']);
+    expect(warnings).toHaveBeenCalledWith(
+      'rule-loader',
+      message,
+      expect.objectContaining({ file: 'bad.yaml' }),
+    );
+  }
+
+  it.each([
+    ['invalid indentation', 'rules:\n  - id: TS001\n   name: misplaced\n'],
+    ['unterminated sequence', 'rules: [\n'],
+  ])('rejects %s without losing a valid sibling', (_label, source) => {
+    write('bad.yaml', source);
+    expectRejected('Failed to parse');
+  });
+
+  it.each([
+    ['zero-byte file', ''],
+    ['comment-only file', '# No rules here\n'],
+    ['empty YAML document', '---\n'],
+  ])('rejects a %s', (_label, source) => {
+    write('bad.yaml', source);
+    // Blank input may fail in the YAML parser; an explicit null document reaches
+    // schema validation. Both must warn and leave the valid sibling available.
+    expectRejected(expect.any(String));
+  });
+
+  it.each(['version', 'category', 'description', 'rules'])(
+    'rejects a document missing required field %s',
+    (field) => {
+      const source = document([rule('TS001')]);
+      delete source[field];
+      write('bad.yaml', source);
+      expectRejected('Invalid ruleset');
+    },
+  );
+
+  it.each(['id', 'name', 'pattern', 'reason', 'category'])(
+    'rejects a document containing a rule without %s',
+    (field) => {
+      const incomplete = rule('TS001');
+      delete incomplete[field];
+      write('bad.yaml', document([incomplete]));
+      expectRejected('Invalid ruleset');
+    },
+  );
+
+  it('warns on a real duplicate, keeps the first rule and indexes only accepted rules', () => {
+    write(
+      'duplicates.yaml',
+      document([
+        rule('TS001', { name: 'First', pattern: 'first$', category: 'ssh' }),
+        rule('TS001', { name: 'Replacement', pattern: 'replacement$', category: 'cloud' }),
+        rule('TS002'),
+      ]),
+    );
+    const loaded = ruleLoader.reloadRules(directory);
+    expect([...loaded.keys()].sort()).toEqual(['TS001', 'TS002', 'TS900']);
+    expect(loaded.get('TS001')).toMatchObject({ name: 'First', category: 'ssh' });
+    expect(loaded.get('TS001').pattern.test('first')).toBe(true);
+    expect(loaded.get('TS001').pattern.test('replacement')).toBe(false);
+    expect(ruleLoader.getRulesByCategory('ssh', directory).map((r) => r.id)).toEqual(['TS001']);
+    expect(ruleLoader.getRulesByCategory('cloud', directory)).toEqual([]);
+    expect(warnings.mock.calls.filter((c) => c[1] === 'Duplicate rule ID — skipping')).toEqual([
+      ['rule-loader', 'Duplicate rule ID — skipping', { ruleId: 'TS001', file: 'duplicates.yaml' }],
+    ]);
+  });
+
+  it('rejects the whole schema-invalid document even when valid rules surround the bad one', () => {
+    write('bad.yaml', document([rule('TS001'), rule('BADID'), rule('TS002')]));
+    expectRejected('Invalid ruleset');
+  });
+
+  it('skips an invalid regex but preserves valid rules on both sides in the same document', () => {
+    write('bad.yaml', document([rule('TS001'), rule('TS002', { pattern: '[' }), rule('TS003')]));
+    const loaded = ruleLoader.reloadRules(directory);
+    expect([...loaded.keys()].sort()).toEqual(['TS001', 'TS003', 'TS900']);
+    expect(loaded.get('TS001').pattern.test('TS001')).toBe(true);
+    expect(loaded.get('TS003').pattern.test('TS003')).toBe(true);
+    expect(
+      ruleLoader
+        .getRulesByCategory('secrets', directory)
+        .map((r) => r.id)
+        .sort(),
+    ).toEqual(['TS001', 'TS003', 'TS900']);
+    expect(warnings).toHaveBeenCalledWith(
+      'rule-loader',
+      'Invalid pattern in rule',
+      expect.objectContaining({ ruleId: 'TS002', file: 'bad.yaml' }),
+    );
+  });
+});

--- a/tests/main/rule-loader.test.js
+++ b/tests/main/rule-loader.test.js
@@ -95,10 +95,8 @@ describe('rule-loader', () => {
   });
 
   describe('duplicate ID handling', () => {
-    it('warns on duplicate and keeps first occurrence', () => {
-      // To test duplicates we need a fixture with dupe IDs.
-      // valid-test.yaml has unique IDs, so this test verifies
-      // the mechanism works with existing fixtures (no dupes = no warn).
+    it('does not warn about duplicate IDs when every ID is unique', () => {
+      // Actual duplicate handling is covered by rule-loader-edge-cases.test.js.
       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
       ruleLoader.reloadRules(FIXTURES_DIR);
 


### PR DESCRIPTION
The YAML loader tests did not exercise actual duplicate IDs, empty files or syntax errors: the duplicate test contained no duplicates and the invalid YAML fixture was syntactically valid. OpenClaw metadata and alias ownership also lacked independent expectations, so generic parity tests could agree after both paths lost the same alias.

Add 17 disposable-fixture tests for YAML failure boundaries and nine OpenClaw contract tests, correct the misleading duplicate-test title, and record the requirement-to-evidence table and completed C1/C2 scope. Production code, rules, database entries, dependencies and frontend are unchanged.

Closes #73
Closes #75

Validation:
- Full coverage: 2,750 passed, four skipped, 155 files. One existing process-launch test exceeded its five-second timeout in the first concurrent run; its isolated rerun and a subsequent full run passed with no timeout or code change.
- Five deliberate mutations in an isolated checkout were caught: duplicate skip (1 failure), schema validation (10), removed legacy alias (2), wrong Gateway port (1), wrong config pattern (1). Original files were restored byte-for-byte.
- Format, build, lint (zero errors; 31 existing warnings), both type checks, both mutation gates, counts, production npm audit and local documentation links passed.

These tests verify existing contracts; they do not claim a live OpenClaw Gateway smoke or change WSL discovery.
