### PR TITLE
docs(etw): record successful real UAC session stop

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,9 +83,11 @@ The dependency is those observations, not the absence of a Windows host.
    leases, bounded writes and owned-session stop. Twelve self-tests and eight
    real normal-token process scenarios passed; these create no ETW session.
    [Recorded evidence](docs/recon/evidence/etw-lifecycle-home-26200-check.json)
-   preserves source/build hashes and outcomes. **Next: explicit user-run UAC
-   empty-session check**, then remaining E1/E2 privilege, crash/orphan and suspend
-   gates. No file provider or Electron connection; E1/E2 remain incomplete.
+   preserves source/build hashes and outcomes. The [real same-account UAC stop](docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json)
+   also passed: empty session, actual 256 × 64 KiB buffers, acknowledged stop and
+   confirmed absence. **Next: elevated graceful-failure cases**, then remaining
+   E1/E2 refusal, crash/orphan and suspend gates. No file provider or Electron
+   connection; E1/E2 remain incomplete.
 
 ## C — existing rules coverage
 
@@ -134,7 +136,8 @@ Keep them outside the active queue while the first ETW sensor is being establish
 ## Execution order
 
 The B2 draft, B3 offline backend contract and B4 isolated lifecycle harness are
-implemented. Continue with the explicit UAC empty-session check and remaining E1/E2 gates in
+implemented; the real same-account UAC empty-session stop passed. Continue with
+elevated graceful-failure cases and remaining E1/E2 gates in
 [etw-sensor-design.md](docs/roadmap/etw-sensor-design.md). Start with
 [next-session.md](memory-bank/next-session.md) and the latest progress handoff.
 All three local experiment sets are complete; do not repeat them without a specific

