### PR TITLE
docs: restore star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,7 @@ The [roadmap](ROADMAP.md) tracks Windows ETW experiments and remaining discovery
 [Feature requests](https://github.com/antropos17/Aegis/issues/new?template=02-feature-request.yml) · [Private vulnerability reports](https://github.com/antropos17/Aegis/security/advisories/new) · [MIT license](LICENSE)
 
 Local monitoring requires no account or subscription. Optional Anthropic analysis uses your own API key and is subject to that service's charges.
+
+## Star history
+
+[![Star History Chart](https://api.star-history.com/image?repos=antropos17/Aegis&type=timeline&legend=top-left)](https://www.star-history.com/?repos=antropos17%2FAegis&type=timeline&legend=top-left)


### PR DESCRIPTION
Restore the Star history chart and its link at the end of README.md. It was removed during the README cleanup even though it remains relevant.

Validation: git diff --check, format:check, build:renderer and lint passed (existing lint warnings only). The restored section matches the version before the cleanup.
