### PR TITLE
docs(etw): retain unexpected early consent evidence

### DIFF
--- a/docs/recon/evidence/etw-lifecycle-home-26200-consent-live.json
+++ b/docs/recon/evidence/etw-lifecycle-home-26200-consent-live.json
@@ -1,0 +1,104 @@
+{
+  "schema": 1,
+  "scope": "Actual refused-consent attempt returned early approval; requested refusal gate failed",
+  "sourceCommit": "76464633e95d36d330ea45d469d59f96072c6176",
+  "normalCheckEvidence": "docs/recon/evidence/etw-lifecycle-home-26200-consent-check.json",
+  "sourceCanonicalLfSha256": {
+    "Broker.cs": "D4FB6743105191DEFA4766210B27FD4C796FA19D4D1669CAB20A2495EDEF0126",
+    "BrokerDeath.cs": "FAB1D4E8102C115898156BE6B3C3FBC0BA9D9425AF30DDD383EB09C0829E36AC",
+    "ConsentBroker.cs": "3BB1FA8403721AB641CFB9DA18B05E2889807EFB05283255176BE2CB8A609462",
+    "ConsentScenarios.cs": "2C801F3B908279AD121A8796D6990396AAE4704FB4A7F741F43469B8FE0D7385",
+    "ConsentTests.cs": "EE9549B3A276F653628D63E3E843E563BE8BF18B76A6447629C941CCFEE999BB",
+    "EtwLifecycle.csproj": "22FE8D550AD99BD026CB9448AAF5F0B83F908EDC977B75FBFD2A15E36B1375F1",
+    "FinalEvidence.cs": "0127B1A626094FB22D2FC60057F17C1CB194D2B1F5E8577BA24BA40AC768F564",
+    "ObservedProcess.cs": "1326CF02909ED85449AB266F8E4C51D89C41A6784B3906E2CA9DF32177A59FCA",
+    "OwnedTrace.cs": "E2D2BCDCBF8F05D9BF6BE765D93017A8F1A89B2FC41C10605661F9FC7BD58CAD",
+    "Peer.cs": "17E30EC3243BE00B01BB4D4D8B305C99822B1583D3F086B388FEE9AB5E381579",
+    "Program.cs": "837020DCFF8489EE678CFD69EC82A7CE89E676BD154218562122E028FE921DE7",
+    "Scenarios.cs": "045D04950B792E15957B8E8462CB455DFE2FA022F766482B19C09E94E1E75D53",
+    "Security.cs": "19FDE5ACE53914B1E8804B9716A2D041D794E09B273BD8ACC385405BA6FADC96",
+    "SelfTest.cs": "4CDC98341FA4FF3C0329EA7E1A838355A10971E5D7DA6671DC66BC3B252FC851",
+    "Wire.cs": "6AB1B7D8DE5502E7D19E51CF2394DCDF872081FD8CF03D406517509663A6C5BE",
+    "Witness.cs": "B3616B5B9E73C7B424712B64C8F79F92B87646EE21127B122775888157B2A1EF",
+    "WitnessTests.cs": "4EC6A152EE01D7CD45D2BD5E3D0B35F3AF5E9D7998AF1480033F954A5C78E895"
+  },
+  "liveRefusalVerified": false,
+  "liveLateConsentVerified": false,
+  "suspendVerified": false,
+  "noHarnessProcessesAfterRun": true,
+  "observations": [
+    "The elevated collector launched after 1567.0161 ms, with verified held identity and exit 2; there was no native launch refusal.",
+    "The negative broker sent no authorization. The authenticated query-only witness returned absence 4201 before and after, then exited 0.",
+    "The expected refusal scenario correctly failed with exitCode 2. This failed attempt must not be included in passing refusal counts.",
+    "These point-in-time queries do not prove continuous absence or recover native counters; all unavailable counters remain null.",
+    "The report cannot establish whether a human saw or accepted a Windows dialog. No UAC UI was automated and no policy was changed."
+  ],
+  "attempts": [
+    {
+      "reportFile": "aegis-etw-refusal-20260908/result.json",
+      "reportSha256": "9D5727EDF71EE137C9E000F026FAE62BE841EE53618AF44F4809B25ACB28D3D9",
+      "report": {
+        "schema": 2,
+        "experiment": "etw-lifecycle",
+        "mode": "uac-refusal",
+        "liveEmptySession": false,
+        "nativeQueryEnabled": true,
+        "fileProviderEnabled": false,
+        "started": "2026-09-08T23:10:02.1711429+00:00",
+        "ended": "2026-09-08T23:10:06.6021828+00:00",
+        "os": "Microsoft Windows NT 10.0.26200.0",
+        "framework": "10.0.10",
+        "executableSha256": "E730A8F0360DCEA47381A16906EF15059E0763FCD82618C39CCEBCCBC77C7568",
+        "assemblySha256": "1383A7A8DE53C902E95D51C8D4F7E6F2867E76ABB6F587EE69AAD022154DF3A0",
+        "outcomes": [
+          {
+            "Live": true,
+            "Scenario": "refusal",
+            "Passed": false,
+            "WitnessAuthenticated": true,
+            "RestrictedAcl": true,
+            "WitnessExitCode": 0,
+            "BrokerExited": true,
+            "BrokerExitCode": 0,
+            "Result": {
+              "Live": true,
+              "Scenario": "refusal",
+              "Outcome": "early-consent",
+              "RestrictedAcl": true,
+              "ExpiredBeforeReturn": false,
+              "LaunchReturned": true,
+              "ChildLaunched": true,
+              "ChildIdentityVerified": true,
+              "ChildExitCode": 2,
+              "NativeError": null,
+              "InjectedDenial": false,
+              "AuthorizationSent": false,
+              "LaunchElapsedMilliseconds": 1567.0161,
+              "Error": null
+            },
+            "Before": {
+              "QueryStatus": 4201,
+              "EventsLost": null,
+              "RealTimeBuffersLost": null,
+              "LogBuffersLost": null,
+              "NumberOfBuffers": null,
+              "BufferSizeKiB": null,
+              "AbsentStatus": null
+            },
+            "After": {
+              "QueryStatus": 4201,
+              "EventsLost": null,
+              "RealTimeBuffersLost": null,
+              "LogBuffersLost": null,
+              "NumberOfBuffers": null,
+              "BufferSizeKiB": null,
+              "AbsentStatus": null
+            },
+            "Error": null
+          }
+        ],
+        "exitCode": 2
+      }
+    }
+  ]
+}

