### PR TITLE
fix: show skill names in observed file events

### DIFF
--- a/docs/roadmap/skill-events.md
+++ b/docs/roadmap/skill-events.md
@@ -1,0 +1,28 @@
+# Skill names in file events
+
+Observed skill paths now carry optional `FileEvent.skill` metadata with `name`,
+`rootPath` and `relativePath`. The name comes from the skill directory; no skill
+contents, frontmatter, scripts or credentials are opened to classify the event.
+An empty relative path denotes an observed skill root. Recognized shapes include
+`skills/<name>`, `skills/.system/<name>/SKILL.md`, plugin-cache skill directories,
+their resource files, and a custom directory containing an observed `SKILL.md`.
+Windows, POSIX and UNC separators are supported.
+
+The flat and grouped feeds display `Skill: testing · SKILL.md` or
+`Skill: improve-animations` for a root event. They derive the same label from older
+events' paths. The full original path remains the reveal/copy target and tooltip.
+Directory-group `holding` observations retain their ordinary path label: they do
+not identify a specific skill file. Audit history preserves the original path,
+action and attribution; no historical records are rewritten.
+
+Skill identity and actor attribution are separate. `Unknown source` means that no
+agent was established for the event. Reading `.claude/skills/foo` alone cannot prove
+that Claude performed the access. The new metadata never substitutes an agent,
+changes attribution strength, clears sensitive classification or changes an action
+such as `created` into `used`. Shared skill directories can be accessed by any tool.
+
+This improves naming of observations already supplied by the file sensors. It does
+not make chokidar observe reads, guarantee capture of transient open/read/close
+operations, or prove that the agent followed a skill's instructions. PID-backed
+handle observations retain their confirmed owner when available. Exact transient
+read attribution remains part of the file-sensor roadmap.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1302,3 +1302,33 @@ components; its AgentCard suggestions concern pre-existing timed flash effects.
 The installed application is not rebuilt or released automatically. Broader frontend
 integration remains separate. A1's WSL no-start race is still unresolved; D2 macOS
 identity or B1 ETW measurement preparation remain independent roadmap work.
+
+## Session handoff — skill names in file events (2026-09-08)
+
+The user reported `unknown` when agents use skills. Repository inspection found no
+skill classification. A read-only check of the existing local September 7 audit
+log found 73 paths containing `skill`, all with unknown actor attribution. Of these,
+72 identify `animation-on-scroll` or `improve-animations` skill paths, including
+created skill-root links/directories. The remaining basename is the generic
+`skills-curated-cache.json`, which must not become a fabricated skill name.
+
+`src/shared/skill-path.js` now derives the skill directory name, root path and relative
+file from observed paths without opening contents. The watcher carries optional
+`FileEvent.skill` for path events and per-PID handle observations. Both flat and
+grouped feeds name the skill and keep the original full reveal target. The renderer
+also recognizes older path-only events. Root creation stays `created`; directory-only
+RM holding observations do not invent an exact skill file.
+
+This fixes missing skill names, not the sensor's unknown actor. Attribution and
+sensitive classification are unchanged. There is no new transient-read capture and
+no claim that a created skill folder was used. Details and the frontend contract are
+in `docs/roadmap/skill-events.md`. Audit history was inspected but not rewritten.
+
+Full coverage passed: 2,809 tests, four skips, 162 files. The 32 new cases cover
+Windows/POSIX/UNC and plugin/system skill paths, roots, resources, lookalikes,
+confirmed versus unknown attribution, sensitive files and both rendered feed modes.
+Component tests prove the displayed label reveals the original full path. The
+component test project now includes both .js and .ts tests. Build, format, lint
+(zero errors, 31 existing warnings), both type checks, both mutation gates, counts
+and production audit passed. Svelte autofixer found no component issues; suggestions
+on ActivityFeed concern existing timed effects. Installed app updates remain separate.

