### PR TITLE
feat(etw): verify elevated cleanup through independent receipt pipe

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,13 +80,13 @@ The dependency is those observations, not the absence of a Windows host.
    The existing `sidecar/procsnap` remains independent.
 4. **B4 (isolated lifecycle harness prepared):** [broker/collector experiment](sidecar/etw-lifecycle/README.md)
    implements restricted local pipes, mutual process identity, authorization,
-   leases, bounded writes and owned-session stop. Twelve self-tests and eight
-   real normal-token process scenarios passed; these create no ETW session.
-   [Recorded evidence](docs/recon/evidence/etw-lifecycle-home-26200-check.json)
-   preserves source/build hashes and outcomes. The [real same-account UAC stop](docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json)
-   also passed: empty session, actual 256 × 64 KiB buffers, acknowledged stop and
-   confirmed absence. **Next: elevated graceful-failure cases**, then remaining
-   E1/E2 refusal, crash/orphan and suspend gates. No file provider or Electron
+   leases, bounded writes and owned-session stop. The independent authenticated
+   cleanup receipt preserves stop evidence when the primary pipe is blocked.
+   [Version 2 evidence](docs/recon/evidence/etw-lifecycle-home-26200-cleanup.json)
+   records 14 self-tests, eight normal-token cases and four real same-account UAC
+   cases: stop, parent stdin EOF, lease and blocked write. Each live case confirmed
+   stop and absence with actual 256 × 64 KiB buffers. **Next: broker-death evidence
+   and orphan-ownership design**, then remaining E1/E2 refusal/crash/suspend gates. No file provider or Electron
    connection; E1/E2 remain incomplete.
 
 ## C — existing rules coverage
@@ -136,8 +136,8 @@ Keep them outside the active queue while the first ETW sensor is being establish
 ## Execution order
 
 The B2 draft, B3 offline backend contract and B4 isolated lifecycle harness are
-implemented; the real same-account UAC empty-session stop passed. Continue with
-elevated graceful-failure cases and remaining E1/E2 gates in
+implemented; real same-account UAC stop and graceful-failure cleanup passed. Continue with
+broker-death evidence, orphan-ownership design and remaining E1/E2 gates in
 [etw-sensor-design.md](docs/roadmap/etw-sensor-design.md). Start with
 [next-session.md](memory-bank/next-session.md) and the latest progress handoff.
 All three local experiment sets are complete; do not repeat them without a specific

--- a/docs/recon/evidence/etw-lifecycle-home-26200-cleanup.json
+++ b/docs/recon/evidence/etw-lifecycle-home-26200-cleanup.json
@@ -1,0 +1,350 @@
+{
+  "schema": 1,
+  "scope": "B4 authenticated cleanup receipt and elevated graceful-failure cases; no file provider",
+  "sourceBaseCommit": "1f7cd82dedd1359dbe2eb4119e6e141d196c45d8",
+  "sourceCanonicalLfSha256": {
+    "Broker.cs": "056A2B22B8AEE9EE727089D2988A57703CFDC2DADBE0AE38BCF24F754F4A0BDF",
+    "EtwLifecycle.csproj": "22FE8D550AD99BD026CB9448AAF5F0B83F908EDC977B75FBFD2A15E36B1375F1",
+    "FinalEvidence.cs": "0127B1A626094FB22D2FC60057F17C1CB194D2B1F5E8577BA24BA40AC768F564",
+    "OwnedTrace.cs": "E2D2BCDCBF8F05D9BF6BE765D93017A8F1A89B2FC41C10605661F9FC7BD58CAD",
+    "Peer.cs": "17E30EC3243BE00B01BB4D4D8B305C99822B1583D3F086B388FEE9AB5E381579",
+    "Program.cs": "00B1363D993FACE8D7049E55C44A67396A466F10568A65FBDED5D97802D1BA94",
+    "Scenarios.cs": "F57956747F10D594D506F0F8DDF44CECAE00738CB21FD8A77CA835B8B7EC37E0",
+    "Security.cs": "C5BC03146F17ED29A35D40144686E65CBEA93E408D858CB434266311A8567AC3",
+    "SelfTest.cs": "9FC11DD1515C05411D7FD58A322EE5BBF3BBFED776048909F708C94F7608B0FE",
+    "Wire.cs": "6AB1B7D8DE5502E7D19E51CF2394DCDF872081FD8CF03D406517509663A6C5BE"
+  },
+  "selfTests": {
+    "passed": 14,
+    "nativeTraceApi": "fake",
+    "realNamedPipes": true
+  },
+  "pendingLiveGates": [
+    "Actual UAC refusal/late consent and alternate credentials",
+    "Broker death with independent authorized absence witness",
+    "Elevated collector crash and orphan ownership/recovery",
+    "Suspend/resume",
+    "Remote and other-logon adversarial clients"
+  ],
+  "reports": [
+    {
+      "reportFile": "aegis-etw-cleanup-check-20260908/result.json",
+      "reportSha256": "F908C61B27B863D326B3D1838725D85F2CD965452155C3949CF0D3726817C4D2",
+      "report": {
+        "schema": 2,
+        "experiment": "etw-lifecycle",
+        "liveEmptySession": false,
+        "fileProviderEnabled": false,
+        "started": "2026-09-08T21:36:21.9266219+00:00",
+        "ended": "2026-09-08T21:36:30.4228663+00:00",
+        "os": "Microsoft Windows NT 10.0.26200.0",
+        "framework": "10.0.10",
+        "executableSha256": "53E9D7D7AC542F1E93CE5CA5DB7480A875873F14EC6AEF1ECE218D85A29C25BB",
+        "assemblySha256": "B677C6888FCA63C1067FF5D450184559C636C80817C2F1F6A6E689B3FDBB2A2C",
+        "outcomes": [
+          {
+            "Scenario": "stop",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "stop",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "stop",
+              "PeerExitCode": 0,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "parent-eof",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "parent-eof",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "parent-eof",
+              "PeerExitCode": 0,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "broker-kill",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": null,
+            "Error": null
+          },
+          {
+            "Scenario": "peer-exit",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "peer-exit",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "peer-failed",
+              "PeerExitCode": 7,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "peer-kill",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "peer-kill",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "eof",
+              "PeerExitCode": -1,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": false,
+              "CleanupReceiptReceived": false
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "lease",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "lease",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "lease-expired",
+              "PeerExitCode": 9,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "blocked-write",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "blocked-write",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "write-timeout",
+              "PeerExitCode": 10,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": false,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "launch-denied",
+            "Passed": true,
+            "PeerExited": false,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "launch-denied",
+              "Authenticated": false,
+              "RestrictedAcl": true,
+              "Outcome": "uac-denied",
+              "PeerExitCode": null,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": false,
+              "CleanupReceiptReceived": false
+            },
+            "Error": "uac-denied"
+          }
+        ],
+        "exitCode": 0
+      }
+    },
+    {
+      "reportFile": "aegis-etw-cleanup-uac-20260908/result.json",
+      "reportSha256": "7EDDDE008C85B15B41DD216880E02FEC89F5F27538B039DEA25CF369E5C73633",
+      "report": {
+        "schema": 2,
+        "experiment": "etw-lifecycle",
+        "liveEmptySession": true,
+        "fileProviderEnabled": false,
+        "started": "2026-09-08T21:36:49.0071271+00:00",
+        "ended": "2026-09-08T21:37:11.1673196+00:00",
+        "os": "Microsoft Windows NT 10.0.26200.0",
+        "framework": "10.0.10",
+        "executableSha256": "53E9D7D7AC542F1E93CE5CA5DB7480A875873F14EC6AEF1ECE218D85A29C25BB",
+        "assemblySha256": "B677C6888FCA63C1067FF5D450184559C636C80817C2F1F6A6E689B3FDBB2A2C",
+        "outcomes": [
+          {
+            "Scenario": "stop",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": true,
+              "Scenario": "stop",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "stop",
+              "PeerExitCode": 0,
+              "InitialStats": {
+                "QueryStatus": 0,
+                "EventsLost": 0,
+                "RealTimeBuffersLost": 0,
+                "LogBuffersLost": 0,
+                "NumberOfBuffers": 256,
+                "BufferSizeKiB": 64,
+                "AbsentStatus": null
+              },
+              "FinalStats": {
+                "QueryStatus": 0,
+                "EventsLost": 0,
+                "RealTimeBuffersLost": 0,
+                "LogBuffersLost": 0,
+                "NumberOfBuffers": 256,
+                "BufferSizeKiB": 64,
+                "AbsentStatus": 4201
+              },
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "parent-eof",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": true,
+              "Scenario": "parent-eof",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "parent-eof",
+              "PeerExitCode": 0,
+              "InitialStats": {
+                "QueryStatus": 0,
+                "EventsLost": 0,
+                "RealTimeBuffersLost": 0,
+                "LogBuffersLost": 0,
+                "NumberOfBuffers": 256,
+                "BufferSizeKiB": 64,
+                "AbsentStatus": null
+              },
+              "FinalStats": {
+                "QueryStatus": 0,
+                "EventsLost": 0,
+                "RealTimeBuffersLost": 0,
+                "LogBuffersLost": 0,
+                "NumberOfBuffers": 256,
+                "BufferSizeKiB": 64,
+                "AbsentStatus": 4201
+              },
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "lease",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": true,
+              "Scenario": "lease",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "lease-expired",
+              "PeerExitCode": 9,
+              "InitialStats": {
+                "QueryStatus": 0,
+                "EventsLost": 0,
+                "RealTimeBuffersLost": 0,
+                "LogBuffersLost": 0,
+                "NumberOfBuffers": 256,
+                "BufferSizeKiB": 64,
+                "AbsentStatus": null
+              },
+              "FinalStats": {
+                "QueryStatus": 0,
+                "EventsLost": 0,
+                "RealTimeBuffersLost": 0,
+                "LogBuffersLost": 0,
+                "NumberOfBuffers": 256,
+                "BufferSizeKiB": 64,
+                "AbsentStatus": 4201
+              },
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "blocked-write",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": true,
+              "Scenario": "blocked-write",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "write-timeout",
+              "PeerExitCode": 10,
+              "InitialStats": {
+                "QueryStatus": 0,
+                "EventsLost": 0,
+                "RealTimeBuffersLost": 0,
+                "LogBuffersLost": 0,
+                "NumberOfBuffers": 256,
+                "BufferSizeKiB": 64,
+                "AbsentStatus": null
+              },
+              "FinalStats": {
+                "QueryStatus": 0,
+                "EventsLost": 0,
+                "RealTimeBuffersLost": 0,
+                "LogBuffersLost": 0,
+                "NumberOfBuffers": 256,
+                "BufferSizeKiB": 64,
+                "AbsentStatus": 4201
+              },
+              "StopAcknowledged": false,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          }
+        ],
+        "exitCode": 0
+      }
+    }
+  ]
+}

