### PR TITLE
feat(etw): add bounded suspend lifecycle harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ src/main/.mutants/
 .DS_Store
 Thumbs.db
 *.ps1
+!/sidecar/etw-lifecycle/Capture-SuspendContext.ps1
 cdp_*.js
 # Local assistant tooling — kept on disk, not part of the public tree
 .claude/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,7 +91,8 @@ The dependency is those observations, not the absence of a Windows host.
    after exit. It retains unknown final counters and grants no orphan-stop authority.
    [Controlled refusal/late-UAC probes](docs/roadmap/etw-consent-suspend.md) passed
    actual refusal and approval after 14.13 seconds; both independently observed
-   session absence. **Next: implement the suspend mode and collect evidence**, plus protected
+   session absence. The dedicated suspend mode now has bounded native power
+   observations and synthetic process checks. **Next: manual sleep/wake evidence**, plus protected
    ownership/recovery design for collector crash. No file provider or Electron
    connection; E1/E2 remain incomplete.
 

--- a/docs/recon/evidence/etw-lifecycle-home-26200-suspend-check.json
+++ b/docs/recon/evidence/etw-lifecycle-home-26200-suspend-check.json
@@ -1,0 +1,432 @@
+{
+  "schema": 1,
+  "scope": "Standalone suspend mode with synthetic power pair and real normal-token processes; actual native observer registration only",
+  "sourceBaseCommit": "54f22ee3d358ad67120a3833681bf1351f7f52cf",
+  "sourceCanonicalLfSha256": {
+    "Broker.cs": "B810413E66A70977395A547E4CA975C4FFE849D9F5E0F102B71980FC10734B18",
+    "BrokerDeath.cs": "FAB1D4E8102C115898156BE6B3C3FBC0BA9D9425AF30DDD383EB09C0829E36AC",
+    "Capture-SuspendContext.ps1": "DB263D00D905057AF66FCFE68F8CD729B401A52A4D3308F365A298A1A4B421EC",
+    "ConsentBroker.cs": "3BB1FA8403721AB641CFB9DA18B05E2889807EFB05283255176BE2CB8A609462",
+    "ConsentScenarios.cs": "2C801F3B908279AD121A8796D6990396AAE4704FB4A7F741F43469B8FE0D7385",
+    "ConsentTests.cs": "EE9549B3A276F653628D63E3E843E563BE8BF18B76A6447629C941CCFEE999BB",
+    "EtwLifecycle.csproj": "22FE8D550AD99BD026CB9448AAF5F0B83F908EDC977B75FBFD2A15E36B1375F1",
+    "FinalEvidence.cs": "0127B1A626094FB22D2FC60057F17C1CB194D2B1F5E8577BA24BA40AC768F564",
+    "ObservedProcess.cs": "1326CF02909ED85449AB266F8E4C51D89C41A6784B3906E2CA9DF32177A59FCA",
+    "OwnedTrace.cs": "E2D2BCDCBF8F05D9BF6BE765D93017A8F1A89B2FC41C10605661F9FC7BD58CAD",
+    "Peer.cs": "6751FE30C9AFCE6CBF0B2DBCEA59F334EF4E294E187932A4079A3C499C129016",
+    "PowerObserver.cs": "13E22D51A74CEBCD9E5E2BDBD6E32E2B381527DF39CCF7B0DDADEC2C0CCF813A",
+    "PowerTests.cs": "46B143FBD52081C95175F8E4365DF5AD76516E330894C7DAFB8F9DD205D8674C",
+    "Program.cs": "401E2EE616C3D6EACC00363741BF318461A1F09D852EB7294EC5E2BEB393BDEB",
+    "Scenarios.cs": "045D04950B792E15957B8E8462CB455DFE2FA022F766482B19C09E94E1E75D53",
+    "Security.cs": "19FDE5ACE53914B1E8804B9716A2D041D794E09B273BD8ACC385405BA6FADC96",
+    "SelfTest.cs": "9CD415A209A22562CAC7057196580F6CA5211F19CF8141FAE597EA5589AD60F6",
+    "SuspendScenario.cs": "55133D99BC7B7E0F154D3E2E2E7BDBC95EBFF240F1807E0323BD3258676B9C24",
+    "Wire.cs": "6AB1B7D8DE5502E7D19E51CF2394DCDF872081FD8CF03D406517509663A6C5BE",
+    "Witness.cs": "85B505582CFF9FFBF3B36658BA51930DE452D5CA9AE9D3CEB7331A87E7CADB57",
+    "WitnessTests.cs": "4EC6A152EE01D7CD45D2BD5E3D0B35F3AF5E9D7998AF1480033F954A5C78E895"
+  },
+  "selfTests": {
+    "passed": 29,
+    "actualNativePowerRegistrationAndUnregistration": true,
+    "nativePowerTransitionObserved": false,
+    "nativeEtwCalls": false,
+    "cancellationAfterArmingStopsNormalCollector": true
+  },
+  "noHarnessProcessesAfterChecks": true,
+  "actualSuspendVerified": false,
+  "limitations": [
+    "Synthetic type 4/18 events cannot pass a live result. Registration success alone does not establish delivery on real sleep.",
+    "All ETW statistics in these process checks remain null; no session or provider was enabled.",
+    "Host capability snapshot exposes connected S0 Modern Standby; S3 and hibernation are unavailable. Capability is not evidence of an actual transition.",
+    "Configured .NET deadlines do not establish their behavior across a real sleep interval. Native callbacks do not stop ETW or block on I/O.",
+    "Production supervisor epochs, other power states/hosts, alternate credentials and collector-crash recovery remain open."
+  ],
+  "reports": [
+    {
+      "reportFile": "aegis-etw-suspend-check-20260908-v3/result.json",
+      "reportSha256": "F4D94CBB316CAED21924454D57FF4FF63569A1C6637EDA9A8048C88A75130554",
+      "report": {
+        "schema": 2,
+        "experiment": "etw-lifecycle",
+        "mode": "check-suspend",
+        "liveEmptySession": false,
+        "nativeQueryEnabled": false,
+        "fileProviderEnabled": false,
+        "started": "2026-09-08T23:53:58.8807641+00:00",
+        "ended": "2026-09-08T23:53:59.5626448+00:00",
+        "os": "Microsoft Windows NT 10.0.26200.0",
+        "framework": "10.0.10",
+        "executableSha256": "7545BA3BD354C7EEDDF036B2AF0C3223949528AF362146CF05F3FE0EEBFC906E",
+        "assemblySha256": "4D318963B229DAC707FEB35F9FA1FAC190AFB2DC158270E75A44F6C0818221A9",
+        "outcomes": [
+          {
+            "Live": false,
+            "Passed": true,
+            "ReadyForSleep": true,
+            "StopRequested": true,
+            "PeerIdentityVerified": true,
+            "PeerExitCode": 0,
+            "BrokerExited": true,
+            "BrokerExitCode": 0,
+            "WitnessAuthenticated": true,
+            "RestrictedAcl": true,
+            "WitnessExitCode": 0,
+            "Preflight": null,
+            "Before": null,
+            "After": null,
+            "Cleanup": {
+              "Live": false,
+              "Scenario": "suspend",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "stop",
+              "PeerExitCode": 0,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Power": {
+              "Synthetic": true,
+              "Registered": false,
+              "Armed": true,
+              "Overflow": false,
+              "Error": null,
+              "UnregisterStatus": null,
+              "Frequency": 10000000,
+              "ArmStamp": {
+                "Type": 0,
+                "Utc": "2026-09-08T23:53:59.4936686+00:00",
+                "MonotonicTicks": 355732114821,
+                "Awake100ns": 355731907177
+              },
+              "Events": [
+                {
+                  "Type": 4,
+                  "Utc": "2026-09-08T23:53:59.4937441+00:00",
+                  "MonotonicTicks": 355732115541,
+                  "Awake100ns": 355731907177
+                },
+                {
+                  "Type": 18,
+                  "Utc": "2026-09-08T23:53:59.4969344+00:00",
+                  "MonotonicTicks": 355732147448,
+                  "Awake100ns": 355731942331
+                }
+              ]
+            },
+            "Error": null,
+            "FailureStage": null
+          }
+        ],
+        "exitCode": 0
+      }
+    },
+    {
+      "reportFile": "aegis-etw-suspend-regression-20260908-v2/result.json",
+      "reportSha256": "242F4CE3E673C6430443379FBCE7F449096346A662D554C41C4FE3CA875355BA",
+      "report": {
+        "schema": 2,
+        "experiment": "etw-lifecycle",
+        "mode": "check",
+        "liveEmptySession": false,
+        "nativeQueryEnabled": false,
+        "fileProviderEnabled": false,
+        "started": "2026-09-08T23:54:02.5804747+00:00",
+        "ended": "2026-09-08T23:54:11.7505672+00:00",
+        "os": "Microsoft Windows NT 10.0.26200.0",
+        "framework": "10.0.10",
+        "executableSha256": "7545BA3BD354C7EEDDF036B2AF0C3223949528AF362146CF05F3FE0EEBFC906E",
+        "assemblySha256": "4D318963B229DAC707FEB35F9FA1FAC190AFB2DC158270E75A44F6C0818221A9",
+        "outcomes": [
+          {
+            "Scenario": "stop",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "stop",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "stop",
+              "PeerExitCode": 0,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "parent-eof",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "parent-eof",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "parent-eof",
+              "PeerExitCode": 0,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "broker-kill",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": null,
+            "Error": null
+          },
+          {
+            "Scenario": "peer-exit",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "peer-exit",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "peer-failed",
+              "PeerExitCode": 7,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "peer-kill",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "peer-kill",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "eof",
+              "PeerExitCode": -1,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": false,
+              "CleanupReceiptReceived": false
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "lease",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "lease",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "lease-expired",
+              "PeerExitCode": 9,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": true,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "blocked-write",
+            "Passed": true,
+            "PeerExited": true,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "blocked-write",
+              "Authenticated": true,
+              "RestrictedAcl": true,
+              "Outcome": "write-timeout",
+              "PeerExitCode": 10,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": false,
+              "CleanupReceiptReceived": true
+            },
+            "Error": null
+          },
+          {
+            "Scenario": "launch-denied",
+            "Passed": true,
+            "PeerExited": false,
+            "BrokerExited": true,
+            "Result": {
+              "Live": false,
+              "Scenario": "launch-denied",
+              "Authenticated": false,
+              "RestrictedAcl": true,
+              "Outcome": "uac-denied",
+              "PeerExitCode": null,
+              "InitialStats": null,
+              "FinalStats": null,
+              "StopAcknowledged": false,
+              "CleanupReceiptReceived": false
+            },
+            "Error": "uac-denied"
+          }
+        ],
+        "exitCode": 0
+      }
+    },
+    {
+      "reportFile": "aegis-etw-suspend-consent-regression-20260908-v2/result.json",
+      "reportSha256": "0372036A63648005C6FAD51289F72B5E29F5C83DDD163BBA16459B69A6A22D48",
+      "report": {
+        "schema": 2,
+        "experiment": "etw-lifecycle",
+        "mode": "check-consent",
+        "liveEmptySession": false,
+        "nativeQueryEnabled": false,
+        "fileProviderEnabled": false,
+        "started": "2026-09-08T23:54:13.4872543+00:00",
+        "ended": "2026-09-08T23:54:14.6576591+00:00",
+        "os": "Microsoft Windows NT 10.0.26200.0",
+        "framework": "10.0.10",
+        "executableSha256": "7545BA3BD354C7EEDDF036B2AF0C3223949528AF362146CF05F3FE0EEBFC906E",
+        "assemblySha256": "4D318963B229DAC707FEB35F9FA1FAC190AFB2DC158270E75A44F6C0818221A9",
+        "outcomes": [
+          {
+            "Live": false,
+            "Scenario": "refusal",
+            "Passed": true,
+            "WitnessAuthenticated": true,
+            "RestrictedAcl": true,
+            "WitnessExitCode": 0,
+            "BrokerExited": true,
+            "BrokerExitCode": 0,
+            "Result": {
+              "Live": false,
+              "Scenario": "refusal",
+              "Outcome": "uac-denied",
+              "RestrictedAcl": true,
+              "ExpiredBeforeReturn": false,
+              "LaunchReturned": true,
+              "ChildLaunched": false,
+              "ChildIdentityVerified": false,
+              "ChildExitCode": null,
+              "NativeError": 1223,
+              "InjectedDenial": true,
+              "AuthorizationSent": false,
+              "LaunchElapsedMilliseconds": 0.4782,
+              "Error": null
+            },
+            "Before": null,
+            "After": null,
+            "Error": null
+          },
+          {
+            "Live": false,
+            "Scenario": "late",
+            "Passed": true,
+            "WitnessAuthenticated": true,
+            "RestrictedAcl": true,
+            "WitnessExitCode": 0,
+            "BrokerExited": true,
+            "BrokerExitCode": 0,
+            "Result": {
+              "Live": false,
+              "Scenario": "late",
+              "Outcome": "late-consent",
+              "RestrictedAcl": true,
+              "ExpiredBeforeReturn": true,
+              "LaunchReturned": true,
+              "ChildLaunched": true,
+              "ChildIdentityVerified": true,
+              "ChildExitCode": 2,
+              "NativeError": null,
+              "InjectedDenial": false,
+              "AuthorizationSent": false,
+              "LaunchElapsedMilliseconds": 162.8784,
+              "Error": null
+            },
+            "Before": null,
+            "After": null,
+            "Error": null
+          }
+        ],
+        "exitCode": 0
+      }
+    },
+    {
+      "reportFile": "aegis-etw-suspend-death-regression-20260908-v2/result.json",
+      "reportSha256": "F1339DB176B9AF4A36FA39E4C96B0E0B2D7B4EACF577968DA2619B18664A5E79",
+      "report": {
+        "schema": 2,
+        "experiment": "etw-lifecycle",
+        "mode": "check-broker-death",
+        "liveEmptySession": false,
+        "nativeQueryEnabled": false,
+        "fileProviderEnabled": false,
+        "started": "2026-09-08T23:54:16.3958182+00:00",
+        "ended": "2026-09-08T23:54:17.0528204+00:00",
+        "os": "Microsoft Windows NT 10.0.26200.0",
+        "framework": "10.0.10",
+        "executableSha256": "7545BA3BD354C7EEDDF036B2AF0C3223949528AF362146CF05F3FE0EEBFC906E",
+        "assemblySha256": "4D318963B229DAC707FEB35F9FA1FAC190AFB2DC158270E75A44F6C0818221A9",
+        "outcomes": [
+          {
+            "Live": false,
+            "Passed": true,
+            "BrokerKilled": true,
+            "BrokerExited": true,
+            "PeerIdentityVerified": true,
+            "PeerExitCode": 0,
+            "WitnessAuthenticated": true,
+            "RestrictedAcl": true,
+            "WitnessExitCode": 0,
+            "Before": null,
+            "After": null,
+            "Error": null,
+            "FailureStage": null
+          }
+        ],
+        "exitCode": 0
+      }
+    }
+  ],
+  "powerContext": {
+    "reportFile": "aegis-etw-suspend-check-20260908-v3/power-context.json",
+    "reportSha256": "73EC5E9174BBCBF8736F352B029DC52E5A9B3C7123B1A3D95B786A6CBC795A32",
+    "report": {
+      "schema": 1,
+      "mode": "check-suspend",
+      "reportSha256": "F4D94CBB316CAED21924454D57FF4FF63569A1C6637EDA9A8048C88A75130554",
+      "capturedUtc": "2026-09-08T23:54:00.7898545+00:00",
+      "intervalStartUtc": "2026-09-08T23:53:58.8807641+00:00",
+      "intervalEndUtc": "2026-09-08T23:53:59.5626448+00:00",
+      "availableStatesAtCapture": "В данной системе доступны следующие состояния спящего режима:\r\n    Ждущий режим (Простой S0 для пониженного энергопотребления) С подключением к сети\r\n\r\nСледующие состояния спящего режима недоступны в данной системе:\r\n    Ждущий режим (S1)\r\n\tСистемное встроенное ПО не поддерживает этот ждущий режим.\r\n\tЭтот ждущий режим отключен, когда поддерживается ждущий режим по питанию S0.\r\n\r\n    Ждущий режим (S2)\r\n\tСистемное встроенное ПО не поддерживает этот ждущий режим.\r\n\tЭтот ждущий режим отключен, когда поддерживается ждущий режим по питанию S0.\r\n\r\n    Ждущий режим (S3)\r\n\tЭтот ждущий режим отключен, когда поддерживается ждущий режим по питанию S0.\r\n\r\n    Гибернация\r\n\tРежим гибернации не включен.\r\n\r\n    Гибридный спящий режим\r\n\tЖдущий режим (S3) недоступен.\r\n\tРежим гибернации недоступен.\r\n\tНизкоуровневая оболочка не поддерживает этот ждущий режим.\r\n\r\n    Быстрый запуск\r\n\tРежим гибернации недоступен.\r\n\r\n",
+      "availableStatesTruncated": false,
+      "powercfgExitCode": 0,
+      "eventQueries": [
+        {
+          "provider": "Microsoft-Windows-Kernel-Power",
+          "status": "no-events",
+          "truncated": false
+        },
+        {
+          "provider": "Microsoft-Windows-Power-Troubleshooter",
+          "status": "no-events",
+          "truncated": false
+        }
+      ],
+      "events": [],
+      "note": "Scoped metadata only; capture-time capabilities do not prove which state the run entered. This file does not upgrade a failed harness report."
+    }
+  }
+}

