### PR TITLE
docs: align GitHub project pages with current behavior

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-question.yml
+++ b/.github/ISSUE_TEMPLATE/03-question.yml
@@ -1,0 +1,17 @@
+name: Question
+description: Ask about setup, usage or project scope
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Describe what you want to understand. Remove API keys and private data before posting.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: If relevant, include your OS, AEGIS version and what you have already tried.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: "💬 Question or Discussion"
-    url: https://github.com/antropos17/Aegis/issues
-    about: "For general questions, open a blank issue with the 'question' label"
+  - name: "Private vulnerability report"
+    url: https://github.com/antropos17/Aegis/security/advisories/new
+    about: "Report a vulnerability privately; do not include details in public issues"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Mission
 
-AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level observability of AI agent behavior without kernel drivers. When AI is embedded in operating systems, browsers, and applications, oversight must not belong to those same companies. AEGIS provides independent, open-source, privacy-first monitoring that runs entirely on the user's machine.
+AEGIS is an **Independent AI Oversight Layer** for local agent processes, file activity and TCP endpoints. Coverage is signature- and sensor-dependent; no overall observability percentage has been established. Monitoring runs locally, with optional external AI analysis and update requests described below.
 
 ## System Overview
 
@@ -17,7 +17,7 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 │  │  │  OBSERVABILITY LAYER   │  │     │  │   VISUALIZATION LAYER  │  │  │
 │  │  │                        │  │     │  │                        │  │  │
 │  │  │  process-scanner.js    │──┼──►  │  │  Radar.svelte (canvas) │  │  │
-│  │  │  file-watcher.js       │──┼──►  │  │  Timeline.svelte       │  │  │
+│  │  │  file-watcher.js       │──┼──►  │  │  GroupedFeed.svelte    │  │  │
 │  │  │  network-monitor.js    │──┼──►  │  │  ActivityFeed.svelte   │  │  │
 │  │  │  baselines.js          │──┼──►  │  │  AgentPanel.svelte     │  │  │
 │  │  │  ai-analysis.js        │──┼──►  │  │  NetworkPanel.svelte   │  │  │
@@ -27,10 +27,10 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 │  │  ┌────────────────────────┐  │     │  ┌────────────────────────┐  │  │
 │  │  │  INFRASTRUCTURE        │  │     │  │   INTELLIGENCE LAYER   │  │  │
 │  │  │                        │  │     │  │                        │  │  │
-│  │  │  config-manager.js     │  │     │  │  ipc.js (store)        │  │  │
-│  │  │  exports.js            │  │     │  │  risk.js (store)       │  │  │
-│  │  │  tray-icon.js          │  │     │  │  theme.js (store)      │  │  │
-│  │  │  logger.js             │  │     │  │  toast.js (store)      │  │  │
+│  │  │  config-manager.js     │  │     │  │  ipc.ts (store)        │  │  │
+│  │  │  exports.js            │  │     │  │  risk.ts (store)       │  │  │
+│  │  │  tray-icon.js          │  │     │  │  theme.ts (store)      │  │  │
+│  │  │  logger.js             │  │     │  │  toast.ts (store)      │  │  │
 │  │  │  scoring-utils.js      │  │     │  │  demo-data.js (store)  │  │  │
 │  │  │  ipc-batcher.js        │  │     │  │                        │  │  │
 │  │  │  zip-writer.js         │  │     │  │                        │  │  │
@@ -60,10 +60,10 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 ### What's Covered Now
 
 #### 1. Process Intelligence — `process-scanner.js`