--- a/docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json
+++ b/docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json
@@ -1,0 +1,87 @@
+{
+  "schema": 1,
+  "scope": "B4 real same-account UAC empty-session normal stop only",
+  "sourceCommit": "01bf4039acd7d21ae233a97510a261e3c2398d94",
+  "historicalBuildSourceSha256": {
+    "Broker.cs": "984A068BCED55DA220FA9964B2FBD0D64F64A84084970A1E80E412C922FFCB22",
+    "EtwLifecycle.csproj": "22FE8D550AD99BD026CB9448AAF5F0B83F908EDC977B75FBFD2A15E36B1375F1",
+    "OwnedTrace.cs": "7C1F6E7EB88D9B91ED30B65EA374CE8A24E1C29EEEE86B56D8663FF04B83310A",
+    "Peer.cs": "C0EBD34998B700A7F4BF22A9C246CA9179E23C055B6A1E606C1934B3729F2108",
+    "Program.cs": "83F991FC10C266EC629B149F508B568942E0753967901ECEB98FA1280A403B0A",
+    "Scenarios.cs": "48A3C265507E4B30E479D939934BDF949F269C0F217D771F05662FDD27A818E5",
+    "Security.cs": "C5BC03146F17ED29A35D40144686E65CBEA93E408D858CB434266311A8567AC3",
+    "SelfTest.cs": "3DFDC48B93453CBB6EEA21AF9FD21F8739C63816F49744F8EB63E5D09D7F064C",
+    "Wire.cs": "2317EC35D274B79A2C860BA1C081979660D87DAFF282626C59D67A8181E153C2"
+  },
+  "sourceCanonicalLfSha256": {
+    "Broker.cs": "984A068BCED55DA220FA9964B2FBD0D64F64A84084970A1E80E412C922FFCB22",
+    "EtwLifecycle.csproj": "22FE8D550AD99BD026CB9448AAF5F0B83F908EDC977B75FBFD2A15E36B1375F1",
+    "OwnedTrace.cs": "E2D2BCDCBF8F05D9BF6BE765D93017A8F1A89B2FC41C10605661F9FC7BD58CAD",
+    "Peer.cs": "C0EBD34998B700A7F4BF22A9C246CA9179E23C055B6A1E606C1934B3729F2108",
+    "Program.cs": "C4DB66A0128BDD924139024E471EA1944B489094FC492CC1A37A735B11602A70",
+    "Scenarios.cs": "48A3C265507E4B30E479D939934BDF949F269C0F217D771F05662FDD27A818E5",
+    "Security.cs": "C5BC03146F17ED29A35D40144686E65CBEA93E408D858CB434266311A8567AC3",
+    "SelfTest.cs": "3DFDC48B93453CBB6EEA21AF9FD21F8739C63816F49744F8EB63E5D09D7F064C",
+    "Wire.cs": "1D55E488DA7131B53E58C258039C0F25370C934C3594414BA77331274FDCFE30"
+  },
+  "sourceVerification": "Canonical LF source hashes match the merged git commit. Historical raw source hashes are retained from the normal-token evidence; raw checkout hashes are not portable across git line-ending conversion. Apphost and assembly match the previously tested binaries byte-for-byte.",
+  "reportFile": "aegis-etw-lifecycle-uac-20260908/result.json",
+  "reportSha256": "11DF24FBCD21D0E9B0A8FB50FB4CA3B2B46FEFC4D9F493AAE7955568F2C43E1E",
+  "sameBuildAsNormalTokenEvidence": true,
+  "pendingLiveGates": [
+    "Actual UAC refusal/cancellation and late consent",
+    "Alternate credentials and other account/session policies",
+    "Elevated collector failure paths and orphan recovery",
+    "Suspend/resume",
+    "Remote and other-logon adversarial clients"
+  ],
+  "report": {
+    "schema": 1,
+    "experiment": "etw-lifecycle",
+    "liveEmptySession": true,
+    "fileProviderEnabled": false,
+    "started": "2026-09-08T21:23:30.4656787+00:00",
+    "ended": "2026-09-08T21:23:34.1288375+00:00",
+    "os": "Microsoft Windows NT 10.0.26200.0",
+    "framework": "10.0.10",
+    "executableSha256": "EDE1ADA0C7945A32A72806A8CAF092926AE9B2C23C4246BCA332F2F9ED42833C",
+    "assemblySha256": "05DEF4E780AAF1A86C418F3369B21EFAC82957C74A4479E550964B734381B7A1",
+    "outcomes": [
+      {
+        "Scenario": "stop",
+        "Passed": true,
+        "PeerExited": true,
+        "BrokerExited": true,
+        "Result": {
+          "Live": true,
+          "Scenario": "stop",
+          "Authenticated": true,
+          "RestrictedAcl": true,
+          "Outcome": "stop",
+          "PeerExitCode": 0,
+          "InitialStats": {
+            "QueryStatus": 0,
+            "EventsLost": 0,
+            "RealTimeBuffersLost": 0,
+            "LogBuffersLost": 0,
+            "NumberOfBuffers": 256,
+            "BufferSizeKiB": 64,
+            "AbsentStatus": null
+          },
+          "FinalStats": {
+            "QueryStatus": 0,
+            "EventsLost": 0,
+            "RealTimeBuffersLost": 0,
+            "LogBuffersLost": 0,
+            "NumberOfBuffers": 256,
+            "BufferSizeKiB": 64,
+            "AbsentStatus": 4201
+          },
+          "StopAcknowledged": true
+        },
+        "Error": null
+      }
+    ],
+    "exitCode": 0
+  }
+}

--- a/docs/roadmap/etw-sensor-design.md
+++ b/docs/roadmap/etw-sensor-design.md
@@ -384,17 +384,28 @@ The self-tests also exercise real pipe ACL/identity rejection and cancellation.
 Native trace calls use a fake only in ownership tests; the process cases make no
 native trace calls and retain null native statistics. These are transport results.
 
-The explicit user-run `uac` command is prepared but has not been executed. It
+The explicit `uac` command passed on the local Home host on 2026-09-08. It
 permits only normal stop of one empty real-time session, with initial query,
 final stop counters and a separate absence query. It enables no provider. Passing
 requires authenticated peer, restricted ACL, known counters, acknowledged stop,