--- a/docs/roadmap/etw-consent-suspend.md
+++ b/docs/roadmap/etw-consent-suspend.md
@@ -61,6 +61,21 @@ ordinary lifecycle broker's launch timeout, implement a production supervisor,
 validate alternate credentials or establish packaged binary integrity. The
 mutable development apphost and assembly remain trusted inputs.
 
+## Recorded live attempt
+
+The first actual `uac-refusal` attempt on 2026-09-08 did **not** produce a refusal.
+The collector launched after 1567.0161 ms, with verified identity and exit 2. The
+broker sent no authorization; the authenticated witness observed absence 4201
+before and after and exited 0. The command correctly reported failure because
+the observed outcome was early consent. No harness processes remained.
+
+The [complete failed report](../recon/evidence/etw-lifecycle-home-26200-consent-live.json)
+retains the raw-report hash, matching normal-check binaries and 17 canonical LF
+source hashes at `7646463`. It cannot establish whether a person saw or accepted
+a dialog. No UAC UI was automated or policy changed. Confirm human interaction
+before repeating; refusal and late-consent gates remain unverified. Suspend was
+not attempted. Do not count this early-approval result as successful refusal.
+
 ## Suspend/resume: procedure design, not a completed experiment
 
 Do not put the host to sleep using an existing `uac`, `uac-failures` or consent

--- a/memory-bank/next-session.md
+++ b/memory-bank/next-session.md
@@ -1,13 +1,14 @@
 # AEGIS — старт следующего чата
 
-Обновлено 2026-09-08 после подготовки управляемых refusal/late-UAC проверок.
+Обновлено 2026-09-08 после первой живой попытки refusal: получен early consent.
 B2: PR #384, `f2f1ac4`; B3: PR #385, `cc47212`, оба merged с пятью зелёными CI.
 B4: PR #386, `01bf403`; первый UAC stop: PR #387, `1f7cd82`, оба merged с пятью
 зелёными CI. Elevated cleanup merged: PR #388, `75c943d`, пять зелёных CI.
 Первый UX-блок merged: PR #389, `69530bd`, пять зелёных CI.
 Второй UX-блок merged: PR #390, `8519796`, пять зелёных CI.
 Broker-death merged: PR #391, `37eac4a`, пять зелёных CI.
-Текущий backend-блок — `codex/etw-consent-gates`; проверь финальный статус PR.
+Consent probes merged: PR #392, `7646463`, пять зелёных CI.
+Текущий backend-блок — `codex/etw-consent-live-evidence`; проверь финальный статус PR.
 Эта инструкция и последний Session handoff в `memory-bank/progress.md` — точка
 продолжения. Сначала проверь текущую ветку и состояние файлов: пользователь может
 принести другие изменения после записи этого контекста.
@@ -153,9 +154,18 @@ collector тем же пользователем. Новый consent-broker за
 Отчёты: `X:/tmp/aegis-etw-consent-check-20260908-v3/result.json` и
 `X:/tmp/aegis-etw-consent-regression-20260908-v2/result.json`; агрегат с 17 LF-хешами —
 `docs/recon/evidence/etw-lifecycle-home-26200-consent-check.json`. ETW не вызывался;
