### PR TITLE
feat: compare ETW buffer budgets and sample sustained memory

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,8 @@ and Hyper-V as well as filtering, event identity, mapping lifecycle and loss.
 The dependency is those observations, not the absence of a Windows host.
 
 1. **B1:** isolated [C#/TraceEvent harness and procedure](sidecar/etw-probe/README.md)
-   are prepared; the first Home matrix is recorded and a repeated load study is ready.
+   are prepared; the first Home matrix and repeated load study are recorded.
+   Smaller-buffer comparisons and a sustained capture are prepared for the next run.
    The [live measurement checklist](docs/recon/kernel-file-etw-measurements.md) remains open.
    Collect results on target systems that answer each question; distinguish verified
    results from environment-limited or unresolved coverage. One machine or a mock

--- a/docs/recon/evidence/etw-home-26200-load.json
+++ b/docs/recon/evidence/etw-home-26200-load.json
@@ -1,0 +1,243 @@
+{
+  "schema": 1,
+  "source": "aegis-etw-load-20260908",
+  "simulation": false,
+  "node": "24.11.1",
+  "npm": "11.6.2",
+  "rows": [
+    {
+      "run": "r1-idle",
+      "exitCode": 0,
+      "durationMs": 16060.3323,
+      "collectorCpuMs": 546.875,
+      "read15Count": 12170,
+      "deliveredEventCount": 63354.0,
+      "processLifetimePeakBytes": 65605632,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 0,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 87.685,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "BB891077C7DC5FAA88E032DD4BC1EB5B276D0C7981B574CB33AEC32590664019",
+        "summary": "E27262B3E1FDC9DC73AB75B215EDA8D0E43361F40B85213B2A369F2DE298BF6F"
+      }
+    },
+    {
+      "run": "r1-npm",
+      "exitCode": 0,
+      "durationMs": 16088.7217,
+      "collectorCpuMs": 562.5,
+      "read15Count": 40944,
+      "deliveredEventCount": 349739.0,
+      "processLifetimePeakBytes": 73949184,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 78,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 105.289,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "ABD8DF0CA4CFCABC3F31809BA4099A3CD6B4738AB64D05AE96255FB659A710EE",
+        "summary": "EF22735E2C3A70DE8D0542E6C38F76EFF4469BB5F17E85E2BED90C31735E9314"
+      }
+    },
+    {
+      "run": "r1-build",
+      "exitCode": 0,
+      "durationMs": 16053.8344,
+      "collectorCpuMs": 406.25,
+      "read15Count": 24951,
+      "deliveredEventCount": 258474.0,
+      "processLifetimePeakBytes": 77520896,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 6,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 2014.546,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "7A6C3BD63FBB467B93123568E5B5589BF4E72709298FA51D539E55B4EE58DFCD",
+        "summary": "1D886B2C1CBFED4617069A0422BAD9E02F059EF7EF7581FA83D2152746993098"
+      }
+    },
+    {
+      "run": "r2-npm",
+      "exitCode": 0,
+      "durationMs": 16115.8321,
+      "collectorCpuMs": 375,
+      "read15Count": 56508,
+      "deliveredEventCount": 384100.0,
+      "processLifetimePeakBytes": 87326720,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 78,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 278.221,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "AEE6841ED9A154094FD0AA669C4E0517F51206DFDF6893625446D11AE4A3482D",
+        "summary": "6AE32D9A0C19A33334188175F325CC752E1901E43366D42D7B528282C519B200"
+      }
+    },
+    {
+      "run": "r2-build",
+      "exitCode": 0,
+      "durationMs": 16106.8886,
+      "collectorCpuMs": 375,
+      "read15Count": 21190,
+      "deliveredEventCount": 226686.0,
+      "processLifetimePeakBytes": 87326720,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 4,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 1915.72,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "672748DF82DADDE5AF61536DDA2059C7EE2580F559ACBA639C65429CA25EFDCD",
+        "summary": "5FC2965963332E220C8E03A1911246CBF1F22E590FEA072DF7D85C875A376D36"
+      }
+    },
+    {
+      "run": "r2-idle",
+      "exitCode": 0,
+      "durationMs": 16083.7044,
+      "collectorCpuMs": 93.75,
+      "read15Count": 2295,
+      "deliveredEventCount": 14007.0,
+      "processLifetimePeakBytes": 87326720,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 0,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 29.734,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "BA00E0B5DC3037168EBAB68480E95E3681EDDCA270F5D93791E84AA5498A1E33",
+        "summary": "2CC920A41BF8DF5812AA57008E055FFF5D461BE07283C96CB57A434397A393A6"
+      }
+    },
+    {
+      "run": "r3-build",
+      "exitCode": 0,
+      "durationMs": 16090.7406,
+      "collectorCpuMs": 296.875,
+      "read15Count": 21404,
+      "deliveredEventCount": 221329.0,
+      "processLifetimePeakBytes": 87326720,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 4,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 387.891,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "C7EFAD82CF1792EEB75C02EA357C9C6F7A3C02FDBAD157EE02D853A279E86FAB",
+        "summary": "4E6DDDFA7996F2876B2BD4AF418FDF927AA72EA9E25191BC5C4E05DDA22DF4C0"
+      }
+    },
+    {
+      "run": "r3-idle",
+      "exitCode": 0,
+      "durationMs": 16041.7637,
+      "collectorCpuMs": 46.875,
+      "read15Count": 28578,
+      "deliveredEventCount": 43542.0,
+      "processLifetimePeakBytes": 87326720,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 0,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 32.498,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "BC4923726CBFAD23A37ACD2E7FD576C81395925AE342679B7A747781BAE8A3B0",
+        "summary": "41BB7B630037EDBAF964FB998776C375337BC28A6048E9C0750936D4B76AF081"
+      }
+    },
+    {
+      "run": "r3-npm",
+      "exitCode": 0,
+      "durationMs": 16070.0049,
+      "collectorCpuMs": 406.25,
+      "read15Count": 69752,
+      "deliveredEventCount": 365770.0,
+      "processLifetimePeakBytes": 87326720,
+      "sessionLoss": {
+        "QueryStatus": 0,
+        "EventsLost": 0,
+        "RealTimeBuffersLost": 0,
+        "LogBuffersLost": 0,
+        "NumberOfBuffers": 1024,
+        "BufferSizeKb": 64
+      },
+      "completedCommands": 88,
+      "failedCommands": 0,
+      "overlapsPreviousWorkload": false,
+      "workloadTailMs": 4.191,
+      "decoderOrRetentionErrors": 0,
+      "sourceHashes": {
+        "workload": "E0497AD99377AC203CDB603735B107D28A237D497CBF97610CED3FA240E87B06",
+        "summary": "48945DBF985AA2D66D43E4569E396A6CBF14ADAE74B242E9D0A792438FBE2B41"
+      }
+    }
+  ]
+}