--- a/docs/roadmap/etw-consent-suspend.md
+++ b/docs/roadmap/etw-consent-suspend.md
@@ -96,39 +96,76 @@ deadline or validate cancellation while a dialog remains pending. Suspend,
 alternate credentials/logons, remote clients, packaging and crash recovery remain
 open. No policy change or security UI automation was used.
 
-## Suspend/resume: procedure design, not a completed experiment
+## Suspend/resume: implemented harness, live transition pending
 
-Do not put the host to sleep using an existing `uac`, `uac-failures` or consent
-command. The current collector has a 25-second lifetime and four-second read
-lease; the witness has two query phases. None records native power transitions.
-A delayed timer or stopped heartbeat alone cannot demonstrate an actual suspend.
-There is no `uac-suspend` command yet.
+Use the new dedicated commands, not `uac`, `uac-failures` or a consent probe:
 
-Prepare a dedicated mode before running this gate:
+```powershell
+& './sidecar/etw-lifecycle/bin/Release/net10.0-windows/EtwLifecycle.exe' check-suspend 'X:/tmp/aegis-etw-suspend-check-new'
+& './sidecar/etw-lifecycle/bin/Release/net10.0-windows/EtwLifecycle.exe' uac-suspend 'X:/tmp/aegis-etw-suspend-uac-new'
+& './sidecar/etw-lifecycle/Capture-SuspendContext.ps1' -ReportDirectory 'X:/tmp/aegis-etw-suspend-uac-new'
+```
 
-1. Add a power-notification observer to the normal coordinator, with a bounded
-   event record. Capture suspend/resume notifications, wall-clock and monotonic
-   timestamps, plus unbiased interrupt time; do not infer a particular sleep
-   state from the notification alone. Preserve the host's available sleep states
-   and scoped System-log transition metadata without exporting the full log.
-2. Extend the witness with an explicit, bounded phase sequence for preflight
-   absence, ready presence and final absence. All consent and authentication must
-   complete before displaying **ready for manual sleep**. Choose test-specific
-   lifetime/deadline behavior that survives the intended sleep interval; record
-   the actual timer behavior across resume instead of assuming all clocks agree.
-3. In this isolated mode, treat a power transition as a terminal gap. Revoke the
-   old launch, attempt its owned-handle stop and require process exits plus final
-   independent absence. Never accept an old delayed `ready`, pong or terminal as
-   a new session. Missing final counters remain null. Do not auto-restart or
-   remove an occupied session. Power callbacks must not block on native stop.
+The normal-token check injects a clearly marked type 4/18 pair and runs real
+broker/collector/witness processes without ETW or sleep. It passes with synthetic
+power evidence only in check mode. A native observer rejects injection.
 