-все native stats null, процессов стенда после проверки нет. Живые refusal/late
-ещё не выполнены: задан вопрос о готовности вручную пройти диалоги, ответа пока нет.
+все native stats null, процессов стенда после проверки нет.
 Не выдавай эти normal-token проверки за реальные UAC-исходы.
+
+После «далее» запущен настоящий `uac-refusal`, но вместо отказа сборщик запустился
+через 1567.0161 мс. Тест корректно НЕ прошёл (exitCode 2): early-consent, native
+error null, authorize false, identity verified, child exit 2. Независимые before
+и after вернули 4201, witness exit 0; процессов стенда не осталось. Полный отчёт
+`X:/tmp/aegis-etw-refusal-20260908/result.json`, агрегат с 17 LF-хешами и совпадающими
+с normal-check binaries — `docs/recon/evidence/etw-lifecycle-home-26200-consent-live.json`.
+Это не подтверждает, видел ли человек диалог или нажимал «Да». UAC UI не
+автоматизировался, политики не менялись. Задан вопрос, появились ли оба окна;
+ответа пока нет. Повтор/late ждут уточнения. Реальный отказ и late не доказаны.
 
 `docs/roadmap/etw-consent-suspend.md` содержит точные команды и отдельный проект
 suspend-проверки. `uac-suspend` пока нет: нужны power observer, явные фазы witness,

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1866,3 +1866,28 @@ connection was added. E1/E2 and protected collector-crash recovery remain open.
 
 Separate user edits appeared in `.codex/agents/ui-designer.toml` and
 `memory-bank/fancy-ui-plan.md`; preserve them outside this backend commit.
+
+## Session handoff — actual consent attempt returned early approval (2026-09-08)
+
+Consent probes merged as PR #392, `7646463`, with five green CI contexts. The user
+said continue. The agent instructed witness Yes / collector No and launched the
+prepared uac-refusal command. The result was early-consent after 1567.0161 ms,
+not a native refusal: child launched, held identity verified, exit 2, native error
+null, authorization false. The command correctly failed with report exitCode 2.
+Authenticated independent before/after queries returned absence 4201 with null
+counters; witness exit 0 and broker exit 0. No harness processes remained.
+
+The full raw report is `X:/tmp/aegis-etw-refusal-20260908/result.json`. Aggregate
+`docs/recon/evidence/etw-lifecycle-home-26200-consent-live.json` retains its hash,
+full result and 17 canonical LF source hashes matching merged `7646463`. Apphost
+and assembly hashes match the previous normal-token check evidence exactly.
+No source or binary changes were needed. The failed expected refusal must never
+be counted as a passed live gate. The report does not establish whether a human
+saw or accepted the dialogs. No security UI automation or UAC policy change occurred.
+
+An asynchronous question asks whether both dialogs appeared or were accidentally
+approved. No response yet; repeated refusal and late-consent launches wait for
+that clarification. Sleep was not attempted. The next implementation prerequisite
+for suspend remains a bounded power observer and suitable phases/lifetimes.
+Branch: `codex/etw-consent-live-evidence`; inspect its final PR/CI/merge status.
+User UI-plan and ui-designer settings edits remain separate and preserved.

--- a/sidecar/etw-lifecycle/README.md
+++ b/sidecar/etw-lifecycle/README.md
@@ -220,6 +220,13 @@ and 17 canonical LF source hashes. No harness processes remained. Actual human
 refusal, late UAC and suspend are pending; their prepared commands/design do not
 constitute live evidence.
 
+A subsequent [actual refusal attempt](../../docs/recon/evidence/etw-lifecycle-home-26200-consent-live.json)
+returned early approval after 1.567 seconds and correctly failed acceptance.
+The collector received no authorization and exited 2; independent queries before
+and after showed absence 4201, and no harness processes remained. The report does
+not identify a human dialog action. Actual refusal and late consent remain open;
+see the [recorded attempt](../../docs/roadmap/etw-consent-suspend.md#recorded-live-attempt).
+
 Local checks also include `dotnet format ... whitespace --verify-no-changes`,
 Release build and the normal AEGIS checks. Existing GitHub CI does not compile or
 run this separate C# harness; its five green contexts cannot replace Windows tests.


### PR DESCRIPTION
The first actual uac-refusal attempt returned an elevated process after 1567.0161 ms instead of native refusal. Preserve the failed report and its exact classification: early-consent, no authorization, verified child identity and exit 2, independent absence 4201 before/after, witness exit 0. Refusal and late-consent gates remain open; the report cannot identify a human dialog action.

The aggregate preserves the raw-report hash, full result and 17 canonical LF source hashes matching the merged consent harness. Binary hashes match the previous normal-token checks. No harness process remained. Update the procedure and handoff to require clarification about the dialogs before repeating. No runtime code, UAC policy or UI automation changes.

Validation: report contents/hashes, source/build correspondence and 54 local links verified; format, renderer build and lint passed. Existing UI-plan and designer-settings edits are excluded.