--- a/docs/recon/kernel-file-etw-measurements.md
+++ b/docs/recon/kernel-file-etw-measurements.md
@@ -65,12 +65,37 @@ set. These are single-run observations, not an overhead budget: background activ
 varied, idle used all event IDs, collector CPU excludes kernel generation cost, and
 the session counters were queried before final stop.
 
-Next use `EtwProbe.exe study <new-output-directory>` from a normal terminal. This
-runs three repetitions each of idle, npm CLI startup and renderer builds, rotating
-their order, with the same candidate mask/IDs/buffer size for every capture. It
-requests one UAC elevation for the fixed collector; workloads retain normal rights.
-This is not an npm-install benchmark, a total-system overhead comparison, or a
-resolution of the mapped/page-fault, Home/Pro and Hyper-V questions.
+## Repeated live load study
+
+The user completed `X:/tmp/aegis-etw-load-20260908` with PR #381's probe, Node
+24.11.1 and npm 11.6.2. The [aggregate evidence](evidence/etw-home-26200-load.json)
+retains all nine outcomes and summary/workload hashes. All three repetitions of
+idle, npm CLI startup and renderer builds completed without decoder/retention
+errors or queried pre-stop session losses. The normal workloads completed 244 npm
+CLI commands and 14 renderer builds successfully. QPC checks show no previous
+workload overlapping the next capture; build tails extended 0.39–2.01 seconds past
+their own captures and were allowed to finish before the next one began.
+
+| Workload | Read 15 events/s, range | Collector CPU as % of one logical processor, range |
+| --- | ---: | ---: |
+| idle | 143–1,781 | 0.292–3.405 |
+| npm CLI | 2,545–4,341 | 2.327–3.496 |
+| renderer build | 1,316–1,554 | 1.845–2.531 |
+
+Rates use collection duration (approximately 16 seconds including tail drain).
+All enabled event types reached 23,834 events/s in one npm run. Background traffic
+was not isolated and there is no tracing-off control, so these are observed rates
+and collector CPU, not total-system overhead or causal workload attribution.
+
+Process-lifetime peak working set reached 83.28 MiB; native queries reported 64 MiB
+of session buffers throughout. The same collector process serves every run, so
+repeated 83.28 MiB peaks do not prove current memory stability or absence of a leak.
+
+Next: `EtwProbe.exe tune <new-directory>` compares 64/32/16 MiB requests with three
+rotated repetitions, then performs one ten-minute continuous capture with 16 MiB
+and cycling normal-user workloads. Current/private/managed memory and session loss
+counters are sampled over time. This preparation has no new live measurements yet;
+the default buffer budget is unchanged and B1 remains open.
 
 ## Hardware-gated checklist
 