-After those prerequisites and normal-token tests pass, on a host the user is
-ready to suspend: launch the dedicated mode, confirm ready/presence, manually
-sleep and wake the computer, then inspect the saved transition evidence and
-cleanup. Repeat only for a different question: short sleep, sleep longer than
-the lease, and hibernation where supported. Distinguish each observed power
-state and retain failures. A wake without a recorded transition pair is
-incomplete; clean absence without transition evidence is only cleanup evidence.
+The live command registers a native callback, then requests two UAC approvals:
+query-only witness and empty-session collector. Approve **both**, using the same
+account. After the exact **READY FOR MANUAL SLEEP** message, use Windows **Sleep**,
+wait about twenty seconds and wake the computer. This first run requires human
+readiness because it affects the host. The harness never invokes sleep, changes
+power policy, disables hibernation or creates a wake task. A failed command retains
+its report. Run the context script after completion, including failure.
+
+The extended witness role accepts exactly `preflight`, `before`, `after`: absence
+before collector launch, presence after readiness, absence after cleanup. The
+existing role still accepts only `before`, `after`. Both use the authenticated
+`etw-witness/1` transport; profile selection is fixed at process launch. No start,
+stop, arbitrary session name or general command was added to the witness.
+
+`PowerObserver` records at most 16 events. Each contains type, UTC, monotonic ticks
+and unbiased interrupt time; the snapshot includes clock frequency and arm stamp.
+Callbacks only capture and signal asynchronous continuations. A pre-arm suspend,
+overflow, callback failure, missing native registration/unregistration, backward
+clock ordering, missing/reversed/repeated transition pair or synthetic live
+evidence cannot pass. The required sequence is suspend 4, automatic resume 18,
+optionally followed by user-resume 7. UTC adjustments do not establish ordering.
+The static native delegate stays rooted; a late callback cannot dereference a
+freed managed object. Failed unregistration is reported and retains the small
+subscription allocation until process exit.
+
+Once armed, suspend triggers a single existing owned-stop request. No restart or
+second launch occurs. Acceptance requires the observed pair, held child identity
+and exit 0, authenticated primary stop and separate cleanup receipt with known
+final counters, broker exit 0 and independent absence with witness exit 0. A lost
+receipt remains incomplete even if absence succeeds. Cleanup on cancellation or
+failure closes normal broker stdin and, if needed, terminates only that broker;
+it never force-kills the elevated collector. Incomplete cleanup preserves failure.
+
+Only the suspend role uses broker/collector lifetime settings of 600 seconds,
+witness 720 seconds and coordinator 480 seconds. Per-read lease remains four
+seconds; pings, write and final-query bounds remain short. These are configured
+.NET deadlines, not proven wall-clock limits across sleep or synchronous native
+calls. Other scenarios retain their original lifetimes. If resume exposes a lease
+or receipt race, the strict result remains failed; do not substitute an ordinary
+stop result for missing power evidence.
+
+The context script records capture-time `powercfg /a`, capped at 8192 characters,
+and at most 64 scoped System events per provider during the report interval:
+Kernel-Power 42/107/506/507 and Power-Troubleshooter 1. Only provider, event ID,
+timestamp and selected numeric state/reason fields are retained. No full event
+messages, user SIDs, device paths or unrelated log are exported. Query failures,
+empty results and truncation are explicit; the script never upgrades acceptance.
+
+The [normal-check evidence](../recon/evidence/etw-lifecycle-home-26200-suspend-check.json)
+records 29 self-tests, including real native registration/unregistration and
+actual normal-token collector cleanup after cancellation when armed, and
+twelve normal-token cases with matching binaries. The power pair is synthetic;
+all ETW statistics remain null. The Home host advertises connected S0 Modern
+Standby; S3 and hibernation are unavailable. Capabilities do not prove an actual
+transition. No real sleep has been recorded yet. Further states/hosts and timer
+behavior across real sleep remain open.
 
 The production supervisor must start a new epoch after resume and report the gap;
 that integration and its old-message rejection tests remain separate from this
