### PR TITLE
docs: refresh contributor credits and workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,12 +284,18 @@ Yes. Aegis source is available under the MIT license and local monitoring needs 
 
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/antropos17"><img src="https://github.com/antropos17.png" width="80px;" alt=""/><br/><sub><b>Antropos7</b></sub></a></td>
-    <td align="center"><a href="https://github.com/ElshadHu"><img src="https://github.com/ElshadHu.png" width="80px;" alt=""/><br/><sub><b>Elshad Humbatli</b></sub></a></td>
-    <td align="center"><a href="https://github.com/skmelendez"><img src="https://github.com/skmelendez.png" width="80px;" alt=""/><br/><sub><b>Steven Melendez</b></sub></a></td>
-    <td align="center"><a href="https://github.com/travisbreaks"><img src="https://github.com/travisbreaks.png" width="80px;" alt=""/><br/><sub><b>travisbreaks</b></sub></a></td>
-    <td align="center"><a href="https://github.com/raye-deng"><img src="https://github.com/raye-deng.png" width="80px;" alt=""/><br/><sub><b>raye-deng</b></sub></a></td>
-    <td align="center"><a href="https://github.com/KJyang-0114"><img src="https://github.com/KJyang-0114.png" width="80px;" alt=""/><br/><sub><b>KJyang-0114</b></sub></a></td>
+    <td align="center"><a href="https://github.com/antropos17"><img src="https://github.com/antropos17.png" width="80" alt=""/><br/><sub><b>Antropos7</b></sub></a></td>
+    <td align="center"><a href="https://github.com/travisbreaks"><img src="https://github.com/travisbreaks.png" width="80" alt=""/><br/><sub><b>travisbreaks</b></sub></a></td>
+    <td align="center"><a href="https://github.com/MsfPablo"><img src="https://github.com/MsfPablo.png" width="80" alt=""/><br/><sub><b>MsfPablo</b></sub></a></td>
+    <td align="center"><a href="https://github.com/raye-deng"><img src="https://github.com/raye-deng.png" width="80" alt=""/><br/><sub><b>raye-deng</b></sub></a></td>
+    <td align="center"><a href="https://github.com/pablo"><img src="https://github.com/pablo.png" width="80" alt=""/><br/><sub><b>pablo</b></sub></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/skmelendez"><img src="https://github.com/skmelendez.png" width="80" alt=""/><br/><sub><b>Steven Melendez</b></sub></a></td>
+    <td align="center"><a href="https://github.com/anupamme"><img src="https://github.com/anupamme.png" width="80" alt=""/><br/><sub><b>anupamme</b></sub></a></td>
+    <td align="center"><a href="https://github.com/mig-builds"><img src="https://github.com/mig-builds.png" width="80" alt=""/><br/><sub><b>mig-builds</b></sub></a></td>
+    <td align="center"><a href="https://github.com/frobel0520"><img src="https://github.com/frobel0520.png" width="80" alt=""/><br/><sub><b>frobel0520</b></sub></a></td>
+    <td align="center"><a href="https://github.com/KJyang-0114"><img src="https://github.com/KJyang-0114.png" width="80" alt=""/><br/><sub><b>KJyang-0114</b></sub></a></td>
   </tr>
 </table>
 

--- a/memory-bank/ai-mistakes.md
+++ b/memory-bank/ai-mistakes.md
@@ -650,10 +650,9 @@ Repeated mistakes by Claude Code — 46 numbered lessons, grouped by category (t
     **Census, so the condition is not read off one case.** Every fork-originated run the API
     still returns — `gh api 'repos/antropos17/Aegis/actions/runs?event=pull_request&per_page=100&page=N'`
     over all five pages, 409 `pull_request` runs, 21 of them from forks across six
-    contributors (anupamme, mig-builds, frobel0520, MsfPablo, ElshadHu, travisbreaks) —
-    splits 21/21 on one line: parked while its author had no merged PR here, unparked after.
-    `ElshadHu` crossed it at #26 (2026-02-19) and `travisbreaks` at #50 (2026-03-01), each
-    with the same before/after shape.
+    contributors — splits 21/21 on one line: parked while its author had no merged PR
+    here, unparked after. Two contributors crossed that boundary at #26 (2026-02-19)
+    and #50 (2026-03-01), each with the same before/after shape.
     **What this does NOT retire.** (b) stands exactly as written, and this entry is why:
     mig-builds was STILL first-time when #273 was updated — the PR merged one minute after
     the second approval — so the second round was required, not redundant. (c) and (d) are


### PR DESCRIPTION
Refresh the curated contributor grid with missing contributors and arrange the cards in two rows. Anonymize the historical workflow case study while retaining its PR references, dates and conclusions.

Validation: renderer build, formatting and inventory checks passed. README changes are limited to the Contributors table; screenshots and test-count references are untouched.