-- **What it sees:** All running processes matched against 110 agent signatures
-- **How:** `tasklist /FO CSV /NH` on Windows, pattern matching against known process names
-- **Depth:** Parent-child process tree resolution via PowerShell (60s TTL cache), IDE host app detection (e.g., "Copilot inside VS Code"), PID tracking for enter/exit events
-- **Coverage:** ~95% of known AI agents. Unknown agents detected via wildcard patterns.
+- **What it sees:** Processes matching 110 agents (262 process-name signatures), plus supported IDE, WSL and local-runtime probes.
+- **How:** The Windows path uses a shared process snapshot from the native sidecar, with a CIM fallback. If the process population cannot be established from the snapshot, the scanner can fall back to `tasklist`. POSIX implementations use `ps`.
+- **Identity:** OS-observed birth times distinguish Windows process lifetimes when available. Missing birth times and synthetic observations have weaker identity; snapshot outages retain existing sessions.
+- **Coverage:** Undetected signatures and processes that start and exit between polls are blind spots. See [known limits](README.md#known-limits).
 
 #### 2. File & Data Access — `file-watcher.js` + `rule-loader.js`
 - **What it sees:** File create/modify/delete in sensitive directories, per-process file handles
@@ -74,13 +74,13 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 #### 3. Network Intelligence — `network-monitor.js`
 - **What it sees:** All outbound TCP connections for detected agent PIDs
 - **How:** `Get-NetTCPConnection` via PowerShell, filtered by PID. Reverse DNS with 5-minute cache.
-- **Depth:** Domain classification against 50+ known-safe vendor patterns (from agent database). Unknown domains flagged. Connection state tracking.
+- **Depth:** Endpoint verdicts are `allowlisted`, `unknown` (no usable resolved identity), or `flagged` (resolved outside the applicable allowlists). Allowlists use database vendor domains and shared patterns. An allowlist match does not establish safe behavior.
 - **Limitation:** Cannot inspect encrypted traffic. Sees endpoints but not payload.
 
 #### 4. Risk Engine — `src/renderer/lib/utils/risk-scoring.js` + `src/main/anomaly-detector.js` + `src/main/baselines.js`
 - **What it computes:** Per-agent risk scores (0-100), trust grades (A+ through F), anomaly scores (0-100)
 - **Where it runs:** risk scoring lives in the RENDERER (`lib/utils/risk-scoring.js`); there is no `src/main/risk-scoring.js`. Anomaly scoring and baselines are main-process modules.
-- **Risk formula:** a sum of six independently capped contributions, each saturating so no single signal can dominate — `min(40, sensitive * 5 * (1 / (1 + sensitive * 0.1)))` + `min(20, sshAwsFiles * 5)` + `min(20, unknownDomains * 8)` + `min(10, networkCount * 0.5)` + `min(5, configFiles * 0.5)` + `min(5, fileCount * 0.02)`, the total clamped to 100. The sensitive term is deliberately sub-linear: the `1 / (1 + sensitive * 0.1)` damping is what stops `sensitive * 10` from pinning the score at 100 on the first burst (ai-mistakes.md #10).
+- **Base risk formula:** Sum `min(40, sensitive * 5 / (1 + sensitive * 0.1))`, `min(20, sshAwsFiles * 5)`, `min(20, flaggedDomains * 8 + unknownDomains * 3)`, `min(10, networkCount * 0.5)`, `min(5, configFiles * 0.5)`, `min(5, fileCount * 0.02)`, and 15 when `httpUnencryptedCount > 0`. Round the sum and clamp it to 100. The renderer supplies time-decayed file counts and subtracts 20, with a floor of zero, for agents marked as false positives. Anomaly scores, including sequence signals, are exposed separately from this risk score.
 - **Anomaly scoring:** 4 weighted dimensions, `composite = Σ(dimension.score × weight)` with `{network: 0.3, filesystem: 0.25, process: 0.25, baseline: 0.2}`. Individual signals such as file volume and sensitive-access spikes are sub-factors inside a dimension, not top-level weighted factors.
 - **Baselines:** Rolling averages over 10 sessions, persisted to `baselines.json`
 
@@ -91,8 +91,8 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 - **Privacy:** Only triggered when user explicitly clicks the button. No background API calls.
 
 #### 6. Audit Trail — `audit-logger.js`
-- **What it logs:** 6 event types are actually emitted — file-access, config-access, network-connection, anomaly-alert, agent-enter, agent-exit. A 7th, `permission-deny`, is listed in the logger's JSDoc and accepted by the renderer timeline, but no call site emits it.
-- **Format:** Append-only JSONL. Each entry follows `AuditRecordV1` (the authoritative definition in `src/shared/types/events.ts`): `{schemaVersion, timestamp, type, agent, pid, instanceId, action, path, severity, riskScore, attribution, details, seq, hash}`. `seq` and `hash` are added at flush time by `audit-hashchain.js`, which makes each daily file an independent SHA-256 chain. `riskScore` is vestigial and always 0 in v1; `attribution: null` means the ownership question does not apply to that event type, which is distinct from `status: 'unattributed'` (question applies, owner unknown). Pre-v1 records are told apart by the ABSENCE of `schemaVersion` — and only for a record that parses and whose hash verifies (in v0, `pid`, `instanceId`, and `attribution` were nested inside `details`, not top-level). The chain proves no record was EDITED; it cannot prove none was lost, since a record that never reached disk leaves no gap.
+- **What it logs:** Activity records include `file-access`, `config-access`, `network-connection`, `anomaly-alert`, `agent-enter` and `agent-exit`. The main process also emits `sequence-detection` and `observation-gap`; the logger records `buffer-overflow-drop` for buffer loss. `permission-deny` remains a legacy accepted type without a current emission site.
+- **Format:** Append-only JSONL. Each entry follows `AuditRecordV1` (the authoritative definition in `src/shared/types/events.ts`): `{schemaVersion, timestamp, type, agent, pid, instanceId, action, path, severity, riskScore, attribution, details, seq, hash}`. `seq` and `hash` are added at flush time by `audit-hashchain.js`, which makes each daily file an independent SHA-256 chain. `riskScore` is vestigial and always 0 in v1; `attribution: null` means the ownership question does not apply to that event type, which is distinct from `status: 'unattributed'` (question applies, owner unknown). Pre-v1 records are told apart by the ABSENCE of `schemaVersion` — and only for a record that parses and whose hash verifies (in v0, `pid`, `instanceId`, and `attribution` were nested inside `details`, not top-level). Chain verification can detect edits relative to a trusted chain state. It cannot prove that no records were lost, or prevent an actor who controls local files from replacing and recomputing an entire chain.
 - **Rotation:** New file per day (`aegis-audit-YYYY-MM-DD.json`), auto-delete after 30 days
 - **Performance:** Buffered writes — flush every 5 seconds or at 50 events
 
@@ -105,9 +105,9 @@ AEGIS is an **Independent AI Oversight Layer** — achieving ~95% user-level obs
 | Blind Spot | Description | Planned Approach / Status |
 |---|---|---|
 | **UI Awareness** | Cannot see what AI agents display or interact with in UI | Accessibility API monitoring (no screen capture) |
-| **Container/VM Detection** | Detected — 7 container/VM agents added (Docker, WSL, Ollama, LM Studio, LocalAI, GPT4All, Jan) | Process pattern matching for containers + GPU monitoring |
+| **Container/VM Detection** | Runtime process signatures and limited WSL discovery exist; this does not enumerate every container or its internal processes | Broader WSL, Docker and Podman discovery; see [roadmap](ROADMAP.md#a--discovery-coverage) |
 | **Sandbox Containment** | Monitor-only — cannot isolate or restrict agents | Non-goal: OS containment (Job Objects, AppContainer) is deliberately out of scope; pair AEGIS with external sandboxing |
-| **GPU Monitoring** | Cannot detect local inference processes | GPU utilization APIs, process GPU memory tracking |
+| **GPU Monitoring** | Per-PID NVIDIA VRAM samples exist; allocated memory does not establish active inference | Define and validate the missing inference signal; see [roadmap](ROADMAP.md#a--discovery-coverage) |
 | **Deep Packet Inspection** | Sees TCP endpoints but not encrypted payloads | Non-goal: TLS interception is deliberately out of scope; endpoints-only is the contract |
 | **Syscall Monitoring** | No kernel-level visibility into system calls | Kernel drivers (Minifilter/Endpoint Security/eBPF) are a non-goal; user-mode ETW telemetry is under evaluation |
 | **Memory Inspection** | Cannot inspect agent process memory | Non-goal: process-memory reading is deliberately out of scope |
@@ -142,9 +142,9 @@ process-scanner.js ◄──── config-manager.js
         │
      App.svelte (root component)
         │
-        ├──► stores/ (ipc.js, risk.js, theme.js, toast.js, demo-data.js)
-        ├──► ShieldTab → Radar, AgentPanel, Timeline
-        ├──► ActivityTab → ActivityFeed, NetworkPanel
+        ├──► stores/ (ipc.ts, risk.ts, theme.ts, toast.ts, demo-data.js)
+        ├──► ShieldTab → Radar, AgentPanel, SummaryCards, ActivityFeed/GroupedFeed
+        ├──► ActivityTab → ActivityFeed/GroupedFeed, NetworkPanel
         ├──► RulesTab → Presets, Permissions, AgentDatabase
         ├──► ReportsTab → Reports, AuditLog, ThreatAnalysis
         └──► Settings, Header, Footer, Toast
@@ -153,45 +153,33 @@ process-scanner.js ◄──── config-manager.js
 ## Data Flow
 
 ```
-Process Scan (every Ns)
-    │
-    ├──► Agent list ──► Renderer (scan-results)
-    │                   ├──► Radar visualization (agent orbits)
-    │                   ├──► Agent cards (trust bars, sparklines)
-    │                   ├──► Risk scoring (time-decay weighted)
-    │                   └──► Agent enter/exit → Audit log
-    │
-    ├──► File Handle Scan (every 3Ns)
-    │    └──► File events ──► Renderer (file-access)
-    │         │               ├──► Activity feed
-    │         │               ├──► Session timeline
-    │         │               └──► Stats update
-    │         └──► Audit log (file-access / config-access)
-    │
-    ├──► Network Scan (every 30s + on agent change)
-    │    └──► Connections ──► Renderer (network-update)
-    │         │               ├──► Network panel
-    │         │               └──► Session timeline
-    │         └──► Audit log (network-connection)
-    │
-    ├──► Baseline Check
-    │    └──► Deviations ──► Renderer (baseline-warnings)
-    │         │               ├──► Toast notifications
-    │         │               ├──► Anomaly feed entries
-    │         │               └──► Session timeline
-    │         └──► Audit log (anomaly-alert)
-    │
-    └──► Anomaly Scores ──► Renderer (anomaly-scores)
-                            └──► Agent card badges
+Process scan (configured interval)
+    ├──► shared process observation → scanner → instance/session reconciliation
+    ├──► baselines, anomaly scores and sequence-rule taps
+    ├──► scan-batch → agents, stats, resourceUsage, anomalyScores stores
+    └──► agent-enter / agent-exit / anomaly-alert audit records
+
+File watcher events + handle scans (max(3 × scan interval, 30 s))
+    ├──► attribution → file-access push → activity feeds
+    └──► file-access / config-access audit records + sequence-rule taps
+
+Network scan (30 s interval and agent-set changes)
+    ├──► endpoint verdicts → network-update push → network panel
+    └──► network-connection audit records + sequence-rule taps
+
+Operational records
+    ├──► sensor health → stats/scan-batch → footer health status
+    ├──► suspend/resume → observation-gap audit record
+    └──► sequence completion → sequence-detection audit record and score
 ```
+
+There are no standalone `scan-results`, `baseline-warnings` or `anomaly-scores` preload channels. Scan results and anomaly scores share `scan-batch`.
 
 ## IPC Channel Reference
 
 ### Invoke (Renderer → Main → Response)
 
-All 40 registered in `src/main/ipc-handlers.js` and exposed through `src/main/preload.js`. A
-channel absent from `preload.js` is unreachable from the renderer under `contextIsolation`,
-so this table is the complete surface — nothing else can be invoked.
+The 44 invoke channels below are exposed through `src/main/preload.js`. Handlers are registered in `src/main/ipc-handlers.js`; update operations delegate to `src/main/app-updates.js`. The bridge exposes named operations rather than arbitrary IPC access.
 
 | Channel | Module | Purpose |
 |---|---|---|
@@ -235,6 +223,10 @@ so this table is the complete surface — nothing else can be invoked.
 | `open-external-url` | main | Open an http/https URL in the default browser |
 | `get-app-version` | main | Current app version string |
 | `test-notification` | main | Trigger a test OS notification |
+| `updates:status` | app-updates | Read updater state |
+| `updates:check` | app-updates | Check signed release metadata |
+| `updates:download` | app-updates | Download and verify the selected installer |
+| `updates:install` | app-updates | Request native confirmation and installation |
 
 `kill-process`, `suspend-process` and `resume-process` each refuse AEGIS's own PID and any
 PID not in the current scan result — see the C-01 guards in `ipc-handlers.js`.
@@ -246,7 +238,7 @@ there is no fire-and-forget path from the renderer.
 
 ### Push (Main → Renderer)
 
-All 9 subscribed via `ipcRenderer.on` in `preload.js`.
+The 10 push channels below are subscribed via `ipcRenderer.on` in `preload.js`.
 
 | Channel | Purpose |
 |---|---|
@@ -259,11 +251,12 @@ All 9 subscribed via `ipcRenderer.on` in `preload.js`.
 | `scan-status` | Scanner state (scanning/idle) |
 | `rules:reloaded` | Rule hot-reload landed, with the new count |
 | `toggle-theme` | Theme toggle from the tray menu |
+| `updates:status` | Safe display state for update status, progress and available actions |
 
 ## Extension Points
 
 ### Adding a New Agent Signature
-Edit `agent-database.json` — append an entry to the `agents` array. The process-name field is `names` (an array of match strings), **not** `processPatterns`, which appears nowhere in the codebase. Alongside it: `id`, `displayName`, `category`, `knownDomains`, `configPaths`, and trust/risk metadata. The process scanner, network monitor, and file watcher all consume this database automatically.
+Edit `agent-database.json` — append an entry to the `agents` array. The process-name field is `names` (an array of match strings), **not** `processPatterns`, which appears nowhere in the codebase. Alongside it: `name`, `displayName`, `category`, `knownDomains`, `configPaths`, and trust/risk metadata. Process signatures and endpoint metadata are consumed by the scanner and network classifier. Database `configPaths` does not add watch roots: register supported directories in `src/shared/constants.js` (`AGENT_CONFIG_PATHS`). Trust/risk metadata does not automatically change the scoring formula or permission defaults.
 
 ### Adding New Sensitive File Rules
 Rules live in `rules/*.yaml` (one file per category), validated against `rules/_schema.json` and loaded by `rule-loader.js` with hot-reload. Add an entry to the ruleset matching the category:
@@ -339,10 +332,10 @@ containing the updater must be installed manually.
 
 AEGIS is designed with privacy as a core architectural constraint:
 
-- **All data stays local.** Settings, baselines, and audit logs are stored in Electron's userData directory. Nothing leaves the machine unless the user explicitly exports it.
+- **Storage is local by default.** Settings, baselines and audit logs are stored in Electron's userData directory. Exports create local files; optional AI analysis and updates make the external requests described below.
 - **No telemetry.** No analytics, no crash reporting, no usage tracking.
 - **Updates are opt-in.** Manual update actions or the saved automatic-update preference contact GitHub for public release files. These requests expose the normal network address to GitHub but do not send monitoring records, settings or API keys.
 - **No cloud sync.** There is no account system, no server, no cloud backend.
-- **AI analysis is opt-in.** Calls to the Anthropic API happen only when the user explicitly clicks "Run AI Threat Analysis." The API key is user-provided and stored locally.
-- **Audit logs are metadata-only.** File paths and agent names are logged. File contents are never read, stored, or transmitted.
-- **Open-source transparency.** Every line of monitoring, scoring, and analysis logic is visible in the source code. There are no hidden behaviors.
+- **AI analysis is opt-in.** An explicit request sends activity metadata to Anthropic, including agent/process names, PIDs, parent chains, sensitive paths, counts and network endpoints as applicable. The user provides the API key. Local key storage uses safeStorage when available and currently falls back to plaintext otherwise.
+- **Audit logs contain monitoring metadata.** File-monitoring events record paths and attribution, not the contents of sensitive files. Token accounting separately reads agent transcript JSONL to extract usage. Settings JSON exports currently include a configured API key; remove it before sharing.
+- **Source review.** Monitoring, scoring and analysis implementations are available in the repository; see [SECURITY.md](SECURITY.md) for the security model and known limitations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ AEGIS is building an independent AI oversight layer — a tool that monitors wha
 ```bash
 git clone https://github.com/antropos17/Aegis.git
 cd Aegis
-npm install
+npm ci
 npm start
 ```
 
-Requires the Node.js version in `engines` in `package.json` (also pinned in `.nvmrc` and used by CI) and Windows 10/11 for full monitoring functionality. The Electron app launches a real-time dashboard that detects AI agents, monitors file access, scans network connections, and scores risk.
+Requires the Node.js version in `engines` in `package.json` (also pinned in `.nvmrc` and used by CI) and Windows 10/11 for the primary supported monitoring path. macOS/Linux support is experimental; see the [known limits](README.md#known-limits). The Electron app launches a dashboard that detects AI agents, monitors file access, scans network connections, and scores risk.
 
 ## Workflow
 
@@ -32,7 +32,9 @@ See [BRANCHING.md](BRANCHING.md) for full details.
 ### Releases
 Releases are automated via [release-please](https://github.com/googleapis/release-please).
 Just write proper conventional commits. release-please creates a Release PR automatically.
-When maintainers merge the Release PR → version bump + CHANGELOG + GitHub Release happen automatically.
+Release PRs created or updated with `GITHUB_TOKEN` can wait for **Approve workflows to run** before CI starts. A maintainer reviews the diff, approves the workflow run and waits for all required checks before merging. See [GitHub's documented approval behavior](https://docs.github.com/en/actions/concepts/security/github_token).
+
+Merging the Release PR creates the version bump, changelog and GitHub Release; the installer workflow then builds and uploads artifacts. A release is ready to download only after that build succeeds.
 
 ## Code Standards
 
@@ -41,9 +43,9 @@ When maintainers merge the Release PR → version bump + CHANGELOG + GitHub Rele
 - **Svelte 5 + Vite for renderer** — component-based architecture with `$state`/`$derived`/`$effect` runes. Main process remains CommonJS.
 - **CommonJS in main process** — `require`/`module.exports` with `init()` dependency injection pattern. Each module receives only the state it needs.
 - **JSDoc headers on all exported functions** — `@param`, `@returns`, `@since` tags required. Include `@file`, `@module`, `@description` at top of every file.
-- **300 line soft limit per file** — split into focused, single-responsibility modules when exceeding.
+- **Aim for 300 lines in new files.** Extract a focused module when adding to an oversized file; do not split existing files solely to meet the target.
 - **`const` over `let`** when the binding doesn't change. Never use `var`.
-- **No external dependencies** without discussion — the project intentionally keeps `dependencies` to three: `ajv` (rule-schema validation), `chokidar` (file watching) and `js-yaml` (ruleset parsing). `electron` is a devDependency. Adding a dependency requires justification.
+- **Justify new dependencies.** The runtime dependencies in `package.json` are `ajv` (schema validation), `chokidar` (file watching), `electron-updater` (updates), `js-yaml` (ruleset parsing) and `semver` (version comparison). Electron is a devDependency used to build and run the desktop shell.
 
 ### Naming Conventions
 
@@ -54,7 +56,7 @@ When maintainers merge the Release PR → version bump + CHANGELOG + GitHub Rele
 
 ### TypeScript
 
-- **New files should be written in TypeScript** (`.ts`) — existing `.js` files will be migrated incrementally
+- **New renderer files use TypeScript** (`.ts` or `<script lang="ts">` in Svelte). Main-process modules remain CommonJS JavaScript with JSDoc; there is no blanket migration requirement
 - **Main process** (`.js`): annotated with JSDoc, which editors use for IntelliSense. `checkJs` is **off** in `tsconfig.base.json`, so `tsc` resolves these files but does not type-check their bodies — the annotations document intent, they are not enforced by the typecheck gate
 - **Renderer** (`.ts`/`.svelte`): native TypeScript with ES modules
 - Shared type definitions live in `src/shared/types/` (`npm run counts:check` derives the file count)
@@ -99,10 +101,10 @@ Add an entry to the `agents` array:
 - `names` — Substrings matched against running process names (case-insensitive). The field is `names`, not `processPatterns`; nothing in the codebase reads a `processPatterns` key
 
 **Important fields:**
-- `knownDomains` — Domains classified as "safe" when this agent connects to them. Without this, the agent's connections will be flagged as unknown.
-- `configPaths` — Directories to monitor for the Hudson Rock config protection feature. These directories are watched for unauthorized access.
-- `defaultTrust` — Initial trust score (0-100). Lower = more suspicious. Affects risk score multiplier.
-- `riskProfile` — `low`, `medium`, or `high`. Affects default permission assignments.
+- `knownDomains` — Vendor endpoint allowlist metadata. An allowlisted endpoint is not a guarantee of safe behavior; unresolved endpoints are `unknown` and resolved names outside the applicable allowlists are `flagged`
+- `configPaths` — Descriptive metadata; adding it does not register a watcher. Add a supported watch root to `AGENT_CONFIG_PATHS` in `src/shared/constants.js` and verify the watcher behavior separately
+- `defaultTrust` — Database metadata; it is not an input to the current risk-scoring formula
+- `riskProfile` — `low`, `medium`, or `high` metadata used by the database UI. It does not select default permissions; `config-manager.js` uses known-agent membership for the initial `monitor`/`block` value
 - `category` — One of the 11 in use: `agent-framework`, `ai-ide`, `autonomous-agent`, `browser-agent`, `cli-tool`, `coding-assistant`, `container-runtime`, `desktop-agent`, `ide-extension`, `local-llm-runtime`, `security-devops`
 
 ### Via the UI
@@ -111,7 +113,7 @@ Users can also add custom agents through the Agent Database Manager in the RULES
 
 ## How to Add a New Monitoring Module
 
-Main process modules follow an `init()` dependency injection pattern:
+Main process modules use an `init(deps)` dependency injection pattern; inspect the neighboring modules for the required dependencies:
 
 ```javascript
 // src/main/my-module.js
@@ -136,8 +138,8 @@ function init(state) {
  */
 function scan() {
   const agents = _state.getLatestAgents();
-  // ... monitoring logic
-  return results;
+  // Replace this example result with the observations produced by the module.
+  return { observedAgents: agents.length };
 }
 
 module.exports = { init, scan };
@@ -154,7 +156,7 @@ If the renderer needs data, register an IPC handler in `registerIpc()` and add t
 
 ## How to Add New Sensitive File Rules
 
-Rules live in `rules/*.yaml` — one ruleset file per category, validated against `rules/_schema.json` and loaded by `src/main/rule-loader.js` with hot-reload. Add an entry to the ruleset for your category:
+Rules live in `rules/*.yaml` — one ruleset file per category, validated against `rules/_schema.json` and loaded by `src/main/rule-loader.js` with edit-triggered hot reload in unpacked runs. Add an entry to the ruleset for your category:
 
 ```yaml
   - id: "SS007"
@@ -188,6 +190,8 @@ When filing issues, use these labels:
 The full set is on the repository's [labels page](https://github.com/antropos17/Aegis/labels); `good first issue` and `help wanted` mark issues that are open to contributors.
 
 ## Reporting Issues
+
+Remove API keys, credentials and private paths from logs or exported settings before attaching them. Report vulnerabilities through the [private security channel](SECURITY.md#reporting-a-vulnerability).
 
 - Use GitHub Issues with a descriptive title
 - Include: OS version, Node.js version, Electron version, steps to reproduce, console output

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-<p align="center">
-  <h1 align="center">AEGIS</h1>
+<div align="center">
+  <h1>AEGIS</h1>
   <p align="center"><b>Independent, OS-level observability for AI coding agents</b></p>
   <p align="center"><i>Watches what AI agents actually do on your machine — processes, files, network — from outside the agents, no hooks required.</i></p>
-</p>
+</div>
 
-**AEGIS is an independent, OS-level observer for AI agents.** It watches agent processes, file access, and network activity regardless of how the agent was launched or whether it cooperates with monitoring — and it ties every observation to a specific agent *instance*, with the evidence for that attribution stated on the record. Built on a CommonJS JavaScript monitoring engine, with TypeScript in the renderer and the shared types. **Open-source, local, no telemetry** — everything stays on your machine.
+**AEGIS monitors local AI agent activity from outside the agents.** It observes detected processes, file access and TCP endpoints, and records whether attribution to an agent instance is confirmed, inferred or unknown. Coverage depends on the available sensors and detection signatures.
+
+**Open-source, monitor-first, no telemetry.** Monitoring data is stored locally. Optional AI analysis sends selected activity metadata to Anthropic when you request it; update checks contact GitHub. See the [privacy details](SECURITY.md#privacy-architecture).
+
+This README describes the current source tree. Installed builds contain the features available at their [release tag](https://github.com/antropos17/Aegis/releases); changes merged afterward require a newer build.
 
 <p align="center">
   <a href="https://github.com/antropos17/Aegis/releases/latest"><img src="https://img.shields.io/github/v/release/antropos17/Aegis?include_prereleases&style=flat-square&label=Release" alt="Release"></a>
@@ -38,14 +42,14 @@
 | **Behavior** | 73 detection rules across 8 categories (YAML, hot-reloaded), rolling 10-session baselines, anomaly scoring over four axes (network / filesystem / process / baseline) |
 | **Local LLMs** | Runtime probes for Ollama and LM Studio, including loaded models; other runtimes such as vLLM and llama.cpp are detected by process signature |
 
-The counted facts above are not hand-maintained: `npm run counts:check` re-derives every documented counter from the tree on each CI run and fails the build when a number in the docs drifts from reality.
+`npm run counts:check` derives the agent, signature, rule and module inventories from source and checks selected declarations in the documentation during CI. It does not validate every number or feature claim in prose.
 
 ## The evidence graph
 
-What separates AEGIS from a process viewer is not the sensors — it is that every event is attached to an agent **instance**, with evidence you can audit:
+AEGIS records instance identity and attribution evidence alongside observed activity:
 
-- **Instance identity.** An agent is keyed as `pid` + OS birth time (`instanceId`), so a recycled PID is a new instance, not a continuation of the old one's history. Identity caching is gated by a witness, and CI runs an injection proof (`npm run verify:gate`, 4 mutants) that goes red if an identity could ever be served from a stale cache.
-- **Attribution with stated evidence.** Every audit record carries `pid`, `instanceId`, and an `attribution` object with one of three statuses — confirmed, inferred, or unattributed — backed by a closed registry of evidence codes. When AEGIS does not know which agent touched a file, it says *unattributed*; it never invents an owner.
+- **Instance identity.** When Windows supplies an OS birth time, `instanceId` combines it with the PID to distinguish process lifetimes. Missing birth times and synthetic discoveries have weaker identity; see the limits below. CI exercises the identity witness with fault injection (`npm run verify:gate`, 4 mutants).
+- **Attribution with stated evidence.** Event Schema v1 includes `pid`, `instanceId` and attribution evidence. Ownership can be confirmed, inferred or unattributed; fields may be null when ownership is unknown or does not apply to an operational record.
 - **Tamper-evident log.** Audit events are hash-chained JSONL (Event Schema v1) with daily rotation, 30-day retention, and explicit loss markers when the write buffer overflows.
 - **Measured, not asserted.** The identity mechanism is benchmarked in-repo: provider birth-time parity was exact for every comparable process in both recorded runs (542/542 and 419/419), and the process-snapshot sidecar costs ~10 ms per scan where the fallback provider costs hundreds to thousands. Per-run tables, environments, and the stated gaps are in [docs/bench/](docs/bench/).
 
@@ -53,23 +57,23 @@ Evidence: [`src/main/process-identity.js`](src/main/process-identity.js) · [`sr
 
 ## Monitor-first
 
-> **AEGIS is a camera, not a guard.** It **observes and logs** — it does **not** block agents at the OS level today. There are no kernel hooks and no automatic enforcement. Process control (kill / suspend / resume) is **manual and user-invoked** only. Active blocking is on the [roadmap](#roadmap), not in the current release. Use AEGIS for visibility, auditing, and anomaly detection — pair it with sandboxing when you need enforcement.
+> **AEGIS observes and logs.** It has no automatic OS-level enforcement. Process control (kill / suspend / resume) is manual and user-invoked. Permission presets affect monitoring and alerting; use a sandbox when you need containment.
 
 ## How AEGIS differs from in-agent oversight
 
 Most AI-agent oversight tools instrument the agent itself — a Claude Code plugin, an IDE extension, an SDK wrapper. That placement has a structural blind spot: an agent only shows up if it (or its user) installed the hook. A raw `python autogpt.py`, an unwrapped binary, or a tool that simply does not cooperate is invisible to in-agent instrumentation.
 
-AEGIS sits at the OS layer instead: it watches process, file, and network activity from outside the agents, so what it sees does not depend on the agent's cooperation — only on AEGIS's own coverage (see [known limits](#known-limits)). It is not the only tool observing agents locally — [AgentSight](https://github.com/eunomia-bpf/agentsight), for example, observes from the eBPF layer on Linux — and hook-based tools are complementary rather than competing: hooks see intent (prompts, tool calls) inside the agents that opted in, while AEGIS sees effects (processes, files, connections) for whatever runs on the machine, linked to agent instances without requiring cooperation.
+AEGIS sits at the OS layer instead: it watches process, file, and network activity from outside the agents, so what it sees does not depend on the agent's cooperation — only on AEGIS's own coverage (see [known limits](#known-limits)). It is not the only tool observing agents locally — [AgentSight](https://github.com/eunomia-bpf/agentsight), for example, observes from the eBPF layer on Linux — and hook-based tools are complementary rather than competing: hooks see intent (prompts, tool calls) inside the agents that opted in, while AEGIS records observed effects (processes, files, connections) within its sensor coverage, with attribution evidence when available.
 
 ## Known limits
 
 A monitor you cannot calibrate is a monitor you cannot trust, so the limits are stated here rather than discovered later. The re-verified findings behind this list, each with an OPEN/CLOSED status, live in the [correctness audit](docs/current-state/CORRECTNESS-AUDIT.md); the short version:
 
 - **Coverage is signature- and heuristic-based.** Detection starts from 110 agents (262 process-name signatures) plus heuristics (WSL, IDE extensions, local LLM probes). An agent binary that matches none of these is not detected.
-- **Polling has a blind spot.** A process born and dead between scan ticks (~10 s) is never observed; the bench pages state this explicitly. Per-event capture via ETW is on the [roadmap](#roadmap), with a static recon already in [docs/recon/kernel-file-etw.md](docs/recon/kernel-file-etw.md).
+- **Polling has a blind spot.** A process born and dead between scan ticks (~10 s) is never observed; the bench pages state this explicitly. Per-event capture via ETW is under development in isolated Windows harnesses; it is not wired into production monitoring. See the [current roadmap](ROADMAP.md#b--windows-etw-attribution).
 - **macOS/Linux identity is degraded.** Those platforms currently supply no OS birth time, so instance identity falls back to PID only and is unsafe under PID reuse. Token-cost tracking is Windows-only.
 - **UI event windows truncate silently.** The renderer keeps bounded event windows that can disagree with totals, and there is no truncation banner yet.
-- **Sensor health is tracked but not yet shown.** The main process records per-sensor health for the filesystem and network sensors, but the UI cannot yet distinguish a quiet machine from a dead sensor, and process-scan overruns are skipped without a counter.
+- **Sensor health has limits.** The footer shows failed or degraded sensors, and suspend/resume gaps are recorded. A healthy status is not proof that every event was captured; process-scan overruns still lack a dedicated counter.
 - **Audit loss markers need a successful flush.** If the process is killed while the disk is still failing, evicted audit entries can be lost without an on-disk marker.
 
 ## What we deliberately do not claim
@@ -85,7 +89,7 @@ Numbers appear in this README only when they are derived from the repository (an
 
 ## Why independent oversight
 
-AI agents run with deep access to files, credentials, and shell commands. The risk is not hypothetical: Kaspersky's write-up of the OpenClaw case reports that a security audit in January 2026 identified **512 vulnerabilities, eight of them critical**, and argues that the deeper problem is architectural — privileged local access combined with the ability to communicate externally ([Kaspersky, 2026-02-10](https://www.kaspersky.com/blog/openclaw-vulnerabilities-exposed/55263/)). Patching fixes bugs; it does not give you visibility into what an agent actually did on your machine. That visibility is the layer AEGIS adds.
+AI coding agents can run shell commands, read credentials and contact external services with the permissions of the user running them. AEGIS provides a local record of the activity its sensors observe, with attribution evidence and known gaps. This helps investigate changes in agent behavior alongside the access controls and sandboxing already in use.
 
 ## Download
 
@@ -98,7 +102,7 @@ Starting with v0.11.0-alpha, releases ship a Windows NSIS installer — download
 ```bash
 git clone https://github.com/antropos17/Aegis.git
 cd Aegis
-npm install
+npm ci
 npm start
 ```
 
@@ -106,29 +110,32 @@ npm start
 
 ### Try without AI agents
 
-Don't have AI agents running? Demo mode lets you explore the full dashboard with simulated data — no real monitoring, no real processes.
+Build the browser demo with simulated data, then preview it locally:
 
 ```bash
-npm run dev
-# then open http://localhost:5174
+npm run build:demo
+npx vite preview --mode demo --host 127.0.0.1 --port 4174
+# open http://127.0.0.1:4174
 ```
 
-The dev server carries the demo scenario engine — `vite.config.js` enables it whenever the command is `serve`, so the simulated dashboard renders without a separate build step and without Electron. For a static, shareable build (no dev server, no Electron), run `npm run build:demo` and serve the resulting `dist/demo` directory with any static file server (the build uses relative asset paths, so any host works).
+The demo cycles through calm, elevated, critical and reset phases with up to 12 simulated agents. It does not monitor real processes; Electron-only operations are unavailable in the browser. The output in `dist/demo` can also be served by a static file server.
 
-Demo mode runs a scenario engine that cycles through four threat phases — **calm → elevated → critical → reset** — with up to 12 simulated AI agents (Claude Code, Copilot, Cursor, and more). File access events, network connections, anomaly scores, and risk assessments are all generated in real time so every tab and feature is fully functional.
-
-Use it to evaluate AEGIS before deploying, demo the UI to your team, or develop new features without needing a live Windows environment.
+Use this built preview for now. `npm run dev` currently has a shared CommonJS import incompatibility that prevents the dashboard from loading; it is not a working shortcut to the demo.
 
 ### Release history
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v0.14.1-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.14.1-alpha) | 2026-09-07 | Evidence-file watchers moved off the main thread; dependency maintenance |
+| [v0.14.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.14.0-alpha) | 2026-09-07 | Sequence rules, observation-gap records, audit indexing and sensor-health work |
+| [v0.13.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.13.0-alpha) | 2026-08-23 | Signed release manifests for offline installer verification |
+| [v0.12.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.12.0-alpha) | 2026-08-22 | Monitoring and renderer updates; see release notes |
 | [v0.11.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.11.0-alpha) | 2026-08-11 | Windows installer, Event Schema v1 attribution, endpoint verdicts, sensor health records, WSL & IDE-extension detection |
 | [v0.10.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.10.0-alpha) | 2026-03-09 | Code cleanup, security hardening, command palette |
-| [v0.9.1-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.9.1-alpha) | 2026-03-08 | Dropdown dedup, skill paths, aegis-context optimized |
+| [v0.9.1-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.9.1-alpha) | 2026-03-09 | Dropdown dedup, skill paths, aegis-context optimized |
 | [v0.9.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.9.0-alpha) | 2026-03-08 | categoryIndex, prompt-craft skill, TS migration stores |
 | [v0.8.2-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.8.2-alpha) | 2026-03-08 | formatBytes TS extraction, meaningful tests, branch cleanup |
-| [v0.8.1-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.8.1-alpha) | 2026-03-07 | Patch release |
+| [v0.8.1-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.8.1-alpha) | 2026-03-08 | Patch release |
 | [v0.8.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.8.0-alpha) | 2026-03-05 | Launch readiness: CSP hardened, OpenClaw integration, README overhaul |
 | [v0.7.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.7.0-alpha) | 2026-03-04 | YAML rulesets, 68 rules, hot-reload, 568 tests |
 | [v0.5.0-alpha](https://github.com/antropos17/Aegis/releases/tag/aegis-v0.5.0-alpha) | 2026-03-03 | Fancy UI redesign, VisTimeline, AgentGraph |
@@ -140,9 +147,9 @@ Use it to evaluate AEGIS before deploying, demo the UI to your team, or develop 
 
 **Analysis** — Behavioral baselines with rolling averages, multi-axis anomaly detection, AI threat assessment via the Anthropic API (opt-in), printable HTML threat reports
 
-**Dashboard** — Bento-grid dashboard: RiskRing gauge, TrustBadge, activity feed with filters, session timeline with attribution tooltips, expandable agent cards, protection presets (Paranoid/Strict/Balanced/Developer), command palette (Ctrl+K), keyboard shortcuts (Ctrl+1-5), dark/light theme, toast notifications, OOM protection
+**Dashboard** — Radar overview, summary cards, filtered and grouped activity feeds, expandable agent/application cards, network panel, sensor-health status, monitoring presets (Paranoid/Strict/Balanced/Developer), command palette (Ctrl+K), keyboard shortcuts (Ctrl+1-5), dark/light and high-contrast themes
 
-**Export** — JSON, CSV, HTML reports, one-click ZIP archive, hash-chained JSONL audit log (daily rotation, 30-day retention)
+**Export** — JSON, CSV, HTML reports, one-click ZIP archive, hash-chained JSONL audit log (daily rotation, 30-day retention). Settings JSON exports can include the API key; remove it before sharing. See [known limitations](SECURITY.md#known-limitations).
 
 **i18n** — Internationalization with an English base (`en.json`); community translations welcome
 
@@ -151,8 +158,8 @@ Use it to evaluate AEGIS before deploying, demo the UI to your team, or develop 
 ## YAML rulesets
 
 - 73 detection rules across 8 categories (AI config, secrets, SSH, cloud, browser, devtools, crypto, certificates)
-- Validated against `rules/_schema.json`; editing a ruleset hot-reloads without a restart
-- Extend by adding a `.yaml` to `rules/`. Rule IDs must be unique — a duplicate ID is skipped, not overridden. A newly added file is picked up on the next reload or restart, since the watcher reacts to changes in existing top-level files
+- Validated against `rules/_schema.json`; edits to existing rulesets hot-reload in an unpacked source run. Watchers are disabled inside packaged ASAR builds
+- Extend by adding a `.yaml` to `rules/`. Rule IDs must be unique — a duplicate ID is skipped, not overridden. A newly added file is picked up on the next reload or restart, since the source-run watcher reacts to changes in existing top-level files
 
 ## Screenshots
 
@@ -211,11 +218,11 @@ Use it to evaluate AEGIS before deploying, demo the UI to your team, or develop 
     │              │  │       ZIP)       │  │   --version)  │
     └──────────────┘  └──────────────────┘  └───────────────┘
 
-  Per-sensor health records live in the main process; surfacing
-  them in the UI is on the roadmap.
+  Per-sensor health is collected in the main process and shown
+  in the footer; suspend/resume gaps are recorded in the audit log.
 ```
 
-**Stack**: Electron 43, Svelte 5, Vite 7, Vitest. The monitoring engine is JavaScript (CommonJS); TypeScript is used in the renderer and the shared types. CI gates every merge with build, lint, svelte-check, test and audit jobs; `npm run counts:check` re-derives every documented counter from the tree, `npm run verify:gate` proves the identity witness against injected mutants, and `npm run verify:seq-gate` proves the sequence engine against injected mutants.
+**Stack**: Electron 43, Svelte 5, Vite 7, Vitest. The monitoring engine is JavaScript (CommonJS); TypeScript is used in the renderer and the shared types. CI gates every merge with build, lint, svelte-check, test and audit jobs; `npm run counts:check` verifies selected inventory declarations against source, `npm run verify:gate` proves the identity witness against injected mutants, and `npm run verify:seq-gate` proves the sequence engine against injected mutants.
 
 ## Agent database
 
@@ -227,41 +234,35 @@ Use it to evaluate AEGIS before deploying, demo the UI to your team, or develop 
 **Frameworks** — LangChain, Semantic Kernel, AutoGen, MetaGPT, TaskWeaver
 **Local LLMs** — Ollama, LM Studio, vLLM, llama.cpp, LocalAI, GPT4All, Jan
 
-Add custom agents via the UI or edit the JSON. See [AGENTS.md](AGENTS.md).
+Add custom agents via the UI or edit the JSON. See [the contributor guide](CONTRIBUTING.md#how-to-add-a-new-agent) for process signatures, endpoint allowlists and config watch roots.
 
 ## Roadmap
 
-Everything below is **planned**, not shipped. AEGIS today is monitor-only (see [Monitor-first](#monitor-first)).
+The [current roadmap](ROADMAP.md) separates completed work, active experiments and remaining requirements. Features merged into source may not be present in the latest installer.
 
-- [ ] Active blocking — enforce rules on violation (userspace, pre-execution; kernel drivers are a non-goal) (today: observe & log only)
-- [ ] Surface per-sensor health in the UI — main-process records exist ([design](docs/roadmap/sensor-health-degraded.md))
-- [ ] MITRE ATT&CK mapping for detection rules
-- [ ] ML-based anomaly detection (today: hard-coded heuristic weights)
-- [ ] First-class macOS & Linux support (currently experimental — [#37](https://github.com/antropos17/Aegis/issues/37))
-- [ ] GPU monitoring for local inference detection
-- [ ] Per-process file attribution (ETW, fanotify) — static recon: [docs/recon/kernel-file-etw.md](docs/recon/kernel-file-etw.md)
-- [ ] Container/VM detection (Docker, WSL)
-- [ ] Browser extension for web-based AI agents
-- [x] Signed Windows auto-updates (implemented; first release requires a manual install)
-- [x] i18n / localization ([#53](https://github.com/antropos17/Aegis/issues/53))
+- **Implemented in source:** sensor-health status and observation gaps, sequence correlations, audit indexing and signed Windows update support. The first installer containing the updater still requires a manual install.
+- **In progress:** Windows ETW file-attribution experiments and lifecycle validation; production monitoring still uses the existing watcher/handle sensors.
+- **Remaining:** broader WSL and container discovery, a meaningful GPU inference signal, macOS/Linux parity, and the other scoped work listed in the roadmap.
+
+AEGIS remains monitor-first. These plans do not imply automatic blocking or sandbox containment.
 
 ## Frequently asked questions
 
 ### What is Aegis?
 
-Aegis is an open-source, OS-level monitor for AI agents. It tracks processes, file access, network activity, and behavioral anomalies in real time, built on Electron 43 and Svelte 5. The monitoring engine is CommonJS JavaScript; the renderer is ES modules, and TypeScript is used in the renderer and the shared type definitions. All data stays local — no telemetry, no cloud dependency.
+Aegis is an open-source, OS-level monitor for AI agents, built on Electron and Svelte. It combines process and network polling with file watchers and behavioral scoring. The monitoring engine uses CommonJS JavaScript, with TypeScript in the renderer and shared types. Monitoring runs locally without telemetry; optional AI analysis and update requests use external services.
 
 ### Why do AI agents need monitoring?
 
-Autonomous AI agents like OpenClaw, AutoGPT, and Devin have deep access to local files, credentials, and shell commands — yet run with minimal oversight. The OpenClaw case is the concrete example: a security audit reported by [Kaspersky](https://www.kaspersky.com/blog/openclaw-vulnerabilities-exposed/55263/) identified 512 vulnerabilities in one popular agent. Aegis provides the independent observability layer, so you can see what agents actually do on your machine.
+An agent may have access to files, credentials and shell commands. Monitoring helps you investigate its observed activity and changes in behavior. Detection has gaps, so visibility complements access controls and sandboxing.
 
 ### How is Aegis different from traditional EDR?
 
-Traditional EDR tools monitor human-driven threats — malware, ransomware, phishing. Aegis is built specifically for AI-agent behavior: it ships with 110 agents (262 process-name signatures) in its detection database, 73 detection rules tuned for agent-specific patterns, and behavioral baselines that track how each agent's activity changes over time. It is also monitor-first: it observes and logs, and leaves enforcement to sandboxing.
+AEGIS focuses on AI-agent process signatures, attribution evidence and behavioral baselines. It is an alpha monitoring tool with manual process controls, and does not provide the prevention, containment or managed response expected from a full EDR deployment.
 
 ### Does Aegis work with MCP tools?
 
-Aegis monitors processes, not protocols. If a tool connected via the Model Context Protocol (MCP) spawns processes, accesses files, or makes network calls, that activity is observed and attributed like any other — Aegis does not parse MCP traffic itself.
+Aegis monitors processes, not protocols. Activity from an MCP tool may be visible when its processes and file/network operations fall within sensor coverage. Aegis does not parse MCP traffic, identify tool calls or guarantee attribution of every MCP action.
 
 ### Is Aegis a replacement for sandboxing?
 
@@ -273,11 +274,11 @@ Aegis ships with 110 agents (262 process-name signatures) in its database, spann
 
 ### Can I use Aegis in production?
 
-Aegis is alpha software (see [Releases](https://github.com/antropos17/Aegis/releases) for the current version) and is recommended for development and testing environments. It is monitor-first — it will not block anything — and production-deployment features such as auto-update and OS-level enforcement are on the [roadmap](#roadmap), not in the current release.
+Aegis is alpha software intended for evaluation and development. Check the [known limits](#known-limits) and the notes for the specific [release](https://github.com/antropos17/Aegis/releases) you install. Current source includes signed Windows update support; published 0.14.1-alpha predates it. Automatic OS-level enforcement is not implemented.
 
 ### Is Aegis free?
 
-Yes. Aegis is released under the MIT license with no telemetry, no cloud requirements, and no paid tiers. The full source code is available on GitHub.
+Yes. Aegis source is available under the MIT license and local monitoring needs no account or subscription. Optional Anthropic analysis uses your own API key and is subject to that service's charges.
 
 ## Contributors
 
@@ -298,7 +299,7 @@ Yes. Aegis is released under the MIT license with no telemetry, no cloud require
 
 If Aegis is useful to you, consider giving it a star on GitHub — it helps others discover the project.
 
-**Teams & Enterprise** — Need centralized dashboards, SIEM integration, or managed deployment? We're building it. [Get notified](mailto:aegis@antropos17.dev?subject=Aegis%20Enterprise%20Interest)
+For deployment or integration requirements, [open a feature request](https://github.com/antropos17/Aegis/issues/new?template=02-feature-request.yml). Centralized management and a hosted service are not currently provided.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ AEGIS monitors AI agents — security is our core mission. We take vulnerabiliti
 
 ### Contact
 
-Report vulnerabilities via [GitHub Security Advisories](https://github.com/antropos17/Aegis/security/advisories).
+Use [Report a vulnerability](https://github.com/antropos17/Aegis/security/advisories/new) to send a private report through GitHub. Do not include vulnerability details or credentials in public issues.
 
 Please include:
 - Description of the vulnerability
@@ -69,23 +69,24 @@ AEGIS follows Electron security best practices:
 - **Context isolation:** Enabled. The renderer process cannot access Node.js APIs.
 - **Node integration:** Disabled in the renderer.
 - **Preload bridge:** All IPC passes through `contextBridge.exposeInMainWorld` with a defined, enumerated API surface (54 channels: 44 invoke + 10 push). No arbitrary IPC.
-- **Content Security Policy:** Strict `default-src 'self'` policy, no external font loading.
+- **Content Security Policy:** `default-src 'self'` and `script-src 'self'`, with no `unsafe-eval` or external font loading. `style-src` permits `unsafe-inline` for application styles.
 - **No remote content:** The app loads only local files. No external URLs in the renderer.
-- **Input sanitization:** All user-visible strings pass through `escapeHtml()` before DOM insertion. Template literals are used for HTML generation, not `innerHTML` with raw strings.
-- **Single-instance lock:** Only one AEGIS instance runs at a time, preventing IPC interception.
+- **Output escaping:** Svelte escapes ordinary text interpolations. Generated HTML reports use explicit escaping; raw HTML insertion and new export paths require their own review.
+- **Single-instance lock:** Prevents duplicate application instances. It does not replace IPC sender checks or protect against a compromised local account.
 - **Application updates:** Windows installer metadata requires an Ed25519 signature from the bundled release public key. SHA-256 and byte length are checked after download and again after native installation confirmation. This authenticates release artifacts independently of Windows Authenticode. Update IPC rejects foreign senders and subframes and accepts no paths or URLs. See [update architecture](ARCHITECTURE.md#application-updates) for supported builds and limitations.
 
 ### Privacy Architecture
 
-- **All data stays local.** No telemetry, no cloud sync, no analytics, no tracking.
-- **AI analysis is opt-in.** API calls to Anthropic only happen when the user explicitly clicks "Run AI Threat Analysis." No background API calls.
+- **Local storage by default.** Settings, baselines and audit logs are stored locally. There is no telemetry, cloud sync, analytics or usage tracking. Optional external requests are described below.
+- **AI analysis is opt-in.** An explicit analysis request sends activity metadata to Anthropic using the configured API key. Depending on the analysis, this includes agent/process names, PIDs, parent chains, sensitive file paths, event counts and network endpoints. Monitoring does not require this service; analysis is not sent in the background.
 - **Update requests are opt-in.** Automatic checks/downloads default to off; manual actions contact public GitHub releases. These requests send no monitoring records, settings or API keys. Installation always requires native confirmation.
-- **Audit logs contain metadata, not content.** File paths and agent names are logged, but file contents are never read or stored.
-- **API key is stored locally** in Electron's userData directory, encrypted via Electron safeStorage (added v0.9.0).
+- **Audit records contain metadata.** File-monitoring records include paths, names and attribution evidence, not the contents of observed sensitive files. Token accounting separately reads local agent transcript JSONL to extract usage; that is distinct from the file-monitoring pipeline.
+- **API-key storage is conditional.** Settings use Electron safeStorage when encryption is available. If it is unavailable or encryption fails, the current implementation saves the key in plaintext in the local settings JSON. The key is decrypted in memory for API requests.
 
 ### Known Limitations
 
 - **Monitor-only:** AEGIS observes and does not enforce at the OS level. Permission states (allow/monitor/block) affect UI display and alerting. OS-level blocking by kernel driver is a deliberate non-goal.
+- **Settings exports can contain the API key:** Export Config serializes in-memory settings, including a configured plaintext key. Remove it before sharing a settings JSON. The ZIP session export removes API-key fields from its settings copy.
 - **Audit logs are plaintext:** JSONL files in `userData/audit-logs/` are unencrypted. They contain file paths and agent names but not file contents.
 - **Process attribution:** chokidar file watchers cannot attribute events to specific processes. Handle-based scanning provides per-process attribution but runs on a timer, not in real-time.
 - **No TLS inspection:** Network monitoring sees connection endpoints only and cannot inspect encrypted traffic. TLS interception is a deliberate non-goal, not a pending feature.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,1 +1,5 @@
-Place icon.ico here for packaging.
+# Application icon
+
+Packaging and the application use `assets/icon.png`. The source artwork is `assets/icon.svg`; `node scripts/make-icon.js` regenerates the PNG.
+
+The existing `icon.ico` is a duplicate PNG under an ICO filename and is not referenced by the packaging configuration. Do not use it as an ICO asset.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,20 +5,13 @@ and IPC architecture specific to this codebase.
 
 ---
 
-## Stack Versions (as of 2026-08-21 — authoritative versions live in `package.json`)
+## Stack
 
-| Dep | Version | Role |
-|-----|---------|------|
-| Svelte | 5.51+ | UI framework (runes mode) |
-| Vite | 7.3+ | Dev server + bundler for renderer |
-| Electron | 43 | Desktop shell + OS APIs |
-| Vitest | 4.0+ | Unit testing (Node env, jsdom available) |
-| chokidar | 3.6 | File system watcher (main process only) |
-| prettier | 3.8 | Code formatter — run before committing |
+Exact dependency ranges live in [package.json](../package.json); [package-lock.json](../package-lock.json) records the installed versions. Use the Node.js version pinned in `.nvmrc` and `npm ci` to reproduce the dependency tree.
 
-**Runtime deps (package.json `dependencies`) — three:** `ajv`, `chokidar`, `js-yaml`. `electron`
-is a devDependency; it ships as the shell, not as a resolved runtime dep. No further runtime
-deps without discussion.
+The application uses Electron, Svelte 5 and Vite. Vitest provides the test runner; Prettier and ESLint cover formatting and linting.
+
+Runtime dependencies are `ajv`, `chokidar`, `electron-updater`, `js-yaml` and `semver`. Electron is a devDependency that supplies the desktop shell. Justify new dependencies in the PR.
 
 ---
 
@@ -91,7 +84,7 @@ export let count = $state(0);
 // count = 5; // compiler error — reassignment of exported $state
 
 // WORKAROUND: wrap in object or use a function
-export const store = { count: $state(0) };
+export const store = $state({ count: 0 });
 store.count = 5; // OK — property mutation, not reassignment
 ```
 
@@ -123,7 +116,8 @@ This is intentional for tab transitions but has a render cost. Avoid nesting `{#
 ```js
 new BrowserWindow({
   webPreferences: {
-    contextIsolation: true,  // enforced since Electron 12, never disable
+    contextIsolation: true,  // keep renderer and preload worlds separate
+    sandbox: true,           // sandbox the renderer
     nodeIntegration: false,  // never enable — would expose Node to renderer
     preload: path.join(__dirname, 'preload.js'),
   },
@@ -148,8 +142,7 @@ contextBridge.exposeInMainWorld('aegis', {
 // GOOD: await a response, catches errors
 const data = await ipcRenderer.invoke('get-stats');
 
-// ONLY for fire-and-forget (no response needed)
-ipcRenderer.send('other-panel-expanded', true);
+// AEGIS exposes no fire-and-forget send method in its preload bridge.
 ```
 
 ### Validate IPC args in main process
@@ -164,14 +157,14 @@ performing file I/O, spawning processes, or writing to disk.
 ```
 OS (chokidar + netstat) --> main process
     --> preload.js (contextBridge) --> window.aegis
-        --> ipc.js stores (agents, events, stats, network, anomalies, resourceUsage)
-            --> risk.js (enrichedAgents derived store)
+        --> ipc.ts stores (agents, events, stats, network, anomalies, resourceUsage)
+            --> risk.ts (enrichedAgents derived store)
                 --> components
 ```
 
 ### Stream channels (pushed from main)
 
-All nine, exactly as subscribed in `preload.js`. There is no `scan-results` or
+The 10 push channels subscribed in `preload.js` are listed below. There is no `scan-results` or
 `anomaly-scores` channel — anomaly scores ride inside `scan-batch`.
 
 | Channel | Store | Payload |
@@ -185,12 +178,13 @@ All nine, exactly as subscribed in `preload.js`. There is no `scan-results` or
 | `toggle-theme` | — | consumed directly in `App.svelte`, not via a store |
 | `agent-resource-usage` | `agentResourceUsage` | per-agent CPU/RAM samples keyed by `instanceId` (read by `AgentCard`) |
 | `rules:reloaded` | — | exposed by `preload.js` but **no renderer subscriber** |
+| `updates:status` | `updateStatus` | update availability, download progress and action state |
 
 ### Invoke channels (renderer requests main)
 
 Common ones: `get-stats`, `get-resource-usage`, `get-agent-database`, `get-settings`,
 `save-settings`, `get-all-permissions`, `save-agent-permissions`, `analyze-session`,
-`kill-process`, `get-audit-entries-before`. All 40 are listed in `src/main/preload.js`; the
+`kill-process`, `get-audit-entries-before`. All 44 invoke channels are listed in `src/main/preload.js`; the
 full table with module attribution is in [ARCHITECTURE.md](../ARCHITECTURE.md).
 
 ### Browser / demo mode guard
@@ -203,7 +197,7 @@ if (window.aegis) {
 }
 ```
 
-`ipc.js` exports `isDemoMode` boolean — components can use it to hide Electron-only UI.
+`ipc.ts` exports `isDemoMode` boolean — components can use it to hide Electron-only UI.
 
 ---
 
@@ -213,12 +207,13 @@ if (window.aegis) {
 
 ```js
 // vite.config.js
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
   const isDemo = mode === 'demo';
+  const withDemoEngine = isDemo || command === 'serve';
   return {
     define: {
       // Replaced at build time — tree-shakeable, zero runtime cost
-      'import.meta.env.VITE_DEMO_MODE': JSON.stringify(isDemo ? 'true' : 'false'),
+      'import.meta.env.VITE_DEMO_MODE': JSON.stringify(withDemoEngine ? 'true' : 'false'),
     },
     build: {
       outDir: isDemo ? '../../dist/demo' : '../../dist/renderer',
@@ -243,12 +238,21 @@ use `base: './'` so asset paths are relative.
 ## Build Commands
 
 ```bash
-npm run dev            # Vite dev server on :5174 (renderer hot-reload only)
-npm run build:renderer # Production renderer build -> dist/renderer/
-npm run build:demo     # Static demo build -> dist/demo/ (no Electron required)
-npm run build          # Full Electron app -> dist/ (platform installer)
-npm start              # build:renderer + launch.js (opens Electron with built renderer)
+npm run build:renderer # Production renderer -> dist/renderer/
+npm run build:demo     # Static browser demo -> dist/demo/
+npm start              # Build renderer, then launch Electron
 ```
+
+Preview the built demo with `npx vite preview --mode demo --host 127.0.0.1 --port 4174`. The unbuilt `npm run dev` server currently fails to load the dashboard because a shared CommonJS helper is imported as ESM; use the built preview until that is fixed.
+
+For a local installer, run these commands in order:
+
+```bash
+npm run build:renderer
+npm run build
+```
+
+`build`/`dist` package the existing renderer output; they do not rebuild it. On Windows the packaging hook compiles the process-snapshot sidecar. Close a source-run AEGIS instance before packaging if it is holding that sidecar executable. Release CI runs the renderer build explicitly before packaging.
 
 ---
 
@@ -297,7 +301,7 @@ Key token namespaces:
 
 - **300-line soft limit** per file — a target for NEW files, not an invariant; 37 existing `src/` files already exceed it. Not enforced by the linter
 - **JSDoc on all exported functions**: `@param`, `@returns`, `@since`
-- **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `security:`
+- **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`; see [BRANCHING.md](../BRANCHING.md)
 - **IPC channel names**: `kebab-case`
 - **CSS class names**: `component-element` (BEM-lite, no nesting depth > 2)
 - **Branch from `master`**, not main

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,25 +1,25 @@
-# Aegis — EDR for AI Agents
+# Aegis — Local Monitoring for AI Agents
 
-> Aegis is an open-source endpoint detection and response (EDR) tool that monitors AI agent processes, file access, network activity, and behavioral anomalies in real time.
+> Aegis is an open-source, monitor-first desktop app for local AI-agent processes, file activity, TCP endpoints and behavioral anomalies.
 
-## Problem
+## Purpose and scope
 
-Autonomous AI agents (OpenClaw, AutoGPT, Devin, CrewAI) now have deep access to local files, credentials, and shell commands. Every existing AI security tool is enterprise SaaS that monitors what humans send *to* AI. Nobody monitors what AI agents do *on local machines*. CrowdStrike, Cisco, and Kaspersky have all flagged security risks in autonomous AI agents — Kaspersky found 512 bugs in OpenClaw alone.
+AI agents can access local files, credentials, shell commands and external services. AEGIS observes supported activity from outside the agent and records attribution evidence. It is one of several approaches to agent observability; in-agent instrumentation and OS-level tools have different coverage.
 
-## Solution
+Monitoring runs locally without telemetry or an account. Optional AI analysis sends activity metadata to Anthropic using the user's API key; update checks contact GitHub. AEGIS has manual process controls but no automatic OS-level enforcement.
 
-Aegis provides the same class of oversight for autonomous AI agents that CrowdStrike provides for traditional endpoints. It runs locally, keeps all data on-device, and is vendor-independent. No telemetry, no cloud, no paid tiers.
+This document describes current source. Installed releases can lag behind it; consult the release tag and README limitations.
 
 ## Installation
 
 ```bash
 git clone https://github.com/antropos17/Aegis.git
 cd Aegis
-npm install
+npm ci
 npm start
 ```
 
-Building from source requires Node.js 24.x, as declared by `engines` in `package.json` and pinned in `.nvmrc` and CI. The tooling floor is lower but still excludes Node 18 and 19 — Vite 7 declares `^20.19.0 || >=22.12.0` and Vitest 4 declares `^20.0.0 || ^22.0.0 || >=24.0.0`. npm 10+. The packaged app ships its own Node runtime inside Electron. Windows 10/11 recommended. macOS/Linux experimental.
+Building from source requires Node.js 24.x, as declared in package.json and pinned in .nvmrc and CI. The packaged app ships its own runtime. Windows 10/11 is the primary platform; macOS/Linux remain experimental. For a browser demo, follow the built-preview instructions in the README.
 
 ## Features
 
@@ -27,10 +27,10 @@ Building from source requires Node.js 24.x, as declared by `engines` in `package
 Tracks 110 known AI agents (262 process-name signatures across their `names` arrays) with parent-child tree resolution and IDE host detection. Covers coding assistants (Claude Code, Copilot, Cursor), autonomous agents (OpenClaw, AutoGPT, CrewAI, Devin), desktop AI (Gemini, Apple Intelligence), frameworks (LangChain, AutoGen, MetaGPT), and local LLMs (Ollama, LM Studio, llama.cpp).
 
 ### File System Access
-Watches sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs) and the 35 AI agent config paths registered in AGENT_CONFIG_PATHS for unauthorized access.
+Watches sensitive directories (.ssh, .aws, .gnupg, .env, cloud configs) and the 35 AI agent config paths registered in AGENT_CONFIG_PATHS for file activity. Database configPaths metadata does not register watch roots automatically.
 
 ### Network Activity
-Logs outbound TCP connections per agent PID with reverse DNS and known-vs-unknown API endpoint classification.
+Logs outbound TCP connections per agent PID with forward-confirmed reverse DNS and allowlisted, unknown or flagged endpoint verdicts. An unresolved endpoint is not assumed safe.
 
 ### Behavioral Analysis
 Applies 73 detection rules across 8 categories (AI config, secrets, SSH, cloud, browser, devtools, crypto, certificates) with rolling 10-session baselines and 4-axis anomaly scoring (Network/FS/Process/Baseline).
@@ -39,13 +39,13 @@ Applies 73 detection rules across 8 categories (AI config, secrets, SSH, cloud, 
 Assigns real-time risk scores with trust grades (A+ through F) using time-decay algorithms and multi-dimensional threat assessment.
 
 ### Dashboard
-Bento grid layout with RiskRing gauge, sparklines, TrustBadge, agent stats, activity feed with filters, session timeline, and expandable agent cards. Protection presets: Paranoid, Strict, Balanced, Developer.
+Radar overview, summary cards, filtered/grouped activity feeds, network panel, expandable agent/application cards and footer sensor health. Monitoring presets: Paranoid, Strict, Balanced, Developer. Presets do not enforce OS-level blocking.
 
 ### Export and Audit
-JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily rotation and 30-day retention.
+JSON, CSV, HTML reports, one-click ZIP archive and hash-chained JSONL audit logging with daily rotation and 30-day retention. Settings JSON exports can contain the plaintext API key; remove it before sharing. ZIP session exports remove API-key fields from their settings copy.
 
 ### YAML Rulesets
-73 detection rules, validated against rules/_schema.json. Editing a ruleset hot-reloads without a restart. Extend by adding a .yaml to rules/; rule IDs must be unique, and a duplicate ID is skipped rather than overriding.
+73 sensitive-path detection rules, validated against rules/_schema.json. Existing ruleset edits hot-reload in unpacked runs; packaged ASAR watchers are disabled. Extend by adding a .yaml to rules/ and reloading or restarting; sensitive-rule IDs must be unique and duplicates are skipped. Sequence correlations live separately in rules/sequences/: keep their IDs unique across files because the sequence loader currently does not reject cross-file duplicates.
 
 ## Documentation
 
@@ -56,14 +56,14 @@ JSON, CSV, HTML reports, one-click ZIP archive, JSONL audit logging with daily r
 
 ## Technical Details
 
-- **Stack**: Electron 43, Svelte 5, Vite 7, TypeScript
+- **Stack**: Electron, Svelte 5, Vite; CommonJS JavaScript in main, TypeScript in the renderer and shared types. Exact versions: package.json
 - **Tests**: Vitest; run `npm test` for current pass/skip and file counts
 - **License**: MIT
 - **Version**: 0.14.1-alpha <!-- x-release-please-version -->
-- **Platform**: Windows, macOS, Linux
+- **Platform**: Windows primary; macOS/Linux experimental
 
 ## Links
 
 - Repository: https://github.com/antropos17/Aegis
-- Website: https://aegisprotect.vercel.app
-- Demo: https://aegis-demo-ten.vercel.app
+- Local demo instructions: https://github.com/antropos17/Aegis#try-without-ai-agents
+- Privacy and external requests: https://github.com/antropos17/Aegis/blob/master/SECURITY.md#privacy-architecture

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Aegis
 
-> Aegis is an open-source endpoint detection and response (EDR) tool that monitors AI agent processes, file access, network activity, and behavioral anomalies in real time.
+> Aegis is an open-source, monitor-first desktop app for local AI-agent processes, file activity, TCP endpoints and behavioral anomalies. It combines polling with event-based file watchers; coverage and attribution have documented limits.
 
 ## Documentation
 
@@ -18,18 +18,20 @@
 - Trust scoring with grades A+ through F using time-decay algorithms
 - Local LLM detection (Ollama, LM Studio, vLLM, llama.cpp)
 - Export to JSON, CSV, HTML reports and ZIP archives
-- YAML rulesets with JSON Schema validation and hot-reload
+- YAML rulesets with JSON Schema validation; edits to existing files hot-reload in unpacked runs
+
+Local monitoring has no telemetry. Optional AI analysis sends activity metadata to Anthropic on request; update actions contact GitHub. AEGIS does not automatically enforce OS-level restrictions.
 
 ## Technical Details
 
-- **Stack**: Electron 43, Svelte 5, Vite 7, TypeScript
+- **Stack**: Electron, Svelte 5, Vite; CommonJS JavaScript in main, TypeScript in the renderer and shared types. Exact versions: package.json
 - **Tests**: Vitest; run `npm test` for current pass/skip and file counts
 - **License**: MIT
 - **Version**: 0.14.1-alpha <!-- x-release-please-version -->
-- **Platform**: Windows, macOS, Linux
+- **Platform**: Windows primary; macOS/Linux experimental
 
 ## Links
 
 - Repository: https://github.com/antropos17/Aegis
-- Website: https://aegisprotect.vercel.app
-- Demo: https://aegis-demo-ten.vercel.app
+- Local demo instructions: https://github.com/antropos17/Aegis#try-without-ai-agents
+- Privacy and external requests: https://github.com/antropos17/Aegis/blob/master/SECURITY.md#privacy-architecture


### PR DESCRIPTION
The public documentation overstates monitoring coverage and privacy, lists obsolete UI and IPC details, and directs users to a broken dev preview and disabled hosted sites. Align README, architecture, security, contributor and LLM-facing pages with the current source and distinguish it from released installers. Document conditional key encryption and settings-export behavior, provide a verified built-demo command, update release history, and add a question issue form plus a direct private-report link.

Screenshots, image markup and numeric test-count references are unchanged. Runtime code, dependencies and workflows are unchanged. The repository About text and disabled homepage link were corrected separately, and private vulnerability reporting was enabled and read back.

Validation: format:check, build:renderer, build:demo, lint (0 errors, 31 existing warnings), counts:check, local Markdown links, issue-form YAML parsing, and screenshot/test-count preservation checks passed. The documented Vite preview command loaded the dashboard in the browser. README was rendered with GitHub's Markdown API.