-child exit 0 and absence status 4201. A rejected or incomplete run remains recorded.
+child exit 0 and absence status 4201. The [recorded live result](../recon/evidence/etw-lifecycle-home-26200-uac-stop.json)
+meets all of these conditions, with actual 256 × 64 KiB buffers and all three
+native loss counters zero. It used the same apphost/assembly as the normal-token
+cases; canonical LF source hashes were checked against the merged git commit.
+A rejected or incomplete run remains recorded.
 
 E1/E2 remain open: actual consent/refusal/late cancellation, alternate credentials,
-cross-integrity access, remote/other-logon clients, suspend and elevated crash/orphan
+cross-integrity behavior outside the verified same-account host, remote/other-logon
+clients, suspend and elevated crash/orphan
 recovery need live evidence. No orphan-removal algorithm exists. The mutable dev
 build is trusted; signature/integrity/deployment checks are not established.
 Accelerated test leases are not production settings; empty-session counters say
 nothing about Kernel-File completeness or cost. Existing CI does not build this
 C# project; Windows Release build, formatter, self-tests and process cases are
 separate local checks. E3–E8 and the remaining B1 questions are unchanged.
+
+Next focused slice: elevated graceful-failure scenarios (parent stdin EOF, lease
+expiry, blocked output), each with final stop and absence evidence. Broker death
+requires an independent authorized absence witness; elevated collector crash also
+requires an orphan-ownership design before claiming cleanup. The normal-stop result
+does not close either of those failure cases and does not require repeating B1.

--- a/memory-bank/next-session.md
+++ b/memory-bank/next-session.md
@@ -1,8 +1,9 @@
 # AEGIS — старт следующего чата
 
-Обновлено 2026-09-08 после изолированного lifecycle-стенда ETW B4.
+Обновлено 2026-09-08 после успешного реального UAC stop на стенде ETW B4.
 B2: PR #384, `f2f1ac4`; B3: PR #385, `cc47212`, оба merged с пятью зелёными CI.
-Финальный статус B4 проверяй по PR ветки `codex/etw-lifecycle-harness`.
+B4: PR #386, `01bf403`, merged с пятью зелёными CI. Новый live-результат —
+PR ветки `codex/etw-uac-stop-evidence`; проверь его финальный статус.
 Эта инструкция и последний Session handoff в `memory-bank/progress.md` — точка
 продолжения. Сначала проверь текущую ветку и состояние файлов: пользователь может
 принести другие изменения после записи этого контекста.
@@ -68,19 +69,26 @@ stdin EOF, смерть broker, exit/kill collector, lease, blocked write и и�
 агрегат с хешами — `docs/recon/evidence/etw-lifecycle-home-26200-check.json`.
 Сборка Release и C# formatter прошли. После проверки процессов стенда не осталось.
 
-**Следующий шаг — явная команда пользователя из обычного PowerShell:**
+**Реальный UAC normal-stop уже прошёл — не запускай его заново без новой причины.**
+После команды пользователя «дальше» агент запустил подготовленный `uac` из обычного
+процесса; повышенный сборщик успешно прошёл взаимную проверку и штатно остановил
+пустую `AEGIS-EtwLifecycle`. Итог:
+`X:/tmp/aegis-etw-lifecycle-uac-20260908/result.json`, exit 0.
+Начальный query и конечный stop: status 0; 256 × 64 КиБ; все три loss counters 0.
+Получены stopped, child exit 0 и отсутствие сессии после stop (4201).
+Файловый provider не включался; процессов стенда после запуска не осталось.
+Агрегат — `docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json`.
+Apphost/assembly совпали с normal-token прогоном; LF-хеши исходников проверены
+против merged commit. Исторические raw-хеши до checkout сохранены отдельно:
+их нельзя напрямую сравнивать после преобразования переносов Git.
+Same-account cross-integrity подтверждён на этом хосте.
 