@@ -85,8 +110,8 @@ Numbers match the [frozen recon](kernel-file-etw.md#hardware-gated).
 | 5 | Cleanup/Close requirements | All three short churn policies resolved the recorded fixture operations; requirements remain unproven. |
 | 6 | Object/key lifetime and reuse | Short churn has no observed conflicts; reuse/lifetime guarantees remain open. |
 | 7 | Minimal mask and IDs | 0x190 and 0x1B0 resolved fresh fixture reads; READ-only did not resolve paths. Minimality remains open. |
-| 8 | Idle/npm/build event rates | First mixed-configuration baseline retained; repeated study prepared, not yet captured. |
-| 9 | CPU/memory/buffers/loss | First collector metrics and zero pre-stop counters recorded; repeat/load and total-system overhead remain open. |
+| 8 | Idle/npm/build event rates | Three repetitions observed per workload on this Home host; background not isolated and npm is CLI startup, not install. |
+| 9 | CPU/memory/buffers/loss | Repeated collector metrics and zero pre-stop losses recorded; smaller buffers, sustained behavior and total-system overhead remain open. |
 | 10 | Fast I/O | Pending: dedicated path evidence; buffered workload alone is insufficient. |
 | 11 | mmap/page faults | 322 warm-mapped operations, zero fixture-path Read samples; dedicated cold/page-fault evidence remains pending. |
 | 12 | Home versus Pro | Pending: same matrix on both editions. |

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1409,3 +1409,48 @@ Expect one Windows elevation prompt and about three to five minutes. Analyze the
 new matrix, workload intervals, collector rates/losses and environment data before
 deciding follow-ups. npm here means `npm --version`, not install; total-system
 overhead, Fast I/O, cold/page-fault, Pro and Hyper-V evidence are still separate work.
+
+## Session handoff — buffer budget and sustained ETW capture (2026-09-08)
+
+The user completed the nine live load runs from PR #381 (`39da76e`) at
+`X:/tmp/aegis-etw-load-20260908`. All returned zero with no reported decoder,
+retention or pre-stop session losses. There were 244 successful npm CLI commands
+and 14 renderer builds. Workload QPC intervals did not overlap subsequent captures.
+`docs/recon/evidence/etw-home-26200-load.json` and the measurement document preserve
+aggregates, source hashes and interpretation limits. Peak working set was a lifetime
+high-water mark in one reused collector, not a current-memory measurement.
+
+User approved smaller-buffer and longer-run work. New `tune` profile requests
+64/32/16 MiB three times each under identical npm CLI load, rotating their positions.
+It then runs one continuous 600-second session with the 16 MiB stress candidate,
+cycling idle/npm/build every minute. The preset does not automatically choose a
+production buffer budget. CLI capture/fixture durations are bounded to 900 seconds.
+The existing load profile still uses its original nine 15-second captures.
+
+`ResourceSampler` records current working set, private bytes, managed live memory,
+GC committed bytes/gen2 counts and native loss counters every five seconds, plus
+initial/final samples. Its single writer keeps a capped in-memory list until stop;
+it does not read the decoder's mutable maps or force GC. Sampler failures, unknown
+loss counters, measured loss and overflow degrade the capture. The sampler stops
+before session stop, including failure cleanup; final-stop losses remain unmeasured.
+Periodic query cost is included in collector CPU. The 64 MiB runs provide a baseline
+with this same new instrumentation.
+
+The collector now polls the coordinator's abort signal and passes cancellation to
+the active capture, rather than waiting ten minutes after Ctrl+C. Repeated abort
+signals tolerate concurrent file creation. The study/tune elevation guard now
+prints a useful static instruction and exits 3 before creating output; this fixes
+the user's previous generic InvalidOperationException from an administrator window.
+
+Validation: C# Release build, 19 self-tests (including balanced plans, phase
+boundaries, sampler stop/cap and missing-counter semantics), short tune protocol
+check with real normal-user npm/build and simulated ETW, and active-abort check
+(failure retained, no successful stop marker and no next capture). New live sampling
+and reduced buffers have not yet been measured; no production sensor/UI changes.
+
+Next: from normal PowerShell run
+`& 'X:/Future/ESCAPE/AEGIS/sidecar/etw-probe/bin/Release/net10.0-windows/EtwProbe.exe' tune 'X:/tmp/aegis-etw-tune-20260908'`.
+One UAC prompt; allow about 13–15 minutes. Analyze actual buffer counts and sampled
+current/private/managed memory alongside loss/degradation, phase intervals and GC.
+Ten minutes on this host cannot prove leak freedom, coverage of all I/O paths or
+universal buffer sufficiency. B1 remains open for those distinct questions.

--- a/sidecar/etw-probe/Capture.cs
+++ b/sidecar/etw-probe/Capture.cs
@@ -44,7 +44,7 @@ internal static class Capture
         await actor.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
     }
 
-    internal static async Task<int> Run(string directory, Options options)
+    internal static async Task<int> Run(string directory, Options options, CancellationToken studyCancellation = default)
     {
         Program.Preflight(directory);
         Native.CheckLayout();
@@ -53,8 +53,9 @@ internal static class Capture
         var actors = new List<Process>();
         string sessionName = "AEGIS-FileProbe-" + Guid.NewGuid().ToString("N");
         TraceEventSession? session = null;
+        ResourceSampler? resources = null;
         Task? consumer = null;
-        using var cancel = new CancellationTokenSource();
+        using var cancel = CancellationTokenSource.CreateLinkedTokenSource(studyCancellation);
         ConsoleCancelEventHandler cancelHandler = (_, e) => { e.Cancel = true; cancel.Cancel(); };
         Console.CancelKeyPress += cancelHandler;
         try
@@ -86,10 +87,12 @@ internal static class Capture
             TimeSpan cpuStart = process.TotalProcessorTime;
             var watch = Stopwatch.StartNew();
             consumer = Task.Run(() => source.Process());
+            resources = new ResourceSampler(sessionName);
             Program.Write(directory, "capture-ready.json", new { qpc = Stopwatch.GetTimestamp() });
             foreach (var actor in actors) { await actor.StandardInput.WriteLineAsync("go"); await actor.StandardInput.FlushAsync(); }
             await Task.WhenAll(actors.Select(p => Done(p, cancel.Token))).WaitAsync(TimeSpan.FromSeconds(options.Seconds + 20), cancel.Token);
             await Task.Delay(1000, cancel.Token); // Drain tail events before querying loss/stopping.
+            await resources.Stop();
             var loss = Native.QueryLoss(sessionName);
             session.Stop();
             await consumer.WaitAsync(TimeSpan.FromSeconds(10));
@@ -101,6 +104,7 @@ internal static class Capture
             await Task.WhenAll(actors.Select(Save));
             Program.Write(directory, "events.json", observation.Samples);
             Program.Write(directory, "schemas.json", observation.Schemas);
+            Program.Write(directory, "resources.json", resources.Samples);
             bool actorsOk = actors.All(p => p.ExitCode == 0);
             Program.Write(directory, "summary.json", new
             {
@@ -110,6 +114,8 @@ internal static class Capture
                 durationMs,
                 collectorCpuMs,
                 collectorPeakWorkingSetBytes,
+                resourceSamplingDegraded = resources.Degraded,
+                omittedResourceSamples = resources.Omitted,
                 loss,
                 observation.Delivered,
                 observation.Unhandled,
@@ -125,7 +131,7 @@ internal static class Capture
                     "Loss query precedes stop; unavailable counters are null. Collector CPU excludes provider-wide kernel cost."
             });
             // Nonzero on degraded observations; retain artifacts for diagnosing the loss.
-            return actorsOk && loss.QueryStatus == 0 && loss.EventsLost == 0 && loss.RealTimeBuffersLost == 0 &&
+            return actorsOk && !resources.Degraded && loss.QueryStatus == 0 && loss.EventsLost == 0 && loss.RealTimeBuffersLost == 0 &&
                 loss.LogBuffersLost == 0 && observation.Unhandled == 0 && observation.PathConflicts == 0 &&
                 observation.DecodeErrors == 0 && observation.OmittedSamples == 0 && observation.MappingResets == 0 && observation.AliasOverflows == 0 ? 0 : 5;
         }
