### PR TITLE
feat: prepare Windows ETW measurement harness

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,8 @@ production implementation. [kernel-file-etw.md](docs/recon/kernel-file-etw.md) l
 and Hyper-V as well as filtering, event identity, mapping lifecycle and loss.
 The dependency is those observations, not the absence of a Windows host.
 
-1. **B1:** prepare an isolated C#/TraceEvent measurement harness and procedure.
+1. **B1:** isolated [C#/TraceEvent harness and procedure](sidecar/etw-probe/README.md)
+   are prepared; [live measurement checklist](docs/recon/kernel-file-etw-measurements.md) remains open.
    Collect results on target systems that answer each question; distinguish verified
    results from environment-limited or unresolved coverage. One machine or a mock
    cannot close all questions.
@@ -115,8 +116,8 @@ Keep them outside the active queue while the first ETW sensor is being establish
 
 Block 0 is this roadmap reconciliation, including the stale B8 status correction.
 Next resolve A1's no-start requirement, then A2 and A3. C1/C2 are implemented with
-evidence linked above. D1 is implemented; B1 measurement preparation and independent
-D2 can follow. A4 starts with recon. Application process grouping is separately
+evidence linked above. D1 is implemented; B1 now needs elevated live measurements;
+independent D2 can follow. A4 starts with recon. Application process grouping is separately
 authorized in both data and the current interface; broader frontend work remains separate.
 
 Keep one logical block per branch and PR. A supplied patch is not complete until

--- a/docs/recon/kernel-file-etw-measurements.md
+++ b/docs/recon/kernel-file-etw-measurements.md
@@ -1,0 +1,54 @@
+# B1 measurement status — 2026-09-08
+
+The [standalone harness](../../sidecar/etw-probe/README.md) is prepared. Live ETW
+capture has **not** run in the current non-administrator session. B1 is still open;
+B2 producer design and B3 production integration cannot be ratified from these tests.
+
+## Observed locally
+
+Windows 11 25H2, build 26200.8655, EditionID Core (Home), x64, 22 logical processors;
+.NET SDK 10.0.302 and runtime 10.0.10. The project pins TraceEvent 3.2.6, restored
+successfully; its direct/transitive NuGet vulnerability check reported none.
+
+TDH returned the registered manifest without elevation. The original artifact is
+`X:/tmp/aegis-etw-preflight-20260908/kernel-file.manifest.xml`, SHA-256
+`8B2A7C91BC7C11930084F8A88443CFE9D4AE166F7C7DC4F44247E694E3CAB411`.
+Read 15 v1 exposes ByteOffset, Irp, FileObject, FileKey, IssuingThreadId, IOSize,
+IOFlags and ExtraFlags; no filename. Create 12 exposes FileObject/FileName,
+NameCreate 10 FileKey/FileName, and Cleanup 13 / Close 14 expose lifecycle fields.
+These are registered schemas on one build, not proof of runtime emission or rundown.
+
+The offline self-tests cover correlation failures, path boundaries, pointer reuse,
+bounded retention, opaque pointer output, QPC retention, option validation, native
+loss-query layout and unavailable counters. Six child-process fixture checks cover
+buffered, async, mapped, preopened, churn and idle, including delaying ledger writes
+until the parent permits them. Neither kind of test starts an ETW session.
+
+## Hardware-gated checklist
+
+Numbers match the [frozen recon](kernel-file-etw.md#hardware-gated).
+
+| # | Required evidence | Current status / next measurement |
+| --- | --- | --- |
+| 1 | Provider PID filter | Pending: target/control, filtered/unfiltered comparison. |
+| 2 | Authoritative issuer | Pending: QPC/caller/header/payload observations; late live TID lookup alone cannot settle it. |
+| 3 | Current manifest / rundown | Registered manifest verified on one Home build; capture-state/rundown behavior pending. |
+| 4 | NameCreate delivery | Pending: names/read and lifecycle runs. |
+| 5 | Cleanup/Close requirements | Pending: close/cleanup/no-eviction comparison and lifecycle analysis. |
+| 6 | Object/key lifetime and reuse | Pending: churn evidence; synthetic map tests do not prove OS semantics. |
+| 7 | Minimal mask and IDs | Pending: READ-only, 0x190, 0x1B0; broaden comparisons if inconclusive. |
+| 8 | Idle/npm/build event rates | Pending: repeated baseline and normal-terminal workload runs. |
+| 9 | CPU/memory/buffers/loss | Pending: repeated load capture; collector CPU excludes kernel generation cost. |
+| 10 | Fast I/O | Pending: dedicated path evidence; buffered workload alone is insufficient. |
+| 11 | mmap/page faults | Pending: warm mapping baseline, then dedicated cold/page-fault experiment. |
+| 12 | Home versus Pro | Pending: same matrix on both editions. |
+| 13 | Hyper-V | Pending: same matrix in a documented guest configuration. |
+
+Preserve the environment, options, exit status and all counter failures with each
+run. Distinguish verified observations, unresolved cases and environment limits.
+Do not turn zero events into a claim that no read happened or call a candidate map
+authoritative attribution. No installed AEGIS behavior changes in this block.
+
+API references: [TraceEvent package](https://www.nuget.org/packages/Microsoft.Diagnostics.Tracing.TraceEvent/3.2.6),
+[session implementation](https://github.com/microsoft/perfview/blob/main/src/TraceEvent/TraceEventSession.cs),
+[native session counters](https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties).

--- a/docs/recon/kernel-file-etw.md
+++ b/docs/recon/kernel-file-etw.md
@@ -114,6 +114,11 @@ package-registry release data, and they are scoped accordingly.
 
 ## HARDWARE-GATED
 
+2026-09-08 follow-up: the [B1 harness and local observation record](kernel-file-etw-measurements.md)
+add a registered manifest check on Windows 11 build 26200.8655. Live capture is
+pending; this does not replace the historical static evidence above or close the
+runtime questions below.
+
 Live-machine ratification items. These are not invitations for further source research; each one
 closes only against observation on the target system.
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -5,7 +5,7 @@ The current version lives in `package.json` (`node -p "require('./package.json')
 Agent, signature, rule and module counts are derived from the tree by `scripts/counts.js` (`npm run counts:check`), not pinned here.
 Entries in this file are appended chronologically, newest at the bottom.
 
-Latest handoff: see "Session handoff — 2026-09-07" at the end. Audit-index blocks 1 and 2
+Latest handoff: see the final "Session handoff" entry below. Audit-index blocks 1 and 2
 are merged; the earlier entry naming block 2 as next work is historical.
 
 ## feat/identity-main — identity migration (branch `feat/identity-main`)
@@ -1332,3 +1332,37 @@ component test project now includes both .js and .ts tests. Build, format, lint
 (zero errors, 31 existing warnings), both type checks, both mutation gates, counts
 and production audit passed. Svelte autofixer found no component issues; suggestions
 on ActivityFeed concern existing timed effects. Installed app updates remain separate.
+
+## Session handoff — B1 ETW measurement preparation (2026-09-08)
+
+After the remaining-plan reconciliation, the user approved B1 measurement work.
+`sidecar/etw-probe` contains a standalone .NET 10 / TraceEvent 3.2.6 harness with
+two synthetic actors, six workload types and an eleven-run PowerShell matrix.
+Samples preserve QPC, header/payload thread fields, candidate fixture path evidence
+and opaque pointer aliases. Bounded maps/samples report overflow. Native session
+queries retain unavailable loss counters as null. Actor ledgers are saved only
+after ETW stops. The existing Electron app and installed application are unchanged.
+
+Local Windows 11 Home (Core), 25H2, build 26200.8655 allowed a non-elevated TDH
+registered-manifest read. This verifies schema fields on this build, not live event
+delivery. The full thirteen-question status and limitations are recorded in
+`docs/recon/kernel-file-etw-measurements.md`; B1 remains open for live evidence.
+Do not advance B2 from synthetic tests or declare an event header PID authoritative.
+
+Validation: Release C# build has zero warnings/errors; 16 self-tests and six
+one-second fixture scenarios passed (32 buffered/async/mapped/preopened operations,
+65 churn, zero idle). The ledger handshake check passed. C# whitespace verification
+and PowerShell syntax parsing passed. Non-admin capture returned 3 without creating
+an output directory. NuGet direct/transitive vulnerability check found none.
+AEGIS coverage: 2,809 passed, four skipped, 162 files. Format, renderer build, lint
+(zero errors, 31 existing warnings), both type checks, both mutation gates, counts
+and production dependency audit passed. Existing CI does not compile this separate
+C# experiment; its Windows validation above was run locally.
+
+Next: in an administrator PowerShell, execute the already-built
+`X:/Future/ESCAPE/AEGIS/sidecar/etw-probe/Run-Matrix.ps1` with
+`-OutputRoot X:/tmp/aegis-etw-matrix-20260908` (must be new). The current Codex session
+is non-admin; no live ETW capture has been attempted. Read the resulting matrix,
+run summaries, schemas, samples and operation ledgers before selecting follow-up
+experiments. Preserve degraded runs and distinguish Home-only results from Pro,
+Hyper-V, Fast I/O and page-fault questions that still need separate measurements.

--- a/sidecar/etw-probe/.gitignore
+++ b/sidecar/etw-probe/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+results/
+!/Run-Matrix.ps1

--- a/sidecar/etw-probe/Capture.cs
+++ b/sidecar/etw-probe/Capture.cs
@@ -1,0 +1,179 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Session;
+
+namespace Aegis.EtwProbe;
+
+internal static class Capture
+{
+    private static async Task<Process> StartActor(string root, string role, string scenario, int seconds)
+    {
+        var process = Process.Start(Program.Child("actor", root, role, scenario, seconds.ToString()))
+            ?? throw new InvalidOperationException("Actor did not start");
+        try
+        {
+            string? ready = await process.StandardOutput.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(15));
+            using var document = JsonDocument.Parse(ready ?? "null");
+            if (!document.RootElement.GetProperty("ready").GetBoolean() ||
+                document.RootElement.GetProperty("pid").GetInt32() != process.Id)
+                throw new InvalidOperationException("Actor handshake mismatch");
+            return process;
+        }
+        catch { End(process); throw; }
+    }
+
+    private static void End(Process process)
+    {
+        try { if (!process.HasExited) process.Kill(entireProcessTree: true); }
+        finally { process.Dispose(); }
+    }
+
+    private static async Task Done(Process actor, CancellationToken token = default)
+    {
+        string? line = await actor.StandardOutput.ReadLineAsync(token);
+        using var document = JsonDocument.Parse(line ?? "null");
+        if (!document.RootElement.GetProperty("done").GetBoolean())
+            throw new InvalidOperationException("Actor completion mismatch");
+    }
+
+    private static async Task Save(Process actor)
+    {
+        await actor.StandardInput.WriteLineAsync("save");
+        await actor.StandardInput.FlushAsync();
+        await actor.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
+    }
+
+    internal static async Task<int> Run(string directory, Options options)
+    {
+        Program.Preflight(directory);
+        Native.CheckLayout();
+        string root = Path.Combine(directory, "aegis-etw-fixture-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var actors = new List<Process>();
+        string sessionName = "AEGIS-FileProbe-" + Guid.NewGuid().ToString("N");
+        TraceEventSession? session = null;
+        Task? consumer = null;
+        using var cancel = new CancellationTokenSource();
+        ConsoleCancelEventHandler cancelHandler = (_, e) => { e.Cancel = true; cancel.Cancel(); };
+        Console.CancelKeyPress += cancelHandler;
+        try
+        {
+            actors.Add(await StartActor(root, "target", options.Scenario, options.Seconds));
+            actors.Add(await StartActor(root, "control", options.Scenario, options.Seconds));
+            var observation = new Observation(root, Native.DevicePath(root), actors.Select(p => p.Id).ToHashSet(), options.Evict);
+            Program.Write(directory, "run.json", new
+            {
+                schema = 1,
+                sessionName,
+                options,
+                actorPids = new { target = actors[0].Id, control = actors[1].Id },
+                fixtureRoot = Path.GetFileName(root)
+            });
+            session = new TraceEventSession(sessionName, TraceEventSessionOptions.Create | TraceEventSessionOptions.NoRestartOnCreate)
+            { StopOnDispose = true, BufferSizeMB = options.BuffersMb };
+            var source = session.Source;
+            source.Dynamic.All += observation.Decode;
+            source.AllEvents += data =>
+            {
+                if (data.ProviderGuid == Program.Provider)
+                    observation.Delivered[(int)data.ID] = observation.Delivered.GetValueOrDefault((int)data.ID) + 1;
+            };
+            source.UnhandledEvents += data => { if (data.ProviderGuid == Program.Provider) observation.Unhandled++; };
+            session.EnableProvider(Program.Provider, TraceEventLevel.Verbose, options.Keywords, new TraceEventProviderOptions
+            { ProcessIDFilter = options.PidFilter ? [actors[0].Id] : null, EventIDsToEnable = options.Events });
+            var process = Process.GetCurrentProcess();
+            TimeSpan cpuStart = process.TotalProcessorTime;
+            var watch = Stopwatch.StartNew();
+            consumer = Task.Run(() => source.Process());
+            foreach (var actor in actors) { await actor.StandardInput.WriteLineAsync("go"); await actor.StandardInput.FlushAsync(); }
+            await Task.WhenAll(actors.Select(p => Done(p, cancel.Token))).WaitAsync(TimeSpan.FromSeconds(options.Seconds + 20), cancel.Token);
+            await Task.Delay(1000, cancel.Token); // Drain tail events before querying loss/stopping.
+            var loss = Native.QueryLoss(sessionName);
+            session.Stop();
+            await consumer.WaitAsync(TimeSpan.FromSeconds(10));
+            process.Refresh();
+            double durationMs = watch.Elapsed.TotalMilliseconds;
+            double collectorCpuMs = (process.TotalProcessorTime - cpuStart).TotalMilliseconds;
+            long collectorPeakWorkingSetBytes = process.PeakWorkingSet64;
+            await Task.WhenAll(actors.Select(Save));
+            Program.Write(directory, "events.json", observation.Samples);
+            Program.Write(directory, "schemas.json", observation.Schemas);
+            bool actorsOk = actors.All(p => p.ExitCode == 0);
+            Program.Write(directory, "summary.json", new
+            {
+                schema = 1,
+                collectionCompleted = true,
+                actorsOk,
+                durationMs,
+                collectorCpuMs,
+                collectorPeakWorkingSetBytes,
+                loss,
+                observation.Delivered,
+                observation.Unhandled,
+                observation.DecodeErrors,
+                observation.DecodedReads,
+                observation.FixturePathReads,
+                observation.UnresolvedActorReads,
+                observation.PathConflicts,
+                observation.OmittedSamples,
+                observation.MappingResets,
+                observation.AliasOverflows,
+                interpretation = "Candidate correlations only; operation ledger does not prove per-operation ETW emission. " +
+                    "Loss query precedes stop; unavailable counters are null. Collector CPU excludes provider-wide kernel cost."
+            });
+            // Nonzero on degraded observations; retain artifacts for diagnosing the loss.
+            return actorsOk && loss.QueryStatus == 0 && loss.EventsLost == 0 && loss.RealTimeBuffersLost == 0 &&
+                loss.LogBuffersLost == 0 && observation.Unhandled == 0 && observation.PathConflicts == 0 &&
+                observation.DecodeErrors == 0 && observation.OmittedSamples == 0 && observation.MappingResets == 0 && observation.AliasOverflows == 0 ? 0 : 5;
+        }
+        catch (Exception error)
+        {
+            Program.Write(directory, "failure.json", new
+            {
+                collectionCompleted = false,
+                sessionName,
+                errorType = error.GetType().Name,
+                hresult = error.HResult
+            });
+            throw;
+        }
+        finally
+        {
+            try { session?.Dispose(); } // Only the GUID-named session this run created.
+            finally
+            {
+                if (consumer != null) { try { await consumer.WaitAsync(TimeSpan.FromSeconds(10)); } catch { /* failure.json/exit code report it */ } }
+                foreach (var actor in actors) { try { End(actor); } catch { /* Continue cleanup of the other owned child. */ } }
+                Console.CancelKeyPress -= cancelHandler;
+            }
+        }
+    }
+
+    internal static async Task<int> CheckFixtures(string directory)
+    {
+        foreach (var scenario in Fixture.Scenarios)
+        {
+            string root = Path.Combine(directory, "aegis-etw-fixture-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            var actor = await StartActor(root, "target", scenario, 1);
+            try
+            {
+                await actor.StandardInput.WriteLineAsync("go");
+                await actor.StandardInput.FlushAsync();
+                await Done(actor).WaitAsync(TimeSpan.FromSeconds(15));
+                if (File.Exists(Path.Combine(root, "target-operations.json")))
+                    throw new InvalidOperationException("Ledger written before permission");
+                await Save(actor);
+                if (actor.ExitCode != 0) throw new InvalidOperationException("Fixture failed");
+                using var json = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "target-operations.json")));
+                int count = json.RootElement.GetProperty("operations").GetInt32();
+                if ((scenario == "idle" && count != 0) || (scenario != "idle" && count <= 0))
+                    throw new InvalidOperationException("Fixture count mismatch");
+                Console.WriteLine($"{scenario}: {count} completed operations");
+            }
+            finally { End(actor); }
+        }
+        return 0;
+    }
+}

--- a/sidecar/etw-probe/EtwProbe.csproj
+++ b/sidecar/etw-probe/EtwProbe.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.6" />
+  </ItemGroup>
+</Project>

--- a/sidecar/etw-probe/Fixture.cs
+++ b/sidecar/etw-probe/Fixture.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using System.IO.MemoryMappedFiles;
+using System.Text.Json;
+
+namespace Aegis.EtwProbe;
+
+internal static class Fixture
+{
+    internal static readonly string[] Scenarios = ["buffered", "async", "mapped", "preopened", "churn", "idle"];
+
+    // Only called by the parent with a new, private stage directory. The actor never
+    // accepts a file supplied by the user, follows no scripts and reads no secrets.
+    internal static async Task<int> Run(string[] args)
+    {
+        if (args.Length != 5 || !Scenarios.Contains(args[3])) throw new ArgumentException("Bad actor options");
+        string root = Path.GetFullPath(args[1]), role = args[2], scenario = args[3];
+        if (!Path.GetFileName(root).StartsWith("aegis-etw-fixture-", StringComparison.Ordinal) ||
+            !Guid.TryParseExact(Path.GetFileName(root)["aegis-etw-fixture-".Length..], "N", out _) ||
+            !new[] { "target", "control" }.Contains(role)) throw new ArgumentException("Invalid fixture scope");
+        int seconds = int.Parse(args[4]);
+        if (seconds is < 1 or > 120) throw new ArgumentException("Invalid actor duration");
+        string file = Path.Combine(root, role + ".dat");
+        using (var output = new FileStream(file, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+            output.Write(new byte[1024 * 1024]);
+        using var preopened = scenario == "preopened" ? File.OpenRead(file) : null;
+        Console.WriteLine(JsonSerializer.Serialize(new { ready = true, pid = Environment.ProcessId, tid = Native.GetCurrentThreadId(), role }));
+        if (await Console.In.ReadLineAsync() != "go") return 4;
+        var watch = Stopwatch.StartNew();
+        var samples = new List<object>();
+        int operations = 0;
+        long bytes = 0;
+        byte[] buffer = new byte[4096];
+        while (watch.Elapsed.TotalSeconds < seconds)
+        {
+            long begin = Stopwatch.GetTimestamp();
+            uint tidBefore = Native.GetCurrentThreadId();
+            int read = 0;
+            if (scenario == "idle") { await Task.Delay(50); continue; }
+            if (scenario == "mapped")
+            {
+                using var mapping = MemoryMappedFile.CreateFromFile(file, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+                using var view = mapping.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+                read = view.ReadArray(0, buffer, 0, buffer.Length);
+            }
+            else if (preopened != null)
+            {
+                preopened.Position = 0;
+                read = preopened.Read(buffer);
+            }
+            else
+            {
+                using var input = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read,
+                    4096, scenario == "async" ? FileOptions.Asynchronous : FileOptions.None);
+                read = scenario == "async" ? await input.ReadAsync(buffer) : input.Read(buffer);
+            }
+            operations++;
+            bytes += read;
+            if (samples.Count < 5000) samples.Add(new
+            {
+                operation = operations,
+                beginQpc = begin,
+                endQpc = Stopwatch.GetTimestamp(),
+                tidBefore,
+                tidAfter = Native.GetCurrentThreadId(),
+                bytes = read
+            });
+            await Task.Delay(scenario == "churn" ? 1 : 20);
+        }
+        double durationMs = watch.Elapsed.TotalMilliseconds;
+        preopened?.Dispose();
+        Console.WriteLine(JsonSerializer.Serialize(new { done = true, operations }));
+        if (await Console.In.ReadLineAsync() != "save") return 4;
+        // Parent stops ETW before permitting ledger writes. This witnesses successful
+        // API operations, not a one-to-one oracle for ETW Read event 15.
+        Program.Write(root, role + "-operations.json", new
+        {
+            schema = 1,
+            role,
+            scenario,
+            pid = Environment.ProcessId,
+            operations,
+            bytes,
+            sampledOperations = samples,
+            omittedOperations = operations - samples.Count,
+            durationMs
+        });
+        return 0;
+    }
+}

--- a/sidecar/etw-probe/Native.cs
+++ b/sidecar/etw-probe/Native.cs
@@ -1,0 +1,86 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Aegis.EtwProbe;
+
+internal static class Native
+{
+    [DllImport("kernel32.dll")] internal static extern uint GetCurrentThreadId();
+    [DllImport("kernel32.dll")] private static extern IntPtr OpenThread(uint access, bool inherit, uint tid);
+    [DllImport("kernel32.dll")] private static extern uint GetProcessIdOfThread(IntPtr thread);
+    [DllImport("kernel32.dll")] private static extern bool CloseHandle(IntPtr handle);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint QueryDosDevice(string device, StringBuilder target, int length);
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+    private static extern uint ControlTrace(ulong handle, string name, IntPtr properties, uint code);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Wnode
+    {
+        public uint BufferSize, ProviderId;
+        public ulong HistoricalContext;
+        public long TimeStamp;
+        public Guid Guid;
+        public uint ClientContext, Flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Properties
+    {
+        public Wnode Wnode;
+        public uint BufferSize, MinimumBuffers, MaximumBuffers, MaximumFileSize, LogFileMode;
+        public uint FlushTimer, EnableFlags;
+        public int AgeLimit;
+        public uint NumberOfBuffers, FreeBuffers, EventsLost, BuffersWritten, LogBuffersLost, RealTimeBuffersLost;
+        public IntPtr LoggerThreadId;
+        public uint LogFileNameOffset, LoggerNameOffset;
+    }
+
+    internal static string? DevicePath(string dosPath)
+    {
+        if (dosPath.Length < 3 || dosPath[1] != ':') return null;
+        var target = new StringBuilder(32768);
+        if (QueryDosDevice(dosPath[..2], target, target.Capacity) == 0) return null;
+        return target + dosPath[2..];
+    }
+
+    internal static uint? ThreadOwner(uint? tid)
+    {
+        if (tid == null || tid == 0) return null;
+        var handle = OpenThread(0x0800, false, tid.Value);
+        if (handle == IntPtr.Zero) return null;
+        try { uint pid = GetProcessIdOfThread(handle); return pid == 0 ? null : pid; }
+        finally { CloseHandle(handle); }
+    }
+
+    internal sealed record Loss(uint QueryStatus, uint? EventsLost, uint? RealTimeBuffersLost,
+        uint? LogBuffersLost, uint? NumberOfBuffers, uint? BufferSizeKb);
+
+    internal static Loss QueryLoss(string name)
+    {
+        int size = Marshal.SizeOf<Properties>() + 4096;
+        var memory = Marshal.AllocHGlobal(size);
+        try
+        {
+            Marshal.Copy(new byte[size], 0, memory, size);
+            var value = new Properties
+            {
+                Wnode = new Wnode { BufferSize = (uint)size },
+                LoggerNameOffset = (uint)Marshal.SizeOf<Properties>()
+            };
+            Marshal.StructureToPtr(value, memory, false);
+            uint status = ControlTrace(0, name, memory, 0); // EVENT_TRACE_CONTROL_QUERY
+            if (status != 0) return new(status, null, null, null, null, null);
+            value = Marshal.PtrToStructure<Properties>(memory);
+            return new(0, value.EventsLost, value.RealTimeBuffersLost, value.LogBuffersLost,
+                value.NumberOfBuffers, value.BufferSize);
+        }
+        finally { Marshal.FreeHGlobal(memory); }
+    }
+
+    internal static void CheckLayout()
+    {
+        if (Marshal.SizeOf<Wnode>() != 48 || Marshal.OffsetOf<Properties>(nameof(Properties.EventsLost)).ToInt32() != 88)
+            throw new InvalidOperationException("EVENT_TRACE_PROPERTIES layout mismatch");
+    }
+}

--- a/sidecar/etw-probe/Observation.cs
+++ b/sidecar/etw-probe/Observation.cs
@@ -1,0 +1,122 @@
+using System.Globalization;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Aegis.EtwProbe;
+
+internal sealed record Input(int Id, int Version, double TimeMs, int HeaderPid, int HeaderTid,
+    uint? IssuingTid, uint? PayloadTid, string? Object, string? Key, string? Name, long Qpc = 0);
+
+internal sealed record Sample(int Id, int Version, double TimeMs, int HeaderPid, int HeaderTid,
+    uint? IssuingTid, uint? PayloadTid, uint? ThreadOwnerAtCallback, string? Object, string? Key,
+    string? FixtureFile, string PathEvidence, long Qpc);
+
+// Candidate correlation for measurement only. It is deliberately not shipped into
+// AEGIS attribution. Mapping disagreements, unknown reads and overflows remain visible.
+internal sealed class Observation(string root, string? deviceRoot, HashSet<int> actorPids, string eviction,
+    int sampleLimit = 20000, int mapLimit = 10000)
+{
+    private readonly Dictionary<string, string> objects = new(), keys = new(), aliases = new();
+    internal readonly List<Sample> Samples = [];
+    internal readonly Dictionary<int, long> Delivered = new();
+    internal readonly Dictionary<string, string[]> Schemas = new();
+    internal long Unhandled, DecodeErrors, OmittedSamples, MappingResets, AliasOverflows;
+    internal long DecodedReads, FixturePathReads, UnresolvedActorReads, PathConflicts;
+
+    internal string? FixtureName(string? path)
+    {
+        if (path == null) return null;
+        var normalized = path.Replace('/', '\\');
+        foreach (var prefix in new[] { root, deviceRoot, "\\??\\" + root, "\\\\?\\" + root })
+        {
+            if (prefix == null) continue;
+            string boundary = prefix.Replace('/', '\\').TrimEnd('\\') + "\\";
+            if (!normalized.StartsWith(boundary, StringComparison.OrdinalIgnoreCase)) continue;
+            string relative = normalized[boundary.Length..];
+            if (relative.Equals("target.dat", StringComparison.OrdinalIgnoreCase)) return "target.dat";
+            if (relative.Equals("control.dat", StringComparison.OrdinalIgnoreCase)) return "control.dat";
+        }
+        return null;
+    }
+
+    private string? Alias(string prefix, string? pointer)
+    {
+        if (pointer == null) return null;
+        string key = prefix + pointer;
+        if (aliases.TryGetValue(key, out var value)) return value;
+        if (aliases.Count >= mapLimit * 2) { AliasOverflows++; return null; }
+        value = prefix + aliases.Count.ToString(CultureInfo.InvariantCulture);
+        aliases[key] = value;
+        return value;
+    }
+
+    internal void Accept(Input value, bool queryThread = false)
+    {
+        if (value.Id == 15) DecodedReads++;
+        var direct = FixtureName(value.Name);
+        // An observed name rebinds the pointer, even when the new path is outside
+        // the fixture. Keeping the old fixture name here would fabricate attribution.
+        if (value.Name != null)
+        {
+            if (value.Object != null) { objects.Remove(value.Object); if (direct != null) objects[value.Object] = direct; }
+            if (value.Key != null) { keys.Remove(value.Key); if (direct != null) keys[value.Key] = direct; }
+        }
+        var byObject = value.Object == null ? null : objects.GetValueOrDefault(value.Object);
+        var byKey = value.Key == null ? null : keys.GetValueOrDefault(value.Key);
+        bool conflict = byObject != null && byKey != null && byObject != byKey;
+        string? file = conflict ? null : direct ?? byObject ?? byKey;
+        string evidence = conflict ? "conflict" : direct != null ? "observed-name" : byObject != null
+            ? "candidate-object" : byKey != null ? "candidate-key" : "unresolved";
+        if (conflict) PathConflicts++;
+        if (value.Id == 15)
+        {
+            if (file != null) FixturePathReads++;
+            else if (actorPids.Contains(value.HeaderPid)) UnresolvedActorReads++;
+        }
+        if (file != null || conflict || actorPids.Contains(value.HeaderPid))
+        {
+            if (Samples.Count >= sampleLimit) OmittedSamples++;
+            else Samples.Add(new(value.Id, value.Version, value.TimeMs, value.HeaderPid, value.HeaderTid,
+                value.IssuingTid, value.PayloadTid, queryThread ? Native.ThreadOwner(value.IssuingTid ?? value.PayloadTid) : null,
+                Alias("o", value.Object), Alias("k", value.Key), file, evidence, value.Qpc));
+        }
+        if ((eviction == "close" && value.Id == 14) || (eviction == "cleanup" && value.Id is 13 or 14))
+        {
+            if (value.Object != null) objects.Remove(value.Object);
+            if (value.Key != null) keys.Remove(value.Key);
+        }
+        if (objects.Count + keys.Count > mapLimit)
+        {
+            objects.Clear(); keys.Clear(); MappingResets++;
+        }
+    }
+
+    internal void Decode(TraceEvent data)
+    {
+        if (data.ProviderGuid != Program.Provider) return;
+        try
+        {
+            if (Schemas.Count < 256) Schemas[$"{(int)data.ID}:{data.Version}"] = data.PayloadNames.Take(64).ToArray();
+            object? Field(string name)
+            {
+                var actual = data.PayloadNames.FirstOrDefault(n => n.Equals(name, StringComparison.OrdinalIgnoreCase));
+                return actual == null ? null : data.PayloadByName(actual);
+            }
+            string? Pointer(string name)
+            {
+                object? field = Field(name);
+                if (field == null) return null;
+                ulong number = field is IntPtr ptr ? unchecked((ulong)ptr.ToInt64()) : Convert.ToUInt64(field, CultureInfo.InvariantCulture);
+                return number == 0 ? null : number.ToString(CultureInfo.InvariantCulture);
+            }
+            uint? Tid(string name) => Field(name) is { } item
+                ? checked((uint)(item is IntPtr ptr ? ptr.ToInt64() : Convert.ToInt64(item, CultureInfo.InvariantCulture))) : null;
+            // Raw QPC is intentional: fixture processes use Stopwatch.GetTimestamp on this host.
+#pragma warning disable CS0618
+            Accept(new((int)data.ID, data.Version, data.TimeStampRelativeMSec, data.ProcessID, data.ThreadID,
+                Tid("IssuingThreadId"), Tid("ThreadId"), Pointer("FileObject"), Pointer("FileKey"),
+                Field("FileName") as string ?? Field("OpenPath") as string, data.TimeStampQPC), true);
+#pragma warning restore CS0618
+        }
+        catch { DecodeErrors++; } // No raw payload/error text (which may contain unrelated paths).
+    }
+}

--- a/sidecar/etw-probe/Program.cs
+++ b/sidecar/etw-probe/Program.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Security.Principal;
+using System.Text.Json;
+using Microsoft.Diagnostics.Tracing.Parsers;
+
+namespace Aegis.EtwProbe;
+
+internal static class Program
+{
+    internal static readonly Guid Provider = new("edd08927-9cc4-4e65-b970-c2560fb5c289");
+    internal static readonly JsonSerializerOptions Json = new() { WriteIndented = true };
+
+    public static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            if (args.Length == 0 || args[0] == "--help")
+            {
+                Console.WriteLine("AEGIS ETW measurement probe (not a production sensor)\n" +
+                    "self-test\npreflight <new-output-directory>\n" +
+                    "capture <new-output-directory> [--seconds 5..120] [--scenario buffered|async|mapped|preopened|churn|idle]\n" +
+                    "  [--keywords 0x1B0] [--events 10,12,13,14,15|all] [--pid-filter none|target]\n" +
+                    "  [--evict close|cleanup|none] [--buffers-mb 16..256]\n" +
+                    "fixture-check <new-output-directory> (no ETW, no elevation)");
+                return 0;
+            }
+            if (args[0] == "self-test") return SelfTest.Run();
+            if (args[0] == "actor") return await Fixture.Run(args);
+            if (!OperatingSystem.IsWindows()) throw new PlatformNotSupportedException("Windows required");
+            if (args.Length < 2) throw new ArgumentException("Output directory required");
+            if (args[0] == "preflight") { Preflight(NewOutput(args[1])); return 0; }
+            if (args[0] == "fixture-check") return await Capture.CheckFixtures(NewOutput(args[1]));
+            if (args[0] != "capture") throw new ArgumentException("Unknown command");
+            var options = Options.Parse(args);
+            if (!Elevated())
+            {
+                Console.Error.WriteLine("ETW capture requires an administrator terminal. No session was started.");
+                return 3;
+            }
+            return await Capture.Run(NewOutput(args[1]), options);
+        }
+        catch (Exception error)
+        {
+            // Exception messages can contain paths. Error type/code suffice for the console.
+            Console.Error.WriteLine($"Probe failed: {error.GetType().Name} (0x{error.HResult:X8}).");
+            return 2;
+        }
+    }
+
+    internal static bool Elevated() => new WindowsPrincipal(WindowsIdentity.GetCurrent())
+        .IsInRole(WindowsBuiltInRole.Administrator);
+
+    internal static string NewOutput(string directory)
+    {
+        var full = Path.GetFullPath(directory);
+        if (Path.Exists(full)) throw new IOException("Output must not already exist");
+        Directory.CreateDirectory(full);
+        return full;
+    }
+
+    internal static void Write(string directory, string name, object value)
+    {
+        using var stream = new FileStream(Path.Combine(directory, name), FileMode.CreateNew, FileAccess.Write);
+        JsonSerializer.Serialize(stream, value, Json);
+    }
+
+    internal static void Preflight(string directory)
+    {
+        using var windows = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+        Write(directory, "environment.json", new
+        {
+            schema = 1,
+            at = DateTimeOffset.UtcNow,
+            os = Environment.OSVersion.VersionString,
+            build = windows?.GetValue("CurrentBuild"),
+            revision = windows?.GetValue("UBR"),
+            edition = windows?.GetValue("EditionID"),
+            displayVersion = windows?.GetValue("DisplayVersion"),
+            framework = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
+            architecture = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString(),
+            logicalProcessors = Environment.ProcessorCount,
+            elevated = Elevated(),
+            provider = Provider,
+            traceEvent = typeof(RegisteredTraceEventParser).Assembly.GetName().Version?.ToString(),
+            stopwatchFrequency = Stopwatch.Frequency
+        });
+        // TDH reads the registered provider metadata, including templates. No trace is started.
+        var manifest = RegisteredTraceEventParser.GetManifestForRegisteredProvider(Provider);
+        File.WriteAllText(Path.Combine(directory, "kernel-file.manifest.xml"), manifest);
+    }
+
+    internal static ProcessStartInfo Child(params string[] arguments)
+    {
+        var executable = Environment.ProcessPath ?? throw new InvalidOperationException("No executable");
+        var start = new ProcessStartInfo(executable)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        if (Path.GetFileNameWithoutExtension(executable).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+            start.ArgumentList.Add(Assembly.GetExecutingAssembly().Location);
+        foreach (var argument in arguments) start.ArgumentList.Add(argument);
+        return start;
+    }
+}
+
+internal sealed record Options(int Seconds, string Scenario, ulong Keywords, List<int>? Events,
+    bool PidFilter, string Evict, int BuffersMb)
+{
+    internal static Options Parse(string[] args)
+    {
+        var values = new Dictionary<string, string>();
+        var allowed = new[] { "--seconds", "--scenario", "--keywords", "--events", "--pid-filter", "--evict", "--buffers-mb" };
+        for (int i = 2; i < args.Length; i += 2)
+        {
+            if (i + 1 >= args.Length || !allowed.Contains(args[i]) || !values.TryAdd(args[i], args[i + 1]))
+                throw new ArgumentException("Invalid or repeated option");
+        }
+        string Get(string key, string fallback) => values.GetValueOrDefault(key, fallback);
+        int seconds = int.Parse(Get("--seconds", "10")), buffers = int.Parse(Get("--buffers-mb", "64"));
+        string scenario = Get("--scenario", "buffered"), evict = Get("--evict", "close"), filter = Get("--pid-filter", "none");
+        if (seconds is < 5 or > 120 || buffers is < 16 or > 256 ||
+            !Fixture.Scenarios.Contains(scenario) || !new[] { "close", "cleanup", "none" }.Contains(evict) ||
+            !new[] { "none", "target" }.Contains(filter)) throw new ArgumentException("Option outside bounds");
+        string keywordText = Get("--keywords", "0x1B0");
+        ulong keywords = keywordText.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+            ? Convert.ToUInt64(keywordText[2..], 16) : ulong.Parse(keywordText);
+        if (keywords == 0) throw new ArgumentException("Explicit nonzero keyword mask required");
+        string eventText = Get("--events", "10,12,13,14,15");
+        var events = eventText == "all" ? null : eventText.Split(',').Select(int.Parse).Distinct().ToList();
+        if (events != null && (events.Count > 64 || events.Any(e => e is < 0 or > 65535)))
+            throw new ArgumentException("Invalid event IDs");
+        return new(seconds, scenario, keywords, events, filter == "target", evict, buffers);
+    }
+}

--- a/sidecar/etw-probe/README.md
+++ b/sidecar/etw-probe/README.md
@@ -1,0 +1,95 @@
+# Kernel-File measurement probe
+
+Standalone Windows B1 experiment for provider
+`edd08927-9cc4-4e65-b970-c2560fb5c289`. It is not wired into AEGIS or its installer.
+Requires .NET 10 SDK to build, .NET 10 runtime to run. TraceEvent is pinned to 3.2.6.
+
+From the repository in a **normal terminal**:
+
+```powershell
+dotnet build sidecar/etw-probe/EtwProbe.csproj -c Release
+sidecar/etw-probe/bin/Release/net10.0-windows/EtwProbe.exe self-test
+sidecar/etw-probe/bin/Release/net10.0-windows/EtwProbe.exe fixture-check X:/tmp/aegis-etw-fixtures-new
+sidecar/etw-probe/bin/Release/net10.0-windows/EtwProbe.exe preflight X:/tmp/aegis-etw-preflight-new
+```
+
+Use new output directories each time. Preflight reads registered TDH metadata and
+OS version/edition without starting ETW. Fixture-check exercises six synthetic
+workloads and the ready/go/done/save protocol without elevation.
+
+Then, in **PowerShell as administrator**, run the already-built probe:
+
+```powershell
+& 'X:/Future/ESCAPE/AEGIS/sidecar/etw-probe/Run-Matrix.ps1' -OutputRoot 'X:/tmp/aegis-etw-matrix-20260908'
+```
+
+The eleven short runs take roughly two minutes, depending on session startup and
+drain time. The runner does not install packages, rebuild, change tracing policy,
+request elevation or stop other trace sessions. Each capture has a unique session
+name, two child processes and its own newly created synthetic 1 MiB files. Ctrl+C
+stops the owned session and children through the probe's cleanup path. If a process
+is forcibly terminated, inspect the exact GUID session name in `run.json` before
+manually stopping that session; never stop all ETW sessions.
+
+## Experiments and artifacts
+
+`Run-Matrix.ps1` compares READ-only, names/read, lifecycle, target-PID filtering,
+preopened handles, asynchronous reads, warm mapped reads and three churn eviction
+policies. These are candidate configurations, not a ratified minimal set.
+Every comparison gets a fresh map and two separate actors: target and control.
+The PID-filter run requests only the target PID; compare control delivery against
+the unfiltered lifecycle run. Zero delivery alone does not prove filtering works.
+
+Each run retains:
+
+- `environment.json`, registered `kernel-file.manifest.xml`, and `run.json` with
+  options, owned session name and actor PIDs.
+- `events.json`: bounded selected samples, raw QPC plus relative milliseconds,
+  header PID/TID, payload TID, optional live thread-owner lookup, opaque per-run
+  pointer aliases and fixture-relative candidate path evidence.
+- `schemas.json`: delivered event IDs/versions and field names, without values.
+- `summary.json`: all delivered provider event counts, decode/retention/map losses,
+  collector CPU milliseconds, lifetime peak working set, collection duration and
+  native session loss/buffer counters queried before stop.
+- Actor `*-operations.json`: successful API operations, QPC intervals, caller TIDs
+  and byte counts. Ledgers are written only after the parent stops ETW.
+
+Exit 0 means collection completed without the reported degradation conditions; it
+does **not** prove Read coverage, correct identity or adequate configuration.
+Exit 5 retains degraded measurements; 3 means elevation missing; 2 means failure
+(type/HRESULT only). An unavailable counter is null, never a measured zero.
+
+The fixture files and selected metadata are retained; no raw ETL is persisted.
+Callbacks see machine-wide events when unfiltered, but persist no unrelated path
+values, command lines, file contents or raw kernel pointer values. Path matching
+accepts only exact target/control fixture paths; unsupported device/SUBST/UNC
+translations stay unresolved. Aggregate counts include unrelated activity.
+
+## Interpretation limits
+
+The ledger witnesses application API completion, not a one-to-one oracle for event
+15 emission. Async continuation TID can differ from the issuing TID. Header PID
+is not declared authoritative. `ThreadOwnerAtCallback` queries the live thread
+table and can race thread exit/reuse; it is a separate observation, not event-time
+identity. Selected samples can omit a read with both unknown path and non-actor
+header PID; global event counts still include it. Therefore this harness alone
+cannot prove absence or settle authoritative issuer attribution.
+
+Object/key maps are experimental. Rebinding to an unrelated observed name
+invalidates fixture evidence; disagreements remain conflicts. Dropped naming
+events can still leave stale associations. Maps and samples are capped and report
+overflow. Close/cleanup/no-eviction runs do not constitute a lifecycle proof.
+
+QPC values use the same host clock as `Stopwatch.GetTimestamp`; convert differences
+with `stopwatchFrequency` from the environment record. Collection duration includes
+startup after enabling and one second of tail drain. CPU measures the collector
+over that interval, excludes provider-wide kernel cost, and includes callback
+thread queries. Peak working set is the collector process lifetime peak.
+Loss is queried before stopping: final drain/stop losses are not measured.
+
+Warm buffered or mapped reads do not prove Fast I/O, cold page faults or coverage
+of every mapping path. For npm/build load, run a 30-second idle capture manually
+while running a known project workload in a separate **normal** terminal; record
+its duration and command separately. Do not run project build scripts elevated.
+Repeat representative runs at least three times and on Home, Pro and Hyper-V
+targets before generalizing. See the [evidence checklist](../../docs/recon/kernel-file-etw-measurements.md).

--- a/sidecar/etw-probe/Run-Matrix.ps1
+++ b/sidecar/etw-probe/Run-Matrix.ps1
@@ -1,0 +1,48 @@
+[CmdletBinding()]
+param(
+    [string]$OutputRoot = (Join-Path ([IO.Path]::GetTempPath()) ('aegis-etw-' + [guid]::NewGuid().ToString('N'))),
+    [ValidateRange(5, 120)][int]$Seconds = 5,
+    [string]$ProbePath = (Join-Path $PSScriptRoot 'bin/Release/net10.0-windows/EtwProbe.exe')
+)
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false # Exit 5 is retained measurement data, not a terminating shell error.
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Open an administrator PowerShell terminal. No ETW session was started.'
+}
+if (-not (Test-Path -LiteralPath $ProbePath -PathType Leaf)) {
+    throw 'Build EtwProbe.csproj in a normal terminal first (see README).'
+}
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+if (Test-Path -LiteralPath $OutputRoot) { throw 'OutputRoot must be a new directory.' }
+$null = New-Item -ItemType Directory -Path $OutputRoot
+$runs = @(
+    @{ Name = 'idle'; Scenario = 'idle'; Mask = '0x1B0'; Events = 'all' },
+    @{ Name = 'read-only'; Scenario = 'buffered'; Mask = '0x100'; Events = '15' },
+    @{ Name = 'names-read'; Scenario = 'buffered'; Mask = '0x190'; Events = '10,12,15' },
+    @{ Name = 'lifecycle'; Scenario = 'buffered'; Mask = '0x1B0'; Events = '10,12,13,14,15' },
+    @{ Name = 'pid-filter'; Scenario = 'buffered'; Filter = 'target' },
+    @{ Name = 'preopened'; Scenario = 'preopened' },
+    @{ Name = 'async'; Scenario = 'async' },
+    @{ Name = 'mapped'; Scenario = 'mapped' },
+    @{ Name = 'churn-close'; Scenario = 'churn' },
+    @{ Name = 'churn-cleanup'; Scenario = 'churn'; Evict = 'cleanup' },
+    @{ Name = 'churn-no-eviction'; Scenario = 'churn'; Evict = 'none' }
+)
+$results = @()
+foreach ($run in $runs) {
+    $mask = if ($run.Mask) { $run.Mask } else { '0x1B0' }
+    $events = if ($run.Events) { $run.Events } else { '10,12,13,14,15' }
+    $filter = if ($run.Filter) { $run.Filter } else { 'none' }
+    $evict = if ($run.Evict) { $run.Evict } else { 'close' }
+    Write-Host ('Measuring ' + $run.Name)
+    & $ProbePath capture (Join-Path $OutputRoot $run.Name) --seconds $Seconds --scenario $run.Scenario --keywords $mask --events $events --pid-filter $filter --evict $evict
+    $probeExit = $LASTEXITCODE
+    $results += [pscustomobject]@{ name = $run.Name; exitCode = $probeExit }
+    if ($probeExit -notin @(0, 5)) { break }
+}
+$results | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $OutputRoot 'matrix.json') -Encoding utf8
+Write-Host ('Results: ' + $OutputRoot)
+if ($results.Count -ne $runs.Count -or @($results | Where-Object exitCode -ne 0).Count -gt 0) { exit 5 }
+exit 0

--- a/sidecar/etw-probe/SelfTest.cs
+++ b/sidecar/etw-probe/SelfTest.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+
+namespace Aegis.EtwProbe;
+
+internal static class SelfTest
+{
+    internal static int Run()
+    {
+        int passed = 0;
+        void Check(bool condition) { if (!condition) throw new InvalidOperationException("Self-test assertion failed"); }
+        void Test(string name, Action action) { action(); passed++; Console.WriteLine("PASS " + name); }
+        var root = @"C:\fixture";
+        Input Row(int id, string? name = null, string? obj = "100", string? key = "200", int pid = 10) =>
+            new(id, 1, 0, pid, 20, 20, null, obj, key, name);
+        Observation New(string evict = "close", int samples = 100, int maps = 100) =>
+            new(root, @"\Device\Volume\fixture", [10, 11], evict, samples, maps);
+
+        Test("fixture path boundary and device path", () =>
+        {
+            var obs = New();
+            Check(obs.FixtureName(root + @"\target.dat") == "target.dat");
+            Check(obs.FixtureName(@"\Device\Volume\fixture\control.dat") == "control.dat");
+            Check(obs.FixtureName(root + @"-other\target.dat") == null);
+            Check(obs.FixtureName(root + @"\..\secret") == null);
+            Check(obs.FixtureName(root + @"\credentials.env") == null);
+        });
+        Test("fresh name then candidate object correlation", () =>
+        {
+            var obs = New(); obs.Accept(Row(12, root + @"\target.dat")); obs.Accept(Row(15));
+            Check(obs.Samples[1].PathEvidence == "candidate-object" && obs.FixturePathReads == 1);
+        });
+        Test("preopened read stays unresolved without path evidence", () =>
+        {
+            var obs = New(); obs.Accept(Row(15));
+            Check(obs.UnresolvedActorReads == 1 && obs.Samples[0].FixtureFile == null);
+        });
+        Test("ETW QPC clock survives sampling", () =>
+        {
+            var obs = New(); obs.Accept(Row(15) with { Qpc = 987654321 });
+            Check(obs.Samples[0].Qpc == 987654321);
+        });
+        Test("name-create key-only candidate", () =>
+        {
+            var obs = New(); obs.Accept(Row(10, root + @"\target.dat", obj: null)); obs.Accept(Row(15));
+            Check(obs.Samples[1].PathEvidence == "candidate-key");
+        });
+        Test("outside-fixture pointer reuse invalidates old mapping", () =>
+        {
+            var obs = New(); obs.Accept(Row(12, root + @"\target.dat"));
+            obs.Accept(Row(12, @"C:\private\secret.env", pid: 99)); obs.Accept(Row(15));
+            Check(obs.Samples[^1].FixtureFile == null);
+            Check(!JsonSerializer.Serialize(obs.Samples).Contains("secret"));
+        });
+        Test("conflicting object and key never select a path", () =>
+        {
+            var obs = New(); obs.Accept(Row(12, root + @"\target.dat", key: null));
+            obs.Accept(Row(10, root + @"\control.dat", obj: null)); obs.Accept(Row(15));
+            Check(obs.PathConflicts == 1 && obs.Samples[^1].PathEvidence == "conflict");
+        });
+        Test("close eviction", () =>
+        {
+            var obs = New(); obs.Accept(Row(12, root + @"\target.dat")); obs.Accept(Row(14)); obs.Accept(Row(15));
+            Check(obs.Samples[^1].FixtureFile == null);
+        });
+        Test("cleanup policy is an explicit experimental switch", () =>
+        {
+            var close = New(); var cleanup = New("cleanup");
+            foreach (var obs in new[] { close, cleanup })
+            { obs.Accept(Row(12, root + @"\target.dat")); obs.Accept(Row(13)); obs.Accept(Row(15)); }
+            Check(close.Samples[^1].FixtureFile != null && cleanup.Samples[^1].FixtureFile == null);
+        });
+        Test("raw pointer values are not serialized", () =>
+        {
+            var obs = New(); obs.Accept(Row(15, obj: "1234567890987654321"));
+            string json = JsonSerializer.Serialize(obs.Samples);
+            Check(!json.Contains("1234567890987654321") && json.Contains("o0"));
+        });
+        Test("record cap reports omitted records", () =>
+        {
+            var obs = New(samples: 1); obs.Accept(Row(15)); obs.Accept(Row(15));
+            Check(obs.Samples.Count == 1 && obs.OmittedSamples == 1);
+        });
+        Test("map cap clears evidence and reports the reset", () =>
+        {
+            var obs = New(maps: 1); obs.Accept(Row(12, root + @"\target.dat")); obs.Accept(Row(15));
+            Check(obs.MappingResets == 1 && obs.Samples[^1].FixtureFile == null);
+        });
+        Test("unrelated payloads leave no output sample", () =>
+        {
+            var obs = New(); obs.Accept(Row(12, @"C:\private\secret.env", pid: 99));
+            Check(obs.Samples.Count == 0);
+        });
+        Test("explicit filters and bounds", () =>
+        {
+            var options = Options.Parse(["capture", "unused", "--keywords", "0x190", "--pid-filter", "target", "--events", "15"]);
+            Check(options.Keywords == 0x190 && options.PidFilter && options.Events!.SequenceEqual([15]));
+            bool rejected = false;
+            try { Options.Parse(["capture", "unused", "--seconds", "999"]); } catch (ArgumentException) { rejected = true; }
+            Check(rejected);
+        });
+        Test("native loss-query ABI and unavailable counters", () =>
+        {
+            Native.CheckLayout();
+            var result = Native.QueryLoss("AEGIS-FileProbe-does-not-exist-" + Guid.NewGuid().ToString("N"));
+            Check(result.QueryStatus != 0 && result.EventsLost == null && result.RealTimeBuffersLost == null);
+        });
+        Test("callback thread-owner query is an observation", () =>
+            Check(Native.ThreadOwner(Native.GetCurrentThreadId()) == Environment.ProcessId));
+        Console.WriteLine($"{passed} self-tests passed");
+        return 0;
+    }
+}


### PR DESCRIPTION
AEGIS needs live Windows Kernel-File evidence before choosing a production read sensor. This adds an isolated .NET 10 / TraceEvent 3.2.6 measurement harness, synthetic target/control processes and an eleven-run matrix covering candidate filters, read modes and mapping eviction policies.

The probe records bounded fixture-only candidate correlations, QPC operation ledgers, delivered-event counts, collector metrics and native session loss counters. Ledgers are saved after tracing stops. Missing paths and unavailable counters remain explicit; header PID and late live thread ownership are not promoted to authoritative attribution. No Electron runtime, installer or frontend behavior changes.

The roadmap and evidence checklist distinguish preparation from live validation. TDH metadata was read on Windows 11 Home 25H2 build 26200.8655; administrator capture is still pending, so B1 and its thirteen hardware questions remain open.

Validation:
- Windows Release build: zero warnings/errors; C# whitespace check passed.
- 16 standalone self-tests and all six real child-process fixture scenarios passed, including the ledger handshake.
- PowerShell syntax check passed; non-admin capture exited 3 without creating output or starting a session.
- NuGet direct/transitive vulnerability check: none reported.
- AEGIS coverage: 2,809 passed, four skipped, 162 files. Format, renderer build, lint, both type checks, both mutation gates, counts and production audit passed.

Existing CI checks the AEGIS project; the new standalone C# build and fixture checks were run locally on Windows. CI configuration is unchanged.