--- a/docs/roadmap/etw-sensor-design.md
+++ b/docs/roadmap/etw-sensor-design.md
@@ -365,18 +365,19 @@ supervisor. B3 is not a substitute for the E1/E2 lifecycle harness.
 
 [`sidecar/etw-lifecycle`](../../sidecar/etw-lifecycle/README.md) adds a standalone
 Windows x64/.NET 10 executable with no third-party packages. Its separate
-`etw-lifecycle/1` protocol exercises transport/lifecycle without pretending to emit
+`etw-lifecycle/2` protocol exercises transport/lifecycle without pretending to emit
 B3 file observations. There is no file provider, decoder or application import.
 
-The normal broker creates a first-instance, remote-rejecting pipe with a protected
+The normal broker creates two first-instance, remote-rejecting pipes with protected
 logon-SID/SYSTEM DACL and limited client rights. Each end verifies the kernel pipe
 peer PID against a held process, exact creation FILETIME, apphost image, user/logon
 SID and expected elevation. Identification SQOS limits client impersonation.
-Authorization must precede session creation. Session stop authority is acquired
+Both endpoints authenticate both pipes before authorization and session creation.
+Session stop authority is acquired
 only after successful StartTrace and retained on failed stop; collisions grant no
 authority over an existing session. Fixed-name occupancy fails closed.
 
-The [local evidence](../recon/evidence/etw-lifecycle-home-26200-check.json) records
+The historical version 1 [local evidence](../recon/evidence/etw-lifecycle-home-26200-check.json) records
 twelve self-tests and eight passing normal-token process cases, with hashes of
 the source, apphost, assembly and raw report. Cases cover stop, stdin EOF, broker
 death, collector exit/kill, lease expiry, blocked output and injected launch denial.
@@ -394,7 +395,25 @@ native loss counters zero. It used the same apphost/assembly as the normal-token
 cases; canonical LF source hashes were checked against the merged git commit.
 A rejected or incomplete run remains recorded.
 