@@ -142,7 +148,11 @@ internal static class Capture
         }
         finally
         {
-            try { session?.Dispose(); } // Only the GUID-named session this run created.
+            try
+            {
+                try { if (resources != null) await resources.DisposeAsync(); }
+                finally { session?.Dispose(); } // Only the GUID-named session this run created.
+            }
             finally
             {
                 if (consumer != null) { try { await consumer.WaitAsync(TimeSpan.FromSeconds(10)); } catch { /* failure.json/exit code report it */ } }

--- a/sidecar/etw-probe/Fixture.cs
+++ b/sidecar/etw-probe/Fixture.cs
@@ -18,7 +18,7 @@ internal static class Fixture
             !Guid.TryParseExact(Path.GetFileName(root)["aegis-etw-fixture-".Length..], "N", out _) ||
             !new[] { "target", "control" }.Contains(role)) throw new ArgumentException("Invalid fixture scope");
         int seconds = int.Parse(args[4]);
-        if (seconds is < 1 or > 120) throw new ArgumentException("Invalid actor duration");
+        if (seconds is < 1 or > 900) throw new ArgumentException("Invalid actor duration");
         string file = Path.Combine(root, role + ".dat");
         using (var output = new FileStream(file, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
             output.Write(new byte[1024 * 1024]);

--- a/sidecar/etw-probe/LoadStudy.cs
+++ b/sidecar/etw-probe/LoadStudy.cs
@@ -7,22 +7,6 @@ namespace Aegis.EtwProbe;
 // coordinator executes the two fixed npm commands, using node's ArgumentList.
 internal static class LoadStudy
 {
-    private sealed record RunSpec(string Name, string Workload);
-
-    private static List<RunSpec> Plan(bool simulation)
-    {
-        string[] kinds = ["idle", "npm", "build"];
-        var runs = new List<RunSpec>();
-        for (int repeat = 0; repeat < (simulation ? 1 : 3); repeat++)
-            for (int slot = 0; slot < 3; slot++)
-            {
-                string kind = kinds[(slot + repeat) % 3];
-                runs.Add(new($"r{repeat + 1}-{kind}", kind));
-            }
-        if (simulation) runs.Add(new("after-build", "idle"));
-        return runs;
-    }
-
     private static async Task Until(Func<bool> ready, Func<bool> failed, int seconds)
     {
         var timer = Stopwatch.StartNew();
@@ -36,8 +20,25 @@ internal static class LoadStudy
 
     private static void Signal(string directory, string name)
     {
-        if (!File.Exists(Path.Combine(directory, name)))
-            Program.Write(directory, name, new { qpc = Stopwatch.GetTimestamp() });
+        string path = Path.Combine(directory, name);
+        long qpc = Stopwatch.GetTimestamp(); // Timestamp precedes visibility of the marker file.
+        FileStream stream;
+        try { stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write); }
+        catch (IOException) when (File.Exists(path)) { return; } // Concurrent Ctrl+C and failure cleanup.
+        using (stream) JsonSerializer.Serialize(stream, new { qpc }, Program.Json);
+    }
+
+    private static async Task WatchAbort(Func<bool> aborted, CancellationTokenSource cancellation)
+    {
+        try
+        {
+            while (!cancellation.IsCancellationRequested)
+            {
+                if (aborted()) { cancellation.Cancel(); return; }
+                await Task.Delay(250, cancellation.Token);
+            }
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { }
     }
 
     private static (string Repo, string Node, string Npm) WorkloadPaths()
@@ -80,22 +81,22 @@ internal static class LoadStudy
             await process.WaitForExitAsync(token).WaitAsync(TimeSpan.FromSeconds(60), token);
             await Task.WhenAll(stdout, stderr).WaitAsync(TimeSpan.FromSeconds(5), token);
             if (process.ExitCode != 0) throw new InvalidOperationException("Workload exited unsuccessfully");
-            return new { beginQpc = begin, endQpc = Stopwatch.GetTimestamp(), exitCode = process.ExitCode };
+            return new { kind, beginQpc = begin, endQpc = Stopwatch.GetTimestamp(), exitCode = process.ExitCode };
         }
         finally { if (!process.HasExited) process.Kill(entireProcessTree: true); }
     }
 
-    internal static async Task<int> Run(string directory, bool simulation)
+    internal static async Task<int> Run(string directory, bool simulation, string profile = "load")
     {
         if (Program.Elevated()) throw new InvalidOperationException("Workloads cannot run elevated");
         var paths = WorkloadPaths(); // Validate normal-user dependencies before requesting UAC.
         using var npmPackage = JsonDocument.Parse(File.ReadAllText(Path.Combine(Path.GetDirectoryName(paths.Npm)!, "../package.json")));
-        var plan = Plan(simulation);
+        var plan = StudyPlan.Create(profile, simulation);
         Program.Write(directory, "study.json", new
         {
-            schema = 1,
+            schema = 2,
+            profile,
             simulation,
-            seconds = simulation ? 1 : 15,
             plan,
             workloadElevated = false,
             nodeVersion = FileVersionInfo.GetVersionInfo(paths.Node).ProductVersion,
@@ -105,7 +106,8 @@ internal static class LoadStudy
             interpretation = "npm measures CLI startup, not install. Build rewrites dist/renderer. " +
                 "No install or dependency changes. Final command may finish after capture; next capture waits."
         });
-        var start = Program.Child(simulation ? "study-collector-check" : "study-collector", directory);
+        string command = profile == "tune" ? "tune-collector" : "study-collector";
+        var start = Program.Child(simulation ? command + "-check" : command, directory);
         start.RedirectStandardInput = start.RedirectStandardOutput = start.RedirectStandardError = false;
         start.UseShellExecute = !simulation;
         start.WindowStyle = ProcessWindowStyle.Hidden;
@@ -124,14 +126,22 @@ internal static class LoadStudy
                 Console.WriteLine("Measuring " + run.Name);
                 var commands = new List<object>();
                 long begin = Stopwatch.GetTimestamp();
+                int nextProgress = 30;
                 while (!File.Exists(Path.Combine(output, "capture-stopped.json")))
                 {
                     if (Failed() || File.Exists(Path.Combine(output, "failure.json")))
                         throw new InvalidOperationException("Capture failed during workload");
-                    if ((Stopwatch.GetTimestamp() - begin) / (double)Stopwatch.Frequency > 90)
+                    double elapsed = (Stopwatch.GetTimestamp() - begin) / (double)Stopwatch.Frequency;
+                    if (elapsed > run.Seconds + 75)
                         throw new TimeoutException("Capture stop timed out");
-                    if (run.Workload == "idle") await Task.Delay(100, cancel.Token);
-                    else commands.Add(await Command(run.Workload, paths, cancel.Token));
+                    if (elapsed >= nextProgress)
+                    {
+                        Console.WriteLine($"  {run.Name}: {(int)elapsed}/{run.Seconds}s");
+                        nextProgress += 30;
+                    }
+                    string kind = StudyPlan.WorkloadAt(run, elapsed);
+                    if (kind == "idle") await Task.Delay(100, cancel.Token);
+                    else commands.Add(await Command(kind, paths, cancel.Token));
                 }
                 if (run.Workload != "idle" && commands.Count == 0)
                     throw new InvalidOperationException("Capture finished before workload began");
@@ -160,7 +170,7 @@ internal static class LoadStudy
         finally { Console.CancelKeyPress -= handler; }
     }
 
-    internal static async Task<int> Collect(string directory, bool simulation)
+    internal static async Task<int> Collect(string directory, bool simulation, string profile = "load")
     {
         if (!simulation && !Program.Elevated()) return 3;
         directory = Path.GetFullPath(directory);
@@ -170,19 +180,26 @@ internal static class LoadStudy
         bool Aborted() => File.Exists(Path.Combine(directory, "abort.json"));
         try
         {
-            foreach (var run in Plan(simulation))
+            foreach (var run in StudyPlan.Create(profile, simulation))
             {
                 if (Aborted()) throw new OperationCanceledException("Coordinator aborted");
                 string output = Program.NewOutput(Path.Combine(directory, run.Name));
                 int code;
-                if (simulation)
+                using var captureCancel = new CancellationTokenSource();
+                Task abortWatch = WatchAbort(Aborted, captureCancel);
+                try
                 {
-                    Signal(output, "capture-ready.json");
-                    await Task.Delay(1000);
-                    Signal(output, "capture-stopped.json");
-                    code = 0;
+                    if (simulation)
+                    {
+                        Signal(output, "capture-ready.json");
+                        await Task.Delay(run.Seconds * 1000, captureCancel.Token);
+                        Signal(output, "capture-stopped.json");
+                        code = 0;
+                    }
+                    else code = await Capture.Run(output, new Options(run.Seconds, "idle", 0x1B0,
+                        [10, 12, 13, 14, 15], false, "close", run.BuffersMb), captureCancel.Token);
                 }
-                else code = await Capture.Run(output, new Options(15, "idle", 0x1B0, [10, 12, 13, 14, 15], false, "close", 64));
+                finally { captureCancel.Cancel(); await abortWatch; }
                 outcomes.Add(new { name = run.Name, workload = run.Workload, exitCode = code });
                 if (code != 0) result = 5;
                 if (code is not (0 or 5)) break;

--- a/sidecar/etw-probe/Program.cs
+++ b/sidecar/etw-probe/Program.cs
@@ -19,7 +19,8 @@ internal static class Program
             {
                 Console.WriteLine("AEGIS ETW measurement probe (not a production sensor)\n" +
                     "self-test\npreflight <new-output-directory>\nstudy <new-output-directory> (normal terminal; one UAC prompt)\n" +
-                    "capture <new-output-directory> [--seconds 5..120] [--scenario buffered|async|mapped|preopened|churn|idle]\n" +
+                    "tune <new-output-directory> (buffer comparison and ten-minute soak; normal terminal)\n" +
+                    "capture <new-output-directory> [--seconds 5..900] [--scenario buffered|async|mapped|preopened|churn|idle]\n" +
                     "  [--keywords 0x1B0] [--events 10,12,13,14,15|all] [--pid-filter none|target]\n" +
                     "  [--evict close|cleanup|none] [--buffers-mb 16..256]\n" +
                     "fixture-check <new-output-directory> (no ETW, no elevation)");
@@ -29,17 +30,24 @@ internal static class Program
             if (args[0] == "actor") return await Fixture.Run(args);
             if (!OperatingSystem.IsWindows()) throw new PlatformNotSupportedException("Windows required");
             if (args.Length < 2) throw new ArgumentException("Output directory required");
-            if (args[0] is "study" or "study-check")
+            if (args[0] is "study" or "study-check" or "tune" or "tune-check")
             {
-                if (Elevated()) throw new InvalidOperationException("Study workloads must run without elevation");
+                if (Elevated())
+                {
+                    Console.Error.WriteLine("Open a normal PowerShell terminal, without 'Run as administrator'. " +
+                        "The study requests elevation for its collector separately. No study was started.");
+                    return 3;
+                }
                 string output = NewOutput(args[1]);
-                bool simulation = args[0] == "study-check";
-                int result = await LoadStudy.Run(output, simulation);
+                bool simulation = args[0].EndsWith("-check", StringComparison.Ordinal);
+                string profile = args[0].StartsWith("tune", StringComparison.Ordinal) ? "tune" : "load";
+                int result = await LoadStudy.Run(output, simulation, profile);
                 if (simulation && result == 0) StudyCheck.Verify(output);
                 return result;
             }
-            if (args[0] is "study-collector" or "study-collector-check")
-                return await LoadStudy.Collect(args[1], args[0] == "study-collector-check");
+            if (args[0] is "study-collector" or "study-collector-check" or "tune-collector" or "tune-collector-check")
+                return await LoadStudy.Collect(args[1], args[0].EndsWith("-check", StringComparison.Ordinal),
+                    args[0].StartsWith("tune", StringComparison.Ordinal) ? "tune" : "load");
             if (args[0] == "preflight") { Preflight(NewOutput(args[1])); return 0; }
             if (args[0] == "fixture-check") return await Capture.CheckFixtures(NewOutput(args[1]));
             if (args[0] != "capture") throw new ArgumentException("Unknown command");
@@ -134,7 +142,7 @@ internal sealed record Options(int Seconds, string Scenario, ulong Keywords, Lis
         string Get(string key, string fallback) => values.GetValueOrDefault(key, fallback);
         int seconds = int.Parse(Get("--seconds", "10")), buffers = int.Parse(Get("--buffers-mb", "64"));
         string scenario = Get("--scenario", "buffered"), evict = Get("--evict", "close"), filter = Get("--pid-filter", "none");
-        if (seconds is < 5 or > 120 || buffers is < 16 or > 256 ||
+        if (seconds is < 5 or > 900 || buffers is < 16 or > 256 ||
             !Fixture.Scenarios.Contains(scenario) || !new[] { "close", "cleanup", "none" }.Contains(evict) ||
             !new[] { "none", "target" }.Contains(filter)) throw new ArgumentException("Option outside bounds");
         string keywordText = Get("--keywords", "0x1B0");

--- a/sidecar/etw-probe/README.md
+++ b/sidecar/etw-probe/README.md
@@ -58,8 +58,8 @@ when interpreting rates. Marker polling contributes to the measured background.
 `study.json` records the plan, simulation flag, Node/npm versions and QPC frequency;
 `matrix.json` records collector outcomes. Workload output is drained and discarded.
 Failures create separate workload/collector failure records. Ctrl+C requests abort
-and stops the owned normal workload tree; the elevated collector ends its current
-bounded capture, then exits. A missing acknowledgement times out after 90 seconds;
+and stops the owned normal workload tree; the elevated collector polls that signal
+every 250 ms and cancels its active capture through session cleanup. A missing acknowledgement times out after 90 seconds;
 the trace has already stopped while awaiting it. Failed/incomplete studies must not
 be treated as nine successful load measurements.
 
@@ -73,6 +73,45 @@ This runs real normal-user npm/build commands against a simulated collector, plu
 an extra idle interval after the build, and asserts the recorded protocol ordering.
 Its `simulation: true` artifacts are not live measurements. Existing CI does not
 build or run this standalone Windows probe.
+
+## Buffer comparison and sustained capture
+
+From a **normal PowerShell terminal**, run:
+
+```powershell
+& 'X:/Future/ESCAPE/AEGIS/sidecar/etw-probe/bin/Release/net10.0-windows/EtwProbe.exe' tune 'X:/tmp/aegis-etw-tune-20260908'
+```
+
+One UAC prompt starts the fixed collector. Expect about 13–15 minutes. First, nine
+15-second npm CLI captures compare requested buffers of 64, 32 and 16 MiB three
+times each, rotating their positions. Mask, IDs, workload and eviction stay fixed.
+Then one continuous ten-minute session uses the 16 MiB stress candidate while the
+normal coordinator cycles idle, npm CLI and renderer builds in one-minute phases.
+This preset does not select a production buffer size automatically. A command may
+finish after a phase boundary; `workload.json` retains its kind and QPC interval.
+The final idle phase provides a short recovery observation without forcing GC.
+
+`resources.json` records current working set, private bytes, managed live bytes,
+GC committed bytes, generation-2 collection count and native session loss counters
+every five seconds, plus initial/final observations. These samples are kept in
+memory and written after stop, capped at 200. The sampler stops before the ETW
+session. Missing metrics, unavailable counters, observed losses or sample overflow
+mark the run degraded. Final-stop losses remain outside the measured interval.
+
+Use actual buffer counts/sizes from native queries, not just the requested MiB.
+Working set, private allocation and GC memory are different quantities; do not sum
+them. `collectorPeakWorkingSetBytes` is still a process-lifetime high-water mark
+across the entire study, so it cannot establish growth or recovery by itself.
+The new timer/query cost is included in collector CPU; the 64 MiB comparison runs
+provide a baseline with the same instrumentation. Ten minutes on this host cannot
+prove leak freedom or universal buffer sufficiency. The idle fixture actors also
+do not stress the candidate path map with a large agent population.
+
+`tune-check <new-directory>` runs the rotated plan with short simulated captures,
+a six-second cycle and a following idle interval. It executes real normal-user
+npm/build workloads and verifies the protocol without elevation or ETW. Direct
+capture durations are bounded to 5–900 seconds; actor ledgers retain at most 5,000
+operation samples and expose omissions.
 
 `Run-Matrix.ps1` compares READ-only, names/read, lifecycle, target-PID filtering,
 preopened handles, asynchronous reads, warm mapped reads and three churn eviction
@@ -89,6 +128,7 @@ Each run retains:
   header PID/TID, payload TID, optional live thread-owner lookup, opaque per-run
   pointer aliases and fixture-relative candidate path evidence.
 - `schemas.json`: delivered event IDs/versions and field names, without values.
+- `resources.json`: bounded time-series memory, GC and session-counter observations.
 - `summary.json`: all delivered provider event counts, decode/retention/map losses,
   collector CPU milliseconds, lifetime peak working set, collection duration and
   native session loss/buffer counters queried before stop.
@@ -97,7 +137,7 @@ Each run retains:
 
 Exit 0 means collection completed without the reported degradation conditions; it
 does **not** prove Read coverage, correct identity or adequate configuration.
-Exit 5 retains degraded measurements; 3 means elevation missing; 2 means failure
+Exit 5 retains degraded measurements; 3 means the wrong elevation level; 2 means failure
 (type/HRESULT only). An unavailable counter is null, never a measured zero.
 
 The fixture files and selected metadata are retained; no raw ETL is persisted.

--- a/sidecar/etw-probe/ResourceSampler.cs
+++ b/sidecar/etw-probe/ResourceSampler.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics;
+
+namespace Aegis.EtwProbe;
+
+internal sealed record ResourceSample(long Qpc, double ElapsedMs, long? WorkingSetBytes,
+    long? PrivateBytes, long? ManagedLiveBytes, long? GcCommittedBytes, int? Gen2Collections,
+    Native.Loss? Loss, string? ErrorType)
+{
+    internal bool Degraded => ErrorType != null || Loss == null || Loss.QueryStatus != 0 ||
+        Loss.EventsLost != 0 || Loss.RealTimeBuffersLost != 0 || Loss.LogBuffersLost != 0;
+}
+
+// One writer; the caller reads Samples only after Stop. No files are written while
+// tracing, no forced GC, and no event dictionaries are read from the timer thread.
+internal sealed class ResourceSampler : IAsyncDisposable
+{
+    private readonly CancellationTokenSource cancel = new();
+    private readonly Task loop;
+    internal readonly List<ResourceSample> Samples = [];
+    internal int Omitted { get; private set; }
+    internal bool Degraded => Omitted != 0 || Samples.Any(sample => sample.Degraded);
+
+    internal ResourceSampler(string sessionName, TimeSpan? interval = null, int limit = 200)
+    {
+        loop = Task.Run(async () =>
+        {
+            using var process = Process.GetCurrentProcess();
+            using var timer = new PeriodicTimer(interval ?? TimeSpan.FromSeconds(5));
+            var watch = Stopwatch.StartNew();
+            void Sample()
+            {
+                if (Samples.Count >= limit) { Omitted++; return; }
+                long qpc = Stopwatch.GetTimestamp();
+                try
+                {
+                    process.Refresh();
+                    Samples.Add(new(qpc, watch.Elapsed.TotalMilliseconds, process.WorkingSet64,
+                        process.PrivateMemorySize64, GC.GetTotalMemory(false), GC.GetGCMemoryInfo().TotalCommittedBytes,
+                        GC.CollectionCount(2), Native.QueryLoss(sessionName), null));
+                }
+                catch (Exception error)
+                {
+                    Samples.Add(new(qpc, watch.Elapsed.TotalMilliseconds, null, null, null, null, null, null,
+                        error.GetType().Name));
+                }
+            }
+            Sample();
+            try { while (await timer.WaitForNextTickAsync(cancel.Token)) Sample(); }
+            catch (OperationCanceledException) when (cancel.IsCancellationRequested) { }
+            Sample(); // Final observation is still before the session stops.
+        });
+    }
+
+    internal async Task Stop()
+    {
+        cancel.Cancel();
+        await loop;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Stop();
+        cancel.Dispose();
+    }
+}

--- a/sidecar/etw-probe/SelfTest.cs
+++ b/sidecar/etw-probe/SelfTest.cs
@@ -106,6 +106,44 @@ internal static class SelfTest
         });
         Test("callback thread-owner query is an observation", () =>
             Check(Native.ThreadOwner(Native.GetCurrentThreadId()) == Environment.ProcessId));
+        Test("buffer comparisons are balanced and soak is one bounded session", () =>
+        {
+            var plan = StudyPlan.Create("tune", false);
+            Check(plan.Count == 10 && plan.Select(r => r.Name).Distinct().Count() == 10);
+            foreach (int size in new[] { 16, 32, 64 })
+            {
+                Check(plan.Take(9).Count(r => r.BuffersMb == size && r.Workload == "npm" && r.Seconds == 15) == 3);
+                Check(plan.Take(9).Select((r, i) => (r, i)).Where(x => x.r.BuffersMb == size).Select(x => x.i % 3).Distinct().Count() == 3);
+            }
+            var soak = plan[^1];
+            Check(soak.Seconds == 600 && soak.BuffersMb == 16);
+            Check(StudyPlan.WorkloadAt(soak, 59.9) == "idle" && StudyPlan.WorkloadAt(soak, 60) == "npm" &&
+                StudyPlan.WorkloadAt(soak, 120) == "build" && StudyPlan.WorkloadAt(soak, 180) == "idle");
+            Check(Options.Parse(["capture", "unused", "--seconds", "600"]).Seconds == 600);
+        });
+        Test("resource failures and losses remain degraded", () =>
+        {
+            var row = new ResourceSample(0, 0, 1, 1, 1, 1, 0, new Native.Loss(0, 0, 0, 0, 1, 64), null);
+            Check(!row.Degraded && (row with { Loss = null }).Degraded);
+            Check((row with { Loss = new Native.Loss(0, 1, 0, 0, 1, 64) }).Degraded);
+            Check((row with { ErrorType = "TestFailure" }).Degraded);
+        });
+        Test("resource sampler stops, reports missing counters and bounded retention", () =>
+        {
+            async Task Exercise()
+            {
+                await using var sampler = new ResourceSampler("AEGIS-FileProbe-missing-" + Guid.NewGuid().ToString("N"),
+                    TimeSpan.FromMilliseconds(10), limit: 1);
+                await Task.Delay(60);
+                await sampler.Stop();
+                Check(sampler.Samples.Count == 1 && sampler.Samples[0].WorkingSetBytes > 0);
+                Check(sampler.Samples[0].Loss?.QueryStatus != 0 && sampler.Degraded && sampler.Omitted > 0);
+                int omitted = sampler.Omitted;
+                await Task.Delay(30);
+                Check(sampler.Omitted == omitted);
+            }
+            Exercise().GetAwaiter().GetResult();
+        });
         Console.WriteLine($"{passed} self-tests passed");
         return 0;
     }

--- a/sidecar/etw-probe/StudyCheck.cs
+++ b/sidecar/etw-probe/StudyCheck.cs
@@ -19,9 +19,10 @@ internal static class StudyCheck
     // An extra idle run after build catches contamination of the next capture.
     internal static void Verify(string directory)
     {
-        Require(Read(directory, "study.json").GetProperty("simulation").GetBoolean());
+        var study = Read(directory, "study.json");
+        Require(study.GetProperty("simulation").GetBoolean());
         var matrix = Read(directory, "matrix.json");
-        Require(matrix.GetArrayLength() == 4);
+        Require(matrix.GetArrayLength() == study.GetProperty("plan").GetArrayLength());
         long previousEnd = 0;
         foreach (var row in matrix.EnumerateArray())
         {

--- a/sidecar/etw-probe/StudyPlan.cs
+++ b/sidecar/etw-probe/StudyPlan.cs
@@ -1,0 +1,40 @@
+namespace Aegis.EtwProbe;
+
+internal sealed record RunSpec(string Name, string Workload, int Seconds, int BuffersMb, int PhaseSeconds = 60);
+
+internal static class StudyPlan
+{
+    internal static List<RunSpec> Create(string profile, bool simulation)
+    {
+        var runs = new List<RunSpec>();
+        if (profile == "load")
+        {
+            string[] kinds = ["idle", "npm", "build"];
+            for (int repeat = 0; repeat < (simulation ? 1 : 3); repeat++)
+                for (int slot = 0; slot < 3; slot++)
+                {
+                    string kind = kinds[(slot + repeat) % 3];
+                    runs.Add(new($"r{repeat + 1}-{kind}", kind, simulation ? 1 : 15, 64));
+                }
+            if (simulation) runs.Add(new("after-build", "idle", 1, 64));
+        }
+        else if (profile == "tune")
+        {
+            int[] buffers = [64, 32, 16];
+            for (int repeat = 0; repeat < 3; repeat++)
+                for (int slot = 0; slot < 3; slot++)
+                {
+                    int size = buffers[(slot + repeat) % 3];
+                    runs.Add(new($"r{repeat + 1}-b{size}", "npm", simulation ? 1 : 15, size));
+                }
+            // A fixed stress candidate, not an automatic declaration that 16 MiB is sufficient.
+            runs.Add(new("soak-b16", "cycle", simulation ? 6 : 600, 16, simulation ? 1 : 60));
+            if (simulation) runs.Add(new("after-build", "idle", 1, 16));
+        }
+        else throw new ArgumentException("Unknown study profile");
+        return runs;
+    }
+
+    internal static string WorkloadAt(RunSpec run, double elapsedSeconds) => run.Workload == "cycle"
+        ? new[] { "idle", "npm", "build" }[(int)(elapsedSeconds / run.PhaseSeconds) % 3] : run.Workload;
+}


### PR DESCRIPTION
The repeated Home load study completed without reported losses, but its lifetime peak working set cannot show memory growth or recovery and its fixed 64 MiB session buffers have not been compared with smaller budgets. Preserve the nine-run measurements and add the next isolated experiment.

The new normal-user `tune` command requests one elevated fixed collector, rotates 64/32/16 MiB buffer requests through nine npm CLI trials, then runs one continuous ten-minute capture at the 16 MiB stress setting with idle/npm/build phases. This does not change the default capture budget or select a production configuration.

A bounded sampler records current/private/managed memory, GC state and native loss counters every five seconds. Unknown counters, losses, sampling failures and overflow degrade results. Samples are persisted after capture; sampling stops before the owned session. Abort now cancels active captures, and launching a study from an administrator terminal prints an actionable instruction before any output is created.

Validation:
- Windows Release build: zero warnings/errors; C# whitespace verification passed.
- 19 self-tests passed, including balanced buffer positions, phase boundaries and sampler loss/cap/stop behavior.
- Short tune protocol check ran real normal-user npm/build workloads with simulated ETW; existing load protocol also passed.
- Active abort retained failure without a successful stop marker or starting the next capture.
- Repository format, renderer build, lint (zero errors, 31 existing warnings) and counts passed locally.

New live buffer/soak measurements remain pending. Existing CI does not compile this standalone Windows harness. No Electron production source, frontend, dependencies or workflow configuration changes.
