### PR TITLE
feat: observe fresh Linux process generations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Explicit user instructions take precedence over anything in AGENTS.md or a skill
 
 ## Project facts
 
-`src/main/` contains 66 main modules: 54 top-level + platform/ 10 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
+`src/main/` contains 67 main modules: 54 top-level + platform/ 11 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
 
 A birth time is observed on the pass that stamps it or is `null`; no cache stores one. A snapshot outage freezes sessions and never splits them. For changes touching identity stamping, the audit chain, or the Windows git worktree flow, `memory-bank/ai-mistakes.md` holds the relevant failure history.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,12 +74,13 @@ production rules or matching behavior; five deliberate mutations were caught.
 
 ## D — platform identity, then sensors
 
-Linux and macOS adapters omit birth time and declare `providesStartTime: false`.
-Their native `<pid>:u` identities cannot distinguish reuse.
+Linux now supplies fresh procfs birth observations. macOS still declares
+`providesStartTime: false`; its native `<pid>:u` identities cannot distinguish reuse.
 
-- **D1:** Linux birth observations from `/proc`, with verified field parsing,
-  clock-tick conversion, boot-time anchoring and process exit/read race handling.
-  Do not assume the host tick rate without evidence.
+- **D1 implemented:** Linux reads field 22 from fresh `/proc/<pid>/stat`, observes
+  CLK_TCK, and pins a boot-ID-bound epoch reference. Kernel ticks provide generation
+  witnesses; unavailable identity yields null birth times and freezes sessions.
+  Tests cover parsing, conversion, PID reuse, outages/recovery and clock corrections.
 - **D2:** select and verify macOS birth-time collection. Document resolution and
   residual ambiguity: a one-second timestamp cannot distinguish every rapid reuse.
 - **D3 / D4:** Linux fanotify/eBPF and macOS Endpoint Security follow platform
@@ -110,9 +111,9 @@ Keep them outside the active queue while the first ETW sensor is being establish
 
 Block 0 is this roadmap reconciliation, including the stale B8 status correction.
 Next resolve A1's no-start requirement, then A2 and A3. C1/C2 are implemented with