--- a/src/main/file-watcher.js
+++ b/src/main/file-watcher.js
@@ -32,6 +32,7 @@ const {
 const { getAllRules, reloadRules } = require('./rule-loader');
 const { EVIDENCE, makeAttribution } = require('./attribution');
 const { readInstanceId } = require('./process-identity');
+const { skillFromPath } = require('../shared/skill-path');
 const sensorHealth = require('./sensor-health');
 // Watch-root registry (design §1) — the plan, its per-root state transitions, and the
 // W derived from it. Pure state: this module keeps ownership of the `fs-chokidar`
@@ -603,6 +604,7 @@ function handleWatcherEvent(action, filePath) {
   // all) proves no agent self-matched. Re-running it against a substituted agent
   // is what let a foreign agent's exemption silently clear `sensitive`.
   const selfAccess = reason !== null && evidence.includes(EVIDENCE.SELF_CONFIG_PATH);
+  const skill = skillFromPath(filePath);
   const event = {
     agent: agent ? agent.agent : '',
     pid: agent ? agent.pid : null,
@@ -616,6 +618,7 @@ function handleWatcherEvent(action, filePath) {
     parentEditor: (agent && agent.parentEditor) || null,
     cwd: (agent && agent.cwd) || null,
     file: filePath,
+    ...(skill ? { skill } : {}),
     sensitive: reason !== null && !selfAccess,
     selfAccess,
     reason: reason || '',
@@ -842,6 +845,7 @@ async function scanFileHandles(agent) {
     // Confirmed: this scan was run FOR agent.pid, so the owner IS the pid.
     const evidence = [EVIDENCE.HANDLE_SCAN_PID];
     if (selfAccess) evidence.push(EVIDENCE.SELF_CONFIG_PATH);
+    const skill = skillFromPath(f);
     const event = {
       agent: agent.agent,
       pid,
@@ -851,6 +855,7 @@ async function scanFileHandles(agent) {
       parentEditor: agent.parentEditor || null,
       cwd: agent.cwd || null,
       file: f,
+      ...(skill ? { skill } : {}),
       sensitive: reason !== null && !selfAccess,
       selfAccess,
       reason: reason || '',

--- a/src/renderer/lib/components/ActivityFeed.svelte
+++ b/src/renderer/lib/components/ActivityFeed.svelte
@@ -3,7 +3,7 @@
   import { addToast } from '../stores/toast.js';
   import { t } from '../i18n/index.js';
   import { getSeverity } from '../utils/timeline-utils';
-  import { shortenPath } from '../utils/path-utils';
+  import { shortenPath, fileActivityLabel } from '../utils/path-utils';
   import { UNKNOWN_SOURCE } from '../utils/grouped-feed-utils';
 
   let { active = true, agentFilter = 'all', severityFilter = 'all', typeFilter = 'all' } = $props();
@@ -223,7 +223,9 @@
           >
           <span class="feed-action">{ev.action || ev._type}</span>
           <button class="feed-path" title={ev.file} onclick={(e) => handlePathClick(ev, e)}
-            >{shortenPath(ev.file)}</button
+            >{ev._type === 'file'
+              ? fileActivityLabel(ev.file, ev.action)
+              : shortenPath(ev.file)}</button
           >
           {#if ev._type === 'file' && ev.file}
             <button

--- a/src/renderer/lib/components/GroupedFeedItem.svelte
+++ b/src/renderer/lib/components/GroupedFeedItem.svelte
@@ -1,6 +1,7 @@
 <script>
   import { t } from '../i18n/index.js';
   import { getSeverity, formatTime, shortenPath } from '../utils/grouped-feed-utils';
+  import { fileActivityLabel } from '../utils/path-utils';
 
   /**
    * @typedef {import('../utils/grouped-feed-utils').FeedEvent} FeedEvent
@@ -63,7 +64,8 @@
   <span class="sev-bar" style:background={sevColor(sev)}></span>
   <span class="feed-dot" style:background={sevColor(sev)} style:box-shadow={sevGlow(sev)}></span>
   <span class="feed-time">{formatTime(ev.timestamp)}</span>
-  <button class="feed-path" title={ev.file} onclick={handlePathClick}>{shortenPath(ev.file)}</button
+  <button class="feed-path" title={ev.file} onclick={handlePathClick}
+    >{ev._type === 'file' ? fileActivityLabel(ev.file, ev.action) : shortenPath(ev.file)}</button
   >
   {#if ev.repeatCount > 1}<span class="feed-repeat">&times;{ev.repeatCount}</span>{/if}
   {#if label}<span

--- a/src/renderer/lib/utils/path-utils.ts
+++ b/src/renderer/lib/utils/path-utils.ts
@@ -4,6 +4,24 @@
  * @since v0.10.0
  */
 
+import { skillFromPath } from '../../../shared/skill-path.js';
+
+/**
+ * Name the skill and its observed file, including events from older producers.
+ * The caller keeps the full original path for reveal/copy and owner attribution.
+ * @param filePath - Observed file path
+ * @param action - Holding observations may identify only a directory group
+ * @returns Skill label or the ordinary shortened path
+ * @since 0.15.0
+ */
+export function fileActivityLabel(filePath: string | undefined, action?: string): string {
+  if (action === 'holding') return shortenPath(filePath);
+  const skill = skillFromPath(filePath);
+  return skill
+    ? `Skill: ${skill.name}${skill.relativePath ? ` · ${skill.relativePath}` : ''}`
+    : shortenPath(filePath);
+}
+
 /**
  * Shorten a file path for display by keeping the last N segments.
  * @param p         - The full file path (forward or back slashes)

--- a/src/shared/skill-path.js
+++ b/src/shared/skill-path.js
@@ -1,0 +1,42 @@
+/**
+ * @file skill-path.js
+ * @description Skill identity from an observed file path, without reading contents.
+ * @since 0.15.0
+ */
+'use strict';
+
+/**
+ * Recognize a SKILL.md entry point, a skills/<name> root or a file under it (including
+ * skills/.system/<name>/). The folder is a path-derived name, not a parsed manifest
+ * title. This never identifies the process that accessed it or proves execution.
+ * @param {unknown} filePath
+ * @returns {{name: string, rootPath: string, relativePath: string}|null}
+ * @since 0.15.0
+ */
+function skillFromPath(filePath) {
+  // eslint-disable-next-line no-control-regex -- Reject control characters in observed path labels.
+  if (typeof filePath !== 'string' || !filePath || /[\x00-\x1f]/.test(filePath)) return null;
+  const normalized = filePath.replace(/\\/g, '/').replace(/\/+$/, '');
+  const parts = normalized.split('/');
+  if (parts.some((p) => p === '..' || p === '.')) return null;
+  let rootIndex = -1;
+  if (parts.at(-1)?.toLowerCase() === 'skill.md') {
+    rootIndex = parts.length - 2;
+  } else {
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (parts[i].toLowerCase() !== 'skills') continue;
+      const candidate = parts[i + 1] === '.system' ? i + 2 : i + 1;
+      if (candidate < parts.length) {
+        rootIndex = candidate;
+        break;
+      }
+    }
+  }
+  const name = parts[rootIndex];
+  if (!name || name.startsWith('.') || /^(?:skills|[a-z]:)$/i.test(name)) return null;
+  const relativePath = parts.slice(rootIndex + 1).join('/');
+  if (!parts.at(-1)) return null;
+  return { name, rootPath: parts.slice(0, rootIndex + 1).join('/'), relativePath };
+}
+
+module.exports = { skillFromPath };

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -84,6 +84,12 @@ export interface FileEvent {
   readonly parentEditor: string | null;
   readonly cwd: string | null;
   readonly file: string;
+  /** Path-derived skill identity, independent of actor attribution; absent on older events. */
+  readonly skill?: {
+    readonly name: string;
+    readonly rootPath: string;
+    readonly relativePath: string;
+  } | null;
   readonly sensitive: boolean;
   readonly selfAccess: boolean;
   readonly reason: string;

--- a/tests/main/file-watcher-skills.test.js
+++ b/tests/main/file-watcher-skills.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import watcher from '../../src/main/file-watcher.js';
+
+describe('skill metadata stays independent from actor attribution', () => {
+  let state;
+  const owner = { pid: 123, agent: 'OpenAI Codex CLI', category: 'ai', instanceId: '123:1000' };
+  beforeEach(() => {
+    state = {
+      getCustomRules: () => [],
+      getLatestAgents: () => [owner],
+      getLatestAiAgents: () => [owner],
+      isMonitoringPaused: () => false,
+      isOtherPanelExpanded: () => false,
+      activityLog: [],
+      knownHandles: new Map(),
+      watchers: [],
+      recordFileAccess: vi.fn(),
+      onFileEvent: vi.fn(),
+    };
+    watcher.init(state);
+    watcher._resetForTest();
+  });
+
+  it('names a shared skill without guessing which online agent touched it', () => {
+    watcher.handleWatcherEvent('modified', '/home/u/.agents/skills/testing/SKILL.md');
+    expect(state.activityLog[0]).toMatchObject({
+      agent: '',
+      pid: null,
+      instanceId: null,
+      action: 'modified',
+      skill: { name: 'testing', relativePath: 'SKILL.md' },
+      attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+    });
+    expect(state.recordFileAccess).not.toHaveBeenCalled();
+    expect(state.onFileEvent).toHaveBeenCalledWith(state.activityLog[0]);
+  });
+
+  it('names a newly created skill root while retaining the observed action and unknown owner', () => {
+    watcher.handleWatcherEvent('created', '/home/u/.claude/skills/improve-animations');
+    expect(state.activityLog[0]).toMatchObject({
+      action: 'created',
+      agent: '',
+      pid: null,
+      skill: { name: 'improve-animations', relativePath: '' },
+      attribution: { status: 'unattributed' },
+    });
+  });
+
+  it('keeps an actual PID-backed handle observation alongside the skill name', async () => {
+    watcher._setDepsForTest({
+      getFileHandles: async () => ['/home/u/.agents/skills/pdf/scripts/render.py'],
+      isReadDetectionAvailable: true,
+    });
+    const result = await watcher.scanAllFileHandles([owner]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      agent: owner.agent,
+      pid: 123,
+      instanceId: '123:1000',
+      skill: { name: 'pdf', relativePath: 'scripts/render.py' },
+      attribution: { status: 'confirmed' },
+    });
+  });
+
+  it('does not turn a credential under a skill folder into harmless self-access', () => {
+    watcher.handleWatcherEvent('modified', '/home/u/.agents/skills/testing/.env');
+    expect(state.activityLog[0]).toMatchObject({
+      sensitive: true,
+      selfAccess: false,
+      skill: { name: 'testing', relativePath: '.env' },
+    });
+  });
+});

--- a/tests/renderer/components/SkillEvents.test.js
+++ b/tests/renderer/components/SkillEvents.test.js
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+
+const noop = () => {};
+window.aegis = {
+  onScanBatch: noop,
+  onFileAccess: noop,
+  onStatsUpdate: noop,
+  onNetworkUpdate: noop,
+  onScanStatus: noop,
+  onTokenCosts: noop,
+  onAgentResourceUsage: noop,
+  getStats: async () => ({}),
+  getResourceUsage: async () => ({}),
+  getFalsePositives: async () => [],
+  getSettings: async () => ({}),
+  getAuditEntriesBefore: async () => [],
+  revealInExplorer: vi.fn(),
+};
+const { events, network } = await import('../../../src/renderer/lib/stores/ipc.js');
+const ActivityFeed = (await import('../../../src/renderer/lib/components/ActivityFeed.svelte'))
+  .default;
+const GroupedFeedItem = (
+  await import('../../../src/renderer/lib/components/GroupedFeedItem.svelte')
+).default;
+const file = 'C:\\Users\\u\\.codex\\plugins\\cache\\provider\\pdf\\1.2\\skills\\pdf\\SKILL.md';
+const ev = {
+  agent: '',
+  pid: null,
+  file,
+  action: 'modified',
+  timestamp: Date.now(),
+  attribution: { status: 'unattributed', evidence: ['no-owner-match'] },
+};
+
+describe('skill names in actual feed components', () => {
+  beforeEach(() => {
+    events.set([]);
+    network.set([]);
+    window.aegis.revealInExplorer.mockClear();
+  });
+
+  it('shows the skill independently of unknown actor and reveals the original full path', async () => {
+    events.set([[ev]]);
+    const view = render(ActivityFeed);
+    expect(view.container.querySelector('.feed-agent')?.textContent.trim()).toBe('Unknown source');
+    const label = view.getByRole('button', { name: 'Skill: pdf · SKILL.md' });
+    expect(label.getAttribute('title')).toBe(file);
+    await fireEvent.click(label);
+    expect(window.aegis.revealInExplorer).toHaveBeenCalledWith(file);
+  });
+
+  it('keeps the same name in grouped events without requiring new backend metadata', () => {
+    const view = render(GroupedFeedItem, {
+      props: { ev: { ...ev, _type: 'file' }, index: 0, groupKey: 'a', onToggle: noop },
+    });
+    expect(view.getByRole('button', { name: 'Skill: pdf · SKILL.md' })).toBeTruthy();
+  });
+
+  it('shows a created skill folder by name without claiming it was used', () => {
+    events.set([
+      [{ ...ev, file: 'C:\\Users\\u\\.claude\\skills\\improve-animations', action: 'created' }],
+    ]);
+    const view = render(ActivityFeed);
+    expect(view.getByRole('button', { name: 'Skill: improve-animations' })).toBeTruthy();
+    expect(view.container.querySelector('.feed-action')?.textContent).toBe('created');
+    expect(view.container.querySelector('.feed-agent')?.textContent.trim()).toBe('Unknown source');
+  });
+});

--- a/tests/renderer/skill-labels.test.js
+++ b/tests/renderer/skill-labels.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { fileActivityLabel, shortenPath } from '../../src/renderer/lib/utils/path-utils.ts';
+
+describe('skill event labels', () => {
+  it('shows names for old events carrying only a path', () => {
+    expect(fileActivityLabel('C:\\Users\\u\\.codex\\skills\\testing\\SKILL.md', 'accessed')).toBe(
+      'Skill: testing · SKILL.md',
+    );
+    expect(fileActivityLabel('/home/u/.agents/skills/pdf/references/api.md', 'modified')).toBe(
+      'Skill: pdf · references/api.md',
+    );
+  });
+  it('keeps directory-only holding observations and ordinary files unchanged', () => {
+    const directory = '/home/u/.codex/skills/testing/references';
+    expect(fileActivityLabel(directory, 'holding')).toBe(shortenPath(directory));
+    expect(fileActivityLabel('/work/src/main.js')).toBe('/work/src/main.js');
+    expect(fileActivityLabel(undefined)).toBe('');
+  });
+});

--- a/tests/shared/skill-path.test.js
+++ b/tests/shared/skill-path.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { skillFromPath } from '../../src/shared/skill-path.js';
+
+describe('skill identity from observed paths', () => {
+  it.each([
+    ['C:\\Users\\u\\.codex\\skills\\testing\\SKILL.md', 'testing', 'SKILL.md'],
+    ['/home/u/.agents/skills/electron-main/SKILL.md', 'electron-main', 'SKILL.md'],
+    ['/work/.claude/skills/review/SKILL.md', 'review', 'SKILL.md'],
+    ['/home/u/.codex/skills/.system/skill-creator/SKILL.md', 'skill-creator', 'SKILL.md'],
+    ['/plugins/cache/provider/pdf/1.2/skills/pdf/SKILL.md', 'pdf', 'SKILL.md'],
+    ['//server/share/skills/my skill/SKILL.md', 'my skill', 'SKILL.md'],
+    ['/home/u/.agents/skills/pdf/scripts/render.py', 'pdf', 'scripts/render.py'],
+    [
+      '/home/u/.codex/skills/.system/skill-creator/references/schema.md',
+      'skill-creator',
+      'references/schema.md',
+    ],
+    ['/custom/location/my-skill/skill.md', 'my-skill', 'skill.md'],
+  ])('recognizes %s', (file, name, relativePath) => {
+    const result = skillFromPath(file);
+    expect(result).toEqual({
+      name,
+      rootPath: file.replace(/\\/g, '/').slice(0, -relativePath.length - 1),
+      relativePath,
+    });
+  });
+
+  it.each([
+    undefined,
+    null,
+    42,
+    'SKILL.md',
+    '/SKILL.md',
+    '/skills/SKILL.md',
+    '/skills/.system/SKILL.md',
+    '/work/not-skills/pdf/script.py',
+    '/work/foo/SKILL.md.bak',
+    '/skills/foo/../../secret',
+    '/skills/foo/./script.py',
+    '/skills/foo/SKILL.md\n',
+  ])('rejects unknown or ambiguous path %s', (file) => {
+    expect(skillFromPath(file)).toBeNull();
+  });
+
+  it.each(['C:\\Users\\u\\.claude\\skills\\improve-animations', '/home/u/.codex/skills/pdf/'])(
+    'names a skill root event: %s',
+    (file) => {
+      const rootPath = file.replace(/\\/g, '/').replace(/\/$/, '');
+      expect(skillFromPath(file)).toEqual({
+        name: rootPath.split('/').at(-1),
+        rootPath,
+        relativePath: '',
+      });
+    },
+  );
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -26,7 +26,7 @@ export default defineConfig({
         },
         test: {
           name: 'components',
-          include: ['tests/renderer/components/**/*.test.ts'],
+          include: ['tests/renderer/components/**/*.test.{js,ts}'],
           environment: 'jsdom',
           setupFiles: ['tests/renderer/components/_setup.ts'],
           css: { modules: { classNameStrategy: 'non-scoped' } },
@@ -74,6 +74,7 @@ export default defineConfig({
         'src/renderer/lib/utils/threat-report.js',
         'src/renderer/lib/stores/toast.ts',
         'src/shared/constants.js',
+        'src/shared/skill-path.js',
       ],
     },
   },


### PR DESCRIPTION
Observed skill paths previously appeared as ordinary files, with no separate skill identity when actor attribution was unknown. Add path-derived skill metadata and explicit names in the flat and grouped feeds, including skill-root creation, plugin/system skills and resource files. Older path-only events receive the same labels; reveal actions retain the original full path.

Actor attribution and actions remain unchanged: an unknown actor is not inferred from a skill name, and creation does not prove usage. Directory-only holding observations do not invent an exact skill file. Classification reads no file contents. This does not add capture of transient reads.

Validation: 2,809 tests passed, four skipped. All local build, formatting, lint, type, mutation, counts and production audit checks passed. Thirty-two new cases include both actual feed components, original reveal targets, confirmed/unknown actor independence and retained sensitive classification. A read-only local audit check recognized all 72 concrete skill paths; the additional generic skills-curated-cache.json remained unclassified.