-E1/E2 remain open: actual consent/refusal/late cancellation, alternate credentials,
+Version 2 adds an independent `cleanup` receipt after the owned stop attempt. Its
+pipe has a separate launch ID, requires sequence 1, and uses the same held-process
+identity/DACL checks. Primary `stopped` and cleanup receipt remain distinct; reason
+and stats must agree when both arrive. A cancelled primary write can leave partial
+framing, so the blocked-output case never resumes primary decoding. Each terminal
+write has its own one-second deadline. Missing/failed/unavailable cleanup evidence
+cannot pass the live acceptance gate. The receipt is collector testimony over a
+separate transport; it is not an independent native observer.
+
+The [version 2 result](../recon/evidence/etw-lifecycle-home-26200-cleanup.json) records
+14 self-tests, eight normal-token cases and four real elevated cases using identical
+binaries. `uac-failures` tests stop (regression of the new two-pipe protocol), parent
+stdin EOF, lease expiry and blocked primary output. All four passed with final
+stop status 0, absence 4201, 256 × 64 KiB buffers and zero native loss counters.
+Child exits were 0, 0, 9 and 10 respectively. Blocked-write has primary acknowledgment
+false and cleanup receipt true. Both processes exited in each case. No file
+provider was enabled, and no harness processes remained after verification.
+
+E1/E2 remain open: actual refusal/late cancellation, alternate credentials,
 cross-integrity behavior outside the verified same-account host, remote/other-logon
 clients, suspend and elevated crash/orphan
 recovery need live evidence. No orphan-removal algorithm exists. The mutable dev
@@ -404,8 +423,7 @@ nothing about Kernel-File completeness or cost. Existing CI does not build this
 C# project; Windows Release build, formatter, self-tests and process cases are
 separate local checks. E3–E8 and the remaining B1 questions are unchanged.
 
-Next focused slice: elevated graceful-failure scenarios (parent stdin EOF, lease
-expiry, blocked output), each with final stop and absence evidence. Broker death
+Next focused slice: a design for broker-death evidence and orphan ownership. Broker death
 requires an independent authorized absence witness; elevated collector crash also
-requires an orphan-ownership design before claiming cleanup. The normal-stop result
-does not close either of those failure cases and does not require repeating B1.
+requires an orphan-ownership design before claiming cleanup. The graceful-failure
+results do not close either crash case and do not require repeating B1.

--- a/memory-bank/next-session.md
+++ b/memory-bank/next-session.md
@@ -1,9 +1,10 @@
 # AEGIS — старт следующего чата
 
-Обновлено 2026-09-08 после успешного реального UAC stop на стенде ETW B4.
+Обновлено 2026-09-08 после реальных elevated graceful-failure проверок ETW B4.
 B2: PR #384, `f2f1ac4`; B3: PR #385, `cc47212`, оба merged с пятью зелёными CI.
-B4: PR #386, `01bf403`, merged с пятью зелёными CI. Новый live-результат —
-PR ветки `codex/etw-uac-stop-evidence`; проверь его финальный статус.
+B4: PR #386, `01bf403`; первый UAC stop: PR #387, `1f7cd82`, оба merged с пятью
+зелёными CI. Новый блок — PR ветки `codex/etw-elevated-cleanup-cases`;
+проверь его финальный статус.
 Эта инструкция и последний Session handoff в `memory-bank/progress.md` — точка
 продолжения. Сначала проверь текущую ветку и состояние файлов: пользователь может
 принести другие изменения после записи этого контекста.
@@ -57,7 +58,7 @@ CI-контекстов этих PR прошли перед merge. Устано�
 сессии и не превращает diagnostic profile в HEALTHY. В нём нет массива событий.
 
 Модули B3 не импортируются приложением. В B4 добавлен отдельный
-`sidecar/etw-lifecycle` (.NET 10, без NuGet-пакетов). Его `etw-lifecycle/1` проверяет
+`sidecar/etw-lifecycle` (.NET 10, без NuGet-пакетов). Текущий `etw-lifecycle/2` проверяет
 собственный транспорт: защищённый локальный pipe, взаимную проверку PID/полного
 FILETIME/image/user/logon/elevation, authorize до создания сессии, lease и stop.
 При совпавшем имени существующей сессии стенд отказывает; чужую сессию не очищает.
@@ -83,8 +84,22 @@ Apphost/assembly совпали с normal-token прогоном; LF-хеши и
 их нельзя напрямую сравнивать после преобразования переносов Git.
 Same-account cross-integrity подтверждён на этом хосте.
 
-Следующий срез — расширить явный elevated harness для parent-stdin EOF, lease
-expiry и blocked output с доказательствами final stop и отсутствия сессии.
+**Новые graceful-failure сценарии тоже реализованы и проверены.** В версии 2 два
+pipe с отдельными ID и одинаковыми DACL/проверками процессов; authorize отправляется
+после проверки обоих. Второй переносит единственный `cleanup` после попытки stop,
+со своим timeout 1 с. Частично записанный основной поток никогда не дочитывается
+в blocked-write. Primary ack и cleanup receipt сохраняются отдельно.
+
+Прошли 14 self-test, восемь normal-token сценариев и `uac-failures` с четырьмя
+реальными сессиями: stop, parent stdin EOF, lease, blocked write. Во всех stop 0,
+absence 4201, 256 × 64 КиБ и loss counters 0; child exit 0/0/9/10 соответственно.
+В blocked-write primary ack false, cleanup receipt true. Процессов стенда не осталось.
+Отчёты: `X:/tmp/aegis-etw-cleanup-check-20260908/result.json` и
+`X:/tmp/aegis-etw-cleanup-uac-20260908/result.json`; агрегат —
+`docs/recon/evidence/etw-lifecycle-home-26200-cleanup.json`, canonical LF-хеши исходников
+и одинаковые binary-хеши обоих прогонов. Не повторяй их без новой причины.
+
+Следующий срез — проект доказательств broker death и владения orphan-сессиями.
 Для broker death нужен независимый разрешённый свидетель отсутствия; для elevated
 collector crash сначала нужен проект владения orphan-сессией. E1/E2 ещё требуют
 реального отказа/позднего UAC, других credentials/logon, remote clients и suspend.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1670,3 +1670,51 @@ Branch: `codex/etw-uac-stop-evidence`; inspect its PR for final CI/merge status.
 Local verification: format, renderer build and lint passed (zero errors, 31 existing
 warnings); 40 local documentation links resolved and the evidence checks passed.
 No new runtime tests were added for this documentation/evidence-only change.