@@ -143,3 +180,7 @@ has a documented sleep-to-hibernation exception. The
 [unbiased interrupt-time clock](https://learn.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryunbiasedinterrupttime)
 excludes sleep and hibernation. These API facts guide the proposed measurements;
 no current result proves suspend behavior of this harness's .NET timers.
+The implementation uses the direct callback form of
+[PowerRegisterSuspendResumeNotification](https://learn.microsoft.com/en-us/windows/win32/api/powerbase/nf-powerbase-powerregistersuspendresumenotification)
+and checks
+[PowerUnregisterSuspendResumeNotification](https://learn.microsoft.com/en-us/windows/win32/api/powerbase/nf-powerbase-powerunregistersuspendresumenotification).

--- a/docs/roadmap/etw-sensor-design.md
+++ b/docs/roadmap/etw-sensor-design.md
@@ -445,7 +445,7 @@ return, and never sends authorization. Normal-token refusal/late checks and thre
 additional self-tests pass; these do not count as human UAC refusal or late consent.
 Live commands require independent native absence before/after and explicit launch
 outcomes. The ordinary broker timeout is unchanged. Suspend still needs a separate
-power observer and suitable lifetimes before a meaningful live test can run.
+power observer and suitable lifetimes; that implementation is described below.
 
 Subsequent [actual consent evidence](../recon/evidence/etw-lifecycle-home-26200-consent-verified.json)
 passes refusal (Windows error 1223, no child launched) and delayed approval
@@ -453,3 +453,12 @@ passes refusal (Windows error 1223, no child launched) and delayed approval
 independently query absence 4201 before and after. Neither broker authorizes ETW;
 all helper processes exit. This verifies the dedicated negative broker on the
 same-account host; ordinary launch deadlines and the other E1/E2 gates are unchanged.
+
+The dedicated [suspend mode](etw-consent-suspend.md#suspendresume-implemented-harness-live-transition-pending)
+now registers bounded native callbacks, uses a preflight/presence/absence witness,
+requests owned stop on suspend and requires a real ordered power pair plus cleanup
+for live acceptance. Twenty-nine self-tests and twelve normal-token cases passed;
+the latter use synthetic power evidence, not real sleep. Native registration is
+verified, while actual power transitions and .NET timer behavior across them remain
+open. Only this role extends process lifetime settings; no auto-sleep or restart
+is implemented, and no production supervisor or Electron wiring is added.

--- a/memory-bank/next-session.md
+++ b/memory-bank/next-session.md
@@ -1,6 +1,6 @@
 # AEGIS — старт следующего чата
 
-Обновлено 2026-09-08 после успешных реальных отказа UAC и позднего подтверждения.
+Обновлено 2026-09-08 после реализации отдельного suspend-стенда без реального сна.
 B2: PR #384, `f2f1ac4`; B3: PR #385, `cc47212`, оба merged с пятью зелёными CI.
 B4: PR #386, `01bf403`; первый UAC stop: PR #387, `1f7cd82`, оба merged с пятью
 зелёными CI. Elevated cleanup merged: PR #388, `75c943d`, пять зелёных CI.
@@ -9,7 +9,8 @@ B4: PR #386, `01bf403`; первый UAC stop: PR #387, `1f7cd82`, оба merged
 Broker-death merged: PR #391, `37eac4a`, пять зелёных CI.
 Consent probes merged: PR #392, `7646463`, пять зелёных CI.
 Первая неуспешная live-попытка сохранена: PR #393, `045f2b0`, пять зелёных CI.
-Текущий backend-блок — `codex/etw-consent-verified`; проверь финальный статус PR.
+Реальные refusal/late прошли: PR #394, `54f22ee`, пять зелёных CI.
+Текущий backend-блок — `codex/etw-suspend-harness`; проверь финальный статус PR.
 Эта инструкция и последний Session handoff в `memory-bank/progress.md` — точка
 продолжения. Сначала проверь текущую ветку и состояние файлов: пользователь может
 принести другие изменения после записи этого контекста.
@@ -184,12 +185,40 @@ Apphost/assembly совпали с normal-token проверками. Код и 
 Диагностика `X:/tmp/aegis-uac-no-dialog-diagnostic-20260908.md` — более ранняя
 промежуточная запись; не возобновлять из неё поиски отсутствующих окон автоматически.
 
-`docs/roadmap/etw-consent-suspend.md` содержит точные команды и отдельный проект
-suspend-проверки. `uac-suspend` пока нет: нужны power observer, явные фазы witness,
-подходящие lifetimes и доказательство реального перехода питания. Не отправляй
-компьютер в сон существующим 25-секундным сценарием и не засчитывай задержку таймера
-как sleep. Следующие задачи — реализация suspend mode и реальные переходы питания,
-и защищённое владение/восстановление при collector crash. E1/E2 ещё требуют
+**Suspend-режим реализован; пользователь явно отложил настоящий сон.**
+На вопрос о готовности ответил «Сон проверим позже». Не запускать live-проверку
+или отправку компьютера в сон без нового указания о готовности.
+`check-suspend` проверяет реальные normal-token процессы с явной синтетической
+парой событий питания; `uac-suspend` регистрирует native callback и требует
+реального suspend 4 → automatic resume 18. В обоих UAC нажать «Да», дождаться
+READY FOR MANUAL SLEEP, вручную выбрать Windows «Сон», через ~20 секунд разбудить.
+`Capture-SuspendContext.ps1 -ReportDirectory <run>` после окончания сохраняет
+powercfg /a и ограниченные метаданные событий System, включая неуспешные прогоны.
+В текущем хосте доступен connected S0 Modern Standby; S3/гибернация недоступны.
+
+`PowerObserver` хранит максимум 16 событий с UTC/QPC/unbiased clock, не делает
+ETW/I/O в callback, отвергает подстановку событий в native-режиме и проверяет
+снятие подписки. Witness-suspend использует preflight/before/after; старый witness
+оставил before/after. Suspend-роль: broker/peer 600 с, witness 720 с, coordinator
+480 с; lease 4 с и короткие I/O bounds сохранены. Реальное поведение .NET timers
+во сне пока не измерено. Запрос owned stop отправляется после suspend; приёмка
+требует power pair + primary/cleanup receipts + final counters + independent
+absence + exits. Нет restart, auto-sleep или elevated kill.
+
+29 self-test и 12 normal-token случаев прошли на одинаковых финальных binaries.
+Проверена настоящая регистрация/снятие native power callback без сна; переходы в
+процессном сценарии синтетические, ETW не вызывался, native stats null. Тест отмены
+после ready также дождался normal collector/broker/witness exit 0. Процессов нет.
+Итоги: `X:/tmp/aegis-etw-suspend-check-20260908-v3/result.json` и `power-context.json`;
+регрессии — `aegis-etw-suspend-regression-20260908-v2`,
+`aegis-etw-suspend-consent-regression-20260908-v2`,
+`aegis-etw-suspend-death-regression-20260908-v2` под `X:/tmp/`.
+Агрегат `docs/recon/evidence/etw-lifecycle-home-26200-suspend-check.json` содержит
+21 LF-хеш исходников (включая ps1), четыре полных отчёта и power context. Скрипт
+контекста проверен и в Windows PowerShell 5.1. Точные шаги и ограничения —
+`docs/roadmap/etw-consent-suspend.md`. Следующие задачи — ручной sleep, когда
+пользователь будет готов, и защищённое владение/восстановление при collector crash.
+E1/E2 ещё требуют
 других credentials/logon и remote clients.
 Автоудаления orphan нет; смерть elevated collector может оставить сессию.
 Не выдавай normal-token kill за проверку очистки ETW. CI не собирает этот C# проект.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1931,3 +1931,62 @@ measurements, normal-stop, graceful failures, broker death or these consent case
 Branch: `codex/etw-consent-verified`; inspect final PR/CI/merge status. The separate
 user edits in `.codex/agents/ui-designer.toml` and `memory-bank/fancy-ui-plan.md`
 remain outside this evidence/docs block.
+
+## Session handoff — bounded suspend harness prepared; real sleep deferred (2026-09-08)
+
+Actual refusal and delayed approval merged as PR #394, `54f22ee`, with five green
+CI contexts. The user said go next. This block implements the dedicated suspend
+mode, native power callback observer, extended witness profile, check-only fixtures,
+regressions and scoped power-context capture. Branch: `codex/etw-suspend-harness`;
+inspect final PR/CI/merge status. No frontend or Electron integration was changed.
+
+PowerObserver registers PowrProf's callback with DEVICE_NOTIFY_CALLBACK. The native
+delegate remains rooted and callbacks only record bounded observations and signal
+asynchronous continuations. Max 16 events; UTC, monotonic ticks/frequency and
+unbiased interrupt time; overflow/error/pre-arm suspend invalidate evidence.
+Acceptance requires native registration and successful unregistration, ordered
+type 4 then 18, with optional subsequent 7. Synthetic injection is check-only.
+Failed unregister retains the small native allocation until process exit; removed
+contexts are safely ignored by the static callback.
+
+The witness-suspend role uses preflight absence, before presence, after absence,
+with the same protected pipe/mutual process identity and query-only authority.
+The existing witness keeps its old two-phase sequence. Only suspend extends
+broker/collector lifetimes to 600 seconds, witness to 720, coordinator to 480.
+Four-second lease and short write/query deadlines remain. Real timer behavior
+across sleep is unverified. After native suspend, the coordinator requests owned
+stop and waits for resume, full primary/cleanup receipts, known final counters,
+process exits and independent absence. Missing evidence remains failed. No restart,
+automatic sleep, power policy change, privileged service or elevated kill exists.
+
+Twenty-nine self-tests passed, including real native registration/unregistration,
+invalid pair evidence, storage cap, native injection rejection, wrong witness
+phases/replay and cancellation. A cancellation after arming test actually stops
+its normal collector and observes broker/collector/witness exit 0. Twelve normal
+process scenarios passed with matching final binaries: new synthetic suspend,
+eight old scenarios, two consent cases and broker death. No ETW calls or actual
+power transitions occurred in these checks. No harness processes remained.
+
+Final result folders under X:/tmp: `aegis-etw-suspend-check-20260908-v3`,
+`aegis-etw-suspend-regression-20260908-v2`,
+`aegis-etw-suspend-consent-regression-20260908-v2`,
+`aegis-etw-suspend-death-regression-20260908-v2`. The aggregate
+`docs/recon/evidence/etw-lifecycle-home-26200-suspend-check.json` holds 21 canonical
+LF source hashes, four full reports and power context. C# Release build and formatter
+passed. Capture-SuspendContext.ps1 was checked in Windows PowerShell 5.1 as well
+as pwsh: it preserves the precise report interval, records bounded powercfg /a and
+selected System event metadata, without full event messages, SIDs or device paths.
+A narrow .gitignore exception tracks this one reusable ps1; other ps1 remain ignored.
+
+The host advertises only connected S0 Modern Standby; S3 and hibernation unavailable.
+An asynchronous readiness question was answered **Сон проверим позже**. Actual
+sleep/wake was therefore not launched. Do not turn the host off, suspend it or
+launch the live test until the user indicates readiness. Commands and acceptance
+are in docs/roadmap/etw-consent-suspend.md. Both UAC prompts need Yes, then wait
+for READY, manual Windows Sleep and wake after about twenty seconds; collect
+power-context.json afterward even on failure. Actual suspend/cleanup, other power
+states, production epochs and collector-crash recovery remain open. Do not repeat
+the completed B1 sets or earlier successful live consent/cleanup tests without cause.
+
+User edits in .codex/agents/ui-designer.toml and memory-bank/fancy-ui-plan.md remain
+separate and must be preserved outside this backend commit.

--- a/sidecar/etw-lifecycle/Broker.cs
+++ b/sidecar/etw-lifecycle/Broker.cs
@@ -13,9 +13,9 @@ internal static class Broker
     internal static async Task<int> Run(string[] args)
     {
         if (args.Length != 3 || args[1] is not ("check" or "live") ||
-            args[2] is not ("stop" or "parent-eof" or "broker-kill" or "peer-exit" or "peer-kill" or "lease" or "blocked-write" or "launch-denied")) throw new ArgumentException();
+            args[2] is not ("stop" or "parent-eof" or "broker-kill" or "peer-exit" or "peer-kill" or "lease" or "blocked-write" or "launch-denied" or "suspend")) throw new ArgumentException();
         bool live = args[1] == "live";
-        if (Security.Current().Elevated || (live && args[2] is not ("stop" or "parent-eof" or "broker-kill" or "lease" or "blocked-write"))) return 3;
+        if (Security.Current().Elevated || (live && args[2] is not ("stop" or "parent-eof" or "broker-kill" or "lease" or "blocked-write" or "suspend"))) return 3;
         string scenario = args[2], id = Guid.NewGuid().ToString("N");
         using var server = Security.Server(id);
         string receiptId = Guid.NewGuid().ToString("N");
@@ -23,7 +23,7 @@ internal static class Broker
         bool acl = Security.RestrictedAcl(server) && Security.RestrictedAcl(receipt);
         if (!acl) throw new UnauthorizedAccessException();
         var self = Security.Current();
-        string fault = scenario == "peer-exit" ? "exit" : scenario == "blocked-write" ? "flood" : "normal";
+        string fault = scenario == "peer-exit" ? "exit" : scenario == "blocked-write" ? "flood" : scenario == "suspend" ? "power" : "normal";
         var info = Program.Child("peer", args[1], id, self.Pid.ToString(CultureInfo.InvariantCulture), self.Birth.ToString(CultureInfo.InvariantCulture), fault, receiptId);
         if (live)
         {
@@ -46,7 +46,7 @@ internal static class Broker
         }
         using var peer = launched;
         var identity = Security.Observe(peer);
-        using var session = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        using var session = new CancellationTokenSource(TimeSpan.FromSeconds(scenario == "suspend" ? 600 : 20));
         bool authenticated = false, stopped = false, cleanup = false;
         string outcome = "peer-failed";
         TraceStats? initial = null, final = null;

--- a/sidecar/etw-lifecycle/Capture-SuspendContext.ps1
+++ b/sidecar/etw-lifecycle/Capture-SuspendContext.ps1
@@ -1,0 +1,49 @@
+param([Parameter(Mandatory = $true)][string] $ReportDirectory)
+$ErrorActionPreference = 'Stop'
+$runDirectory = [IO.Path]::GetFullPath($ReportDirectory)
+$run = Get-Content -LiteralPath (Join-Path $runDirectory 'result.json') -Raw | ConvertFrom-Json
+if ($run.mode -notin @('check-suspend', 'uac-suspend')) { throw 'A suspend-mode report is required.' }
+$fromOffset = if ($run.started -is [DateTime] -or $run.started -is [DateTimeOffset]) { [DateTimeOffset]$run.started } else { [DateTimeOffset]::Parse($run.started) }
+$untilOffset = if ($run.ended -is [DateTime] -or $run.ended -is [DateTimeOffset]) { [DateTimeOffset]$run.ended } else { [DateTimeOffset]::Parse($run.ended) }
+$from = $fromOffset.LocalDateTime
+$until = $untilOffset.LocalDateTime
+$events = @()
+$queries = @()
+foreach ($provider in @('Microsoft-Windows-Kernel-Power', 'Microsoft-Windows-Power-Troubleshooter')) {
+    $ids = if ($provider -eq 'Microsoft-Windows-Kernel-Power') { @(42, 107, 506, 507) } else { @(1) }
+    try {
+        $found = @(Get-WinEvent -FilterHashtable @{ LogName = 'System'; ProviderName = $provider; Id = $ids; StartTime = $from; EndTime = $until } -MaxEvents 65 -ErrorAction Stop)
+        $queries += [ordered]@{ provider = $provider; status = 'ok'; truncated = ($found.Count -gt 64) }
+        foreach ($event in @($found | Select-Object -First 64)) {
+            $xml = [xml]$event.ToXml()
+            $fields = [ordered]@{}
+            foreach ($field in @($xml.Event.EventData.Data)) {
+                if ($field.Name -in @('TargetState', 'EffectiveState', 'Reason') -and $field.InnerText -match '^[0-9]{1,10}$') {
+                    $fields[$field.Name] = $field.InnerText
+                }
+            }
+            $events += [ordered]@{ provider = $provider; id = $event.Id; utc = $event.TimeCreated.ToUniversalTime().ToString('o'); numericFields = $fields }
+        }
+    } catch {
+        $status = if ($_.FullyQualifiedErrorId -like 'NoMatchingEventsFound*') { 'no-events' } else { 'query-failed' }
+        $queries += [ordered]@{ provider = $provider; status = $status; truncated = $false }
+    }
+}
+$powerText = (& (Join-Path ([Environment]::SystemDirectory) 'powercfg.exe') /a | Out-String)
+$powerExit = $LASTEXITCODE
+$context = [ordered]@{
+    schema = 1; mode = $run.mode; reportSha256 = (Get-FileHash -LiteralPath (Join-Path $runDirectory 'result.json') -Algorithm SHA256).Hash
+    capturedUtc = [DateTimeOffset]::UtcNow.ToString('o')
+    intervalStartUtc = $fromOffset.ToUniversalTime().ToString('o'); intervalEndUtc = $untilOffset.ToUniversalTime().ToString('o')
+    availableStatesAtCapture = $powerText.Substring(0, [Math]::Min(8192, $powerText.Length))
+    availableStatesTruncated = ($powerText.Length -gt 8192); powercfgExitCode = $powerExit
+    eventQueries = $queries; events = $events
+    note = 'Scoped metadata only; capture-time capabilities do not prove which state the run entered. This file does not upgrade a failed harness report.'
+}
+$destination = Join-Path $runDirectory 'power-context.json'
+$stream = [IO.File]::Open($destination, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write)
+try {
+    $bytes = [Text.Encoding]::UTF8.GetBytes(($context | ConvertTo-Json -Depth 12))
+    $stream.Write($bytes, 0, $bytes.Length)
+} finally { $stream.Dispose() }
+Write-Output "Saved scoped power context: $destination"

--- a/sidecar/etw-lifecycle/Peer.cs
+++ b/sidecar/etw-lifecycle/Peer.cs
@@ -8,7 +8,7 @@ internal static class Peer
     internal static async Task<int> Run(string[] args)
     {
         if (args.Length != 7 || args[1] is not ("check" or "live") ||
-            args[5] is not ("normal" or "exit" or "flood")) throw new ArgumentException();
+            args[5] is not ("normal" or "exit" or "flood" or "power")) throw new ArgumentException();
         bool live = args[1] == "live";
         if (live && args[5] == "exit") throw new ArgumentException();
         if (Security.Current().Elevated != live) return 3;
@@ -21,7 +21,7 @@ internal static class Peer
         if (receiptId == id) throw new InvalidDataException();
         using var receipt = Security.Client(receiptId);
         Security.Verify(receipt, parent, birth, false, false);
-        using var lifetime = new CancellationTokenSource(TimeSpan.FromSeconds(25));
+        using var lifetime = new CancellationTokenSource(TimeSpan.FromSeconds(args[5] == "power" ? 600 : 25));
         using var ownerGone = new CancellationTokenSource();
         using var io = CancellationTokenSource.CreateLinkedTokenSource(lifetime.Token, ownerGone.Token);
         var watch = Watch(parent, ownerGone, lifetime.Token);

--- a/sidecar/etw-lifecycle/PowerObserver.cs
+++ b/sidecar/etw-lifecycle/PowerObserver.cs
@@ -1,0 +1,135 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Aegis.EtwLifecycle;
+
+internal sealed record PowerStamp(uint Type, DateTimeOffset Utc, long MonotonicTicks, ulong Awake100ns);
+internal sealed record PowerRecord(bool Synthetic, bool Registered, bool Armed, bool Overflow,
+    string? Error, uint? UnregisterStatus, long Frequency, PowerStamp? ArmStamp, PowerStamp[] Events);
+
+// Callback work is bounded recording/signalling only. It never stops ETW or waits for I/O.
+internal sealed class PowerObserver : IDisposable
+{
+    private readonly object gate = new();
+    private readonly List<PowerStamp> events = new(16);
+    private readonly bool synthetic;
+    private bool registered, armed, overflow, closed, beforeArmSuspend;
+    private string? error;
+    private uint? unregisterStatus;
+    private PowerStamp? armStamp;
+    private IntPtr registration, parameters, key;
+    private static long nextKey;
+    private static readonly ConcurrentDictionary<IntPtr, PowerObserver> Observers = new();
+    private static readonly Callback NativeCallback = Notify;
+    internal TaskCompletionSource Suspend { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    internal TaskCompletionSource Resume { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate uint Callback(IntPtr context, uint type, IntPtr setting);
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Subscription { public IntPtr Callback, Context; }
+    [DllImport("powrprof.dll")]
+    private static extern uint PowerRegisterSuspendResumeNotification(uint flags, IntPtr recipient, out IntPtr registration);
+    [DllImport("powrprof.dll")]
+    private static extern uint PowerUnregisterSuspendResumeNotification(IntPtr registration);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool QueryUnbiasedInterruptTime(out ulong value);
+
+    internal PowerObserver(bool synthetic)
+    {
+        this.synthetic = synthetic;
+        if (synthetic) return;
+        key = new IntPtr(Interlocked.Increment(ref nextKey));
+        parameters = Marshal.AllocHGlobal(Marshal.SizeOf<Subscription>());
+        Marshal.StructureToPtr(new Subscription { Callback = Marshal.GetFunctionPointerForDelegate(NativeCallback), Context = key }, parameters, false);
+        Observers[key] = this;
+        uint status = PowerRegisterSuspendResumeNotification(2, parameters, out registration);
+        if (status != 0)
+        {
+            Observers.TryRemove(key, out _); Marshal.FreeHGlobal(parameters); parameters = IntPtr.Zero;
+            throw new Win32Exception((int)status);
+        }
+        registered = true;
+    }
+
+    internal void Arm()
+    {
+        lock (gate)
+        {
+            if (closed || armed || beforeArmSuspend || error != null) throw new InvalidOperationException("power-arm-invalid");
+            armStamp = Capture(0); armed = true;
+        }
+    }
+
+    internal static PowerStamp Capture(uint type)
+    {
+        if (!QueryUnbiasedInterruptTime(out var awake)) throw new Win32Exception();
+        return new(type, DateTimeOffset.UtcNow, Stopwatch.GetTimestamp(), awake);
+    }
+
+    internal void Inject(PowerStamp stamp)
+    {
+        if (!synthetic) throw new InvalidOperationException("native-observer-cannot-inject");
+        Record(stamp);
+    }
+
+    private static uint Notify(IntPtr context, uint type, IntPtr setting)
+    {
+        if (!Observers.TryGetValue(context, out var observer)) return 0;
+        try { observer.Record(Capture(type)); }
+        catch (Exception) { lock (observer.gate) observer.error = "power-callback-failed"; }
+        return 0; // Never allow managed exceptions across the native callback boundary.
+    }
+
+    private void Record(PowerStamp stamp)
+    {
+        lock (gate)
+        {
+            if (closed) return;
+            if (!armed) { if (stamp.Type == 4) beforeArmSuspend = true; return; }
+            if (events.Count == 16) { overflow = true; return; }
+            events.Add(stamp);
+            if (stamp.Type == 4) Suspend.TrySetResult();
+            if (stamp.Type == 18) Resume.TrySetResult();
+        }
+    }
+
+    internal PowerRecord Snapshot()
+    {
+        lock (gate) return new(synthetic, registered, armed, overflow, error, unregisterStatus,
+            Stopwatch.Frequency, armStamp, events.ToArray());
+    }
+
+    internal static bool ValidPair(PowerRecord record, bool live)
+    {
+        if (record.Synthetic == live || record.Registered != live || !record.Armed || record.Overflow ||
+            record.Error != null || record.UnregisterStatus != (live ? 0u : null) || record.Frequency <= 0 ||
+            record.ArmStamp is not { Type: 0, MonotonicTicks: >= 0 } || record.Events.Length is < 2 or > 16) return false;
+        var previous = record.ArmStamp;
+        int phase = 0;
+        foreach (var stamp in record.Events)
+        {
+            if (stamp.MonotonicTicks <= previous.MonotonicTicks || stamp.Awake100ns < previous.Awake100ns) return false;
+            if (phase == 0 && stamp.Type == 4) phase = 1;
+            else if (phase == 1 && stamp.Type == 18) phase = 2;
+            else if (phase != 2 || stamp.Type != 7) return false;
+            previous = stamp;
+        }
+        return phase == 2;
+    }
+
+    public void Dispose()
+    {
+        lock (gate) { if (closed) return; closed = true; }
+        if (!registered) return;
+        uint status = PowerUnregisterSuspendResumeNotification(registration);
+        lock (gate) unregisterStatus = status;
+        Observers.TryRemove(key, out _);
+        // If unregister fails, keep the tiny native subscription memory alive until
+        // process exit. The immortal delegate safely ignores its removed context.
+        if (status == 0) { Marshal.FreeHGlobal(parameters); parameters = IntPtr.Zero; }
+    }
+}

--- a/sidecar/etw-lifecycle/PowerTests.cs
+++ b/sidecar/etw-lifecycle/PowerTests.cs
@@ -1,0 +1,120 @@
+namespace Aegis.EtwLifecycle;
+
+internal static class PowerTests
+{
+    internal static Task NativeRegistration()
+    {
+        using var observer = new PowerObserver(false);
+        observer.Arm();
+        bool rejected = false;
+        try { observer.Inject(PowerObserver.Capture(4)); }
+        catch (InvalidOperationException) { rejected = true; }
+        Check(rejected);
+        observer.Dispose(); observer.Dispose();
+        var record = observer.Snapshot();
+        Check(record.Registered && !record.Synthetic && record.UnregisterStatus == 0 && record.ArmStamp != null);
+        // Registration is a real native API check, never proof of an actual transition.
+        return Task.CompletedTask;
+    }
+
+    private static PowerRecord ValidRecord()
+    {
+        var arm = new PowerStamp(0, DateTimeOffset.UtcNow, 100, 100);
+        return new(false, true, true, false, null, 0, 1000, arm,
+            [arm with { Type = 4, MonotonicTicks = 110, Awake100ns = 110 },
+             arm with { Type = 18, MonotonicTicks = 200, Awake100ns = 120 }]);
+    }
+
+    internal static Task PairEvidence()
+    {
+        var valid = ValidRecord(); Check(PowerObserver.ValidPair(valid, true));
+        foreach (var record in new[] {
+            valid with { Synthetic = true }, valid with { Registered = false }, valid with { Armed = false },
+            valid with { Overflow = true }, valid with { UnregisterStatus = null }, valid with { UnregisterStatus = 5 },
+            valid with { Error = "power-callback-failed" }, valid with { Frequency = 0 }, valid with { ArmStamp = null },
+            valid with { Events = [] }, valid with { Events = [valid.Events[0]] },
+            valid with { Events = [valid.Events[1], valid.Events[0]] },
+            valid with { Events = [valid.Events[0], valid.Events[1] with { Type = 7 }] },
+            valid with { Events = [valid.Events[0], valid.Events[1] with { MonotonicTicks = 110 }] },
+            valid with { Events = [valid.Events[0], valid.Events[1] with { Awake100ns = 109 }] },
+            valid with { Events = [.. valid.Events, valid.Events[0] with { MonotonicTicks = 300, Awake100ns = 130 }] }
+        }) Check(!PowerObserver.ValidPair(record, true));
+        var simulated = valid with { Synthetic = true, Registered = false, UnregisterStatus = null };
+        Check(PowerObserver.ValidPair(simulated, false));
+        Check(!PowerObserver.ValidPair(simulated, true));
+        // Wall-clock adjustments do not invalidate monotonic ordering.
+        Check(PowerObserver.ValidPair(valid with { Events = [valid.Events[0], valid.Events[1] with { Utc = DateTimeOffset.MinValue }] }, true));
+        return Task.CompletedTask;
+    }
+
+    internal static Task BoundedObserver()
+    {
+        using var observer = new PowerObserver(true); observer.Arm();
+        for (int i = 0; i < 20; i++) observer.Inject(PowerObserver.Capture(i == 0 ? 4u : 18u));
+        Check(observer.Snapshot() is { Overflow: true, Events.Length: 16 });
+        observer.Dispose(); observer.Inject(PowerObserver.Capture(4));
+        Check(observer.Snapshot().Events.Length == 16);
+        using var stale = new PowerObserver(true); stale.Inject(PowerObserver.Capture(4));
+        bool rejected = false; try { stale.Arm(); } catch (InvalidOperationException) { rejected = true; }
+        Check(rejected);
+        return Task.CompletedTask;
+    }
+
+    internal static Task CleanupEvidence()
+    {
+        var present = new TraceStats(0, 0, 0, 0, 256, 64);
+        var absent = new TraceStats(4201, null, null, null, null, null);
+        var cleanup = new BrokerResult(true, "suspend", true, true, "stop", 0, present, present with { AbsentStatus = 4201 }, true, true);
+        var valid = new SuspendResult(true, false, true, true, true, 0, true, 0, true, true, 0,
+            absent, present, absent, cleanup, ValidRecord(), null, null);
+        Check(SuspendScenario.Accepts(valid));
+        foreach (var result in new[] {
+            valid with { ReadyForSleep = false }, valid with { StopRequested = false }, valid with { PeerIdentityVerified = false },
+            valid with { PeerExitCode = null }, valid with { BrokerExited = false }, valid with { BrokerExitCode = 2 },
+            valid with { WitnessAuthenticated = false }, valid with { RestrictedAcl = false }, valid with { WitnessExitCode = null },
+            valid with { Preflight = present }, valid with { Before = absent }, valid with { After = null },
+            valid with { After = absent with { EventsLost = 0 } }, valid with { Power = null },
+            valid with { Cleanup = cleanup with { CleanupReceiptReceived = false } },
+            valid with { Cleanup = cleanup with { FinalStats = null } },
+            valid with { Cleanup = cleanup with { Scenario = "stop" } },
+            valid with { Error = "timeout" }, valid with { FailureStage = "wait-resume" }
+        }) Check(!SuspendScenario.Accepts(result));
+        return Task.CompletedTask;
+    }
+
+    internal static async Task Cancelled()
+    {
+        using var abort = new CancellationTokenSource(); abort.Cancel();
+        var result = await SuspendScenario.Run(true, abort.Token);
+        Check(!result.Passed && !result.ReadyForSleep && !result.WitnessAuthenticated && result.Power == null && result.Error == "cancelled");
+    }
+
+    internal static async Task WitnessPhases()
+    {
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var witness = await Witness.Start(false, deadline.Token, suspend: true);
+        try
+        {
+            bool rejected = false;
+            try { await witness.Query("before", deadline.Token); } catch (InvalidDataException) { rejected = true; }
+            Check(rejected);
+            foreach (string phase in new[] { "preflight", "before", "after" }) Check(await witness.Query(phase, deadline.Token) == null);
+            rejected = false;
+            try { await witness.Query("after", deadline.Token); } catch (InvalidDataException) { rejected = true; }
+            Check(rejected);
+        }
+        finally { await witness.Finish(); }
+        Check(witness.ExitCode == 0);
+    }
+
+    internal static async Task CancelAfterReady()
+    {
+        using var abort = new CancellationTokenSource();
+        var result = await SuspendScenario.Run(false, abort.Token, () => abort.Cancel());
+        Check(!result.Passed && result.ReadyForSleep && !result.StopRequested && result.Error == "cancelled" &&
+            result.PeerIdentityVerified && result.PeerExitCode == 0 && result.BrokerExited &&
+            result.BrokerExitCode == 0 && result.WitnessExitCode == 0 && result.Power is { Synthetic: true, Events.Length: 0 });
+    }
+
+    private static void Check(bool value) { if (!value) throw new InvalidOperationException("power-assertion-failed"); }
+}

--- a/sidecar/etw-lifecycle/Program.cs
+++ b/sidecar/etw-lifecycle/Program.cs
@@ -26,16 +26,18 @@ internal static class Program
                     "uac-broker-death <new-output-directory> (two UAC launches; query-only witness and empty-session collector)\n" +
                     "check-consent <new-output-directory> (injected refusal / delayed normal launch; no ETW)\n" +
                     "uac-refusal <new-output-directory> (approve witness UAC, reject collector UAC)\n" +
-                    "uac-late <new-output-directory> (approve witness UAC; wait 10 seconds before accepting collector UAC)");
+                    "uac-late <new-output-directory> (approve witness UAC; wait 10 seconds before accepting collector UAC)\n" +
+                    "check-suspend <new-output-directory> (synthetic power pair, real normal processes; no ETW/sleep)\n" +
+                    "uac-suspend <new-output-directory> (two UAC approvals; wait for READY, manually sleep and wake)");
                 return 0;
             }
             if (args[0] == "self-test" && args.Length == 1) return await SelfTest.Run();
             if (args[0] == "peer") return await Peer.Run(args);
             if (args[0] == "broker") return await Broker.Run(args);
             if (args[0] == "rogue") return await SelfTest.Rogue(args);
-            if (args[0] == "witness") return await Witness.Run(args);
+            if (args[0] is "witness" or "witness-suspend") return await Witness.Run(args);
             if (args[0] == "consent-broker") return await ConsentBroker.Run(args);
-            if (args.Length != 2 || args[0] is not ("check" or "uac" or "uac-failures" or "check-broker-death" or "uac-broker-death" or "check-consent" or "uac-refusal" or "uac-late")) throw new ArgumentException();
+            if (args.Length != 2 || args[0] is not ("check" or "uac" or "uac-failures" or "check-broker-death" or "uac-broker-death" or "check-consent" or "uac-refusal" or "uac-late" or "check-suspend" or "uac-suspend")) throw new ArgumentException();
             if (Security.Current().Elevated)
             {
                 Console.Error.WriteLine("Use a normal PowerShell terminal. No run was started.");
@@ -54,7 +56,13 @@ internal static class Program
             Console.CancelKeyPress += cancel;
             try
             {
-                if (consent)
+                if (args[0] is "check-suspend" or "uac-suspend")
+                {
+                    var outcome = await SuspendScenario.Run(live, abort.Token);
+                    outcomes.Add(outcome);
+                    if (!outcome.Passed) result = 2;
+                }
+                else if (consent)
                 {
                     foreach (string scenario in args[0] == "check-consent" ? new[] { "refusal", "late" } : new[] { args[0] == "uac-refusal" ? "refusal" : "late" })
                     {

--- a/sidecar/etw-lifecycle/README.md
+++ b/sidecar/etw-lifecycle/README.md
@@ -77,7 +77,11 @@ the collector or wait ten seconds before approving it. Their dedicated broker
 never authorizes session creation; it closes both pipes on expiry and launch
 return. Independent before/after queries must show absence. See the exact
 [consent procedure and suspend prerequisites](../../docs/roadmap/etw-consent-suspend.md).
-This does not change the ordinary broker's launch deadline or implement suspend.
+This does not change the ordinary broker's launch deadline. The separate
+`check-suspend` / `uac-suspend` mode now implements bounded power callbacks,
+preflight/presence/absence witness phases and owned stop on the transition.
+Its live acceptance still requires actual manual sleep and wake. See the same
+procedure for UAC approvals, READY, manual Sleep and scoped context capture.
 
 ## Boundaries and authentication
 
@@ -115,13 +119,15 @@ two bounded diagnostic lines to the coordinator; the pipe uses a four-byte LE
 length and closed UTF-8 JSON frames capped at 64 KiB/depth 8. Flood test frames are
 capped at 16 KiB padding. No frame backlog or background task list accumulates.
 
-The experiment uses 500 ms broker pings, a 4 s peer read lease, 2 s write deadlines,
+The ordinary scenarios use 500 ms broker pings, a 4 s peer read lease, 2 s write deadlines,
 25 s maximum peer lifetime and a 1 s best-effort terminal write on each pipe. These accelerated
 test values differ from the B2 production proposals. The collector also holds and
 watches its broker process; broker death cancels I/O independently of pipe traffic.
 Cleanup runs before the terminal write, so blocked output cannot prevent attempting
 session stop. Native ETW calls are synchronous; this experiment does not establish
-a hard deadline for a stuck kernel call.
+a hard deadline for a stuck kernel call. Only suspend uses 600-second broker/peer,
+720-second witness and 480-second coordinator settings; the four-second lease
+and short I/O bounds stay unchanged. Their actual behavior across sleep is pending.
 
 After attempting stop, the collector tries `stopped` on the primary pipe, then one
 `cleanup` frame on the separate pipe with its own ID and sequence 1. This second
@@ -159,13 +165,17 @@ collision, unavailable query and failed stop; kernel-read DACL; first-instance
 collision; real mutual peer identity; wrong client/server processes; authorization
 timeout; a cancelled coordinator request; invalid/foreign/conflicting cleanup
 receipts; and rejection of missing counters, absence, identity or child exit.
-There are 22 self-tests. Native session calls in the ownership
+There are 29 self-tests. Native session calls in the ownership
 unit tests use an explicit fake API.
 The added tests reject incomplete broker-death evidence, foreign/replayed witness
 phases, fabricated normal-mode statistics, oversized/truncated/unknown-field
 frames, cancellation before launch, and loss of the held process exit observation.
 Consent tests reject incomplete native evidence, injected live denial, early
 approval, missing child identity/exit and cancellation before any helper launch.
+Power tests cover real registration/unregistration without sleeping, injection
+rejection, ordered transition evidence, bounded storage, cleanup acceptance,
+pre-launch cancellation, cleanup after cancellation when armed, and the three-phase
+witness's rejection of wrong order/replay. The armed-cancellation hook is check-only.
 
 `check` saves `result.json` with environment/runtime, build hashes, mode, scenario
 outcomes, actual peer exit codes, primary stop acknowledgments and separate cleanup
@@ -235,6 +245,13 @@ Both authenticated witnesses queried absence 4201 before/after and exited 0;
 all harness processes exited. Binary hashes match the normal-token cases. Five
 earlier failed attempts are retained. Same-account refusal and late approval in
 this dedicated broker are verified; suspend and the other listed gates remain open.
+
+The [suspend check evidence](../../docs/recon/evidence/etw-lifecycle-home-26200-suspend-check.json)
+records 29 self-tests and twelve normal-token cases on the new matching binaries.
+The new process case has a synthetic power pair and null native statistics. Real
+native registration passed; real power transition and ETW cleanup across sleep
+remain unverified. The scoped context capture found no power events during that
+synthetic run, as expected. No harness processes remained.
 
 Local checks also include `dotnet format ... whitespace --verify-no-changes`,
 Release build and the normal AEGIS checks. Existing GitHub CI does not compile or

--- a/sidecar/etw-lifecycle/SelfTest.cs
+++ b/sidecar/etw-lifecycle/SelfTest.cs
@@ -180,6 +180,13 @@ internal static class SelfTest
         await Test("consent evidence requires independent native absence and process exits", ConsentTests.NativeEvidence);
         await Test("consent rejects injected live denial, early approval and unknown child identity", ConsentTests.LaunchOutcomes);
         await Test("cancelled consent probe cannot launch witness or broker", ConsentTests.Cancelled);
+        await Test("native power registration and disposal reject injected events", PowerTests.NativeRegistration);
+        await Test("power evidence requires ordered native suspend and automatic resume", PowerTests.PairEvidence);
+        await Test("power observations are bounded and reject a stale pre-arm suspend", PowerTests.BoundedObserver);
+        await Test("suspend acceptance requires both transition and actual cleanup evidence", PowerTests.CleanupEvidence);
+        await Test("cancelled suspend launches no observer or helper", PowerTests.Cancelled);
+        await Test("suspend witness enforces preflight, presence and absence phases", PowerTests.WitnessPhases);
+        await Test("cancelling an armed suspend check stops its real normal-token collector", PowerTests.CancelAfterReady);
         Console.WriteLine($"{passed} lifecycle self-tests passed; no ETW session or elevation.");
         return 0;
     }

--- a/sidecar/etw-lifecycle/SuspendScenario.cs
+++ b/sidecar/etw-lifecycle/SuspendScenario.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Aegis.EtwLifecycle;
+
+internal sealed record SuspendResult(bool Live, bool Passed, bool ReadyForSleep, bool StopRequested,
+    bool PeerIdentityVerified, int? PeerExitCode, bool BrokerExited, int? BrokerExitCode,
+    bool WitnessAuthenticated, bool RestrictedAcl, int? WitnessExitCode,
+    TraceStats? Preflight, TraceStats? Before, TraceStats? After, BrokerResult? Cleanup,
+    PowerRecord? Power, string? Error, string? FailureStage);
+
+internal static class SuspendScenario
+{
+    private static bool Absent(TraceStats? stats) => stats is
+    {
+        QueryStatus: 4201, EventsLost: null, RealTimeBuffersLost: null, LogBuffersLost: null,
+        NumberOfBuffers: null, BufferSizeKiB: null, AbsentStatus: null
+    };
+    private static bool Present(TraceStats? stats) => stats is
+    {
+        QueryStatus: 0, EventsLost: not null, RealTimeBuffersLost: not null, LogBuffersLost: not null,
+        NumberOfBuffers: > 0, BufferSizeKiB: > 0, AbsentStatus: null
+    };
+
+    internal static bool Accepts(SuspendResult result)
+    {
+        if (!result.ReadyForSleep || !result.StopRequested || !result.PeerIdentityVerified || result.PeerExitCode != 0 ||
+            !result.BrokerExited || result.BrokerExitCode != 0 || !result.WitnessAuthenticated || !result.RestrictedAcl ||
+            result.WitnessExitCode != 0 || result.Error != null || result.FailureStage != null || result.Power == null ||
+            !PowerObserver.ValidPair(result.Power, result.Live) || result.Cleanup is not { Scenario: "suspend" } cleanup) return false;
+        // Suspend deliberately requests the existing owned stop. Validate its full
+        // receipt/counters contract while preserving the actual scenario in the report.
+        if (!FinalEvidence.Accepts(result.Live, "stop", cleanup with { Scenario = "stop" }, 0)) return false;
+        return result.Live ? Absent(result.Preflight) && Present(result.Before) && Absent(result.After)
+            : result.Preflight == null && result.Before == null && result.After == null;
+    }
+
+    internal static async Task<SuspendResult> Run(bool live, CancellationToken cancellation = default, Action? afterArmForTest = null)
+    {
+        if (live && afterArmForTest != null) throw new ArgumentException("live-test-hook-forbidden");
+        Witness? witness = null; Process? broker = null; ObservedProcess? peer = null; PowerObserver? power = null;
+        TraceStats? preflight = null, before = null, after = null; BrokerResult? cleanup = null;
+        bool ready = false, stopRequested = false, identity = false, beforeQueried = false;
+        string? error = null, failureStage = null; string stage = "power-register";
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        deadline.CancelAfter(TimeSpan.FromSeconds(live ? 480 : 35));
+        try
+        {
+            deadline.Token.ThrowIfCancellationRequested();
+            power = new PowerObserver(!live);
+            stage = "witness-launch";
+            witness = await Witness.Start(live, deadline.Token, suspend: true);
+            preflight = await witness.Query("preflight", deadline.Token);
+            if (live && !Absent(preflight)) throw new InvalidDataException();
+            deadline.Token.ThrowIfCancellationRequested();
+            stage = "broker-ready";
+            broker = Process.Start(Program.Child("broker", live ? "live" : "check", "suspend")) ?? throw new InvalidOperationException();
+            using var message = JsonDocument.Parse(await Scenarios.Line(broker.StandardOutput, deadline.Token));
+            if (!message.RootElement.TryGetProperty("kind", out var kind) || kind.GetString() != "ready") throw new InvalidDataException();
+            stage = "collector-identity";
+            peer = new ObservedProcess(message.RootElement.GetProperty("peerPid").GetInt32());
+            var actual = peer.Identity; var self = Security.Current();
+            identity = actual.Birth.ToString(CultureInfo.InvariantCulture) == message.RootElement.GetProperty("peerBirth").GetString() &&
+                actual.Image.Equals(Program.Executable, StringComparison.OrdinalIgnoreCase) && actual.User == self.User &&
+                actual.Logon == self.Logon && actual.Elevated == live;
+            if (!identity) throw new UnauthorizedAccessException();
+            stage = "query-before";
+            before = await witness.Query("before", deadline.Token); beforeQueried = true;
+            if (live && !Present(before)) throw new InvalidDataException();
+            if (peer.HasExited || broker.HasExited) throw new InvalidDataException();
+            stage = "power-arm";
+            power.Arm(); ready = true;
+            afterArmForTest?.Invoke();
+            deadline.Token.ThrowIfCancellationRequested();
+            if (live) Console.WriteLine("READY FOR MANUAL SLEEP. Use Windows Sleep, then wake this computer. Do not hibernate for this first run. No automatic sleep or restart will occur.");
+            else power.Inject(PowerObserver.Capture(4)); // Explicit check-only fixture, never native power evidence.
+            stage = "wait-suspend";
+            var brokerExit = broker.WaitForExitAsync(deadline.Token);
+            if (await Task.WhenAny(power.Suspend.Task, brokerExit).WaitAsync(deadline.Token) == brokerExit) throw new InvalidDataException();
+            await power.Suspend.Task.WaitAsync(deadline.Token);
+            stage = "request-owned-stop";
+            await broker.StandardInput.WriteLineAsync("stop".AsMemory(), deadline.Token);
+            await broker.StandardInput.FlushAsync(deadline.Token); stopRequested = true;
+            if (!live) power.Inject(PowerObserver.Capture(18));
+            stage = "wait-resume";
+            await power.Resume.Task.WaitAsync(deadline.Token);
+            stage = "cleanup-receipt";
+            cleanup = JsonSerializer.Deserialize<BrokerResult>(await Scenarios.Line(broker.StandardOutput, deadline.Token), Wire.Json)
+                ?? throw new InvalidDataException();
+            await brokerExit; await peer.WaitForExit(deadline.Token);
+            stage = "query-after";
+            // A successful pair alone never establishes session cleanup.
+            beforeQueried = false; after = await witness.Query("after", deadline.Token);
+        }
+        catch (Exception failure)
+        {
+            error = cancellation.IsCancellationRequested ? "cancelled" : Program.ErrorCode(failure); failureStage = stage;
+        }
+        finally
+        {
+            if (broker != null && !broker.HasExited)
+            {
+                broker.StandardInput.Close();
+                try { await broker.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(7)); }
+                catch (TimeoutException) { broker.Kill(); await broker.WaitForExitAsync(); }
+            }
+            if (peer != null && !peer.HasExited)
+            {
+                using var wait = new CancellationTokenSource(TimeSpan.FromSeconds(7));
+                try { await peer.WaitForExit(wait.Token); }
+                catch (OperationCanceledException) { error ??= "peer-exit-unverified"; failureStage ??= "cleanup"; }
+            }
+            if (beforeQueried && witness != null)
+            {
+                try { after = await witness.Query("after", CancellationToken.None); }
+                catch (Exception) { error ??= "final-query-unverified"; failureStage ??= "cleanup"; }
+            }
+            if (witness != null) await witness.Finish();
+            power?.Dispose();
+        }
+        try
+        {
+            var result = new SuspendResult(live, false, ready, stopRequested, identity, peer?.ExitCode,
+                broker?.HasExited == true, broker?.HasExited == true ? broker.ExitCode : null,
+                witness?.Authenticated == true, witness?.RestrictedAcl == true, witness?.ExitCode,
+                preflight, before, after, cleanup, power?.Snapshot(), error, failureStage);
+            return result with { Passed = Accepts(result) };
+        }
+        finally { peer?.Dispose(); broker?.Dispose(); witness?.Dispose(); }
+    }
+}

--- a/sidecar/etw-lifecycle/Witness.cs
+++ b/sidecar/etw-lifecycle/Witness.cs
@@ -18,18 +18,20 @@ internal sealed class Witness : IDisposable
     private readonly Process process;
     private readonly StreamReader reader;
     private int queries;
+    private readonly string[] phases;
     internal bool RestrictedAcl { get; }
     internal bool Authenticated { get; private set; }
     internal bool Exited => process.HasExited;
     internal int? ExitCode => Exited ? process.ExitCode : null;
 
-    private Witness(string id, bool live, NamedPipeServerStream pipe, Process process, bool acl)
+    private Witness(string id, bool live, NamedPipeServerStream pipe, Process process, bool acl, bool suspend)
     {
         this.id = id; this.live = live; this.pipe = pipe; this.process = process;
         RestrictedAcl = acl; reader = Reader(pipe);
+        phases = suspend ? ["preflight", "before", "after"] : ["before", "after"];
     }
 
-    internal static async Task<Witness> Start(bool live, CancellationToken token)
+    internal static async Task<Witness> Start(bool live, CancellationToken token, bool suspend = false)
     {
         token.ThrowIfCancellationRequested();
         if (Security.Current().Elevated) throw new UnauthorizedAccessException();
@@ -41,7 +43,7 @@ internal sealed class Witness : IDisposable
             bool acl = Security.RestrictedAcl(pipe);
             if (!acl) throw new UnauthorizedAccessException();
             var self = Security.Current();
-            var info = Program.Child("witness", live ? "live" : "check", id,
+            var info = Program.Child(suspend ? "witness-suspend" : "witness", live ? "live" : "check", id,
                 self.Pid.ToString(CultureInfo.InvariantCulture), self.Birth.ToString(CultureInfo.InvariantCulture));
             if (live)
             {
@@ -50,7 +52,7 @@ internal sealed class Witness : IDisposable
             }
             // Consent itself has no cancellable deadline. A late helper still needs this held parent.
             var process = Process.Start(info) ?? throw new InvalidOperationException();
-            witness = new(id, live, pipe, process, acl);
+            witness = new(id, live, pipe, process, acl, suspend);
             ulong birth = Security.Observe(process).Birth;
             using var deadline = CancellationTokenSource.CreateLinkedTokenSource(token);
             deadline.CancelAfter(TimeSpan.FromSeconds(10));
@@ -70,7 +72,7 @@ internal sealed class Witness : IDisposable
 
     internal async Task<TraceStats?> Query(string phase, CancellationToken token)
     {
-        if (!Authenticated || queries >= 2 || phase != (queries == 0 ? "before" : "after"))
+        if (!Authenticated || queries >= phases.Length || phase != phases[queries])
             throw new InvalidDataException();
         queries++; // a failed exchange cannot be retried on partially consumed framing
         using var deadline = CancellationTokenSource.CreateLinkedTokenSource(token);
@@ -90,7 +92,8 @@ internal sealed class Witness : IDisposable
 
     internal static async Task<int> Run(string[] args)
     {
-        if (args.Length != 5 || args[1] is not ("live" or "check")) throw new ArgumentException();
+        if (args.Length != 5 || args[0] is not ("witness" or "witness-suspend") || args[1] is not ("live" or "check")) throw new ArgumentException();
+        bool suspend = args[0] == "witness-suspend";
         bool live = args[1] == "live";
         if (Security.Current().Elevated != live) return 3;
         string id = args[2];
@@ -98,10 +101,10 @@ internal sealed class Witness : IDisposable
         using var pipe = Security.Client(id);
         Security.Verify(pipe, parent, ulong.Parse(args[4], CultureInfo.InvariantCulture), false, false);
         using var reader = Reader(pipe);
-        using var lifetime = new CancellationTokenSource(TimeSpan.FromSeconds(165));
+        using var lifetime = new CancellationTokenSource(TimeSpan.FromSeconds(suspend ? 720 : 165));
         using (var hello = new CancellationTokenSource(TimeSpan.FromSeconds(2)))
             await Write(pipe, new("etw-witness/1", id, "hello", live, true, null), hello.Token);
-        foreach (string phase in new[] { "before", "after" })
+        foreach (string phase in suspend ? new[] { "preflight", "before", "after" } : new[] { "before", "after" })
         {
             await Read(reader, id, phase, live, false, lifetime.Token);
             // This helper has exactly one native operation: QUERY of the fixed harness name.
@@ -116,7 +119,7 @@ internal sealed class Witness : IDisposable
     internal static void Validate(WitnessFrame frame, string id, string phase, bool live, bool reply)
     {
         if (frame.Protocol != "etw-witness/1" || !Guid.TryParseExact(id, "N", out _) || frame.Id != id ||
-            phase is not ("hello" or "before" or "after") || frame.Phase != phase || frame.Live != live ||
+            phase is not ("hello" or "preflight" or "before" or "after") || frame.Phase != phase || frame.Live != live ||
             frame.Reply != reply || ((!live || !reply || phase == "hello") && frame.Stats != null))
             throw new InvalidDataException();
     }


### PR DESCRIPTION
The lifecycle harness could not distinguish actual sleep from a delayed timer and its short process lifetimes were unsuitable for manual sleep testing. Add dedicated check-suspend/uac-suspend modes with bounded native power observations, preflight/presence/absence witness phases and an owned-stop request after suspend. Live acceptance requires an ordered native suspend/resume pair, full cleanup receipts/counters, held process exits and independent final absence. Synthetic events cannot pass the live gate.

Only the suspend role extends process lifetime settings. Native callbacks record at most 16 timestamped events and signal continuations; they do not perform ETW stop or wait for I/O. Failed/unregistered/missing power evidence stays incomplete. No automatic sleep, elevated kill, restart, policy change, provider or Electron wiring is added. Capture-SuspendContext.ps1 retains bounded capability text and selected System event metadata, with a narrow gitignore exception for this one script.

Validation: Windows Release build and formatter; 29 self-tests, including actual native registration/unregistration and cleanup after cancellation when armed; twelve normal-token process cases with matching binaries. Verified 21 canonical LF source hashes, full reports, scoped context and 60 local links. Context script tested in Windows PowerShell 5.1 and pwsh. Repository format/build/lint/counts passed. Existing CI does not build this separate C# harness.

The user explicitly deferred actual sleep. Native power transitions, timer behavior across sleep and live cleanup remain unverified. The host currently advertises connected S0 Modern Standby; other power states and production supervisor behavior remain separate gates.