-evidence linked above. B1 measurement preparation and independent D1 / D2 can
-follow; A4 starts with recon. If A1 cannot yet meet its requirement, D1 is an
-independent next block.
+evidence linked above. D1 is implemented; B1 measurement preparation and independent
+D2 can follow. A4 starts with recon. Application process grouping is separately
+authorized in both data and the current interface; broader frontend work remains separate.
 
 Keep one logical block per branch and PR. A supplied patch is not complete until
 reviewed, verified and merged. Use `AGENTS.md` for the authorized git cycle and

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **66** = 54 top-level + 10 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **67** = 54 top-level + 11 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **50** (plus `src/renderer/App.svelte` → **51** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **16** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |
@@ -161,13 +161,16 @@ counters follow the main ring plus its eviction hook.
 `instanceIdSource` (`scan-loop.js:526-528`), mirroring `injectDetectedExternalAgents`. The
 baselines/risk quarantine that made this visible was correct and is unchanged.
 
-### F-E06 — Linux/Darwin supply no OS birth time → real agents fall back to `"<pid>:u"` — **OPEN**
+### F-E06 — Darwin supplies no OS birth time — **PARTIAL: Linux implemented**
 
-**User sees:** After PID reuse on non-Windows, sessions, knownHandles and scores can continue under
+**User sees:** After PID reuse on macOS, sessions, knownHandles and scores can continue under
 a new process as if it were the old one (degraded identity).
 
-**Where:** `platform/linux.js:247` and `platform/darwin.js:149` both document that
-`getParentProcessMap` entries carry no `startTime`; `win32.js` supplies one.
+**Where:** `platform/darwin.js` still omits birth time. Linux now reads fresh kernel
+start ticks through `platform/linux-process-map.js`, with observed CLK_TCK and a
+boot-ID-bound epoch reference. An unreadable observation returns null births and
+failed identity health, freezing sessions. Epoch values have the resolution of
+kernel ticks and the initial boot-time reference; they are not exact wall-clock times.
 
 **Mechanism:** Space-3 identity is honest but reuse-unsafe. The product claims instance identity
 generally; the platform gap is silent to the user.
@@ -447,7 +450,7 @@ window (≈500) vs feed (200) vs risk quarantine of unattributed — F-E04.
 5. **F-E04** four independent event windows, no truncation disclosure.
 6. **F-S04** pid-keyed maps cannot represent two agents on one pid, and pid-0 synthetics now reach
    the scan list.
-7. **F-E06** linux/darwin have no OS birth time → degraded identity under PID reuse.
+7. **F-E06** Darwin has no OS birth time → degraded identity under PID reuse; Linux implemented.
 8. **F-E10** token costs silently absent on non-Windows.
 9. **F-S06** `riskHistory` sparkline is dead UI.
 10. **F-S02** `getRulesByCategory` tested but never called.

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 66 CommonJS modules (54 top-level + 10 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 67 CommonJS modules (54 top-level + 11 platform/ + 2 token-adapters/)
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1238,3 +1238,33 @@ rerun and the subsequent full coverage run passed without changing code or timeo
 Format, build, lint (zero errors, 31 existing warnings), both type checks, both
 mutation gates, counts and the production dependency audit also passed. Local
 document links were verified. Closure of #73/#75 is attached to the test PR merge.
+
+## Session handoff — Linux process generations, D1 (2026-09-08)
+
+Linux now provides fresh birth observations and boot-ID/start-tick generation
+witnesses through `platform/linux-process-map.js`. CLK_TCK is observed, never
+assumed. Only the clock frequency and a boot-ID-bound epoch reference survive
+passes; per-PID birth times are always read on the pass that stamps them. The
+reference stays stable over wall-clock corrections. Epoch milliseconds remain an
+estimate limited by kernel tick resolution and the initial btime reference.
+Field definitions: [proc_pid_stat(5)](https://www.man7.org/linux/man-pages/man5/proc_pid_stat.5.html)
+and [kernel proc documentation](https://www.kernel.org/doc/html/v6.15/filesystems/proc.html).
+
+Vanished PIDs are skipped. Malformed/unreadable identity observations produce a
+population-only ps fallback, null births and FAILED proc-snapshot health. The
+existing session freeze handles this outage without splitting recovered sessions.
+macOS identity collection remains D2. WSL distribution discovery is a separate
+Windows adapter and is unchanged by native Linux D1.
+
+Fifteen new tests cover parsing, frequency, fresh reuse, boot/clock changes,
+outage/recovery and the real scanner/enrichment/session pipeline. Full coverage:
+2,765 passed, four skipped, 156 files. Format, build, lint (31 existing warnings),
+both type checks, both mutation gates, counts and production audit passed. Native
+Ubuntu/Node 24.18.1 smoke verified two observations against live procfs: five
+processes, CLK_TCK 100, 14 ms for the two passes in this single local sample.
+
+Continue the same user request with application process grouping, explicitly
+authorized for BOTH data and the current interface. Retain individual PIDs and
+security/session identities; expose application trees and distinguish independent
+launches from children. Process trees cannot establish chat counts. Broader visual
+redesign remains outside this work.

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -219,8 +219,8 @@ function getAppHealth() {
       .sort()
       .map((id) => llmHealth[id]),
   ];
-  // win32 only (gap F). linux and darwin own no snapshot leaf and must not contribute
-  // a fabricated one — their `providesStartTime: false` already answers the question.
+  // Windows and Linux publish their process-map observation health. macOS has no
+  // snapshot leaf and retains its explicit providesStartTime: false capability.
   if (typeof platform.getSnapshotHealth === 'function') {
     records.push(platform.getSnapshotHealth());
   }

--- a/src/main/platform/linux-process-map.js
+++ b/src/main/platform/linux-process-map.js
@@ -1,0 +1,149 @@
+/**
+ * @file linux-process-map.js
+ * @description Fresh Linux process generations from procfs, with a named outage.
+ * @since 0.15.0
+ */
+'use strict';
+
+const sensor = require('../sensor-health');
+const { parseParentProcessMapFromPs } = require('./posix-shared');
+
+/**
+ * Parse one complete stat record. comm may contain spaces, parentheses or newlines;
+ * the last ')' terminates it because the remaining fields are numeric/state data.
+ * @param {string} text
+ * @param {number} expectedPid
+ * @returns {{name: string, ppid: number, ticks: bigint}|null}
+ */
+function parseStat(text, expectedPid) {
+  const open = text.indexOf('(');
+  const close = text.lastIndexOf(')');
+  if (open < 1 || close <= open || Number(text.slice(0, open).trim()) !== expectedPid) return null;
+  const fields = text
+    .slice(close + 1)
+    .trim()
+    .split(/\s+/);
+  const name = text.slice(open + 1, close);
+  if (!name || fields.length < 20 || !/^[A-Za-z]$/.test(fields[0])) return null;
+  if (!/^\d+$/.test(fields[1]) || !/^\d+$/.test(fields[19])) return null;
+  const ppid = Number(fields[1]);
+  if (!Number.isSafeInteger(ppid)) return null;
+  return { name, ppid, ticks: BigInt(fields[19]) };
+}
+
+/**
+ * Own the Linux process-map observation. No per-PID observation is cached. Only
+ * CLK_TCK and a boot-ID-bound epoch reference survive passes. Pinning that global
+ * reference prevents a wall-clock correction from changing every live identity.
+ * Epoch values are therefore estimates in the first observed boot reference;
+ * fresh kernel start ticks, not the wall clock, prove each process generation.
+ * @param {{fs: typeof import('fs'), execFile: Function}} deps
+ * @returns {{getParentProcessMap: Function, getSnapshotHealth: Function}}
+ * @since 0.15.0
+ */
+function createProcessMapReader({ fs, execFile }) {
+  let clockTicks = null;
+  let clockProbe = null;
+  let bootReference = null;
+  let health = sensor.createSensorHealth('proc-snapshot');
+
+  function run(command, args) {
+    return new Promise((resolve) => {
+      execFile(
+        command,
+        args,
+        { timeout: 5000, maxBuffer: 4 * 1024 * 1024, windowsHide: true },
+        (err, stdout) => {
+          resolve(err ? null : String(stdout || ''));
+        },
+      );
+    });
+  }
+
+  async function getClockTicks() {
+    if (clockTicks !== null) return clockTicks;
+    if (!clockProbe) {
+      clockProbe = run('getconf', ['CLK_TCK'])
+        .then((text) => {
+          const value = text !== null && /^\d+$/.test(text.trim()) ? Number(text.trim()) : NaN;
+          if (Number.isSafeInteger(value) && value > 0) clockTicks = value;
+          return clockTicks;
+        })
+        .finally(() => {
+          clockProbe = null;
+        });
+    }
+    return clockProbe;
+  }
+
+  function readBootId() {
+    const id = fs.readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim();
+    if (!/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(id)) throw Error('boot-id');
+    return id.toLowerCase();
+  }
+
+  /**
+   * Read this pass or return a population-only ps fallback with no birth claims.
+   * A vanished PID is normal during enumeration. Other unread or malformed stat
+   * records invalidate identity for the pass, so session reconciliation freezes.
+   * @returns {Promise<Map<number, object>>}
+   * @since 0.15.0
+   */
+  async function getParentProcessMap() {
+    try {
+      const hz = await getClockTicks();
+      if (hz === null) throw Error('clock-ticks');
+      const bootId = readBootId();
+      const match = fs.readFileSync('/proc/stat', 'utf8').match(/^btime (\d+)$/m);
+      if (!match || !Number.isSafeInteger(Number(match[1])) || Number(match[1]) <= 0)
+        throw Error('boot-time');
+      if (!bootReference || bootReference.id !== bootId)
+        bootReference = { id: bootId, seconds: BigInt(match[1]) };
+      const entries = fs.readdirSync('/proc').filter((entry) => /^\d+$/.test(entry));
+      const map = new Map();
+      for (const entry of entries) {
+        const pid = Number(entry);
+        if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+        let text;
+        try {
+          text = fs.readFileSync(`/proc/${entry}/stat`, 'utf8');
+        } catch (err) {
+          if (err.code === 'ENOENT' || err.code === 'ESRCH') continue;
+          throw err;
+        }
+        const parsed = parseStat(text, pid);
+        if (!parsed) throw Error('process-stat');
+        const millis = bootReference.seconds * 1000n + (parsed.ticks * 1000n) / BigInt(hz);
+        if (millis <= 0n || millis > BigInt(Number.MAX_SAFE_INTEGER)) throw Error('process-time');
+        map.set(pid, {
+          name: parsed.name,
+          ppid: parsed.ppid,
+          startTime: Number(millis),
+          witness: `${bootId}:${parsed.ticks}`,
+          witnessSource: 'linuxStartTicks',
+        });
+      }
+      if (map.size === 0 || readBootId() !== bootId) throw Error('process-table');
+      health = sensor.markHealthy(health, Date.now());
+      return map;
+    } catch (_) {
+      health = sensor.markFailed(health, Date.now(), {
+        error: 'linux-proc-identity-unavailable',
+        detail: 'linux-proc-identity-unavailable',
+      });
+      const text = await run('ps', ['-axo', 'pid=,ppid=,comm=']);
+      const map = text === null ? new Map() : parseParentProcessMapFromPs(text);
+      for (const entry of map.values()) entry.startTime = null;
+      return map;
+    }
+  }
+
+  /** @returns {object} @since 0.15.0 */
+  function getSnapshotHealth() {
+    return sensor.toPlain(health);
+  }
+
+  return { getParentProcessMap, getSnapshotHealth };
+}
+
+module.exports = { createProcessMapReader };

--- a/src/main/platform/linux.js
+++ b/src/main/platform/linux.js
@@ -23,7 +23,6 @@ const {
   killProcess,
   suspendProcess,
   resumeProcess,
-  parseParentProcessMapFromPs,
 } = require('./posix-shared');
 
 /** @type {RegExp[]} Linux-specific file-path patterns to ignore */
@@ -54,48 +53,10 @@ function listProcesses() {
   });
 }
 
-/**
- * Build a map of all processes with their parent PIDs.
- * Uses /proc directly for speed, falls back to `ps`.
- * @returns {Promise<Map<number, {name: string, ppid: number}>>}
- */
-function getParentProcessMap() {
-  const map = new Map();
-  // Try /proc first (faster, no subprocess)
-  try {
-    const entries = fs.readdirSync('/proc').filter((e) => /^\d+$/.test(e));
-    for (const pidStr of entries) {
-      try {
-        const stat = fs.readFileSync(path.join('/proc', pidStr, 'stat'), 'utf-8');
-        // Format: pid (comm) state ppid ...
-        const match = stat.match(/^(\d+)\s+\((.+?)\)\s+\S+\s+(\d+)/);
-        if (match) {
-          map.set(parseInt(match[1], 10), {
-            name: match[2],
-            ppid: parseInt(match[3], 10),
-          });
-        }
-      } catch (_) {
-        // Process may have exited
-      }
-    }
-    if (map.size > 0) return Promise.resolve(map);
-  } catch (_) {
-    // /proc not available, fall back to ps
-  }
-
-  return new Promise((resolve) => {
-    _execFile('ps', ['-axo', 'pid=,ppid=,comm='], { maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
-      if (err) {
-        resolve(map);
-        return;
-      }
-      const parsed = parseParentProcessMapFromPs(stdout);
-      for (const [pid, info] of parsed) map.set(pid, info);
-      resolve(map);
-    });
-  });
-}
+const processMapReader = require('./linux-process-map').createProcessMapReader({
+  fs,
+  execFile: (...args) => _execFile(...args),
+});
 
 /**
  * Get raw TCP connections for given PIDs.
@@ -243,16 +204,11 @@ async function getProcessCwds(pids) {
 }
 
 module.exports = {
-  /**
-   * `getParentProcessMap` entries carry no `startTime` here — `/proc/<pid>/stat`
-   * field 22 would supply one, but it is not wired. process-utils reads this flag
-   * as "no generation is observable", which keeps its parent-chain and cwd caches
-   * on their plain TTL contract instead of paying a /proc walk every scan tick.
-   * @type {boolean}
-   */
-  providesStartTime: false,
+  /** Fresh procfs generations are observed each pass; outages remain explicit. */
+  providesStartTime: true,
   listProcesses,
-  getParentProcessMap,
+  getParentProcessMap: processMapReader.getParentProcessMap,
+  getSnapshotHealth: processMapReader.getSnapshotHealth,
   getRawTcpConnections,
   getFileHandles,
   getProcessCwd,

--- a/src/main/process-identity.js
+++ b/src/main/process-identity.js
@@ -51,12 +51,13 @@
  *       apart across the boundary do not. `tests/fixtures/bench/derived/
  *       D1-pid-reuse-same-ms/` models that first pair, and what a pid-only join
  *       can and cannot say about it.
- *     - linux: 10 ms would be available from `/proc/<pid>/stat` field 22 at the
- *       usual USER_HZ=100. The `/proc/stat` btime anchor carries up to ±1 s of
- *       systematic error, but it is identical for every process on the machine,
- *       so it affects only cross-machine comparability — never distinguishability.
- *       NOT WIRED: platform/linux.js `getParentProcessMap` omits startTime today,
- *       so linux resolves to space 3.
+ *     - linux: `/proc/<pid>/stat` field 22, converted using observed CLK_TCK and
+ *       floored to milliseconds (10 ms at CLK_TCK=100). The boot-ID-bound btime
+ *       reference is pinned for this AEGIS lifetime so wall-clock corrections do
+ *       not split live identities. Epoch values are estimates in that reference,
+ *       with second-resolution anchoring; fresh boot ID + start ticks provide the
+ *       generation witness. No per-PID birth observation is cached. An unread
+ *       procfs pass produces null birth times and freezes session reconciliation.
  *     - darwin: 1 SECOND at best (`ps` lstart/etime). Reuse inside one second
  *       would require the macOS pid counter to wrap (~99k spawns in that second).
  *       NOT WIRED: platform/darwin.js omits startTime, so darwin resolves to

--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -76,8 +76,8 @@ function isProcessPopulationReliable() {
  * façade would not name; with the export in place, keeping it would leave a second
  * path that can disagree with the first.
  *
- * `null` is returned where no façade publishes the leaf — linux and darwin, which own
- * no snapshot. That branch answers nothing in practice: both set
+ * `null` is returned where no façade publishes the leaf — currently darwin, which
+ * owns no snapshot. That branch answers nothing in practice: it sets
  * `providesStartTime: false`, and {@link getIdentityQuality} returns on that flag
  * before it ever reaches here. It is the honest value for "this platform carries no
  * witness", not a fallback.
@@ -105,7 +105,7 @@ function readSnapshotState() {
  * @since 0.12.0
  */
 function getIdentityQuality() {
-  // darwin/linux publish no birth time at all → identify() yields "<pid>:u".
+  // Platforms without birth times (currently darwin) retain "<pid>:u".
   if (_providesStartTime !== true) return 'unknown';
   const state = readSnapshotState();
   if (state === sensorHealth.SENSOR_HEALTH_STATE.HEALTHY) return 'witnessed';
@@ -119,7 +119,7 @@ function getIdentityQuality() {
  * PLATFORM PROVIDES.
  *
  * Deliberately not a bare `getIdentityQuality() === 'unknown'`. That value is
- * `unknown` PERMANENTLY on linux and darwin — neither adapter publishes a birth time
+ * `unknown` PERMANENTLY on darwin — that adapter publishes no birth time
  * at all — so acting on it there would freeze session tracking forever on platforms
  * where `<pid>:u` is the normal, documented steady state (process-identity.js space
  * 3), not a fault. Degradation is a RELATIVE notion: it exists only where the

--- a/src/main/process-utils.js
+++ b/src/main/process-utils.js
@@ -18,13 +18,12 @@ const { EDITORS } = require('../shared/constants');
 let _getParentProcessMap = _platform.getParentProcessMap;
 let _getProcessCwds = _platform.getProcessCwds;
 /**
- * Whether this platform's `getParentProcessMap` carries an OS birth time. Only
- * win32 does today — from the snapshot sidecar's 100 ns creation time, floored to
+ * Whether this platform's `getParentProcessMap` carries an OS birth time. Windows
+ * uses the snapshot sidecar's 100 ns creation time, floored to
  * epoch-ms by `ticksToEpochMs` (platform/process-snapshot.js), with the CIM
  * `Win32_Process.CreationDate` observation as the emergency fallback behind it.
- * linux and darwin omit it, and neither may pay a per-scan subprocess or /proc
- * walk to serve a Windows-only generation check. The flag is what gates the
- * generation proof below.
+ * Linux reads fresh procfs start ticks with a boot reference. macOS still omits
+ * birth times and retains its TTL-only path. The flag gates generation proof.
  * @type {boolean}
  */
 let _providesStartTime = _platform.providesStartTime === true;
@@ -347,7 +346,7 @@ async function _stampFromFreshBirthTimes(agents, forceRefresh, observedMap) {
 
 /**
  * Stamp `parentChain` on a platform that declares NO per-pass birth-time
- * observation (`providesStartTime: false` — linux, darwin). The TTL-bounded
+ * observation (`providesStartTime: false` — currently darwin). The TTL-bounded
  * parent-chain cache answers, and a pass whose pids are all cached costs no provider
  * call at all. Adding a per-pass process map here would buy nothing — this platform
  * declares no birth time to prove a generation with — and would cost a `ps` spawn or
@@ -528,7 +527,7 @@ const CWD_CACHE_TTL = 60000;
  *     witness) → nothing is proven, so the cwd is re-fetched rather than
  *     inherited from the old generation;
  *   - `undefined` (this record never passed through enrichment — every pid on
- *     linux/darwin, pid ≤ 0, and any direct caller that skipped the stamp) → the
+ *     darwin, pid ≤ 0, and any direct caller that skipped the stamp) → the
  *     record established no generation, so none is invented for it and the plain
  *     TTL contract applies exactly as it did before generations existed.
  * @param {Array} agents

--- a/src/shared/types/process.ts
+++ b/src/shared/types/process.ts
@@ -14,24 +14,27 @@ export interface ProcessInfo {
  * Where a generation witness came from. `sequence` = the kernel SequenceNumber
  * (Microsoft's documented PID-reuse detector); `createTime100ns` = process creation
  * time in 100 ns ticks; `startTimeMs` = the epoch-ms birth time, stringified — what
- * the emergency CIM observation can offer. The source is compared alongside the
+ * the emergency CIM observation can offer; `linuxStartTicks` = boot ID plus fresh
+ * kernel start ticks. The source is compared alongside the
  * value, so witnesses of different provenance are never equal.
  */
-export type GenerationWitnessSource = 'sequence' | 'createTime100ns' | 'startTimeMs';
+export type GenerationWitnessSource =
+  'sequence' | 'createTime100ns' | 'startTimeMs' | 'linuxStartTicks';
 
-/** Parent process info from a snapshot observation (sidecar, or CIM fallback) */
+/** Parent process info from a snapshot observation (sidecar, CIM or Linux procfs) */
 export interface ParentProcessInfo {
   readonly name: string;
   readonly ppid: number;
   /**
-   * OS process-creation time (epoch ms). Supplied by win32 only; darwin/linux map
-   * entries omit it, so the field is null there.
+   * OS process-creation time (epoch ms). Windows supplies it directly; Linux derives
+   * it from fresh start ticks and a boot-ID-bound epoch reference. Null on failure
+   * or on platforms without a birth-time provider (currently macOS).
    */
   readonly startTime?: number | null;
   /**
    * Generation witness for this pid, always a string — 64-bit values that a JS
-   * number cannot hold without losing low digits. Present only when the snapshot
-   * sidecar served the observation; the CIM fallback omits it and process-utils
+   * number cannot hold without losing low digits. Supplied by the Windows sidecar
+   * or Linux procfs reader; the CIM fallback omits it and process-utils
    * derives a `startTimeMs` witness instead.
    */
   readonly witness?: string | null;
@@ -75,7 +78,7 @@ export interface DetectedAgent {
   /**
    * OS process-creation time (epoch ms), attached by
    * `process-utils.enrichWithParentChains`. Null when the platform withholds it
-   * (darwin/linux today) or for synthetic pid-0 agents. Distinct from the
+   * (darwin today) or for synthetic pid-0 agents. Distinct from the
    * AEGIS-observed session `firstSeen`.
    */
   readonly startTime?: number | null;

--- a/tests/main/platform/linux-process-map.test.js
+++ b/tests/main/platform/linux-process-map.test.js
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import readerModule from '../../../src/main/platform/linux-process-map.js';
+import scanner from '../../../src/main/process-scanner.js';
+import utils from '../../../src/main/process-utils.js';
+import sessions from '../../../src/main/session-tracker.js';
+
+const BOOT_ID = '11111111-1111-4111-8111-111111111111';
+const BOOT_PATH = '/proc/sys/kernel/random/boot_id';
+const BOOT_SECONDS = 1700000000;
+
+function stat(pid, name, ppid, ticks) {
+  const fields = Array(20).fill('0');
+  fields[0] = 'S';
+  fields[1] = String(ppid);
+  fields[19] = String(ticks);
+  return `${pid} (${name}) ${fields.join(' ')}\n`;
+}
+
+describe('Linux procfs birth observations', () => {
+  let files;
+  let fs;
+  let exec;
+  let reader;
+
+  beforeEach(() => {
+    files = new Map([
+      [BOOT_PATH, BOOT_ID],
+      ['/proc/stat', `cpu 1 2 3\nbtime ${BOOT_SECONDS}\n`],
+      ['/proc/100/stat', stat(100, 'claude', 200, 12345)],
+      ['/proc/200/stat', stat(200, 'node', 1, 10000)],
+    ]);
+    fs = {
+      readdirSync: vi.fn(() => ['100', '200', 'self', 'stat']),
+      readFileSync: vi.fn((file) => {
+        if (!files.has(file)) throw Object.assign(Error('gone'), { code: 'ENOENT' });
+        const value = files.get(file);
+        if (value instanceof Error) throw value;
+        return value;
+      }),
+    };
+    exec = vi.fn((cmd, _args, _opts, cb) => {
+      cb(null, cmd === 'getconf' ? '100\n' : '100 200 claude\n200 1 node\n');
+    });
+    reader = readerModule.createProcessMapReader({ fs, execFile: exec });
+  });
+
+  it('uses the observed CLK_TCK and field 22 rather than an assumed frequency', async () => {
+    exec.mockImplementation((_cmd, _args, _opts, cb) => cb(null, '250\n'));
+    expect(reader.getSnapshotHealth().state).toBe('STARTING');
+    const map = await reader.getParentProcessMap();
+    expect(map.get(100)).toEqual({
+      name: 'claude',
+      ppid: 200,
+      startTime: BOOT_SECONDS * 1000 + 49380,
+      witness: `${BOOT_ID}:12345`,
+      witnessSource: 'linuxStartTicks',
+    });
+    expect(exec).toHaveBeenCalledWith(
+      'getconf',
+      ['CLK_TCK'],
+      expect.objectContaining({ timeout: 5000 }),
+      expect.any(Function),
+    );
+    expect(reader.getSnapshotHealth().state).toBe('HEALTHY');
+  });
+
+  afterEach(() => {
+    scanner._resetForTest();
+    utils._resetForTest();
+    sessions._resetForTest();
+  });
+
+  it('stamps real scan identities, freezes an outage and observes replacement after recovery', async () => {
+    scanner._resetForTest();
+    utils._resetForTest();
+    sessions._resetForTest();
+    scanner._setPlatformForTest({ providesStartTime: true, ...reader });
+    utils._setPlatformForTest({ providesStartTime: true });
+    async function pass() {
+      const result = await scanner.scanProcesses({ sharedObservation: true });
+      await utils.enrichWithParentChains(result.agents, { processMap: result.processMap });
+      return result.agents;
+    }
+    const first = await pass();
+    expect(first[0]).toMatchObject({
+      instanceIdSource: 'os',
+      generationWitnessSource: 'linuxStartTicks',
+    });
+    expect(sessions.reconcile(first).entered).toHaveLength(1);
+    const original = files.get('/proc/100/stat');
+    files.set('/proc/100/stat', 'invalid');
+    const outage = await pass();
+    expect(outage[0].startTime).toBeNull();
+    expect(scanner.isIdentityDegraded()).toBe(true);
+    expect(sessions.reconcile(outage, { identityDegraded: scanner.isIdentityDegraded() })).toEqual({
+      entered: [],
+      exited: [],
+    });
+    files.set('/proc/100/stat', original);
+    const recovered = await pass();
+    expect(scanner.isIdentityDegraded()).toBe(false);
+    expect(recovered[0].instanceId).toBe(first[0].instanceId);
+    expect(sessions.reconcile(recovered)).toEqual({ entered: [], exited: [] });
+    files.set('/proc/100/stat', stat(100, 'claude', 200, 12346));
+    const replacement = await pass();
+    expect(replacement[0].instanceId).not.toBe(first[0].instanceId);
+    expect(sessions.reconcile(replacement).entered).toHaveLength(1);
+  });
+
+  it('re-observes PID reuse inside the cache TTL and cannot serve a mutated old map', async () => {
+    const first = await reader.getParentProcessMap();
+    first.get(100).name = 'poisoned';
+    files.set('/proc/100/stat', stat(100, 'claude', 200, 12346));
+    const second = await reader.getParentProcessMap();
+    expect(second.get(100)).toMatchObject({
+      name: 'claude',
+      startTime: BOOT_SECONDS * 1000 + 123460,
+      witness: `${BOOT_ID}:12346`,
+    });
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync.mock.calls.filter(([p]) => p === '/proc/100/stat')).toHaveLength(2);
+  });
+
+  it('parses comm containing parentheses, a state-looking substring and a newline', async () => {
+    files.set('/proc/100/stat', stat(100, 'a) R 99\n (b)', 200, 12345));
+    expect((await reader.getParentProcessMap()).get(100)).toMatchObject({
+      name: 'a) R 99\n (b)',
+      ppid: 200,
+      startTime: BOOT_SECONDS * 1000 + 123450,
+    });
+  });
+
+  it('keeps the same boot reference over a wall-clock adjustment', async () => {
+    const first = await reader.getParentProcessMap();
+    files.set('/proc/stat', `btime ${BOOT_SECONDS + 3600}\n`);
+    const second = await reader.getParentProcessMap();
+    expect(second.get(100)).toEqual(first.get(100));
+  });
+
+  it('binds the reference and witness to the observed boot ID', async () => {
+    const first = await reader.getParentProcessMap();
+    const nextBoot = '22222222-2222-4222-8222-222222222222';
+    files.set(BOOT_PATH, nextBoot);
+    files.set('/proc/stat', `btime ${BOOT_SECONDS + 10000}\n`);
+    const second = await reader.getParentProcessMap();
+    expect(second.get(100).witness).toBe(`${nextBoot}:12345`);
+    expect(second.get(100).startTime).toBe(first.get(100).startTime + 10000000);
+  });
+
+  it('skips a PID that exits during enumeration without losing valid peers', async () => {
+    files.delete('/proc/100/stat');
+    expect([...(await reader.getParentProcessMap()).keys()]).toEqual([200]);
+    expect(reader.getSnapshotHealth().state).toBe('HEALTHY');
+  });
+
+  it.each([
+    ['denied stat', '/proc/100/stat', Object.assign(Error('private path'), { code: 'EACCES' })],
+    ['truncated stat', '/proc/100/stat', '100 (claude) S 200'],
+    ['wrong PID', '/proc/100/stat', stat(101, 'claude', 200, 12345)],
+    ['unsafe birth time', '/proc/100/stat', stat(100, 'claude', 200, '999999999999999999999')],
+    ['invalid boot time', '/proc/stat', 'btime 1e9\n'],
+    ['invalid boot ID', BOOT_PATH, 'not-a-boot-id'],
+  ])(
+    '%s yields population-only fallback and failed identity, then recovers',
+    async (_label, file, value) => {
+      const original = files.get(file);
+      const first = await reader.getParentProcessMap();
+      files.set(file, value);
+      const failed = await reader.getParentProcessMap();
+      expect(
+        [...failed.values()].every((p) => p.startTime === null && p.witness === undefined),
+      ).toBe(true);
+      expect(reader.getSnapshotHealth()).toMatchObject({
+        state: 'FAILED',
+        lastError: 'linux-proc-identity-unavailable',
+      });
+      expect(JSON.stringify(reader.getSnapshotHealth())).not.toContain('private path');
+      files.set(file, original);
+      expect((await reader.getParentProcessMap()).get(100)).toEqual(first.get(100));
+      expect(reader.getSnapshotHealth().state).toBe('HEALTHY');
+    },
+  );
+
+  it('retries an unavailable clock-frequency probe and never assumes 100', async () => {
+    exec.mockImplementationOnce((_cmd, _args, _opts, cb) => cb(Error('missing')));
+    const failed = await reader.getParentProcessMap();
+    expect(failed.get(100).startTime).toBeNull();
+    expect(reader.getSnapshotHealth().state).toBe('FAILED');
+    expect((await reader.getParentProcessMap()).get(100).startTime).toBe(
+      BOOT_SECONDS * 1000 + 123450,
+    );
+    expect(exec.mock.calls.filter(([cmd]) => cmd === 'getconf')).toHaveLength(2);
+  });
+
+  it('returns an empty failed observation when procfs and ps both fail', async () => {
+    fs.readdirSync.mockImplementation(() => {
+      throw Error('proc unavailable');
+    });
+    exec.mockImplementation((cmd, _args, _opts, cb) =>
+      cmd === 'getconf' ? cb(null, '100') : cb(Error('ps unavailable')),
+    );
+    expect((await reader.getParentProcessMap()).size).toBe(0);
+    expect(reader.getSnapshotHealth().state).toBe('FAILED');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -58,6 +58,7 @@ export default defineConfig({
         'src/main/platform/proc-snapshot-client.js',
         'src/main/platform/process-snapshot.js',
         'src/main/platform/linux.js',
+        'src/main/platform/linux-process-map.js',
         'src/main/platform/darwin.js',
         'src/main/platform/win32.js',
         'src/main/platform/index.js',


### PR DESCRIPTION
Linux process records previously used unknown birth identities, allowing a reused PID to retain the previous process's session key. Read fresh kernel start ticks with observed CLK_TCK and a boot-ID-bound epoch reference; publish generation witnesses and explicit identity health. A procfs outage returns population-only records with null births and freezes session reconciliation until recovery.

Validation: 2,765 tests passed, four skipped; renderer build, lint, formatting, both type checks, both mutation gates, inventory counts and production dependency audit passed. Native Ubuntu smoke independently checked the current process against live procfs. Fifteen new regressions cover parsing, clock conversion, reuse, clock corrections and the scanner/session outage path.

The epoch reference has kernel-tick/btime resolution; it is not an exact wall-clock timestamp. macOS birth collection and WSL multi-distribution discovery remain separate work.