+
+## Session handoff — ETW B4 elevated graceful-failure cleanup (2026-09-08)
+
+The real normal UAC stop evidence merged as PR #387, `1f7cd82`, with five green
+contexts. The user asked to continue. The isolated C# harness now uses
+`etw-lifecycle/2` and report schema 2, adding a separate authenticated cleanup pipe.
+Both pipes use the existing restricted DACL, first-instance/remote-rejection flags,
+identification SQOS and mutual held-process identity checks before authorization.
+No new token privileges, dependencies, file providers or Electron imports.
+
+The collector attempts owned-session stop before either terminal write. It tries
+primary `stopped`, then one independent `cleanup` frame with a separate ID,
+sequence 1 and its own one-second deadline. The broker checks reason/stat agreement
+when the primary terminal arrived. A blocked primary can contain a partial frame;
+it is never decoded again in that scenario. Primary acknowledgment and cleanup
+receipt stay separate. FinalEvidence rejects missing receipts, unknown counters,
+failed/unknown absence, identity mismatch and missing/wrong child exit. The separate
+receipt is authenticated collector testimony, not an independent native observer.
+
+`uac-failures` launches four sequential fresh broker/collector pairs and stops on
+first failure: stop (new-protocol regression), parent stdin EOF, expired lease and
+blocked primary write. Abrupt elevated kill scenarios remain rejected. Local
+Windows Release build passed without warnings/errors, C# whitespace verification
+passed, 14 self-tests and all eight normal-token process cases passed.
+
+The actual UAC batch also passed on the Home host at 21:36–21:37 UTC. Every empty
+session reported initial query 0, final stop 0, absence 4201, 256 × 64 KiB buffers
+and all three loss counters zero. Expected child exits were 0/0/9/10. Blocked-write
+kept StopAcknowledged false and CleanupReceiptReceived true. Both processes exited
+in every case; no harness processes remained. No file provider was enabled.
+
+Raw reports: `X:/tmp/aegis-etw-cleanup-check-20260908/result.json` and
+`X:/tmp/aegis-etw-cleanup-uac-20260908/result.json`. The aggregate
+`docs/recon/evidence/etw-lifecycle-home-26200-cleanup.json` retains report hashes,
+both complete reports and ten canonical LF source hashes. Both runs used identical
+apphost/assembly binaries. Historical version 1 evidence is unchanged.
+
+Repository format, renderer build and lint passed (zero errors, 31 existing
+warnings); 41 local links and ten source hashes verified. Existing GitHub CI does
+not build/test this C# project; local Windows checks are separate evidence.
+Branch: `codex/etw-elevated-cleanup-cases`; inspect its PR for final CI/merge status.
+
+Next focused block is the design for broker-death evidence and orphan ownership.
+Broker death needs an independent authorized absence witness; collector crash
+needs an ownership/recovery design before any claim of cleanup. Actual UAC refusal,
+late consent, alternate credentials/logons, remote clients and suspend remain open.
+Do not repeat the completed four live cases, first UAC stop or B1 matrix/load/tune
+without a new question. Frontend, production wiring and installed app stay separate.

--- a/sidecar/etw-lifecycle/Broker.cs
+++ b/sidecar/etw-lifecycle/Broker.cs
@@ -5,7 +5,8 @@ using System.Text.Json;
 namespace Aegis.EtwLifecycle;
 
 internal sealed record BrokerResult(bool Live, string Scenario, bool Authenticated, bool RestrictedAcl,
-    string Outcome, int? PeerExitCode, TraceStats? InitialStats, TraceStats? FinalStats, bool StopAcknowledged);
+    string Outcome, int? PeerExitCode, TraceStats? InitialStats, TraceStats? FinalStats, bool StopAcknowledged,
+    bool CleanupReceiptReceived = false);
 
 internal static class Broker
 {
@@ -14,14 +15,16 @@ internal static class Broker
         if (args.Length != 3 || args[1] is not ("check" or "live") ||
             args[2] is not ("stop" or "parent-eof" or "broker-kill" or "peer-exit" or "peer-kill" or "lease" or "blocked-write" or "launch-denied")) throw new ArgumentException();
         bool live = args[1] == "live";
-        if (Security.Current().Elevated || (live && args[2] != "stop")) return 3;
+        if (Security.Current().Elevated || (live && args[2] is not ("stop" or "parent-eof" or "lease" or "blocked-write"))) return 3;
         string scenario = args[2], id = Guid.NewGuid().ToString("N");
         using var server = Security.Server(id);
-        bool acl = Security.RestrictedAcl(server);
+        string receiptId = Guid.NewGuid().ToString("N");
+        using var receipt = Security.Server(receiptId);
+        bool acl = Security.RestrictedAcl(server) && Security.RestrictedAcl(receipt);
         if (!acl) throw new UnauthorizedAccessException();
         var self = Security.Current();
         string fault = scenario == "peer-exit" ? "exit" : scenario == "blocked-write" ? "flood" : "normal";
-        var info = Program.Child("peer", args[1], id, self.Pid.ToString(CultureInfo.InvariantCulture), self.Birth.ToString(CultureInfo.InvariantCulture), fault);
+        var info = Program.Child("peer", args[1], id, self.Pid.ToString(CultureInfo.InvariantCulture), self.Birth.ToString(CultureInfo.InvariantCulture), fault, receiptId);
         if (live)
         {
             info.UseShellExecute = true; info.Verb = "runas"; info.WindowStyle = ProcessWindowStyle.Hidden;
@@ -44,7 +47,7 @@ internal static class Broker
         using var peer = launched;
         var identity = Security.Observe(peer);
         using var session = new CancellationTokenSource(TimeSpan.FromSeconds(20));
-        bool authenticated = false, stopped = false;
+        bool authenticated = false, stopped = false, cleanup = false;
         string outcome = "peer-failed";
         TraceStats? initial = null, final = null;
         ulong sent = 0, received = 0;
@@ -52,6 +55,8 @@ internal static class Broker
         {
             await server.WaitForConnectionAsync(session.Token);
             Security.Verify(server, peer, identity.Birth, true, live);
+            await receipt.WaitForConnectionAsync(session.Token);
+            Security.Verify(receipt, peer, identity.Birth, true, live);
             authenticated = true;
             var hello = await Read();
             if (hello.Kind != "hello") throw new InvalidDataException();
@@ -62,7 +67,7 @@ internal static class Broker
             Console.WriteLine(JsonSerializer.Serialize(new { kind = "ready", peerPid = peer.Id, peerBirth = identity.Birth.ToString(CultureInfo.InvariantCulture) }));
             if (scenario == "blocked-write")
             {
-                await peer.WaitForExitAsync(session.Token); // deliberately do not read flooded pipe
+                // Read only the separate cleanup pipe below; primary stays blocked.
                 outcome = "write-timeout";
             }
             else if (scenario is "lease" or "peer-exit" or "peer-kill")
@@ -89,6 +94,9 @@ internal static class Broker
                 if (terminal.Kind != "stopped") throw new InvalidDataException();
                 final = terminal.Stats; stopped = true; outcome = terminal.Code;
             }
+            var confirmation = await Wire.Read(receipt, receiptId, live, session.Token);
+            FinalEvidence.ValidateReceipt(confirmation, outcome, final, stopped);
+            final = confirmation.Stats; cleanup = true;
             await peer.WaitForExitAsync(session.Token);
         }
         catch (Exception error) when (error is IOException or OperationCanceledException or UnauthorizedAccessException)
@@ -109,7 +117,7 @@ internal static class Broker
             }
         }
         int? exit = peer.HasExited ? peer.ExitCode : null;
-        Console.WriteLine(JsonSerializer.Serialize(new BrokerResult(live, scenario, authenticated, acl, outcome, exit, initial, final, stopped)));
+        Console.WriteLine(JsonSerializer.Serialize(new BrokerResult(live, scenario, authenticated, acl, outcome, exit, initial, final, stopped, cleanup)));
         return 0;
 
         async Task<Frame> Read()