-```powershell
-& 'X:/Future/ESCAPE/AEGIS/sidecar/etw-lifecycle/bin/Release/net10.0-windows/EtwLifecycle.exe' uac 'X:/tmp/aegis-etw-lifecycle-uac-20260908'
-```
-
-Этот UAC-прогон ещё не выполнен. Он создаёт только пустую ETW-сессию
-`AEGIS-EtwLifecycle`, сохраняет начальные/конечные счётчики и проверяет отсутствие
-после stop; файловый provider не включается. Нужна новая выходная папка. Если
-бинарник отсутствует, сначала `dotnet build sidecar/etw-lifecycle/EtwLifecycle.csproj -c Release`.
-Разбор результата — следующий отдельный блок. E1/E2 ещё требуют реального
-отказа/позднего UAC, других credentials/logon, cross-integrity, suspend и crash/orphan
-cleanup. Автоудаления orphan нет; смерть elevated collector может оставить сессию.
+Следующий срез — расширить явный elevated harness для parent-stdin EOF, lease
+expiry и blocked output с доказательствами final stop и отсутствия сессии.
+Для broker death нужен независимый разрешённый свидетель отсутствия; для elevated
+collector crash сначала нужен проект владения orphan-сессией. E1/E2 ещё требуют
+реального отказа/позднего UAC, других credentials/logon, remote clients и suspend.
+Автоудаления orphan нет; смерть elevated collector может оставить сессию.
 Не выдавай normal-token kill за проверку очистки ETW. CI не собирает этот C# проект.
 Не повторяй три завершённых набора замеров. Подключение к Electron и установка
 в этот стенд не входят; полный B1 и E3–E8 остаются открыты.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1631,3 +1631,42 @@ cross-integrity, remote/other-logon, suspend and elevated crash/orphan cases.
 Never mark E1/E2 complete from the normal-token tests. Production integration,
 frontend, installed app, dependencies, workflows and default buffer budgets remain
 unchanged. Do not repeat the completed B1 matrix/load/tune measurement sets.
+
+## Session handoff — ETW B4 real UAC normal stop (2026-09-08)
+
+B4 merged as PR #386, `01bf403`, after five green CI contexts. The user asked to
+continue. No UAC report existed, so the agent launched the previously prepared
+explicit `uac` command from the normal coordinator. It completed successfully
+on the local Home host at 21:23 UTC; the command was not merely left prepared.
+
+`X:/tmp/aegis-etw-lifecycle-uac-20260908/result.json` records exit 0, liveEmptySession
+true and fileProviderEnabled false. Same-account normal broker and elevated peer
+passed mutual authentication and restricted DACL validation. Initial query and
+final stop both returned status 0, with 256 buffers of 64 KiB and all three native
+loss counters zero. Stop was acknowledged; peer exited 0, broker exited, and the
+post-stop absence query returned 4201. No harness processes remained afterward.
+
+The apphost/assembly SHA-256 values match the previous normal-token check exactly.
+`docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json` preserves the raw report
+hash, report data, source commit and canonical LF hashes checked against that
+commit. Historical raw build-source hashes are retained separately: checkout
+changes line endings, so those raw hashes are not portable checkout identifiers.
+No source or dependency was changed for this evidence block.
+
+This confirms only same-account cross-integrity access and normal empty-session
+stop on this host. E1/E2 remain open for actual refusal/late consent, alternate
+credentials/logons, remote clients, suspend and elevated crash/orphan recovery.
+An empty session says nothing about file-read completeness, attribution or cost.
+
+Next focused implementation: extend the explicit elevated harness with parent
+stdin EOF, lease expiry and blocked output, retaining final stop and absence
+evidence. Broker death needs an independent authorized absence witness; elevated
+collector crash first needs an orphan-ownership design. Do not kill an elevated
+collector or stop a possibly foreign session as an improvised cleanup test.
+The completed UAC normal stop and the three B1 measurement sets need no repeat
+without a new question. Frontend and production integration remain separate.
+
+Branch: `codex/etw-uac-stop-evidence`; inspect its PR for final CI/merge status.
+Local verification: format, renderer build and lint passed (zero errors, 31 existing
+warnings); 40 local documentation links resolved and the evidence checks passed.
+No new runtime tests were added for this documentation/evidence-only change.