--- a/sidecar/etw-lifecycle/FinalEvidence.cs
+++ b/sidecar/etw-lifecycle/FinalEvidence.cs
@@ -1,0 +1,32 @@
+namespace Aegis.EtwLifecycle;
+
+// A terminal frame and an independent cleanup receipt are different observations.
+// Neither a clean exit nor receipt delivery can turn unavailable ETW stats into zero.
+internal static class FinalEvidence
+{
+    internal static void ValidateReceipt(Frame frame, string outcome, TraceStats? primary, bool acknowledged)
+    {
+        if (frame.Kind != "cleanup" || frame.Seq != "1" || frame.Code != outcome ||
+            (acknowledged && frame.Stats != primary)) throw new InvalidDataException();
+    }
+
+    internal static bool Accepts(bool live, string scenario, BrokerResult result, int brokerExit)
+    {
+        bool expected = scenario switch
+        {
+            "stop" => result.Outcome == "stop" && result.PeerExitCode == 0 && result.StopAcknowledged,
+            "parent-eof" => result.Outcome == "parent-eof" && result.PeerExitCode == 0 && result.StopAcknowledged,
+            "lease" => result.Outcome == "lease-expired" && result.PeerExitCode == 9 && result.StopAcknowledged,
+            "peer-exit" => !live && result.Outcome == "peer-failed" && result.PeerExitCode == 7,
+            "peer-kill" => !live && result.Outcome == "eof" && result.PeerExitCode is not null and not 0 && !result.StopAcknowledged && !result.CleanupReceiptReceived,
+            "blocked-write" => result.Outcome == "write-timeout" && result.PeerExitCode == 10 && !result.StopAcknowledged,
+            _ => false
+        };
+        bool native = !live ? result.InitialStats == null && result.FinalStats == null :
+            result.InitialStats is { QueryStatus: 0, NumberOfBuffers: > 0, BufferSizeKiB: > 0 } &&
+            result.FinalStats is { QueryStatus: 0, AbsentStatus: 4201, EventsLost: not null, RealTimeBuffersLost: not null, LogBuffersLost: not null };
+        bool receipt = !live && scenario == "peer-kill" || result.CleanupReceiptReceived;
+        return expected && native && receipt && result.Live == live && result.Scenario == scenario &&
+            result.Authenticated && result.RestrictedAcl && brokerExit == 0;
+    }
+}

--- a/sidecar/etw-lifecycle/Peer.cs
+++ b/sidecar/etw-lifecycle/Peer.cs
@@ -7,16 +7,20 @@ internal static class Peer
 {
     internal static async Task<int> Run(string[] args)
     {
-        if (args.Length != 6 || args[1] is not ("check" or "live") ||
+        if (args.Length != 7 || args[1] is not ("check" or "live") ||
             args[5] is not ("normal" or "exit" or "flood")) throw new ArgumentException();
         bool live = args[1] == "live";
-        if (live && args[5] != "normal") throw new ArgumentException();
+        if (live && args[5] == "exit") throw new ArgumentException();
         if (Security.Current().Elevated != live) return 3;
         string id = args[2];
         using var parent = Process.GetProcessById(int.Parse(args[3], CultureInfo.InvariantCulture));
         ulong birth = ulong.Parse(args[4], CultureInfo.InvariantCulture);
         using var pipe = Security.Client(id);
         Security.Verify(pipe, parent, birth, false, false);
+        string receiptId = args[6];
+        if (receiptId == id) throw new InvalidDataException();
+        using var receipt = Security.Client(receiptId);
+        Security.Verify(receipt, parent, birth, false, false);
         using var lifetime = new CancellationTokenSource(TimeSpan.FromSeconds(25));
         using var ownerGone = new CancellationTokenSource();
         using var io = CancellationTokenSource.CreateLinkedTokenSource(lifetime.Token, ownerGone.Token);
@@ -57,6 +61,14 @@ internal static class Peer
             {
                 using var terminal = new CancellationTokenSource(TimeSpan.FromSeconds(1));
                 await Wire.Write(pipe, Wire.Make(id, ++sent, "stopped", live, reason, final), terminal.Token);
+            }
+            catch (Exception error) when (error is IOException or OperationCanceledException) { }
+            // Independent authenticated pipe: primary framing may have been left
+            // partial by a cancelled write. Never resume decoding that stream.
+            try
+            {
+                using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                await Wire.Write(receipt, Wire.Make(receiptId, 1, "cleanup", live, reason, final), deadline.Token);
             }
             catch (Exception error) when (error is IOException or OperationCanceledException) { }
             lifetime.Cancel();

--- a/sidecar/etw-lifecycle/Program.cs
+++ b/sidecar/etw-lifecycle/Program.cs
@@ -20,14 +20,15 @@ internal static class Program
             {
                 Console.WriteLine("Isolated ETW lifecycle experiment; no file provider or Electron connection.\n" +
                     "self-test\ncheck <new-output-directory> (normal token, no ETW/UAC)\n" +
-                    "uac <new-output-directory> (normal terminal, one UAC; empty ETW session)");
+                    "uac <new-output-directory> (normal terminal, one UAC; empty ETW session)\n" +
+                    "uac-failures <new-output-directory> (four UAC launches; empty sessions, stop/EOF/lease/blocked write)");
                 return 0;
             }
             if (args[0] == "self-test" && args.Length == 1) return await SelfTest.Run();
             if (args[0] == "peer") return await Peer.Run(args);
             if (args[0] == "broker") return await Broker.Run(args);
             if (args[0] == "rogue") return await SelfTest.Rogue(args);
-            if (args.Length != 2 || args[0] is not ("check" or "uac")) throw new ArgumentException();
+            if (args.Length != 2 || args[0] is not ("check" or "uac" or "uac-failures")) throw new ArgumentException();
             if (Security.Current().Elevated)
             {
                 Console.Error.WriteLine("Use a normal PowerShell terminal. No run was started.");
@@ -37,7 +38,7 @@ internal static class Program
             if (Path.Exists(output)) throw new IOException();
             Directory.CreateDirectory(output);
             var started = DateTimeOffset.UtcNow;
-            bool live = args[0] == "uac";
+            bool live = args[0] != "check";
             var outcomes = new List<object>();
             int result = 0;
             using var abort = new CancellationTokenSource();
@@ -45,7 +46,7 @@ internal static class Program
             Console.CancelKeyPress += cancel;
             try
             {
-                foreach (var scenario in live ? new[] { "stop" } :
+                foreach (var scenario in args[0] == "uac-failures" ? new[] { "stop", "parent-eof", "lease", "blocked-write" } : live ? new[] { "stop" } :
                     new[] { "stop", "parent-eof", "broker-kill", "peer-exit", "peer-kill", "lease", "blocked-write", "launch-denied" })
                 {
                     var outcome = await Scenarios.Run(live, scenario, abort.Token);
@@ -61,7 +62,7 @@ internal static class Program
             finally { Console.CancelKeyPress -= cancel; }
             Write(output, "result.json", new
             {
-                schema = 1,
+                schema = 2,
                 experiment = "etw-lifecycle",
                 liveEmptySession = live,
                 fileProviderEnabled = false,

--- a/sidecar/etw-lifecycle/README.md
+++ b/sidecar/etw-lifecycle/README.md
@@ -1,9 +1,11 @@
 # Isolated ETW lifecycle harness (B4)
 
-This Windows x64/.NET 10 experiment checks process/pipe ownership and prepares an
-explicit empty-session UAC check. It has no third-party packages, file provider,
+This Windows x64/.NET 10 experiment checks process/pipe ownership and explicit
+empty-session UAC cleanup. It has no third-party packages, file provider,
 file-event decoder, Electron import, installer integration or production defaults.
-Its `etw-lifecycle/1` wire is deliberately separate from B3's `etw-file/1`.
+Its `etw-lifecycle/2` wire is deliberately separate from B3's `etw-file/1`.
+Version 2 adds an independent authenticated cleanup pipe and report schema 2;
+historical version 1 evidence remains unchanged.
 
 ## Run
 
@@ -18,7 +20,7 @@ dotnet build sidecar/etw-lifecycle/EtwLifecycle.csproj -c Release
 Use a new output directory for each run; existing directories are rejected.
 The `check` command launches normal-token processes and never calls StartTrace.
 Its eight scenarios take about nine seconds in the recorded local run; this is
-not a performance budget. Both modes reject an already elevated coordinator.
+not a performance budget. All coordinator modes reject an already elevated token.
 Run the apphost `.exe`, not `dotnet EtwLifecycle.dll`, so peer image checks have
 one fixed executable. The executable/managed assembly hashes are saved in the report.
 
@@ -37,7 +39,16 @@ No provider is enabled and no file contents, paths, reads or process command lin
 are collected. Requested session buffers are 256 × 64 KiB for this explicit
 experiment; actual counts are reported. The measurement probe's budget is unchanged.
 
-Only the normal-stop scenario is currently available under elevation. Actual
+`uac-failures` runs four sequential fresh broker/collector pairs: stop, parent stdin
+EOF, lease expiry and blocked primary output. Each launch can request UAC. The
+batch stops at the first failed case and retains its report. These cases passed on
+the local Home host on 2026-09-08; use a new directory for any justified rerun:
+
+```powershell
+& './sidecar/etw-lifecycle/bin/Release/net10.0-windows/EtwLifecycle.exe' uac-failures 'X:/tmp/aegis-etw-cleanup-uac-new'
+```
+
+Elevated abrupt-kill scenarios remain rejected by the broker. Actual
 UAC refusal/cancellation, alternate credentials, elevated crash cleanup, suspend
 and hostile remote/other-logon clients remain live gates. Same-account cross-integrity
 pipe/process access succeeded on the recorded host. The development source
@@ -45,9 +56,9 @@ and build directory are trusted inputs; this is not a signed privileged service.
 
 ## Boundaries and authentication
 
-The coordinator starts a normal-token broker. The broker creates one random local
-pipe with `FILE_FLAG_FIRST_PIPE_INSTANCE`, `PIPE_REJECT_REMOTE_CLIENTS` and a protected
-DACL. The DACL permits the current logon SID to read/write data, read attributes
+The coordinator starts a normal-token broker. The broker creates two random local
+pipes, each with `FILE_FLAG_FIRST_PIPE_INSTANCE`, `PIPE_REJECT_REMOTE_CLIENTS` and a
+protected DACL. Each DACL permits the current logon SID to read/write data, read attributes
 and synchronize, plus LocalSystem access. It omits create-instance rights from the
 client grant. Default Everyone/Anonymous access is not used. The client specifies
 identification-level SQOS so a server cannot impersonate the elevated client.
@@ -55,7 +66,8 @@ identification-level SQOS so a server cannot impersonate the elevated client.
 The broker holds the process returned by its fixed apphost launch. After connection
 it compares the OS pipe client PID with that held process, exact creation FILETIME,
 image path, user SID, logon SID and expected elevation. The collector independently
-checks the pipe server against a held broker process and the launch creation witness.
+checks each pipe server against a held broker process and the launch creation witness.
+Both pipe connections must pass authentication before the broker sends authorization.
 The random launch ID binds messages; it is not sufficient proof of identity.
 No user-specified executable, shell command, output path or provider configuration
 is passed to the elevated process.
@@ -79,12 +91,21 @@ length and closed UTF-8 JSON frames capped at 64 KiB/depth 8. Flood test frames 
 capped at 16 KiB padding. No frame backlog or background task list accumulates.
 
 The experiment uses 500 ms broker pings, a 4 s peer read lease, 2 s write deadlines,
-25 s maximum peer lifetime and a 1 s best-effort terminal write. These accelerated
+25 s maximum peer lifetime and a 1 s best-effort terminal write on each pipe. These accelerated
 test values differ from the B2 production proposals. The collector also holds and
 watches its broker process; broker death cancels I/O independently of pipe traffic.
 Cleanup runs before the terminal write, so blocked output cannot prevent attempting
 session stop. Native ETW calls are synchronous; this experiment does not establish
 a hard deadline for a stuck kernel call.
+
+After attempting stop, the collector tries `stopped` on the primary pipe, then one
+`cleanup` frame on the separate pipe with its own ID and sequence 1. This second
+receipt carries the same reason/final statistics and has a separate one-second
+write deadline. If the primary terminal arrived, conflicting receipts are rejected.
+The blocked-output case never resumes primary decoding: cancellation may have left
+a partial frame there. The broker waits for the separate receipt and actual child
+exit. An absent receipt, failed stop or unknown absence cannot pass live acceptance.
+This receipt is the authenticated collector's report, not a second native observer.
 
 The normal coordinator deadline is 35 s per case; the explicit UAC case allows
 150 s. Ctrl+C is recorded as cancellation and closes broker stdin, allowing a
@@ -110,11 +131,14 @@ interpret the normal-token kill tests as evidence of privileged ETW cleanup.
 configuration; oversized length and truncation; sequence replay; ownership on
 collision, unavailable query and failed stop; kernel-read DACL; first-instance
 collision; real mutual peer identity; wrong client/server processes; authorization
-timeout; and a cancelled coordinator request. Native session calls in the ownership
+timeout; a cancelled coordinator request; invalid/foreign/conflicting cleanup
+receipts; and rejection of missing counters, absence, identity or child exit.
+There are 14 self-tests. Native session calls in the ownership
 unit tests use an explicit fake API.
 
 `check` saves `result.json` with environment/runtime, build hashes, mode, scenario
-outcomes, actual peer exit codes and stop acknowledgments. All native statistics
+outcomes, actual peer exit codes, primary stop acknowledgments and separate cleanup
+receipt flags. All native statistics
 must be null in this mode. The expected outcomes are checked explicitly:
 
 | Case | Required observation |
@@ -125,15 +149,17 @@ must be null in this mode. The expected outcomes are checked explicitly:
 | peer-exit | Deliberate nonzero collector exit 7; failure remains visible. |
 | peer-kill | Abrupt collector kill; broker gets EOF and no stop acknowledgment. |
 | lease | Withhold pings; terminal lease-expired, exit 9. |
-| blocked-write | Stop reading the flooded pipe; collector write deadline exits 10, no acknowledgment claimed. |
+| blocked-write | Primary pipe stays unread; write deadline exits 10, primary acknowledgment false, separate cleanup receipt required. |
 | launch-denied | Check-only injection of Win32 error 1223; no collector starts, refusal survives into the report. This does not exercise UAC. |
 
-The UAC case passes only with authenticated peer, restricted DACL, initial query
+Each UAC case passes only with authenticated peer on both pipes, restricted DACLs, initial query
 success, actual buffer fields, stop-query success with known loss counters,
-absence status 4201, acknowledgment and child exit 0. Failed runs remain on disk.
+absence status 4201, separate cleanup receipt and the expected child exit: 0 for
+stop/EOF, 9 for lease expiry, 10 for blocked write. Primary acknowledgment is required
+except in blocked-write, where it must be false. Failed runs remain on disk.
 An empty session with zero losses says nothing about Kernel-File coverage or cost.
 
-The [real UAC stop evidence](../../docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json)
+The historical version 1 [real UAC stop evidence](../../docs/recon/evidence/etw-lifecycle-home-26200-uac-stop.json)
 records a passing same-account run using the same apphost/assembly as the eight
 normal-token cases. Both identity checks and the restricted DACL passed; initial
 and final native calls returned status 0, with 256 buffers of 64 KiB and all three
@@ -142,10 +168,13 @@ post-stop absence query returned 4201. No harness processes remained on the host
 Source hashes include canonical LF values to account for git checkout's CRLF/LF
 conversion; the binary hashes match exactly.
 
-This closes only the local same-account normal-stop slice of E1/E2. The next
-implementation slice should extend the explicit harness with graceful parent-EOF,
-lease expiry and blocked-output cases under elevation, retaining final stop and
-absence evidence. Broker death needs an independent authorized absence witness;
+The [version 2 cleanup evidence](../../docs/recon/evidence/etw-lifecycle-home-26200-cleanup.json)
+records 14 self-tests, eight normal-token and four real elevated cases using the
+same new binaries. All live cases reported successful stop and absence 4201,
+256 × 64 KiB buffers and zero native loss counters. Blocked output reported no
+primary acknowledgment and a valid separate receipt. No harness processes remained.
+These results cover local same-account graceful failure paths. Broker death still
+needs an independent authorized absence witness;
 an elevated collector crash additionally needs a defined orphan-ownership design.
 Do not claim cleanup from a missing pipe acknowledgment or normal-token kill test.
 

--- a/sidecar/etw-lifecycle/Scenarios.cs
+++ b/sidecar/etw-lifecycle/Scenarios.cs
@@ -42,20 +42,7 @@ internal static class Scenarios
             string summary = await Line(broker.StandardOutput, timeout.Token);
             var result = JsonSerializer.Deserialize<BrokerResult>(summary, Wire.Json) ?? throw new InvalidDataException();
             await broker.WaitForExitAsync(timeout.Token);
-            bool expected = scenario switch
-            {
-                "stop" => result.Outcome == "stop" && result.PeerExitCode == 0 && result.StopAcknowledged,
-                "parent-eof" => result.Outcome == "parent-eof" && result.PeerExitCode == 0 && result.StopAcknowledged,
-                "lease" => result.Outcome == "lease-expired" && result.PeerExitCode == 9 && result.StopAcknowledged,
-                "peer-exit" => result.Outcome == "peer-failed" && result.PeerExitCode == 7,
-                "peer-kill" => result.Outcome == "eof" && result.PeerExitCode != 0 && !result.StopAcknowledged,
-                "blocked-write" => result.Outcome == "write-timeout" && result.PeerExitCode == 10 && !result.StopAcknowledged,
-                _ => false
-            };
-            bool final = !live ? result.InitialStats == null && result.FinalStats == null :
-                result.InitialStats is { QueryStatus: 0, NumberOfBuffers: not null, BufferSizeKiB: not null } &&
-                result.FinalStats is { QueryStatus: 0, AbsentStatus: 4201, EventsLost: not null, RealTimeBuffersLost: not null, LogBuffersLost: not null };
-            return new(scenario, expected && final && result.Authenticated && result.RestrictedAcl && broker.ExitCode == 0,
+            return new(scenario, FinalEvidence.Accepts(live, scenario, result, broker.ExitCode),
                 result.PeerExitCode.HasValue, true, result, null);
         }
         catch (Exception error)

--- a/sidecar/etw-lifecycle/SelfTest.cs
+++ b/sidecar/etw-lifecycle/SelfTest.cs
@@ -39,6 +39,7 @@ internal static class SelfTest
             {
                 Wire.Make(id, 1, "hello", false) with { Seq = "01" },
                 Wire.Make(id, 1, "hello", false) with { Protocol = "etw-file/1" },
+                Wire.Make(id, 1, "hello", false) with { Protocol = "etw-lifecycle/1" },
                 Wire.Make(id, 1, "hello", false) with { Live = true },
                 Wire.Make(id, 1, "hello", false) with { Id = Guid.NewGuid().ToString("N") }
             }) await Reject(() => { Wire.Validate(value, id, false); return Task.CompletedTask; });
@@ -118,17 +119,21 @@ internal static class SelfTest
         await Test("missing authorization expires before ready", async () =>
         {
             string id = Guid.NewGuid().ToString("N"); using var server = Security.Server(id);
+            string receiptId = Guid.NewGuid().ToString("N"); using var receipt = Security.Server(receiptId);
             var self = Security.Current();
             using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(8));
             var connect = server.WaitForConnectionAsync(deadline.Token);
+            var receiptConnect = receipt.WaitForConnectionAsync(deadline.Token);
             using var peer = Process.Start(Program.Child("peer", "check", id,
-                self.Pid.ToString(System.Globalization.CultureInfo.InvariantCulture), self.Birth.ToString(System.Globalization.CultureInfo.InvariantCulture), "normal")) ?? throw new InvalidOperationException();
+                self.Pid.ToString(System.Globalization.CultureInfo.InvariantCulture), self.Birth.ToString(System.Globalization.CultureInfo.InvariantCulture), "normal", receiptId)) ?? throw new InvalidOperationException();
             try
             {
-                await connect;
+                await connect; await receiptConnect;
                 Check((await Wire.Read(server, id, false, deadline.Token)).Kind == "hello");
                 var terminal = await Wire.Read(server, id, false, deadline.Token);
                 Check(terminal.Kind == "stopped" && terminal.Code == "lease-expired" && terminal.Stats == null);
+                var confirmation = await Wire.Read(receipt, receiptId, false, deadline.Token);
+                FinalEvidence.ValidateReceipt(confirmation, "lease-expired", null, true);
                 await peer.WaitForExitAsync(deadline.Token); Check(peer.ExitCode == 9);
             }
             finally { if (!peer.HasExited) peer.Kill(); await peer.WaitForExitAsync(); }
@@ -138,6 +143,34 @@ internal static class SelfTest
             using var cancelled = new CancellationTokenSource(); cancelled.Cancel();
             var result = await Scenarios.Run(false, "stop", cancelled.Token);
             Check(!result.Passed && result.Error == "cancelled" && result.BrokerExited);
+        });
+        await Test("cleanup receipt rejects wrong sequence, reason and conflicting stats", async () =>
+        {
+            string id = Guid.NewGuid().ToString("N");
+            var stats = new TraceStats(0, 0, 0, 0, 256, 64, 4201);
+            var valid = Wire.Make(id, 1, "cleanup", true, "stop", stats);
+            FinalEvidence.ValidateReceipt(valid, "stop", stats, true);
+            foreach (var frame in new[] { valid with { Seq = "2" }, valid with { Kind = "stopped" },
+                valid with { Code = "lease-expired" }, valid with { Stats = null },
+                valid with { Stats = stats with { EventsLost = 1 } } })
+                await Reject(() => { FinalEvidence.ValidateReceipt(frame, "stop", stats, true); return Task.CompletedTask; });
+            using var bytes = new MemoryStream();
+            await Wire.Write(bytes, valid, CancellationToken.None); bytes.Position = 0;
+            await Reject(() => Wire.Read(bytes, Guid.NewGuid().ToString("N"), true, CancellationToken.None));
+        });
+        await Test("live cleanup needs receipt, known counters, absence and actual exit", () =>
+        {
+            var stats = new TraceStats(0, 0, 0, 0, 256, 64, 4201);
+            var valid = new BrokerResult(true, "blocked-write", true, true, "write-timeout", 10, stats, stats, false, true);
+            Check(FinalEvidence.Accepts(true, "blocked-write", valid, 0));
+            foreach (var result in new[] { valid with { CleanupReceiptReceived = false }, valid with { PeerExitCode = null },
+                valid with { Authenticated = false }, valid with { RestrictedAcl = false }, valid with { StopAcknowledged = true },
+                valid with { FinalStats = null }, valid with { FinalStats = stats with { AbsentStatus = 5 } },
+                valid with { FinalStats = stats with { EventsLost = null } }, valid with { FinalStats = stats with { QueryStatus = 5 } },
+                valid with { Live = false }, valid with { Scenario = "lease" } })
+                Check(!FinalEvidence.Accepts(true, "blocked-write", result, 0));
+            Check(!FinalEvidence.Accepts(true, "blocked-write", valid, 2));
+            return Task.CompletedTask;
         });
         Console.WriteLine($"{passed} lifecycle self-tests passed; no ETW session or elevation.");
         return 0;

--- a/sidecar/etw-lifecycle/Wire.cs
+++ b/sidecar/etw-lifecycle/Wire.cs
@@ -22,16 +22,16 @@ internal static class Wire
         MaxDepth = 8
     };
     private static readonly UTF8Encoding Utf8 = new(false, true);
-    private static readonly string[] Kinds = ["hello", "authorize", "ready", "ping", "pong", "stop", "stopped", "padding"];
+    private static readonly string[] Kinds = ["hello", "authorize", "ready", "ping", "pong", "stop", "stopped", "padding", "cleanup"];
     private static readonly string[] Codes = ["none", "stop", "parent-eof", "lease-expired", "peer-failed", "write-timeout"];
 
     internal static Frame Make(string id, ulong seq, string kind, bool live,
         string code = "none", TraceStats? stats = null, string padding = "") =>
-        new("etw-lifecycle/1", id, seq.ToString(CultureInfo.InvariantCulture), kind, live, code, stats, padding);
+        new("etw-lifecycle/2", id, seq.ToString(CultureInfo.InvariantCulture), kind, live, code, stats, padding);
 
     internal static void Validate(Frame frame, string id, bool live)
     {
-        if (frame.Protocol != "etw-lifecycle/1" || frame.Id != id || !Guid.TryParseExact(id, "N", out _) ||
+        if (frame.Protocol != "etw-lifecycle/2" || frame.Id != id || !Guid.TryParseExact(id, "N", out _) ||
             frame.Live != live || !Kinds.Contains(frame.Kind) || !Codes.Contains(frame.Code) ||
             !ulong.TryParse(frame.Seq, NumberStyles.None, CultureInfo.InvariantCulture, out var seq) || seq == 0 ||
             frame.Seq != seq.ToString(CultureInfo.InvariantCulture) ||


### PR DESCRIPTION
A blocked primary pipe can contain a partial frame after write cancellation, so the lifecycle harness could not retain trustworthy final ETW stop evidence for that failure. Add an independently authenticated cleanup pipe, checked against the same held peer before authorization. The collector attempts owned-session stop before either terminal write; the separate receipt has its own bounded deadline and is checked for reason/stat consistency.

The isolated protocol/report move to version 2. Primary acknowledgment remains separate from cleanup receipt. Missing receipt, unknown counters/absence or incorrect process exit cannot pass live acceptance. The new uac-failures command runs four fresh pairs sequentially: normal stop, parent stdin EOF, lease expiry and blocked primary write. Elevated abrupt-kill cases remain rejected.

Validation on the local Windows Home host:
- Release build: zero warnings/errors; C# whitespace verification passed.
- 14 self-tests and eight real normal-token scenarios passed.
- Four actual elevated empty-session cases passed, each with final stop status 0 and absence 4201; expected child exits 0/0/9/10. Blocked-write reports primary acknowledgment false and cleanup receipt true. No harness processes remained.
- Source/build/report hashes and both full reports are recorded. Same binaries used for normal and elevated cases; no file provider was enabled.
- Repository format/build/lint/counts passed; lint retains 31 existing warnings. 41 local documentation links and ten source hashes verified.

Existing CI does not compile this standalone C# harness. The receipt is authenticated collector testimony over a separate transport, not an independent native observer. Broker death, elevated crash/orphan ownership, refusal/late consent, alternate credentials/logons and suspend remain E1/E2 gates. No Electron/frontend, dependency, installer or production-default changes.