--- a/sidecar/etw-lifecycle/README.md
+++ b/sidecar/etw-lifecycle/README.md
@@ -22,7 +22,9 @@ not a performance budget. Both modes reject an already elevated coordinator.
 Run the apphost `.exe`, not `dotnet EtwLifecycle.dll`, so peer image checks have
 one fixed executable. The executable/managed assembly hashes are saved in the report.
 
-The following is **prepared, not executed by the development agent**:
+The explicit UAC check was **executed successfully on the local Home host on
+2026-09-08**. This command is the procedure for a future targeted run; the recorded
+successful stop does not need repeating without a new question:
 
 ```powershell
 & './sidecar/etw-lifecycle/bin/Release/net10.0-windows/EtwLifecycle.exe' uac 'X:/tmp/aegis-etw-lifecycle-uac-new'
@@ -35,9 +37,10 @@ No provider is enabled and no file contents, paths, reads or process command lin
 are collected. Requested session buffers are 256 × 64 KiB for this explicit
 experiment; actual counts are reported. The measurement probe's budget is unchanged.
 
-Only the successful-stop scenario is currently available under elevation. Actual
+Only the normal-stop scenario is currently available under elevation. Actual
 UAC refusal/cancellation, alternate credentials, elevated crash cleanup, suspend
-and hostile remote/other-logon clients remain live gates. The development source
+and hostile remote/other-logon clients remain live gates. Same-account cross-integrity
+pipe/process access succeeded on the recorded host. The development source
 and build directory are trusted inputs; this is not a signed privileged service.
 
 ## Boundaries and authentication
@@ -129,6 +132,22 @@ The UAC case passes only with authenticated peer, restricted DACL, initial query
 success, actual buffer fields, stop-query success with known loss counters,
 absence status 4201, acknowledgment and child exit 0. Failed runs remain on disk.
 An empty session with zero losses says nothing about Kernel-File coverage or cost.
+
+The [real UAC stop evidence](../../docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json)
+records a passing same-account run using the same apphost/assembly as the eight
+normal-token cases. Both identity checks and the restricted DACL passed; initial
+and final native calls returned status 0, with 256 buffers of 64 KiB and all three
+loss counters zero. Stop was acknowledged, both processes exited, and the
+post-stop absence query returned 4201. No harness processes remained on the host.
+Source hashes include canonical LF values to account for git checkout's CRLF/LF
+conversion; the binary hashes match exactly.
+
+This closes only the local same-account normal-stop slice of E1/E2. The next
+implementation slice should extend the explicit harness with graceful parent-EOF,
+lease expiry and blocked-output cases under elevation, retaining final stop and
+absence evidence. Broker death needs an independent authorized absence witness;
+an elevated collector crash additionally needs a defined orphan-ownership design.
+Do not claim cleanup from a missing pipe acknowledgment or normal-token kill test.
 
 Local checks also include `dotnet format ... whitespace --verify-no-changes`,
 Release build and the normal AEGIS checks. Existing GitHub CI does not compile or


### PR DESCRIPTION
The isolated lifecycle harness now has a successful real same-account UAC normal-stop result on the local Windows Home host. Record the exact report and build hashes, canonical source hashes checked against the merged commit, and the measured start/stop/absence outcomes.

The normal broker and elevated collector passed mutual authentication and pipe ACL validation. The empty session reported 256 buffers of 64 KiB, zero loss counters, acknowledged stop, child exit 0 and post-stop absence status 4201. No file provider was enabled. The binaries match the prior normal-token experiment exactly.

Update ROADMAP, harness instructions and session handoff so this completed run is not repeated. Remaining E1/E2 cases include actual refusal/late consent, alternate accounts/logons, elevated failure paths, suspend and crash/orphan recovery. No production integration or source changes.

Validation: live command exit 0; no remaining harness processes; report/build/source verification passed; 40 documentation links resolved; format, renderer build and lint passed (zero errors, 31 existing warnings). Existing CI does not execute this C# experiment.
