### PR TITLE
feat(etw): connect bounded diagnostic file backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ out/
 coverage/
 # Compiled snapshot sidecar — built from sidecar/procsnap, never committed
 build/sidecar/
+/sidecar/etw-file/bin/
+/sidecar/etw-file/obj/
 # Raw bench run output written by bench/run.js (manifest, ndjson, reports).
 # Never commit it: it is machine-local. The committed, redacted copies live in
 # tests/fixtures/bench/ (see that README). Gold-image numbers go in docs/bench/.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Explicit user instructions take precedence over anything in AGENTS.md or a skill
 
 ## Project facts
 
-`src/main/` contains 70 main modules: 55 top-level + platform/ 13 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
+`src/main/` contains 72 main modules: 55 top-level + platform/ 15 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
 
 A birth time is observed on the pass that stamps it or is `null`; no cache stores one. A snapshot outage freezes sessions and never splits them. For changes touching identity stamping, the audit chain, or the Windows git worktree flow, `memory-bank/ai-mistakes.md` holds the relevant failure history.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,8 +75,8 @@ The dependency is those observations, not the absence of a Windows host.
    and authoritative attribution remain gated; the remaining B1 questions stay open.
 3. **B3 (offline backend contract implemented):** separate framed protocol
    validator/decoder and pure session-health reducer with synthetic fixtures.
-   Both modules remain outside the live module graph. No launch/UAC, real ETW,
-   main wiring, audit or frontend.
+   Originally offline; B5 below connects these modules to the optional diagnostic
+   backend. No audit or frontend observation admission.
    The existing `sidecar/procsnap` remains independent.
 4. **B4 (isolated lifecycle harness prepared):** [broker/collector experiment](sidecar/etw-lifecycle/README.md)
    implements restricted local pipes, mutual process identity, authorization,
@@ -92,9 +92,17 @@ The dependency is those observations, not the absence of a Windows host.
    [Controlled refusal/late-UAC probes](docs/roadmap/etw-consent-suspend.md) passed
    actual refusal and approval after 14.13 seconds; both independently observed
    session absence. The dedicated suspend mode now has bounded native power
-   observations and synthetic process checks. **Next: manual sleep/wake evidence**, plus protected
-   ownership/recovery design for collector crash. No file provider or Electron
-   connection; E1/E2 remain incomplete.
+   observations and synthetic process checks. Manual sleep/wake is deferred by the
+   user; protected ownership/recovery for collector crash remains open. This empty
+   session harness has no file provider; E1/E2 remain incomplete.
+5. **B5 (diagnostic backend implemented; narrow live smoke passed):**
+   [connected file backend](docs/roadmap/etw-file-backend.md) adds the fixed provider,
+   bounded queues and naming maps, candidate process witnesses, lifecycle supervisor,
+   explicit verified restart and optional Electron health wiring. Enabled only by a
+   development root flag; packaged capture stays gated. New live evidence confirms
+   a scoped Read/header PID candidate and owned stop, with zero native losses but
+   substantial counted ingress drops. E4/E5 authoritative attribution, independent
+   cleanup/recovery and the remaining E3/E6–E8 live gates remain open.
 
 ## C — existing rules coverage
 
@@ -142,10 +150,12 @@ Keep them outside the active queue while the first ETW sensor is being establish
 
 ## Execution order
 
-The B2 draft, B3 offline backend contract and B4 isolated lifecycle harness are
-implemented; real same-account UAC stop and graceful-failure cleanup passed. Continue with
-remaining suspend, pending-dialog cancellation and collector-crash ownership gates in
-[etw-sensor-design.md](docs/roadmap/etw-sensor-design.md). Start with
+The B2 draft, B3 protocol, B4 lifecycle harness and B5 diagnostic backend are
+implemented; real same-account UAC stop and graceful-failure cleanup passed only
+for B4. B5's narrow live file smoke passed; application queue loss under burst traffic
+still needs work before production admission. Sleep/wake remains deferred;
+pending-dialog cancellation, collector-crash ownership and evidence admission remain
+open in [etw-sensor-design.md](docs/roadmap/etw-sensor-design.md). Start with
 [next-session.md](memory-bank/next-session.md) and the latest progress handoff.
 All three local experiment sets are complete; do not repeat them without a specific
 new question. B1's remaining coverage/environment questions stay explicit.

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **70** = 55 top-level + 13 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **72** = 55 top-level + 15 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **50** (plus `src/renderer/App.svelte` → **51** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **16** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/docs/recon/evidence/etw-file-home-26200-backend.json
+++ b/docs/recon/evidence/etw-file-home-26200-backend.json
@@ -1,0 +1,1115 @@
+{
+  "schema": 1,
+  "recordedAt": "2026-09-09T13:29:49.399Z",
+  "scope": "B5 diagnostic backend. One narrow live smoke on current binaries; not production admission or a loss-free transport result.",
+  "sourceHashNormalization": "UTF-8 text with CRLF normalized to LF; current final source only",
+  "sourceHashes": {
+    "scripts/launch.js": "e745cebbe5d3c8fdded2ac4245bf8a1bf1272cb234e156df580dc892e5ffa5d0",
+    "scripts/verify-etw-file.mjs": "1c177c30225ae3ca6a1d05881a94f3e3bcf46bc4a293a3ad1911bb58cb92af64",
+    "sidecar/etw-file/EtwFile.csproj": "9e34c6ad37d5751758d618095cf6b32ae54d90382855ece0b622fa2588589205",
+    "sidecar/etw-file/FileBroker.cs": "a3ebc5c3f81ffd2942a267c644922e3d9bd7e5353ff3993eaa927fb8019e6738",
+    "sidecar/etw-file/FileCapture.cs": "318d80a666392cbf1ab3b03666b1fec28f1d57e958229f0e050a639bb1726dc3",
+    "sidecar/etw-file/FileCollector.cs": "efb8192d075521ab2dd5abc0d55874e276f3ebab94ac34aa4406a8b267064cdb",
+    "sidecar/etw-file/FileGeneration.cs": "8520aa3bda23ee51bf6efe556f7aa72a2b31fa75f2cd7d8dd2077047369ff768",
+    "sidecar/etw-file/FileMapping.cs": "c0c2975837899e9e820328a8cd638e24c183ab0c3d36d9c0cb58cc936855922c",
+    "sidecar/etw-file/FilePipeline.cs": "6987c8887e5a162a0fd592ffd361e4005202e87fd5b9495531af04a644c2a773",
+    "sidecar/etw-file/FileScope.cs": "05976472d37b07c60be71aedb6fb89da795ba0a41d527a3b41d244bd5aee5ca0",
+    "sidecar/etw-file/FileTests.cs": "48449bf11e46c9ebcf937c3b3ee81893718bd2a3d9c35ca5d7012744b3775b70",
+    "sidecar/etw-file/FileTrace.cs": "25fd9d2f46a0d66c01610a1c4a5b03bc6042af654e6bcd2cdf85ec69e94c4dc6",
+    "sidecar/etw-file/FileWire.cs": "a4ff54d4c725f1de8d1ae4c814851e77abe01348fe4ab64a6609b9507a332f7d",
+    "sidecar/etw-file/Program.cs": "b879d22901405a5597e99a23b3c255ad1f20806e50bb990d822e71e111b9268d",
+    "sidecar/etw-lifecycle/Security.cs": "19fde5ace53914b1e8804b9716a2d041d794e09b273bd8acc385405ba6fadc96",
+    "src/main/main.js": "3ff6c21c7473995970594e2f5835fc227cd05bbbefc65cf1da86b16ad61bc7c4",
+    "src/main/platform/etw-file-health.js": "38e6d3976a6897c1e0799b0f65b93794d6e5c4fcf86ce81c73e24380a5a22207",
+    "src/main/platform/etw-file-protocol.js": "3522761aa103e4dd69e4a025acb00665b4ad0c975cfcc769b8dc62b94cbe9aa1",
+    "src/main/platform/etw-file-runtime.js": "cea6d4a6dc456a73673838374dcb310c47ce8f262220e0c55b3b67ad0063f1e5",
+    "src/main/platform/etw-file-supervisor.js": "1e0b7df56f0d95166861c989558531d46d9d551bf2d46af8afc3af120be1151f"
+  },
+  "normal": {
+    "file": "aegis-etw-file-check-20260909-v6.json",
+    "sha256": "2efd915ef03e8df7acd44cb6e6ddbdafa5b7546be0daf5ab173e7e6f69d01778",
+    "report": {
+      "schema": 1,
+      "live": false,
+      "synthetic": true,
+      "startedAt": "2026-09-09T13:26:29.898Z",
+      "binarySha256": "eeb3c04698b6aa6a37c88e2a9de42862314099e37be4bac8245424a54d093bb3",
+      "assemblySha256": "2ac9da0c6597f8ee77a3ab5ddfcd2173ce88600584a0a2c39d1f72269e1b6938",
+      "cases": [
+        {
+          "kind": "normal-stop",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 1617,
+          "ringDropped": 0,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "93f04044-5842-4bfa-a209-21a4160a70c0",
+            "sessionId": "7d252d6c-e5de-44a0-afd5-ac0dba7ecfd5",
+            "endedAt": 1788960390467,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "106671617608",
+                "unixMs": "1788960390307",
+                "uncertaintyQpc": "10754"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "106670134282"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "explicit-new-session",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 1617,
+          "ringDropped": 0,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "334853d4-79f7-4805-b7d3-12859ef9fb3e",
+            "sessionId": "fff25f5a-396b-4cf5-b408-3dcedb2607ad",
+            "endedAt": 1788960391061,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "106677586753",
+                "unixMs": "1788960390904",
+                "uncertaintyQpc": "10712"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "106676157458"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "parent-eof-unverified",
+          "summary": {
+            "launchId": "d99001b1-3107-4300-a130-07e0375ae1d5",
+            "sessionId": "655057be-ad60-4138-8ab9-1ac9607cbee4",
+            "endedAt": 1788960391563,
+            "phase": "failed",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain",
+              "stream-ended"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "106683489947",
+                "unixMs": "1788960391494",
+                "uncertaintyQpc": "10556"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "106682185639"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "stopReason": null,
+            "exitCode": 2,
+            "stopVerified": false
+          }
+        }
+      ],
+      "passed": true,
+      "observationCheck": {
+        "observed": true,
+        "named": true,
+        "fixtureRead": false,
+        "leaked": false
+      },
+      "endedSessions": [
+        {
+          "launchId": "93f04044-5842-4bfa-a209-21a4160a70c0",
+          "sessionId": "7d252d6c-e5de-44a0-afd5-ac0dba7ecfd5",
+          "endedAt": 1788960390467,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "106671617608",
+              "unixMs": "1788960390307",
+              "uncertaintyQpc": "10754"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "106670134282"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "334853d4-79f7-4805-b7d3-12859ef9fb3e",
+          "sessionId": "fff25f5a-396b-4cf5-b408-3dcedb2607ad",
+          "endedAt": 1788960391061,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "106677586753",
+              "unixMs": "1788960390904",
+              "uncertaintyQpc": "10712"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "106676157458"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "d99001b1-3107-4300-a130-07e0375ae1d5",
+          "sessionId": "655057be-ad60-4138-8ab9-1ac9607cbee4",
+          "endedAt": 1788960391563,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "106683489947",
+              "unixMs": "1788960391494",
+              "uncertaintyQpc": "10556"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "106682185639"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      ],
+      "endedAt": "2026-09-09T13:26:31.564Z"
+    }
+  },
+  "live": {
+    "file": "aegis-etw-file-live-20260909-05.json",
+    "sha256": "f9dd18bff69b33966a4a766d44b1df28c2802cae5f970504505abc3c53159afe",
+    "report": {
+      "schema": 1,
+      "live": true,
+      "synthetic": false,
+      "startedAt": "2026-09-09T13:27:33.634Z",
+      "binarySha256": "eeb3c04698b6aa6a37c88e2a9de42862314099e37be4bac8245424a54d093bb3",
+      "assemblySha256": "2ac9da0c6597f8ee77a3ab5ddfcd2173ce88600584a0a2c39d1f72269e1b6938",
+      "cases": [
+        {
+          "kind": "normal-stop",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": true,
+          "ringBytes": 372639,
+          "ringDropped": 0,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "a59c4580-421c-441b-af66-2a520fef8b02",
+            "sessionId": "f75f008d-7a52-46bc-af20-758997a8f71a",
+            "endedAt": 1788960466322,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "dropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "88772",
+              "filtered": "76418",
+              "dropped": "12061",
+              "decoderErrors": "0",
+              "mapEpoch": "286",
+              "mapResets": "286",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "107329499863",
+                "unixMs": "1788960456095",
+                "uncertaintyQpc": "10220"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "queryStatus": 0,
+              "asOfQpc": "107430166131"
+            },
+            "finalTotals": {
+              "delivered": "88772",
+              "filtered": "76418",
+              "dropped": "12061",
+              "decoderErrors": "0",
+              "mapEpoch": "286",
+              "mapResets": "286",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        }
+      ],
+      "passed": true,
+      "observationCheck": {
+        "observed": true,
+        "named": true,
+        "fixtureRead": true,
+        "leaked": false
+      },
+      "endedSessions": [
+        {
+          "launchId": "a59c4580-421c-441b-af66-2a520fef8b02",
+          "sessionId": "f75f008d-7a52-46bc-af20-758997a8f71a",
+          "endedAt": 1788960466322,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "dropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "88772",
+            "filtered": "76418",
+            "dropped": "12061",
+            "decoderErrors": "0",
+            "mapEpoch": "286",
+            "mapResets": "286",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "107329499863",
+              "unixMs": "1788960456095",
+              "uncertaintyQpc": "10220"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "queryStatus": 0,
+            "asOfQpc": "107430166131"
+          },
+          "finalTotals": {
+            "delivered": "88772",
+            "filtered": "76418",
+            "dropped": "12061",
+            "decoderErrors": "0",
+            "mapEpoch": "286",
+            "mapResets": "286",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      ],
+      "endedAt": "2026-09-09T13:27:46.340Z"
+    }
+  },
+  "earlierAttempts": [
+    {
+      "file": "aegis-etw-file-live-20260909-01.json",
+      "sha256": "c88462a13b241f06e34e3bb5412fd37a5b54248dc18a6879010898dbc2d50fe9",
+      "report": {
+        "schema": 1,
+        "live": true,
+        "synthetic": false,
+        "startedAt": "2026-09-09T13:06:58.072Z",
+        "binarySha256": "eeb3c04698b6aa6a37c88e2a9de42862314099e37be4bac8245424a54d093bb3",
+        "assemblySha256": "dcf9ef27ed2f72a520a6716a5f1f51aa88abed0303d0bf661968143de6a9ea74",
+        "cases": [],
+        "passed": false,
+        "error": "observation-contract",
+        "finalHealth": {
+          "sensorId": "etw-file",
+          "state": "DEGRADED",
+          "lastAttemptAt": 1788959228756,
+          "lastSuccessAt": 1788959228756,
+          "lastError": null,
+          "consecutiveFailures": 0,
+          "lossCount": 0,
+          "detail": "experimental-correlation,mapResets,dropped,mapping-uncertain,identity-uncertain"
+        },
+        "endedSessions": [
+          {
+            "launchId": "79beec6c-b448-42db-ba46-dd598b95c38e",
+            "sessionId": "c327bf1e-37ff-4587-83e8-15a99dc41160",
+            "endedAt": 1788959230804,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "mapResets",
+              "dropped",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "69956",
+              "filtered": "13118",
+              "dropped": "55638",
+              "decoderErrors": "0",
+              "mapEpoch": "8062",
+              "mapResets": "8062",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "94975355341",
+                "unixMs": "1788959220681",
+                "uncertaintyQpc": "10331"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "queryStatus": 0,
+              "asOfQpc": "95076093529"
+            },
+            "finalTotals": {
+              "delivered": "69956",
+              "filtered": "13118",
+              "dropped": "55638",
+              "decoderErrors": "0",
+              "mapEpoch": "8062",
+              "mapResets": "8062",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 944,
+            "stopReason": "shutdown",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        ],
+        "endedAt": "2026-09-09T13:07:10.831Z"
+      }
+    },
+    {
+      "file": "aegis-etw-file-live-20260909-02.json",
+      "sha256": "8842498876aa249afcf90df8cf4051b04acb0b847d301a4b8eab9b272cb9bc9b",
+      "report": {
+        "schema": 1,
+        "live": true,
+        "synthetic": false,
+        "startedAt": "2026-09-09T13:10:37.329Z",
+        "binarySha256": "eeb3c04698b6aa6a37c88e2a9de42862314099e37be4bac8245424a54d093bb3",
+        "assemblySha256": "e2651e1c46eec96c7cd44cfc089e7a32b1c7408c593da08b1bf7371fa35826eb",
+        "cases": [
+          {
+            "kind": "normal-stop",
+            "observedRead": true,
+            "observedScopedCandidate": true,
+            "observedFixturePidCandidate": true,
+            "ringBytes": 369384,
+            "ringDropped": 330,
+            "sensorState": "DEGRADED",
+            "summary": {
+              "launchId": "2f8006bc-33e1-49eb-9d2d-004a0bd1b019",
+              "sessionId": "9e04664f-6aed-4308-849d-38e703951b69",
+              "endedAt": 1788959449691,
+              "phase": "stopped",
+              "reasons": [
+                "experimental-correlation",
+                "dropped",
+                "mapResets",
+                "mapping-uncertain",
+                "identity-uncertain"
+              ],
+              "maxima": {
+                "eventsLost": "0",
+                "realTimeBuffersLost": "0",
+                "logBuffersLost": "0",
+                "delivered": "87332",
+                "filtered": "9409",
+                "dropped": "77337",
+                "decoderErrors": "0",
+                "mapEpoch": "118",
+                "mapResets": "118",
+                "mapConflicts": "0"
+              },
+              "capture": {
+                "buffers": {
+                  "count": 256,
+                  "sizeKiB": 64
+                },
+                "frequency": "10000000",
+                "clock": {
+                  "qpc": "97164107756",
+                  "unixMs": "1788959439556",
+                  "uncertaintyQpc": "10206"
+                }
+              },
+              "finalCounters": {
+                "eventsLost": "0",
+                "realTimeBuffersLost": "0",
+                "logBuffersLost": "0",
+                "queryStatus": 0,
+                "asOfQpc": "97264842731"
+              },
+              "finalTotals": {
+                "delivered": "87332",
+                "filtered": "9409",
+                "dropped": "77337",
+                "decoderErrors": "0",
+                "mapEpoch": "118",
+                "mapResets": "118",
+                "mapConflicts": "0"
+              },
+              "ringDropped": 330,
+              "stopReason": "operator-stop",
+              "exitCode": 0,
+              "stopVerified": true
+            }
+          }
+        ],
+        "passed": true,
+        "observationCheck": {
+          "observed": true,
+          "named": true,
+          "fixtureRead": true,
+          "leaked": false
+        },
+        "endedSessions": [
+          {
+            "launchId": "2f8006bc-33e1-49eb-9d2d-004a0bd1b019",
+            "sessionId": "9e04664f-6aed-4308-849d-38e703951b69",
+            "endedAt": 1788959449691,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "dropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "87332",
+              "filtered": "9409",
+              "dropped": "77337",
+              "decoderErrors": "0",
+              "mapEpoch": "118",
+              "mapResets": "118",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "97164107756",
+                "unixMs": "1788959439556",
+                "uncertaintyQpc": "10206"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "queryStatus": 0,
+              "asOfQpc": "97264842731"
+            },
+            "finalTotals": {
+              "delivered": "87332",
+              "filtered": "9409",
+              "dropped": "77337",
+              "decoderErrors": "0",
+              "mapEpoch": "118",
+              "mapResets": "118",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 330,
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        ],
+        "endedAt": "2026-09-09T13:10:49.716Z"
+      }
+    },
+    {
+      "file": "aegis-etw-file-live-20260909-03.json",
+      "sha256": "110a35a5df83e30194283df6e0ab102c67a8a3d71519a0de3f6a6cb9eb2064fd",
+      "report": {
+        "schema": 1,
+        "live": true,
+        "synthetic": false,
+        "startedAt": "2026-09-09T13:13:27.986Z",
+        "binarySha256": "eeb3c04698b6aa6a37c88e2a9de42862314099e37be4bac8245424a54d093bb3",
+        "assemblySha256": "ac1ad40272105e811d8a6fd38c604ca95a1718d9e92c71ac60a41c0b86e85750",
+        "cases": [
+          {
+            "kind": "normal-stop",
+            "observedRead": true,
+            "observedScopedCandidate": true,
+            "observedFixturePidCandidate": true,
+            "ringBytes": 374609,
+            "ringDropped": 5607,
+            "sensorState": "DEGRADED",
+            "summary": {
+              "launchId": "19db4aa0-dcd2-4cb6-b003-f40d099e1a2b",
+              "sessionId": "4eacf810-ca53-4cc8-9b6b-9543da351d48",
+              "endedAt": 1788959620562,
+              "phase": "stopped",
+              "reasons": [
+                "experimental-correlation",
+                "dropped",
+                "mapResets",
+                "mapping-uncertain",
+                "identity-uncertain"
+              ],
+              "maxima": {
+                "eventsLost": "0",
+                "realTimeBuffersLost": "0",
+                "logBuffersLost": "0",
+                "delivered": "83945",
+                "filtered": "40947",
+                "dropped": "37135",
+                "decoderErrors": "0",
+                "mapEpoch": "202",
+                "mapResets": "202",
+                "mapConflicts": "0"
+              },
+              "capture": {
+                "buffers": {
+                  "count": 256,
+                  "sizeKiB": 64
+                },
+                "frequency": "10000000",
+                "clock": {
+                  "qpc": "98872943611",
+                  "unixMs": "1788959610440",
+                  "uncertaintyQpc": "10317"
+                }
+              },
+              "finalCounters": {
+                "eventsLost": "0",
+                "realTimeBuffersLost": "0",
+                "logBuffersLost": "0",
+                "queryStatus": 0,
+                "asOfQpc": "98973568435"
+              },
+              "finalTotals": {
+                "delivered": "83945",
+                "filtered": "40947",
+                "dropped": "37135",
+                "decoderErrors": "0",
+                "mapEpoch": "202",
+                "mapResets": "202",
+                "mapConflicts": "0"
+              },
+              "ringDropped": 5607,
+              "stopReason": "operator-stop",
+              "exitCode": 0,
+              "stopVerified": true
+            }
+          }
+        ],
+        "passed": true,
+        "observationCheck": {
+          "observed": true,
+          "named": true,
+          "fixtureRead": true,
+          "leaked": false
+        },
+        "endedSessions": [
+          {
+            "launchId": "19db4aa0-dcd2-4cb6-b003-f40d099e1a2b",
+            "sessionId": "4eacf810-ca53-4cc8-9b6b-9543da351d48",
+            "endedAt": 1788959620562,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "dropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "83945",
+              "filtered": "40947",
+              "dropped": "37135",
+              "decoderErrors": "0",
+              "mapEpoch": "202",
+              "mapResets": "202",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "98872943611",
+                "unixMs": "1788959610440",
+                "uncertaintyQpc": "10317"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "queryStatus": 0,
+              "asOfQpc": "98973568435"
+            },
+            "finalTotals": {
+              "delivered": "83945",
+              "filtered": "40947",
+              "dropped": "37135",
+              "decoderErrors": "0",
+              "mapEpoch": "202",
+              "mapResets": "202",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 5607,
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        ],
+        "endedAt": "2026-09-09T13:13:40.574Z"
+      }
+    },
+    {
+      "file": "aegis-etw-file-live-20260909-04.json",
+      "sha256": "f210fb0f58cffc7657feb331c754962c71241ee5c2d87d37753b1e33cda1d94c",
+      "report": {
+        "schema": 1,
+        "live": true,
+        "synthetic": false,
+        "startedAt": "2026-09-09T13:15:59.192Z",
+        "binarySha256": "eeb3c04698b6aa6a37c88e2a9de42862314099e37be4bac8245424a54d093bb3",
+        "assemblySha256": "2078acaa5004e7fae5203104bf647930d493c274fcb978e63d4598e6cbe0da19",
+        "cases": [
+          {
+            "kind": "normal-stop",
+            "observedRead": true,
+            "observedScopedCandidate": true,
+            "observedFixturePidCandidate": true,
+            "ringBytes": 396933,
+            "ringDropped": 0,
+            "sensorState": "DEGRADED",
+            "summary": {
+              "launchId": "b78ebdb2-aa2c-4d5f-95b8-73a4d04ef736",
+              "sessionId": "9c8296d1-2481-48e1-a9a0-0622d7d660da",
+              "endedAt": 1788959771481,
+              "phase": "stopped",
+              "reasons": [
+                "experimental-correlation",
+                "dropped",
+                "mapResets",
+                "mapping-uncertain",
+                "identity-uncertain"
+              ],
+              "maxima": {
+                "eventsLost": "0",
+                "realTimeBuffersLost": "0",
+                "logBuffersLost": "0",
+                "delivered": "81366",
+                "filtered": "63687",
+                "dropped": "17435",
+                "decoderErrors": "0",
+                "mapEpoch": "238",
+                "mapResets": "238",
+                "mapConflicts": "0"
+              },
+              "capture": {
+                "buffers": {
+                  "count": 256,
+                  "sizeKiB": 64
+                },
+                "frequency": "10000000",
+                "clock": {
+                  "qpc": "100382155456",
+                  "unixMs": "1788959761361",
+                  "uncertaintyQpc": "10214"
+                }
+              },
+              "finalCounters": {
+                "eventsLost": "0",
+                "realTimeBuffersLost": "0",
+                "logBuffersLost": "0",
+                "queryStatus": 0,
+                "asOfQpc": "100482850951"
+              },
+              "finalTotals": {
+                "delivered": "81366",
+                "filtered": "63687",
+                "dropped": "17435",
+                "decoderErrors": "0",
+                "mapEpoch": "238",
+                "mapResets": "238",
+                "mapConflicts": "0"
+              },
+              "ringDropped": 0,
+              "stopReason": "operator-stop",
+              "exitCode": 0,
+              "stopVerified": true
+            }
+          }
+        ],
+        "passed": true,
+        "observationCheck": {
+          "observed": true,
+          "named": true,
+          "fixtureRead": true,
+          "leaked": false
+        },
+        "endedSessions": [
+          {
+            "launchId": "b78ebdb2-aa2c-4d5f-95b8-73a4d04ef736",
+            "sessionId": "9c8296d1-2481-48e1-a9a0-0622d7d660da",
+            "endedAt": 1788959771481,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "dropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "81366",
+              "filtered": "63687",
+              "dropped": "17435",
+              "decoderErrors": "0",
+              "mapEpoch": "238",
+              "mapResets": "238",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "100382155456",
+                "unixMs": "1788959761361",
+                "uncertaintyQpc": "10214"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "queryStatus": 0,
+              "asOfQpc": "100482850951"
+            },
+            "finalTotals": {
+              "delivered": "81366",
+              "filtered": "63687",
+              "dropped": "17435",
+              "decoderErrors": "0",
+              "mapEpoch": "238",
+              "mapResets": "238",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        ],
+        "endedAt": "2026-09-09T13:16:11.502Z"
+      }
+    }
+  ],
+  "previousSourceHashes": {
+    "scripts/launch.js": "e745cebbe5d3c8fdded2ac4245bf8a1bf1272cb234e156df580dc892e5ffa5d0",
+    "scripts/verify-etw-file.mjs": "1c177c30225ae3ca6a1d05881a94f3e3bcf46bc4a293a3ad1911bb58cb92af64",
+    "sidecar/etw-file/EtwFile.csproj": "9e34c6ad37d5751758d618095cf6b32ae54d90382855ece0b622fa2588589205",
+    "sidecar/etw-file/FileBroker.cs": "a3ebc5c3f81ffd2942a267c644922e3d9bd7e5353ff3993eaa927fb8019e6738",
+    "sidecar/etw-file/FileCapture.cs": "318d80a666392cbf1ab3b03666b1fec28f1d57e958229f0e050a639bb1726dc3",
+    "sidecar/etw-file/FileCollector.cs": "54fa9a6b5d404568e79ac83647fa8fc31a36ed7e9e61e3fc3a7a63e120ccafa3",
+    "sidecar/etw-file/FileGeneration.cs": "8520aa3bda23ee51bf6efe556f7aa72a2b31fa75f2cd7d8dd2077047369ff768",
+    "sidecar/etw-file/FileMapping.cs": "42e17a46eb1960ad0edb47e98ce73f8ffbfb412254806a7a358d69cb97b1ff74",
+    "sidecar/etw-file/FileScope.cs": "05976472d37b07c60be71aedb6fb89da795ba0a41d527a3b41d244bd5aee5ca0",
+    "sidecar/etw-file/FileTests.cs": "2e0271e0753f4b0ce0b954420639785d4e7df20c355b43fc42727a25b7b00515",
+    "sidecar/etw-file/FileTrace.cs": "25fd9d2f46a0d66c01610a1c4a5b03bc6042af654e6bcd2cdf85ec69e94c4dc6",
+    "sidecar/etw-file/FileWire.cs": "a4ff54d4c725f1de8d1ae4c814851e77abe01348fe4ab64a6609b9507a332f7d",
+    "sidecar/etw-file/Program.cs": "b879d22901405a5597e99a23b3c255ad1f20806e50bb990d822e71e111b9268d",
+    "sidecar/etw-lifecycle/Security.cs": "19fde5ace53914b1e8804b9716a2d041d794e09b273bd8acc385405ba6fadc96",
+    "src/main/main.js": "3ff6c21c7473995970594e2f5835fc227cd05bbbefc65cf1da86b16ad61bc7c4",
+    "src/main/platform/etw-file-health.js": "38e6d3976a6897c1e0799b0f65b93794d6e5c4fcf86ce81c73e24380a5a22207",
+    "src/main/platform/etw-file-protocol.js": "3522761aa103e4dd69e4a025acb00665b4ad0c975cfcc769b8dc62b94cbe9aa1",
+    "src/main/platform/etw-file-runtime.js": "cea6d4a6dc456a73673838374dcb310c47ce8f262220e0c55b3b67ad0063f1e5",
+    "src/main/platform/etw-file-supervisor.js": "1e0b7df56f0d95166861c989558531d46d9d551bf2d46af8afc3af120be1151f"
+  },
+  "previousSourceHashesScope": "single-mapper/writer implementation measured in live attempt 04; not the current pipeline",
+  "limitations": [
+    "Earlier attempts retain their own binary hashes, not a claim to match final source.",
+    "Final live run: ETW counters zero, application dropped 12061 of 88772 delivered, diagnostic ring eviction zero.",
+    "The live check is scoped path/header PID candidate and owned stop testimony, not event-time identity proof or an independent absence witness.",
+    "Earlier runs had different ambient workloads and are not a controlled performance comparison.",
+    "Sleep deferred. Deployment, protected crash recovery, sustained memory and remaining E3-E8 admission gates remain open."
+  ]
+}

--- a/docs/roadmap/etw-file-backend.md
+++ b/docs/roadmap/etw-file-backend.md
@@ -1,0 +1,85 @@
+# B5 — connected diagnostic ETW backend
+
+Implemented 2026-09-09 in `codex/etw-file-backend`, following the user's request to
+do the file/transport/backend block while deferring real sleep/wake. See the
+[runnable commands and exact bounds](../../sidecar/etw-file/README.md).
+
+The source graph is now Electron main → `etw-file-runtime` → `etw-file-supervisor`
+→ existing protocol/health modules → fixed normal C# broker → authenticated pipe
+→ elevated file collector. Startup requires an explicit development root flag;
+packaged enablement remains blocked. No renderer, IPC channel, FileEvent adapter,
+scoring, sequence, baseline or audit consumer receives diagnostic observations.
+The existing app-health composer receives one optional `etw-file` leaf and keeps
+its process-population gate independent.
+
+## What this implements
+
+| Part | Behavior | Remaining evidence |
+| --- | --- | --- |
+| Provider | Native StartTrace/EnableTraceEx2, fixed diagnostic event-ID filter and mask, TraceEvent 3.2.6 consumer, final handle-based stop counters; narrow live smoke passed | Independent absence and broader live coverage |
+| Transport | Closed framed commands, known diagnostic schemas, bounded queues/batches, backpressure, heartbeat/lease/write deadlines | Real sustained elevated transport, total memory/kernel cost |
+| Lifecycle | Explicit start/stop and new IDs on verified restart, request correlation, old callback/frame rejection, pause/suspend/quit stop, bounded ended summaries | Actual sleep/wake is deferred; pending-dialog cancellation and protected collector-crash recovery remain open |
+| Paths | Preceding names only, null preopened paths, epoch invalidation on loss/conflict/close/order/cap, scope minimization | Object/key semantics under actual reuse, reparse identity, E5 admission |
+| Processes | Separate header/issuing TID, uncached full FILETIME observation with its own interval, no agent join | E4 event-time issuer/generation proof; matching public instanceId is insufficient |
+| Health | Diagnostic DEGRADED state, sticky losses, null unmeasured native counters, failed EOF/stop timeout, no population fallback | No claim of complete kernel read coverage |
+
+No automatic elevated restart or orphan deletion was introduced. A failed capture
+blocks retries until a separate trusted recovery path is established; restarting
+the app still cannot overwrite an occupied fixed session name. The bounded normal
+broker may be terminated after a cleanup grace period; the elevated collector
+receives EOF/lease/parent-exit triggers and is never killed by main.
+
+## Local acceptance
+
+22 C# self-tests cover map lifecycle/TTL/order/rebinding/conflict, retained-string
+caps, 100,000-input overload with counted discard, PID reuse without borrowed birth,
+wire framing/replay/foreign context/closed commands and native structure layout.
+An unread-output test verifies that the separately bounded mapper continues draining
+raw input while the outbound stage fills and counts its own drops. v1 queue fields
+report maxima across the independently bounded stages; dropped is their combined
+loss, including discarded queued candidates on invalidation.
+Three actual normal-token process scenarios exercise two clean sessions and parent
+EOF through the JS supervisor. Their native counters stay null and their events
+are explicitly synthetic. The process test reports build hashes and never writes
+raw paths/observations. Native sleep or UAC was not exercised by these tests.
+
+The JS protocol/reducer/supervisor tests and the actual main health-composer tests
+cover ring entry/byte caps, control backpressure, wrong IDs, replay, lost heartbeat,
+stop timeout, explicit restart, ended-summary eviction, and forbidden attribution
+fields. The composer checks prove a failed ETW leaf degrades the app without
+changing process-population reliability or writing diagnostic data to audit/stats.
+
+After the user approved the UAC test, the first live attempt failed fixture-path
+acceptance while still confirming owned stop. Subsequent implementation passes
+moved the blocking ETW consumer onto a dedicated thread, used event QPC for the
+ingress-loss boundary, woke the mapper on queue arrival and limited unresolved-path
+output to ten diagnostic samples per second. Known selected paths are unsampled.
+The final implementation also separates the mapper from native queries and writes
+with a second bounded queue. No buffer-default increase was used.
+
+The final [evidence aggregate](../recon/evidence/etw-file-home-26200-backend.json)
+retains 20 canonical LF source hashes, three normal-token process cases, the final
+live report and all four earlier live attempts. Final normal/live C# binary hashes
+match. The final live run passed a fixture path/header PID Read candidate, actual
+256 × 64 KiB buffers, final stop query 0, three native loss counters 0 and broker/
+collector exit 0. No helper processes remained. These are new file-backend binaries,
+not recycled B1 or empty-session evidence.
+
+**Transport is still degraded:** application queues dropped 12,061 of 88,772 delivered events;
+76,418 were deliberately filtered, decoder errors and ring evictions were zero.
+The sample limiter contributes to filtering, not overflow. These runs had different
+ambient workloads and are not a controlled performance comparison. Native zero
+loss does not erase application drops. Optimizing/validating burst handling under
+sustained machine-wide traffic remains an E3 gate; no production readiness claim.
+Sleep/wake remains explicitly deferred. The successful smoke does not close E4/E5
+event-time identity or the independent cleanup/recovery and deployment gates.
+
+## API basis
+
+The collector owns the session it successfully starts and stops by its original
+handle. Provider filtering follows Microsoft's [EnableTraceEx2 parameters](https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-enable_trace_parameters)
+and [ETW session configuration](https://learn.microsoft.com/en-us/windows/win32/etw/configuring-and-starting-an-event-tracing-session).
+The realtime source and raw QPC handling use the installed TraceEvent 3.2.6 API;
+[Microsoft's source](https://github.com/microsoft/perfview/blob/main/src/TraceEvent/ETWTraceEventSource.cs)
+explains why realtime loss is queried from the controller rather than inferred
+from the consumer's initial trace header.

--- a/docs/roadmap/etw-sensor-design.md
+++ b/docs/roadmap/etw-sensor-design.md
@@ -1,6 +1,13 @@
 # B2 — Windows ETW file sensor design
 
-Status: B2 architecture draft, B3 offline contract and B4 isolated lifecycle harness,
+Status update 2026-09-09: [B5 diagnostic backend](etw-file-backend.md) now connects
+the protocol/reducer to an explicit development-only file collector and Electron
+health leaf. Packaged capture and authoritative attribution remain gated. The
+following B2–B4 sections retain their scope/history; B5 records implemented bounds
+and deviations (queue telemetry maxima across two capped stages, conservative close invalidation,
+fresh candidate handle observations, no independent receipt on the file transport).
+
+Historical status: B2 architecture draft, B3 offline contract and B4 isolated lifecycle harness,
 2026-09-08. B2 source
 contracts were checked at `53b20e4`; B3 implements only the isolated JS codec and
 session-health reducer described below. No production sensor, UI, dependency,
@@ -131,6 +138,7 @@ and are range-checked as BigInt in JS; PIDs/TIDs are bounded uint32 numbers.
 | `observations` | Session ID, transport sequence, at most 128 records. Each has session-local event sequence, provider/event/version, QPC, header PID/TID, nullable payload/issuing TID, candidate path/provenance, issuer and generation evidence states. |
 | `health` / `heartbeat` | Current state/reasons, session counters or null plus query status/as-of, delivered/filtered/dropped counts, map epoch/resets/conflicts, queue depth/bytes/high-water marks, coverage profile. |
 | `stop` / `stopped` / `error` | Request ID, final sequences/counters, stop/drain result and static error code. Idempotent stop; EOF without valid stopped is an incomplete capture. |
+| `ping` | B5 client lease renewal, empty closed data object. Same session/sequence binding; wrong-direction at the collector-message reducer. |
 
 Proposed observation fields include `path: string|null`,
 `pathEvidence: observed-name|candidate-object|candidate-key|conflict|unresolved`,

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,12 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 70 CommonJS modules (55 top-level + 13 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 72 CommonJS modules (55 top-level + 15 platform/ + 2 token-adapters/)
+
+Optional development ETW: main → platform/etw-file-runtime → etw-file-supervisor
+→ normal `sidecar/etw-file` broker → authenticated elevated file collector.
+Only the `etw-file` health leaf reaches app stats. Diagnostic observations stay
+in bounded main memory and never become FileEvents. Packaged enablement is gated;
+see [backend record](../docs/roadmap/etw-file-backend.md).
 
 Core modules:
 - main.js — orchestrator, module wiring, lifecycle

--- a/memory-bank/next-session.md
+++ b/memory-bank/next-session.md
@@ -1,5 +1,49 @@
 # AEGIS — старт следующего чата
 
+## Актуальное продолжение — B5, 2026-09-09
+
+Пользователь попросил весь блок файловых событий/транспорта/backend, оставив сон
+на потом. На `codex/etw-file-backend` реализован новый диагностический сборщик
+`sidecar/etw-file`, supervisor/runtime и подключение листа здоровья в main.
+Проверь финальный PR/CI/merge статус. Подробности и команды:
+`docs/roadmap/etw-file-backend.md`, `sidecar/etw-file/README.md`.
+
+Это заменяет старое утверждение ниже, что протокол/health не импортируются приложением.
+Захват требует явного development-флага с одним корнем; packaged-сборка не включает
+его. Файловые события остаются кандидатами в ограниченной памяти main, agent и
+instanceId всегда null. Нет передачи в FileEvent, risk, baseline, sequence или audit.
+Нельзя объявлять весь пункт «надёжная атрибуция» завершённым: E4/E5 ещё открыты.
+
+Прошли 22 C# self-test и три настоящих normal-token процессных сценария: две
+штатные сессии и EOF с неподтверждённой остановкой. События синтетические, native
+counters null. Последний результат `X:/tmp/aegis-etw-file-check-20260909-v6.json`.
+JS-проверки протокола/reducer/supervisor и main-composer прошли (110 тестов).
+Пользователь разрешил реальный UAC-тест. Финальный live smoke прошёл:
+`X:/tmp/aegis-etw-file-live-20260909-05.json`, совпавшие с normal binaries, кандидат
+Read с путём/PID тестового процесса, native counters 0, stop/child exit 0.
+Но очереди приложения отбросили 12 061 из 88 772 событий; это оставшаяся деградация,
+а не завершённый E3. 76 418 событий отфильтрованы по политике, ring eviction 0.
+Mapper отделён от query/write вторым ограниченным буфером; каждый 4096 / 4 МиБ.
+В telemetry очередей указаны максимумы между двумя этапами, не сумма; dropped общий.
+Агрегат `docs/recon/evidence/etw-file-home-26200-backend.json` сохраняет 20 LF-хешей
+исходников, final normal/live и четыре ранних live-попытки, включая первый отказ
+приёмки. Независимого absence witness и подтверждённой атрибуции нет.
+СОН ПО-ПРЕЖНЕМУ ОТЛОЖЕН. Следующее backend-улучшение — потери на всплесках нагрузки.
+
+Чистая копия backend-патча прошла format/build/lint, TypeScript/Svelte, coverage
+(2928 pass, 4 skip при maxWorkers=2), оба verify gate, counts и npm audit.
+Первый неограниченный local coverage упёрся в ENOMEM/отсутствующий Electron dist;
+после установки dist и ограничения workers повтор прошёл без изменения тестов.
+Проверка NuGet с transitive dependencies также не нашла известных уязвимостей.
+Это локальные результаты; финальные пять CI и merge проверяй отдельно.
+
+Во время работы появились отдельные изменения App/AgentCard/DemoBanner/ShieldTab,
+observatory components/styles/assets и LiveRadar test. Они пользовательские, как
+и `.codex/agents/ui-designer.toml`, `memory-bank/fancy-ui-plan.md`; не включать их
+в backend-коммит. Полную проверку backend проводить на чистом checkout коммита.
+
+## Предыдущая передача — B4
+
 Обновлено 2026-09-08 после реализации отдельного suspend-стенда без реального сна.
 B2: PR #384, `f2f1ac4`; B3: PR #385, `cc47212`, оба merged с пятью зелёными CI.
 B4: PR #386, `01bf403`; первый UAC stop: PR #387, `1f7cd82`, оба merged с пятью

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1990,3 +1990,101 @@ the completed B1 sets or earlier successful live consent/cleanup tests without c
 
 User edits in .codex/agents/ui-designer.toml and memory-bank/fancy-ui-plan.md remain
 separate and must be preserved outside this backend commit.
+
+## Session handoff — connected diagnostic file backend B5 (2026-09-09)
+
+The user explicitly requested the file/queue/identity/path/backend block while
+deferring real sleep. Branch codex/etw-file-backend implements a new sidecar/etw-file
+project, reusing the restricted pipe identity code through a linked source file.
+The fixed native Kernel-File diagnostic profile now has a bounded ingress queue,
+conservative path maps, uncached candidate FILETIME observations, bounded framing,
+heartbeat/lease, handle-owned stop and final native counters. The separate lifecycle
+harness and all three completed B1 measurement sets were left unchanged.
+
+Main imports a development-only runtime/supervisor and includes its optional health
+leaf in the actual app-health composer. Explicit root opt-in is required, packaged
+enablement is blocked. No renderer IPC or diagnostic FileEvent/audit/risk/baseline/
+sequence admission exists. Agent and instanceId remain null; later process handle
+observations cannot prove event-time identity. E4/E5 are not declared complete.
+
+The supervisor bounds its ring and ended summaries, preserves session loss maxima,
+correlates start/stop IDs, rejects stale frames/callbacks, and waits for stopped plus
+successful child exit before explicit restart. EOF/timeout never certifies cleanup;
+failures block retries and may terminate only the normal broker after cleanup grace.
+Suspend/pause/shutdown clear diagnostic memory and request stop. Resume/unpause never
+relaunch elevated capture automatically. No extra OS observation-gap audit record.
+
+Local checks passed: Release build without warnings, C# formatter, 21 self-tests
+(including 100,000-input overload), 110 focused JS protocol/reducer/supervisor/composer
+tests, three actual normal-token broker/collector cases through the JS supervisor.
+Those cases use synthetic inputs and null native counters; they exercise two clean
+sessions with fresh IDs and a parent-EOF failure with blocked restart. Latest report:
+X:/tmp/aegis-etw-file-check-20260909-final.json. No EtwFile processes remained after
+the earlier normal checks; recheck after any new run. Full repository/CI checks and
+final PR status must be read from the final completion rather than inferred here.
+
+The live test command is prepared and an asynchronous readiness question was sent.
+No reply yet at this handoff. Do not infer real provider acceptance from earlier B1
+or empty-session binaries. Real sleep/wake is explicitly deferred. Independent native
+absence verification, protected collector-crash recovery, deployment trust and the
+remaining live E3/E4/E5/E6–E8 coverage gates stay open. Exact bounds and limitations:
+docs/roadmap/etw-file-backend.md and sidecar/etw-file/README.md.
+
+Separate user work now also changes renderer App/AgentCard/DemoBanner/ShieldTab and
+adds observatory components/styles/assets plus LiveRadar tests. Preserve all of it,
+along with ui-designer settings and fancy-ui-plan. Validate the backend commit in a
+clean checkout so the user's unfinished frontend does not enter this PR.
+
+Live follow-up: the user explicitly approved the prepared test. Four short UAC
+attempts were run, without any sleep. The first failed fixture-path acceptance;
+it still stopped cleanly and retained counted ingress losses. Subsequent changes
+put the blocking consumer on a dedicated thread, used dropped-event QPC rather
+than receipt time for ingress invalidation, signalled queue arrival instead of
+polling and sampled unresolved output at ten records/second (deliberate filtering).
+Known selected paths remain unsampled. Final normal process report:
+X:/tmp/aegis-etw-file-check-20260909-v4.json; final live report:
+X:/tmp/aegis-etw-file-live-20260909-04.json. Their C# binary hashes match.
+
+The final live smoke passed a Read candidate with the temporary fixture's path and
+normal workload header PID; final native query 0, actual 256 × 64 KiB buffers,
+all three native loss counters 0, stop acknowledgement and broker/collector exit 0.
+No EtwFile helpers remained. Ingress nevertheless dropped 17,435 of 81,366 delivered
+events; 63,687 were deliberately filtered; decoder errors and ring eviction zero.
+This is a degraded diagnostic backend. E3 burst handling and sustained bounded
+memory still need validation/optimization. The runs had different ambient loads,
+so do not advertise a controlled performance improvement from their ratios.
+
+docs/recon/evidence/etw-file-home-26200-backend.json retains 19 canonical LF final
+source hashes, normal and final live results plus all three earlier live attempts.
+Earlier reports retain their own binary hashes without claiming final source
+equivalence. This closes only the narrow smoke; independent native absence,
+protected collector-crash recovery, E4/E5 admission, deployment and other E3–E8
+gates remain open. Real sleep/wake remains explicitly deferred.
+
+Final B5 follow-up supersedes the preceding v4 figures: a dedicated mapper now
+drains ingress independently of native queries and pipe writes. Ingress/outbound
+are individually capped at 4096 / 4 MiB; v1 queue fields expose maxima across stages,
+while dropped combines their counted losses. An unread-output self-test proves
+ingress still drains without overflow when the output stage is full. There are now
+22 C# self-tests. Final normal report is aegis-etw-file-check-20260909-v6.json;
+matching live report is aegis-etw-file-live-20260909-05.json (both under X:/tmp).
+The fifth short UAC smoke passed scope/header-PID candidate and owned stop, native
+losses zero, application drops 12061 of 88772 delivered, filtered 76418, no decoder
+errors or ring eviction. No helper processes remained. No claim of complete or
+loss-free transport; sustained E3 admission remains open.
+
+The final aggregate retains 20 current LF source hashes, the prior v4 source-hash
+set as historical provenance, final normal/live results and all four earlier live
+attempts. These are narrow functional runs under differing ambient load. Real
+sleep remains deferred. Continue with final clean-checkout/CI/PR results below.
+
+Clean validation checkout X:/tmp/aegis-etw-backend-validation-20260909 has the exact
+staged source tree (no user frontend edits). Format/build/lint passed (31 existing
+lint warnings), TS/Svelte passed with no Svelte diagnostics, production npm audit
+and transitive NuGet vulnerability check reported none. Full coverage passed 2928
+tests with 4 skips using --maxWorkers=2; both witness/sequence verification gates
+and counts passed. The initial unconstrained coverage failed from ENOMEM/worker
+startup failures plus an absent Electron dist. Installing the existing Electron
+package's binary and bounding workers resolved it without source/test changes.
+C# Release/formatter, 22 self-tests, three normal-token process cases, final live
+smoke and all 20 evidence source hashes are verified. Final PR/CI/merge follows.

--- a/scripts/launch.js
+++ b/scripts/launch.js
@@ -15,5 +15,8 @@ const electron = require('electron');
 delete process.env.ELECTRON_RUN_AS_NODE;
 
 // Use spawn instead of execFileSync for live stdout streaming (needed for PERF timing)
-const child = spawn(electron, ['.'], { stdio: 'inherit', cwd: process.cwd() });
+const child = spawn(electron, ['.', ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  cwd: process.cwd(),
+});
 child.on('exit', (code) => process.exit(code ?? 0));

--- a/scripts/verify-etw-file.mjs
+++ b/scripts/verify-etw-file.mjs
@@ -1,0 +1,141 @@
+// Explicit local process check. --live additionally requests real UAC and ETW.
+// No raw observations or filesystem paths are written into the report.
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import supervisor from '../src/main/platform/etw-file-supervisor.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const executable = path.join(root, 'sidecar/etw-file/bin/Release/net10.0-windows/EtwFile.exe');
+const live = process.argv.includes('--live');
+const destination = process.argv.find((value) => value.startsWith('--report='))?.slice(9);
+if (process.platform !== 'win32' || !destination || fs.existsSync(destination))
+  throw new Error('Windows and a new --report=<file> are required');
+const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'aegis-etw-file-'));
+const file = path.join(fixture, 'fixture.dat');
+fs.writeFileSync(file, Buffer.alloc(4096, 7));
+const report = {
+  schema: 1,
+  live,
+  synthetic: !live,
+  startedAt: new Date().toISOString(),
+  binarySha256: createHash('sha256').update(fs.readFileSync(executable)).digest('hex'),
+  assemblySha256: createHash('sha256')
+    .update(fs.readFileSync(executable.replace(/\.exe$/, '.dll')))
+    .digest('hex'),
+  cases: [],
+  passed: false,
+};
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+async function until(predicate, ms) {
+  const deadline = performance.now() + ms;
+  while (!predicate()) {
+    if (performance.now() >= deadline) throw new Error('deadline');
+    await delay(25);
+  }
+}
+let broker;
+const sensor = supervisor.createSupervisor({
+  spawnBroker: (launchId, sessionId) => {
+    broker = spawn(executable, [live ? 'broker' : 'check-broker', launchId, sessionId, fixture], {
+      windowsHide: true,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    return broker;
+  },
+});
+try {
+  // Each retry below is explicit and follows verified cleanup, never an automatic failure retry.
+  for (let index = 0; index < (live ? 1 : 2); index++) {
+    if (!sensor.start()) throw new Error('start-blocked');
+    await until(() => ['running', 'failed'].includes(sensor.getDiagnostics().phase), 135000);
+    if (sensor.getDiagnostics().phase !== 'running') throw new Error('start-failed');
+    let observed = false,
+      named = false,
+      fixtureRead = false,
+      leaked = false;
+    const deadline = performance.now() + (live ? 10000 : 3000);
+    while (performance.now() < deadline) {
+      if (live) fs.readFileSync(file); // Only this ordinary process performs the fixture workload.
+      const records = sensor.getDiagnostics().records;
+      observed ||= records.some((r) => r.eventId === 15);
+      named ||= records.some((r) => r.path === file);
+      fixtureRead ||= records.some(
+        (r) => r.path === file && r.eventId === 15 && r.headerPid === process.pid,
+      );
+      leaked ||= records.some(
+        (r) =>
+          r.agent !== null ||
+          r.instanceId !== null ||
+          (r.path !== null && !r.path.startsWith(fixture + '\\')),
+      );
+      if (!live && observed) break;
+      await delay(25);
+    }
+    report.observationCheck = { observed, named, fixtureRead, leaked };
+    if (!observed || leaked || (live && !fixtureRead)) throw new Error('observation-contract');
+    const before = sensor.getDiagnostics();
+    sensor.stop();
+    await until(() => sensor.getDiagnostics().summaries.length > index, 20000);
+    const result = sensor.getDiagnostics().summaries.at(-1);
+    if (!result.stopVerified) throw new Error('stop-unverified');
+    if (
+      live &&
+      (result.finalCounters?.queryStatus !== 0 ||
+        ['eventsLost', 'realTimeBuffersLost', 'logBuffersLost'].some(
+          (key) => result.finalCounters[key] !== '0',
+        ))
+    )
+      throw new Error('native-loss-or-unmeasured');
+    report.cases.push({
+      kind: index ? 'explicit-new-session' : 'normal-stop',
+      observedRead: observed,
+      observedScopedCandidate: named,
+      observedFixturePidCandidate: fixtureRead,
+      ringBytes: before.ringBytes,
+      ringDropped: before.ringDropped,
+      sensorState: sensor.getHealth().state,
+      summary: result,
+    });
+  }
+  if (!live) {
+    if (!sensor.start()) throw new Error('start-blocked');
+    await until(() => sensor.getDiagnostics().phase === 'running', 15000);
+    broker.stdin.end();
+    await until(() => sensor.getDiagnostics().summaries.length === 3, 25000);
+    const result = sensor.getDiagnostics().summaries.at(-1);
+    if (result.stopVerified || !sensor.getDiagnostics().restartBlocked)
+      throw new Error('false-cleanup');
+    report.cases.push({ kind: 'parent-eof-unverified', summary: result });
+  }
+  report.passed = true;
+} catch (error) {
+  report.error = error.message;
+  report.finalHealth = sensor.getHealth();
+  process.exitCode = 2;
+} finally {
+  sensor.dispose();
+  if (broker && broker.exitCode === null) {
+    try {
+      await until(() => broker.exitCode !== null, 35000);
+    } catch {
+      report.cleanupUnverified = true;
+      report.passed = false;
+      process.exitCode = 2;
+    }
+  }
+  report.endedSessions = sensor.getDiagnostics().summaries;
+  report.endedAt = new Date().toISOString();
+  fs.writeFileSync(destination, JSON.stringify(report, null, 2) + '\n', { flag: 'wx' });
+  console.log(
+    JSON.stringify({
+      passed: report.passed,
+      live,
+      cases: report.cases.length,
+      error: report.error,
+    }),
+  );
+}

--- a/sidecar/etw-file/EtwFile.csproj
+++ b/sidecar/etw-file/EtwFile.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.6" />
+    <Compile Include="../etw-lifecycle/Security.cs" Link="Security.cs" />
+  </ItemGroup>
+</Project>

--- a/sidecar/etw-file/FileBroker.cs
+++ b/sidecar/etw-file/FileBroker.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics;
+
+namespace Aegis.EtwLifecycle;
+
+internal static class FileBroker
+{
+    internal static async Task<int> Run(string[] args)
+    {
+        bool live = args[0] == "broker";
+        if (Security.Current().Elevated || !FileWire.Id(args[1]) || !FileWire.Id(args[2])) return 3;
+        var scope = new FileScope(args[3]); // Validate before any UAC request.
+        string pipeId = Guid.NewGuid().ToString("N");
+        using var pipe = Security.Server(pipeId);
+        if (!Security.RestrictedAcl(pipe)) return 3;
+        var self = Security.Current();
+        var info = Program.Child(live ? "collector" : "check-collector", args[1], args[2], pipeId,
+            self.Pid.ToString(), self.Birth.ToString(), scope.Root, FileWire.Profile);
+        if (live)
+        {
+            info.UseShellExecute = true; info.Verb = "runas"; info.WindowStyle = ProcessWindowStyle.Hidden;
+            info.RedirectStandardInput = info.RedirectStandardOutput = info.RedirectStandardError = false;
+        }
+        // Closing the pipe on expiry prevents a late elevated child from authorizing capture.
+        // It does not cancel or dismiss the OS consent dialog.
+        using var lifetime = new CancellationTokenSource();
+        using var startup = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        using var expire = startup.Token.Register(() => pipe.Dispose());
+        using var child = Process.Start(info) ?? throw new InvalidOperationException();
+        try
+        {
+            var identity = Security.Observe(child);
+            await pipe.WaitForConnectionAsync(startup.Token);
+            Security.Verify(pipe, child, identity.Birth, true, live);
+            startup.CancelAfter(Timeout.InfiniteTimeSpan);
+            var read = new FileWire(args[1], args[2]);
+            var controls = new FileWire(args[1], args[2]);
+            int terminalObserved = 0;
+            Stream input = Console.OpenStandardInput(), output = Console.OpenStandardOutput();
+            var inbound = Task.Run(async () =>
+            {
+                while (true) await FileWire.Forward(pipe, await controls.Read(input, true, lifetime.Token), lifetime.Token);
+            });
+            var outbound = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    var frame = await read.Read(pipe, false, lifetime.Token);
+                    if (frame.t == "stopped") Volatile.Write(ref terminalObserved, 1);
+                    await FileWire.Forward(output, frame, lifetime.Token);
+                    if (frame.t == "stopped") return;
+                }
+            });
+            try
+            {
+                var first = await Task.WhenAny(inbound, outbound);
+                // Main closes stdin immediately after accepting stopped. Its EOF may
+                // win the scheduling race with the outbound task completing its flush.
+                if (first == inbound && Volatile.Read(ref terminalObserved) == 0) await inbound;
+                await outbound;
+                await child.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(7));
+                return child.ExitCode == 0 ? 0 : 2;
+            }
+            finally
+            {
+                lifetime.Cancel(); pipe.Dispose(); input.Dispose();
+                try { await Task.WhenAll(inbound, outbound).WaitAsync(TimeSpan.FromSeconds(6)); } catch { }
+            }
+        }
+        finally
+        {
+            pipe.Dispose(); // Independent EOF cleanup trigger; never terminate elevated child.
+            try { await child.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(12)); } catch { }
+        }
+    }
+}

--- a/sidecar/etw-file/FileCapture.cs
+++ b/sidecar/etw-file/FileCapture.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Aegis.EtwLifecycle;
+
+internal sealed class FileCapture(FileIngress ingress) : IDisposable
+{
+    internal static readonly Guid Provider = new("edd08927-9cc4-4e65-b970-c2560fb5c289");
+    private ETWTraceEventSource? source;
+    internal Task? Consumer;
+    internal void Start()
+    {
+        source = new ETWTraceEventSource(FileTrace.Name, TraceEventSourceType.Session);
+        source.Dynamic.All += Decode;
+        source.UnhandledEvents += value => { if (value.ProviderGuid == Provider) ingress.DecodeError(); };
+        // Process() blocks for the lifetime of the trace; do not occupy the shared
+        // pool worker needed by the mapper and pipe continuations during bursts.
+        Consumer = Task.Factory.StartNew(() => source.Process(), CancellationToken.None,
+            TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    }
+    private void Decode(TraceEvent value)
+    {
+        if (value.ProviderGuid != Provider) return;
+        try
+        {
+            int id = (int)value.ID;
+            if (!FileWire.Schemas.Contains($"{id}:{value.Version}")) { ingress.DecodeError(); return; }
+            object? Field(string key)
+            {
+                var actual = value.PayloadNames.FirstOrDefault(n => n.Equals(key, StringComparison.OrdinalIgnoreCase));
+                return actual == null ? null : value.PayloadByName(actual);
+            }
+            ulong Pointer(string key) => Field(key) is { } field ?
+                field is IntPtr pointer ? unchecked((ulong)pointer.ToInt64()) : Convert.ToUInt64(field, CultureInfo.InvariantCulture) : 0;
+            uint? Tid(string key) => Field(key) is { } field ? checked((uint)(field is IntPtr pointer ?
+                pointer.ToInt64() : Convert.ToInt64(field, CultureInfo.InvariantCulture))) : null;
+            string? name = Field("FileName") as string ?? Field("OpenPath") as string;
+            if (name?.Length > 32768 || (id is 10 or 12 && name == null) ||
+                (id == 10 && Field("FileKey") == null) || (id is 12 or 13 or 14 or 15 && Field("FileObject") == null) ||
+                (id == 15 && (Field("FileKey") == null || Field("IssuingThreadId") == null)))
+            { ingress.DecodeError(); return; }
+#pragma warning disable CS0618
+            long qpc = value.TimeStampQPC;
+#pragma warning restore CS0618
+            if (qpc < 0) { ingress.DecodeError(); return; }
+            ingress.Enqueue(new(0, id, value.Version, qpc, unchecked((uint)value.ProcessID), unchecked((uint)value.ThreadID),
+                Tid("IssuingThreadId"), Tid("ThreadId"), Pointer("FileObject"), Pointer("FileKey"), name));
+        }
+        catch { ingress.DecodeError(); }
+    }
+    public void Dispose() { source?.Dispose(); }
+}

--- a/sidecar/etw-file/FileCollector.cs
+++ b/sidecar/etw-file/FileCollector.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Aegis.EtwLifecycle;
+
+internal static class FileCollector
+{
+    internal static async Task<int> Run(string[] args)
+    {
+        bool live = args[0] == "collector";
+        if (Security.Current().Elevated != live || !FileWire.Id(args[1]) || !FileWire.Id(args[2]) || args[7] != FileWire.Profile) return 3;
+        using var parent = Process.GetProcessById(int.Parse(args[4]));
+        using var pipe = Security.Client(args[3]);
+        Security.Verify(pipe, parent, ulong.Parse(args[5]), false, false);
+        var scope = new FileScope(args[6]);
+        var ingress = new FileIngress();
+        using var pipeline = new FilePipeline(ingress, scope, live);
+        var send = new FileWire(args[1], args[2]);
+        var read = new FileWire(args[1], args[2]);
+        using var lifetime = new CancellationTokenSource();
+        using var trace = live ? new FileTrace() : null;
+        using var capture = live ? new FileCapture(ingress) : null;
+        FileStats stats = new(50, null, null, null, null, null);
+        bool owns = false, stopped = false, drained = false;
+        string? stopRequest = null;
+        long lastSample = 0, statsAsOf = Stopwatch.GetTimestamp();
+        uint? previousEvents = 0, previousReal = 0, previousLog = 0;
+        Task? controls = null;
+        var parentGone = Task.Run(async () =>
+        {
+            try { await parent.WaitForExitAsync(lifetime.Token); lifetime.Cancel(); }
+            catch (OperationCanceledException) { }
+        });
+        try
+        {
+            await send.Write(pipe, "hello", new
+            {
+                build = live ? "etw-file-diagnostic-dev-1" : "etw-file-synthetic-check-1",
+                profile = FileWire.Profile,
+                schemas = FileWire.Schemas
+            }, lifetime.Token);
+            using var authorize = CancellationTokenSource.CreateLinkedTokenSource(lifetime.Token);
+            authorize.CancelAfter(TimeSpan.FromSeconds(10));
+            var start = await read.Read(pipe, true, authorize.Token);
+            if (start.t != "start") throw new InvalidDataException();
+            if (trace != null)
+            {
+                stats = trace.Start(); owns = true;
+                if (stats.Status != 0 || stats.Buffers == null || stats.Size == null) throw new InvalidOperationException();
+                capture!.Start(); trace.Enable(); stats = trace.Query();
+                if (stats.Status != 0) throw new InvalidOperationException();
+                CheckStats();
+            }
+            else
+            {
+                // Check mode never calls ETW or observes other processes; null native counters.
+                long qpc = Stopwatch.GetTimestamp();
+                ingress.Enqueue(new(0, 12, 1, qpc, 71, 72, null, null, 1, 0, scope.Root + "\\fixture.dat"));
+                ingress.Enqueue(new(0, 15, 1, qpc + 1, 71, 72, 72, null, 1, 0, null));
+            }
+            long before = Stopwatch.GetTimestamp();
+            lastSample = before;
+            string unix = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+            long after = Stopwatch.GetTimestamp();
+            await send.Write(pipe, "ready", new
+            {
+                requestId = start.data.GetProperty("requestId").GetString(),
+                frequency = Stopwatch.Frequency.ToString(),
+                clock = new { qpc = before.ToString(), unixMs = unix, uncertaintyQpc = (after - before + (Stopwatch.Frequency + 999) / 1000).ToString() },
+                buffers = new { count = stats.Buffers ?? 256, sizeKiB = stats.Size ?? 64 },
+                telemetry = Telemetry()
+            }, lifetime.Token);
+            var stopSignal = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            controls = Task.Run(async () =>
+            {
+                try
+                {
+                    while (true)
+                    {
+                        using var lease = CancellationTokenSource.CreateLinkedTokenSource(lifetime.Token);
+                        lease.CancelAfter(TimeSpan.FromSeconds(10));
+                        var command = await read.Read(pipe, true, lease.Token);
+                        if (command.t == "stop") { stopSignal.TrySetResult(command.data.GetProperty("requestId").GetString()!); return; }
+                        if (command.t != "ping") throw new InvalidDataException();
+                    }
+                }
+                catch { lifetime.Cancel(); }
+            });
+            while (!stopSignal.Task.IsCompleted)
+            {
+                lifetime.Token.ThrowIfCancellationRequested();
+                if (capture?.Consumer?.IsCompleted == true) throw new IOException();
+                if (pipeline.Worker.IsCompleted) throw new IOException();
+                if (Stopwatch.GetTimestamp() - lastSample > 2 * Stopwatch.Frequency)
+                {
+                    Sample();
+                    await send.Write(pipe, "heartbeat", Telemetry(), lifetime.Token);
+                }
+                if (!await Pump(lifetime.Token)) await Task.Delay(10, lifetime.Token);
+            }
+            stopRequest = await stopSignal.Task;
+            if (trace != null) { stats = trace.Stop(); stopped = stats.Status == 0; owns = !stopped; CheckStats(); }
+            else stopped = true;
+            using var drain = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            if (capture?.Consumer != null) await capture.Consumer.WaitAsync(drain.Token);
+            pipeline.Complete();
+            while (!pipeline.Worker.IsCompleted)
+            {
+                if (!await Pump(drain.Token)) await Task.Delay(10, drain.Token);
+            }
+            await pipeline.Worker;
+            while (await Pump(drain.Token)) { }
+            drained = true;
+            await send.Write(pipe, "stopped", new
+            {
+                requestId = stopRequest,
+                drained,
+                stopped,
+                finalEventSeq = ingress.Totals().Delivered.ToString(),
+                telemetry = Telemetry()
+            }, lifetime.Token);
+            return stopped ? 0 : 2;
+        }
+        finally
+        {
+            // All failure paths stop our handle BEFORE waiting for pipe tasks.
+            if (owns) { stats = trace!.Stop(); stopped = stats.Status == 0; }
+            lifetime.Cancel();
+            pipeline.Cancel();
+            pipe.Dispose();
+            if (controls != null) { try { await controls; } catch { } }
+            await parentGone;
+            try { await pipeline.Worker.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+            if (capture?.Consumer != null) { try { await capture.Consumer.WaitAsync(TimeSpan.FromSeconds(5)); } catch { } }
+        }
+
+        void Sample()
+        {
+            lastSample = Stopwatch.GetTimestamp();
+            if (trace != null) stats = trace.Query();
+            CheckStats();
+        }
+        void CheckStats()
+        {
+            statsAsOf = Stopwatch.GetTimestamp();
+            if (stats.Status != 0 || stats.Events != previousEvents || stats.RealTime != previousReal || stats.Log != previousLog)
+                pipeline.Invalidate(statsAsOf);
+            previousEvents = stats.Events; previousReal = stats.RealTime; previousLog = stats.Log;
+        }
+        object Telemetry()
+        {
+            return new
+            {
+                operational = true,
+                reasons = new[] { "mapping-uncertain", "identity-uncertain" },
+                counters = new
+                {
+                    eventsLost = stats.Events?.ToString(),
+                    realTimeBuffersLost = stats.RealTime?.ToString(),
+                    logBuffersLost = stats.Log?.ToString(),
+                    queryStatus = stats.Status,
+                    asOfQpc = statsAsOf.ToString()
+                },
+                totals = pipeline.Totals(),
+                queues = pipeline.Queues(),
+                coverage = FileWire.Profile
+            };
+        }
+        async Task<bool> Pump(CancellationToken token)
+        {
+            var records = new List<FileObservation>();
+            int bytes = 0;
+            bool consumed = false;
+            for (int i = 0; i < 128 && bytes < 32 * 1024; i++)
+            {
+                var record = pipeline.Take();
+                if (record == null) break;
+                consumed = true;
+                bytes += JsonSerializer.SerializeToUtf8Bytes(record).Length;
+                records.Add(record);
+            }
+            if (records.Count > 0) await send.Write(pipe, "observations", new { records }, token);
+            return consumed;
+        }
+    }
+}

--- a/sidecar/etw-file/FileGeneration.cs
+++ b/sidecar/etw-file/FileGeneration.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Aegis.EtwLifecycle;
+
+internal static class FileGeneration
+{
+    [DllImport("kernel32.dll")] private static extern SafeProcessHandle OpenProcess(uint rights, bool inherit, uint pid);
+    [DllImport("kernel32.dll")]
+    private static extern bool GetProcessTimes(SafeProcessHandle process,
+        out ulong birth, out ulong exit, out ulong kernel, out ulong user);
+
+    // One fresh held-handle observation. Never cached, never stamps an agent and never
+    // says the process was the issuer at the earlier ETW timestamp.
+    internal static FileObservation Observe(FileObservation value)
+    {
+        if (value.issuerStatus != "candidate") return value;
+        long from = Stopwatch.GetTimestamp();
+        using var handle = OpenProcess(0x1000, false, value.headerPid);
+        if (handle.IsInvalid || !GetProcessTimes(handle, out ulong birth, out ulong exit, out _, out _) || birth == 0 || exit != 0) return value;
+        long to = Stopwatch.GetTimestamp();
+        return value with
+        {
+            generationStatus = "candidate",
+            generationWitness = birth.ToString(),
+            generationSource = "createTime100ns",
+            generationInterval = new { fromQpc = from.ToString(), toQpc = to.ToString() }
+        };
+    }
+}

--- a/sidecar/etw-file/FileMapping.cs
+++ b/sidecar/etw-file/FileMapping.cs
@@ -1,0 +1,137 @@
+using System.Text;
+
+namespace Aegis.EtwLifecycle;
+
+internal sealed record FileInput(ulong Seq, int Id, int Version, long Qpc, uint Pid, uint Tid,
+    uint? Issuing, uint? Payload, ulong Object, ulong Key, string? Name)
+{
+    internal int Bytes => 256 + (Name?.Length ?? 0) * 2 + (Name == null ? 0 : Encoding.UTF8.GetByteCount(Name));
+}
+internal sealed record FileObservation(string eventSeq, string provider, int eventId, int version, string qpc,
+    uint headerPid, uint headerTid, uint? issuingTid, uint? payloadTid, string? path, string pathEvidence,
+    string issuerStatus = "candidate", string generationStatus = "unresolved", string? generationWitness = null,
+    string? generationSource = null, object? generationInterval = null, object? agent = null, object? instanceId = null);
+
+internal sealed class FileMapping(FileScope scope, long frequency, int cap = 32768, int byteCap = 8 * 1024 * 1024)
+{
+    private sealed record Name(string Path, long Qpc, int Bytes);
+    private readonly Dictionary<(bool Key, ulong Pointer), Name> names = new();
+    private long latest, barrier;
+    private int bytes;
+    internal ulong Epoch, Resets, Conflicts;
+    internal int Count => names.Count;
+    internal int Bytes => bytes;
+    internal void Reset(long qpc)
+    {
+        names.Clear(); bytes = 0; Epoch++; Resets++; barrier = Math.Max(barrier, Math.Max(latest, qpc));
+    }
+    private void Remove((bool, ulong) key)
+    {
+        if (names.Remove(key, out var value)) bytes -= value.Bytes;
+    }
+    private Name? Lookup(bool key, ulong pointer, long qpc)
+    {
+        if (!names.TryGetValue((key, pointer), out var value)) return null;
+        if (qpc <= value.Qpc || qpc - value.Qpc > 30 * frequency) { Remove((key, pointer)); return null; }
+        return value;
+    }
+    internal FileObservation? Accept(FileInput input)
+    {
+        bool old = input.Qpc < latest || input.Qpc <= barrier;
+        latest = Math.Max(latest, input.Qpc);
+        if (old) { Reset(latest); return input.Id == 15 ? Make(input, null, "unresolved") : null; }
+        if (input.Name != null)
+        {
+            string? selected = scope.Select(input.Name);
+            foreach (var pointer in new[] { (false, input.Object), (true, input.Key) })
+            {
+                if (pointer.Item2 == 0) continue;
+                // Rebinds and names outside the selected root also retire prior evidence.
+                if (names.TryGetValue(pointer, out var prior) && prior.Path != selected)
+                { Conflicts++; Reset(input.Qpc); return null; }
+                Remove(pointer);
+                if (selected == null) continue;
+                int cost = 128 + selected.Length * 2 + Encoding.UTF8.GetByteCount(selected);
+                if (names.Count >= cap || bytes + cost > byteCap) { Reset(input.Qpc); return null; }
+                names[pointer] = new(selected, input.Qpc, cost); bytes += cost;
+            }
+        }
+        if (input.Id is 10 or 12) return null;
+        var byObject = Lookup(false, input.Object, input.Qpc);
+        var byKey = Lookup(true, input.Key, input.Qpc);
+        bool conflict = byObject != null && byKey != null && byObject.Path != byKey.Path;
+        bool retire = input.Id is 13 or 14 && (input.Object == 0 || input.Key == 0 ||
+            names.ContainsKey((false, input.Object)) || names.ContainsKey((true, input.Key)));
+        if (retire || conflict)
+        {
+            // Relationship between object/key lifetimes is unproven; retire whole epoch.
+            if (conflict) Conflicts++;
+            Reset(input.Qpc);
+        }
+        if (input.Id != 15) return null;
+        return Make(input, conflict ? null : byObject?.Path ?? byKey?.Path,
+            conflict ? "conflict" : byObject != null ? "candidate-object" : byKey != null ? "candidate-key" : "unresolved");
+    }
+    private static FileObservation Make(FileInput value, string? path, string evidence) =>
+        new(value.Seq.ToString(), FileCapture.Provider.ToString(), value.Id, value.Version, value.Qpc.ToString(),
+            value.Pid, value.Tid, value.Issuing, value.Payload, path, evidence,
+            value.Pid is 0 or uint.MaxValue ? "unresolved" : "candidate");
+}
+
+internal sealed class FileIngress(int cap = 4096, int byteCap = 4 * 1024 * 1024)
+{
+    private readonly object gate = new();
+    private readonly Queue<FileInput> queue = new();
+    private readonly SemaphoreSlim available = new(0, 1);
+    private int bytes, highRecords, highBytes;
+    private bool gap;
+    private long latestQpc;
+    internal ulong Delivered, Dropped, DecoderErrors;
+    internal void Enqueue(FileInput value)
+    {
+        lock (gate)
+        {
+            Delivered++;
+            latestQpc = Math.Max(latestQpc, value.Qpc);
+            value = value with { Seq = Delivered };
+            if (available.CurrentCount == 0) available.Release();
+            if (queue.Count >= cap || bytes + value.Bytes > byteCap) { Dropped++; gap = true; return; }
+            queue.Enqueue(value); bytes += value.Bytes;
+            highRecords = Math.Max(highRecords, queue.Count); highBytes = Math.Max(highBytes, bytes);
+        }
+    }
+    internal void DecodeError()
+    {
+        lock (gate)
+        {
+            Delivered++; DecoderErrors++; gap = true;
+            if (available.CurrentCount == 0) available.Release();
+        }
+    }
+    internal void WaitBlocking(CancellationToken token) => available.Wait(100, token);
+    internal (FileInput? Input, bool Gap, long Qpc) Take()
+    {
+        lock (gate)
+        {
+            if (gap)
+            {
+                Dropped += (ulong)queue.Count; queue.Clear(); bytes = 0; gap = false;
+                return (null, true, latestQpc);
+            }
+            if (!queue.TryDequeue(out var value)) return (null, false, latestQpc);
+            bytes -= value.Bytes; return (value, false, value.Qpc);
+        }
+    }
+    internal object Queues()
+    {
+        lock (gate) return new { records = queue.Count, bytes, highWaterRecords = highRecords, highWaterBytes = highBytes };
+    }
+    internal (ulong Delivered, ulong Dropped, ulong Errors) Totals()
+    {
+        lock (gate) return (Delivered, Dropped, DecoderErrors);
+    }
+    internal (int Records, int Bytes, int HighRecords, int HighBytes) Snapshot()
+    {
+        lock (gate) return (queue.Count, bytes, highRecords, highBytes);
+    }
+}

--- a/sidecar/etw-file/FilePipeline.cs
+++ b/sidecar/etw-file/FilePipeline.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Aegis.EtwLifecycle;
+
+// A separate bounded mapper keeps pipe writes and native statistics queries out
+// of the raw lifecycle ingress drain. All retained output has its own byte cap.
+internal sealed class FilePipeline : IDisposable
+{
+    private sealed record Output(FileObservation Record, int Bytes);
+    private readonly object gate = new();
+    private readonly Queue<Output> outbound = new();
+    private readonly FileIngress ingress;
+    private readonly FileMapping map;
+    private readonly bool live;
+    private readonly CancellationTokenSource cancel = new();
+    private int bytes, highRecords, highBytes;
+    private bool completed;
+    private ulong filtered, outputDropped;
+    internal ulong OutputDropped { get { lock (gate) return outputDropped; } }
+    internal Task Worker { get; }
+    internal FilePipeline(FileIngress input, FileScope scope, bool native)
+    {
+        ingress = input; map = new(scope, Stopwatch.Frequency); live = native;
+        Worker = Task.Factory.StartNew(Run, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    }
+    internal void Invalidate(long qpc)
+    {
+        lock (gate)
+        {
+            map.Reset(qpc);
+            outputDropped += (ulong)outbound.Count; outbound.Clear(); bytes = 0;
+        }
+    }
+    internal void Complete() { lock (gate) completed = true; }
+    internal void Cancel() => cancel.Cancel();
+    private void Run()
+    {
+        long lastGeneration = 0, lastUnresolved = 0;
+        try
+        {
+            while (true)
+            {
+                cancel.Token.ThrowIfCancellationRequested();
+                var (input, gap, qpc) = ingress.Take();
+                if (gap) { Invalidate(qpc); continue; }
+                if (input == null)
+                {
+                    lock (gate) { if (completed) return; }
+                    ingress.WaitBlocking(cancel.Token); continue;
+                }
+                FileObservation? record;
+                ulong epoch;
+                lock (gate)
+                {
+                    record = map.Accept(input); epoch = map.Epoch;
+                    if (record == null) { filtered++; continue; }
+                }
+                long time = Stopwatch.GetTimestamp();
+                if (record.path == null)
+                {
+                    if (time - lastUnresolved < Stopwatch.Frequency / 10) { lock (gate) filtered++; continue; }
+                    lastUnresolved = time;
+                }
+                if (live && time - lastGeneration >= Stopwatch.Frequency / 100)
+                { record = FileGeneration.Observe(record); lastGeneration = time; }
+                int cost = 1024 + JsonSerializer.SerializeToUtf8Bytes(record).Length + (record.path?.Length ?? 0) * 2;
+                lock (gate)
+                {
+                    if (epoch != map.Epoch || outbound.Count >= 4096 || bytes + cost > 4 * 1024 * 1024)
+                    { outputDropped++; continue; }
+                    outbound.Enqueue(new(record, cost)); bytes += cost;
+                    highRecords = Math.Max(highRecords, outbound.Count); highBytes = Math.Max(highBytes, bytes);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancel.IsCancellationRequested) { }
+    }
+    internal FileObservation? Take()
+    {
+        lock (gate)
+        {
+            if (!outbound.TryDequeue(out var item)) return null;
+            bytes -= item.Bytes; return item.Record;
+        }
+    }
+    internal object Totals()
+    {
+        lock (gate)
+        {
+            var total = ingress.Totals();
+            return new
+            {
+                delivered = total.Delivered.ToString(),
+                filtered = filtered.ToString(),
+                dropped = (total.Dropped + outputDropped).ToString(),
+                decoderErrors = total.Errors.ToString(),
+                mapEpoch = map.Epoch.ToString(),
+                mapResets = map.Resets.ToString(),
+                mapConflicts = map.Conflicts.ToString()
+            };
+        }
+    }
+    internal object Queues()
+    {
+        lock (gate)
+        {
+            var input = ingress.Snapshot();
+            // v1 queue fields describe maxima across two independently capped stages.
+            return new
+            {
+                records = Math.Max(input.Records, outbound.Count),
+                bytes = Math.Max(input.Bytes, bytes),
+                highWaterRecords = Math.Max(input.HighRecords, highRecords),
+                highWaterBytes = Math.Max(input.HighBytes, highBytes)
+            };
+        }
+    }
+    public void Dispose() { cancel.Cancel(); if (Worker.IsCompleted) cancel.Dispose(); }
+}

--- a/sidecar/etw-file/FileScope.cs
+++ b/sidecar/etw-file/FileScope.cs
@@ -1,0 +1,45 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Aegis.EtwLifecycle;
+
+// A lexical retention boundary, not an assertion about reparse targets or ownership.
+internal sealed class FileScope
+{
+    private static readonly UTF8Encoding Utf8 = new(false, true);
+    internal string Root { get; }
+    private readonly string[] prefixes;
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern uint QueryDosDevice(string name, StringBuilder target, int size);
+    internal FileScope(string root, bool queryDevice = true)
+    {
+        if (root.Length < 4 || !char.IsAsciiLetter(root[0]) || root[1] != ':' || root[2] != '\\' ||
+            root.Length > 1024 || root.Any(char.IsControl) || root[3..].Contains(':') || root.Contains('/') ||
+            root.Split('\\').Skip(1).Any(v => v is "." or ".." || v.EndsWith(' ') || v.EndsWith('.')))
+            throw new ArgumentException();
+        Root = root.TrimEnd('\\');
+        if (Root.Length < 4) throw new ArgumentException(); // Never a whole drive.
+        var list = new List<string> { Root, @"\??\" + Root, @"\\?\" + Root };
+        if (queryDevice)
+        {
+            var target = new StringBuilder(32768);
+            if (QueryDosDevice(Root[..2], target, target.Capacity) == 0) throw new InvalidOperationException();
+            list.Add(target + Root[2..]);
+        }
+        prefixes = list.ToArray();
+    }
+    internal string? Select(string? name)
+    {
+        if (name == null || name.Length > 32768 || name.Any(char.IsControl)) return null;
+        try { if (Utf8.GetByteCount(name) > 32768) return null; }
+        catch (EncoderFallbackException) { return null; }
+        if (name.Split('\\').Any(v => v is "." or "..")) return null;
+        foreach (var prefix in prefixes)
+            if (name.StartsWith(prefix + "\\", StringComparison.OrdinalIgnoreCase))
+            {
+                string selected = Root + name[prefix.Length..];
+                return Utf8.GetByteCount(selected) <= 32768 ? selected : null;
+            }
+        return null;
+    }
+}

--- a/sidecar/etw-file/FileTests.cs
+++ b/sidecar/etw-file/FileTests.cs
@@ -1,0 +1,145 @@
+using System.Buffers.Binary;
+using System.Text.Json;
+
+namespace Aegis.EtwLifecycle;
+
+internal static class FileTests
+{
+    internal static int Run()
+    {
+        int passed = 0;
+        void Test(string name, Action body) { body(); passed++; Console.WriteLine("PASS " + name); }
+        var scope = new FileScope(@"C:\fixture", false);
+        FileInput Input(int id, long qpc, ulong obj = 1, ulong key = 0, string? name = null) =>
+            new((ulong)qpc, id, id == 10 ? 0 : 1, qpc, 71, 72, 72, null, obj, key, name);
+        FileMapping Map(int cap = 32768, int bytes = 8 * 1024 * 1024) => new(scope, 10, cap, bytes);
+        void Name(FileMapping map, long qpc = 1, ulong obj = 1, ulong key = 0, string path = @"C:\fixture\a") =>
+            map.Accept(Input(12, qpc, obj, key, path));
+        Test("native layout", FileTrace.Layout);
+        Test("scope boundary and device spelling", () =>
+        {
+            Check(scope.Select(@"C:\fixture2\a") == null);
+            Check(scope.Select(@"\??\C:\fixture\a") == @"C:\fixture\a");
+            Check(scope.Select(@"C:\fixture\..\outside") == null);
+            Check(scope.Select("C:\\fixture\\x\nsecret") == null);
+        });
+        Test("reject broad or ambiguous roots", () =>
+        {
+            foreach (var root in new[] { @"C:\", @"C:\fixture\..\a", @"\\server\share", "C:\\fixture " })
+                Reject(() => new FileScope(root, false));
+        });
+        Test("preopened remains unresolved; no backfill", () =>
+        {
+            var map = Map(); var first = map.Accept(Input(15, 1)); Name(map, 2);
+            Check(first?.path == null); Check(map.Accept(Input(15, 3))?.pathEvidence == "candidate-object");
+        });
+        Test("earlier name yields candidate only", () =>
+        {
+            var map = Map(); Name(map); var value = map.Accept(Input(15, 2));
+            Check(value?.path == @"C:\fixture\a" && value.generationWitness == null && value.agent == null && value.instanceId == null);
+        });
+        Test("PID reuse never carries cached birth", () =>
+        {
+            var map = Map(); Name(map);
+            var a = map.Accept(Input(15, 2))! with { generationWitness = "134000000000001111", generationStatus = "candidate" };
+            var b = map.Accept(Input(15, 3)); Check(a.generationWitness != null && b?.generationWitness == null);
+        });
+        Test("same QPC is insufficient ordering", () => { var map = Map(); Name(map); Check(map.Accept(Input(15, 1))?.path == null); });
+        Test("late event clears mapping epoch", () =>
+        {
+            var map = Map(); Name(map, 5); Check(map.Accept(Input(15, 4))?.path == null);
+            Check(map.Accept(Input(15, 6))?.path == null && map.Resets > 0);
+        });
+        Test("close and cleanup retire related evidence", () =>
+        {
+            foreach (int id in new[] { 13, 14 }) { var map = Map(); Name(map, key: 2); map.Accept(Input(id, 2)); Check(map.Accept(Input(15, 3, key: 2))?.path == null); }
+        });
+        Test("conflicting object and key are unresolved", () =>
+        {
+            var map = Map(); Name(map); Name(map, 2, 0, 2, @"C:\fixture\b");
+            var result = map.Accept(Input(15, 3, key: 2)); Check(result?.pathEvidence == "conflict" && result.path == null && map.Count == 0);
+        });
+        Test("rebind outside root cannot keep old path", () =>
+        {
+            var map = Map(); Name(map); Name(map, 2, path: @"C:\outside\secret"); Check(map.Accept(Input(15, 3))?.path == null);
+        });
+        Test("TTL expiry is unresolved", () => { var map = Map(); Name(map); Check(map.Accept(Input(15, 302))?.path == null); });
+        Test("map cap invalidates whole epoch", () =>
+        {
+            var map = Map(1); Name(map); Name(map, 2, 2); Check(map.Count == 0 && map.Resets == 1);
+        });
+        Test("map byte bound includes retained strings", () => { var map = Map(bytes: 10); Name(map); Check(map.Count == 0 && map.Bytes == 0); });
+        Test("loss boundary rejects buffered names", () =>
+        {
+            var map = Map(); Name(map); map.Reset(10); Name(map, 5); Check(map.Accept(Input(15, 11))?.path == null);
+            Name(map, 12); Check(map.Accept(Input(15, 13))?.path != null);
+        });
+        Test("ingress overflow accounts retained evidence too", () =>
+        {
+            var queue = new FileIngress(1); queue.Enqueue(Input(12, 1)); queue.Enqueue(Input(15, 2));
+            Check(queue.Take().Gap); Check(queue.Totals() == (2UL, 2UL, 0UL)); Check(queue.Take().Input == null);
+        });
+        Test("ingress byte cap and decoder loss", () =>
+        {
+            var queue = new FileIngress(byteCap: 100); queue.Enqueue(Input(15, 1)); queue.DecodeError();
+            Check(queue.Take().Gap && queue.Totals() == (2UL, 1UL, 1UL));
+        });
+        Test("sustained ingress overload remains bounded", () =>
+        {
+            var queue = new FileIngress();
+            for (int i = 1; i <= 100000; i++) queue.Enqueue(Input(15, i));
+            using var json = JsonDocument.Parse(JsonSerializer.Serialize(queue.Queues()));
+            Check(json.RootElement.GetProperty("records").GetInt32() <= 4096);
+            Check(json.RootElement.GetProperty("bytes").GetInt32() <= 4 * 1024 * 1024);
+            Check(queue.Take().Gap && queue.Totals().Dropped == 100000);
+        });
+        Test("mapper drains independently of an unread output queue", () =>
+        {
+            var queue = new FileIngress();
+            using var pipeline = new FilePipeline(queue, scope, false);
+            for (int batch = 0; batch < 80; batch++)
+            {
+                long qpc = batch * 1000 + 1;
+                queue.Enqueue(Input(12, qpc, name: @"C:\fixture\a"));
+                for (int i = 1; i <= 100; i++) queue.Enqueue(Input(15, qpc + i));
+                Check(SpinWait.SpinUntil(() => queue.Snapshot().Records == 0, 2000));
+            }
+            pipeline.Complete(); pipeline.Worker.WaitAsync(TimeSpan.FromSeconds(3)).GetAwaiter().GetResult();
+            using var json = JsonDocument.Parse(JsonSerializer.Serialize(pipeline.Queues()));
+            Check(json.RootElement.GetProperty("records").GetInt32() <= 4096);
+            Check(json.RootElement.GetProperty("bytes").GetInt32() <= 4 * 1024 * 1024);
+            Check(pipeline.OutputDropped > 0 && queue.Totals().Dropped == 0); // Outbound cap, while ingress keeps draining.
+            pipeline.Invalidate(1000000); Check(pipeline.Take() == null);
+        });
+        Test("wire round trip and replay rejection", () =>
+        {
+            using var stream = new MemoryStream(); var writer = new FileWire("launch", "session");
+            writer.Write(stream, "stop", new { requestId = "stop1" }, default).GetAwaiter().GetResult();
+            stream.Position = 0; var reader = new FileWire("launch", "session");
+            Check(reader.Read(stream, true, default).GetAwaiter().GetResult().t == "stop"); stream.Position = 0;
+            Reject(() => reader.Read(stream, true, default).GetAwaiter().GetResult());
+        });
+        Test("oversize prefix and foreign session rejected", () =>
+        {
+            byte[] bytes = new byte[4]; BinaryPrimitives.WriteInt32LittleEndian(bytes, FileWire.Limit + 1);
+            Reject(() => new FileWire("l", "s").Read(new MemoryStream(bytes), true, default).GetAwaiter().GetResult());
+            using var stream = new MemoryStream(); new FileWire("foreign", "s").Write(stream, "ping", new { }, default).GetAwaiter().GetResult();
+            stream.Position = 0; Reject(() => new FileWire("l", "s").Read(stream, true, default).GetAwaiter().GetResult());
+        });
+        Test("control objects reject unknown and duplicate fields", () =>
+        {
+            foreach (string json in new[] { "{\"requestId\":\"a\",\"path\":\"secret\"}", "{\"requestId\":\"a\",\"requestId\":\"b\"}" })
+            {
+                using var doc = JsonDocument.Parse(json); Reject(() => FileWire.Shape(doc.RootElement, "requestId"));
+            }
+        });
+        Console.WriteLine($"{passed} self-tests passed; no ETW session or UAC requested.");
+        return 0;
+    }
+    private static void Check(bool value) { if (!value) throw new InvalidOperationException("check-failed"); }
+    private static void Reject(Action value)
+    {
+        bool rejected = false; try { value(); } catch { rejected = true; }
+        Check(rejected);
+    }
+}

--- a/sidecar/etw-file/FileTrace.cs
+++ b/sidecar/etw-file/FileTrace.cs
@@ -1,0 +1,119 @@
+using System.Runtime.InteropServices;
+
+namespace Aegis.EtwLifecycle;
+
+internal sealed record FileStats(uint Status, uint? Events, uint? RealTime, uint? Log, uint? Buffers, uint? Size);
+
+// Fixed diagnostic session. Only StartTrace success grants handle-based stop authority.
+internal sealed class FileTrace : IDisposable
+{
+    internal const string Name = "AEGIS-EtwFileDiagnostic";
+    private ulong handle;
+    private bool owned;
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Wnode
+    {
+        public uint BufferSize, ProviderId; public ulong HistoricalContext;
+        public long TimeStamp; public Guid Guid; public uint ClientContext, Flags;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Properties
+    {
+        public Wnode Wnode;
+        public uint BufferSize, MinimumBuffers, MaximumBuffers, MaximumFileSize, LogFileMode;
+        public uint FlushTimer, EnableFlags; public int AgeLimit;
+        public uint NumberOfBuffers, FreeBuffers, EventsLost, BuffersWritten, LogBuffersLost, RealTimeBuffersLost;
+        public IntPtr LoggerThreadId; public uint LogFileNameOffset, LoggerNameOffset;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Filter { public ulong Pointer; public uint Size, Type; }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct EnableParameters
+    {
+        public uint Version, EnableProperty, ControlFlags; public Guid Source;
+        public IntPtr Filters; public uint Count;
+    }
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+    private static extern uint StartTrace(out ulong handle, string name, IntPtr properties);
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+    private static extern uint ControlTrace(ulong handle, string? name, IntPtr properties, uint code);
+    [DllImport("advapi32.dll")]
+    private static extern uint EnableTraceEx2(ulong handle, in Guid provider, uint code, byte level,
+        ulong any, ulong all, uint timeout, in EnableParameters parameters);
+    internal static void Layout()
+    {
+        if (IntPtr.Size != 8 || Marshal.SizeOf<Wnode>() != 48 || Marshal.SizeOf<Filter>() != 16 ||
+            Marshal.OffsetOf<Properties>(nameof(Properties.EventsLost)).ToInt32() != 88 ||
+            Marshal.OffsetOf<EnableParameters>(nameof(EnableParameters.Filters)).ToInt32() != 32)
+            throw new InvalidOperationException();
+    }
+    private static IntPtr Allocate()
+    {
+        Layout();
+        int size = Marshal.SizeOf<Properties>() + 4096;
+        var memory = Marshal.AllocHGlobal(size); Marshal.Copy(new byte[size], 0, memory, size);
+        Marshal.StructureToPtr(new Properties
+        {
+            Wnode = new Wnode { BufferSize = (uint)size, Flags = 0x20000, ClientContext = 1, Guid = Guid.NewGuid() },
+            LoggerNameOffset = (uint)Marshal.SizeOf<Properties>(),
+            BufferSize = 64,
+            MinimumBuffers = 256,
+            MaximumBuffers = 256,
+            LogFileMode = 0x100,
+            FlushTimer = 1
+        }, memory, false);
+        return memory;
+    }
+    internal FileStats Start()
+    {
+        if (owned) throw new InvalidOperationException();
+        var memory = Allocate();
+        try
+        {
+            uint status = StartTrace(out handle, Name, memory);
+            if (status != 0) throw new System.ComponentModel.Win32Exception((int)status);
+            owned = true;
+            return Query();
+        }
+        finally { Marshal.FreeHGlobal(memory); }
+    }
+    internal void Enable()
+    {
+        if (!owned) throw new InvalidOperationException();
+        // EVENT_FILTER_EVENT_ID: BOOLEAN, reserved byte, USHORT count, USHORT IDs.
+        byte[] ids = [1, 0, 5, 0, 10, 0, 12, 0, 13, 0, 14, 0, 15, 0];
+        var data = Marshal.AllocHGlobal(ids.Length);
+        var descriptor = Marshal.AllocHGlobal(Marshal.SizeOf<Filter>());
+        try
+        {
+            Marshal.Copy(ids, 0, data, ids.Length);
+            Marshal.StructureToPtr(new Filter { Pointer = (ulong)data.ToInt64(), Size = (uint)ids.Length, Type = 0x80000200 }, descriptor, false);
+            var parameters = new EnableParameters { Version = 2, Filters = descriptor, Count = 1 };
+            uint status = EnableTraceEx2(handle, in FileCapture.Provider, 1, 5, 0x1b0, 0, 5000, in parameters);
+            if (status != 0) throw new System.ComponentModel.Win32Exception((int)status);
+        }
+        finally { Marshal.FreeHGlobal(descriptor); Marshal.FreeHGlobal(data); }
+    }
+    internal FileStats Query() => Control(0);
+    internal FileStats Stop()
+    {
+        if (!owned) throw new InvalidOperationException();
+        var result = Control(1);
+        if (result.Status == 0) owned = false;
+        return result;
+    }
+    private FileStats Control(uint code)
+    {
+        if (!owned) throw new InvalidOperationException();
+        var memory = Allocate();
+        try
+        {
+            uint status = ControlTrace(handle, null, memory, code);
+            if (status != 0) return new(status, null, null, null, null, null);
+            var value = Marshal.PtrToStructure<Properties>(memory);
+            return new(0, value.EventsLost, value.RealTimeBuffersLost, value.LogBuffersLost, value.NumberOfBuffers, value.BufferSize);
+        }
+        finally { Marshal.FreeHGlobal(memory); }
+    }
+    public void Dispose() { if (owned) Stop(); }
+}

--- a/sidecar/etw-file/FileWire.cs
+++ b/sidecar/etw-file/FileWire.cs
@@ -1,0 +1,70 @@
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+
+namespace Aegis.EtwLifecycle;
+
+internal sealed record Envelope(string t, string proto, string launchId, string sessionId, string seq, JsonElement data);
+internal sealed class FileWire(string launch, string session)
+{
+    internal const string Protocol = "etw-file/1", Profile = "home-26200-diagnostic-v1";
+    internal const int Limit = 256 * 1024;
+    internal static readonly string[] Schemas = ["10:0", "12:1", "13:1", "14:1", "15:1"];
+    private static readonly UTF8Encoding Utf8 = new(false, true);
+    private ulong sent, received;
+    internal static bool Id(string value) => value.Length is > 0 and <= 64 && value.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_');
+    internal static void Shape(JsonElement value, params string[] names)
+    {
+        if (value.ValueKind != JsonValueKind.Object) throw new InvalidDataException();
+        var actual = value.EnumerateObject().Select(p => p.Name).ToArray();
+        if (actual.Length != names.Length || actual.Distinct().Count() != names.Length || names.Any(n => !value.TryGetProperty(n, out _)))
+            throw new InvalidDataException();
+    }
+    internal async Task<Envelope> Read(Stream stream, bool control, CancellationToken token)
+    {
+        byte[] header = new byte[4];
+        await stream.ReadExactlyAsync(header, token);
+        uint length = BinaryPrimitives.ReadUInt32LittleEndian(header);
+        if (length is 0 or > Limit) throw new InvalidDataException();
+        byte[] body = new byte[length];
+        await stream.ReadExactlyAsync(body, token);
+        using var json = JsonDocument.Parse(Utf8.GetString(body), new JsonDocumentOptions { MaxDepth = 16 });
+        Shape(json.RootElement, "t", "proto", "launchId", "sessionId", "seq", "data");
+        var frame = json.RootElement.Deserialize<Envelope>() ?? throw new InvalidDataException();
+        if (!Id(launch) || !Id(session) || frame.launchId != launch || frame.sessionId != session || frame.proto != Protocol ||
+            !ulong.TryParse(frame.seq, out ulong seq) || seq == 0 || seq.ToString() != frame.seq || seq <= received)
+            throw new InvalidDataException();
+        received = seq;
+        if (control)
+        {
+            if (frame.t == "start")
+            {
+                Shape(frame.data, "requestId", "profile", "buffersMiB");
+                if (frame.data.GetProperty("profile").GetString() != Profile || frame.data.GetProperty("buffersMiB").GetInt32() != 16)
+                    throw new InvalidDataException();
+            }
+            else if (frame.t == "stop") Shape(frame.data, "requestId");
+            else if (frame.t == "ping") Shape(frame.data);
+            else throw new InvalidDataException();
+            if (frame.t != "ping" && !Id(frame.data.GetProperty("requestId").GetString() ?? "")) throw new InvalidDataException();
+        }
+        else if (frame.t is not ("hello" or "ready" or "observations" or "health" or "heartbeat" or "stopped" or "error"))
+            throw new InvalidDataException();
+        return frame with { data = frame.data.Clone() };
+    }
+    internal async Task Write(Stream stream, string kind, object data, CancellationToken token)
+    {
+        await Forward(stream, new Envelope(kind, Protocol, launch, session, (++sent).ToString(), JsonSerializer.SerializeToElement(data)), token);
+    }
+    internal static async Task Forward(Stream stream, Envelope message, CancellationToken token)
+    {
+        byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(message);
+        if (bytes.Length > Limit) throw new InvalidDataException();
+        byte[] header = new byte[4]; BinaryPrimitives.WriteInt32LittleEndian(header, bytes.Length);
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(token);
+        deadline.CancelAfter(TimeSpan.FromSeconds(5));
+        await stream.WriteAsync(header, deadline.Token);
+        await stream.WriteAsync(bytes, deadline.Token);
+        await stream.FlushAsync(deadline.Token);
+    }
+}

--- a/sidecar/etw-file/Program.cs
+++ b/sidecar/etw-file/Program.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics;
+
+namespace Aegis.EtwLifecycle;
+
+internal static class Program
+{
+    internal static string Executable => Environment.ProcessPath ?? throw new InvalidOperationException();
+    internal static ProcessStartInfo Child(params string[] args)
+    {
+        var info = new ProcessStartInfo(Executable)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        foreach (string arg in args) info.ArgumentList.Add(arg);
+        return info;
+    }
+    private static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            if (args is ["self-test"]) return FileTests.Run();
+            if (args.Length == 4 && args[0] is "broker" or "check-broker") return await FileBroker.Run(args);
+            if (args.Length == 8 && args[0] is "collector" or "check-collector") return await FileCollector.Run(args);
+            return 3;
+        }
+        catch { return 2; } // No raw exception, path, SID or pipe nonce on either stream.
+    }
+}

--- a/sidecar/etw-file/README.md
+++ b/sidecar/etw-file/README.md
@@ -1,0 +1,115 @@
+# Diagnostic Kernel-File backend
+
+Development opt-in only. This is the first connected file producer, distinct from
+the frozen `etw-probe` measurements and the empty-session `etw-lifecycle` harness.
+It does not emit FileEvents, identify agents, update risk/baselines/sequences, or
+persist paths. Packaged AEGIS refuses enablement until deployment and lifecycle
+gates are closed. No installer, service or default production buffer budget changes.
+
+Build on Windows x64 with .NET 10:
+
+```powershell
+dotnet build sidecar/etw-file/EtwFile.csproj -c Release
+& sidecar/etw-file/bin/Release/net10.0-windows/EtwFile.exe self-test
+node scripts/verify-etw-file.mjs --report=X:/tmp/etw-file-check-new.json
+```
+
+The default process check launches only normal-token processes. File observations
+are injected fixtures, native loss counters stay null. It exercises the actual
+C# broker/collector, framed JS decoder and supervisor, two clean sessions with
+different IDs, then parent EOF with unverified stop and blocked retry. The report
+retains build hashes and bounded session summaries, with no raw observations.
+Choose a new report path on every run. Temporary fixture folders are retained.
+
+For a separately agreed live check, run the following from normal PowerShell and
+approve **one** UAC prompt. The ordinary Node process reads its own temporary test
+file for ten seconds; only the collector elevates. This never sleeps the computer.
+
+```powershell
+node scripts/verify-etw-file.mjs --live --report=X:/tmp/etw-file-live-new.json
+```
+
+Live acceptance requires a Read candidate matching the fixture path and the normal
+workload's header PID, no outgoing path outside the selected root, known final zero
+native loss counters, valid stopped acknowledgement and broker/collector exit 0.
+This is a smoke test, not proof of event-time issuer semantics or complete read coverage.
+Failed checks still request stop and retain final summaries. No elevated kill or
+orphan cleanup is attempted. Real sleep/wake remains deferred by the user.
+
+After building the renderer, explicitly enable a development app session with a
+single local subdirectory (not an entire drive, UNC root, dot-segment or relative path):
+
+```powershell
+node scripts/launch.js '--etw-file-diagnostic-root=X:\tmp\my-fixture'
+```
+
+Without this flag no broker is spawned and the `etw-file` leaf is DISABLED.
+Only health enters the existing app-health payload; diagnostic observations remain
+in the main-process runtime's bounded `getDiagnostics()` ring. No renderer IPC was
+added. Pause, suspend and quit request stop and erase the ring. Resume/unpause never
+automatically prompt for UAC. The internal runtime supports explicit restart after
+verified stop and child exit; a new app invocation is currently the user-facing
+way to start another capture. The separately owned frontend is unchanged.
+
+## Boundaries and accounting
+
+- Normal broker and elevated collector reuse the lifecycle harness's restricted
+  local pipe ACL and mutual PID/full FILETIME/image/user/logon/elevation checks.
+  The collector authorizes capture only after a valid start command. Consent is
+  bounded by a 120-second pipe deadline; this does not dismiss an OS UAC dialog.
+  Mutable development binaries are trusted. Protected installation/signatures,
+  alternate credentials and other-logon clients are still E1 gates.
+- The collector uses fixed `AEGIS-EtwFileDiagnostic`, StartTrace success grants
+  handle-based ownership, and occupied names fail. Kernel-File IDs 10/12/13/14/15,
+  mask 0x1B0, requested 256 buffers of 64 KiB. The application cannot select other
+  providers, commands, output files or session names. Actual buffers are reported.
+- The callback only decodes the known schema pairs and enqueues copied input.
+  Ingress is capped at 4,096 entries and 4 MiB including retained string estimates.
+  A gap discards buffered inputs with counted loss and invalidates the map epoch.
+  A dedicated mapper drains ingress independently of pipe writes and native counter
+  queries. Its outbound queue is separately capped at 4,096 entries / 4 MiB; overflow
+  there counts loss without blocking raw mapping. The writer retains one bounded
+  batch, with at most 128 records and a 256 KiB wire limit. The v1 telemetry queue
+  fields report maxima across the two separately capped stages, not their sum.
+  Broker readers/writers retain one frame per direction, writes expire after five
+  seconds. Heartbeats run between bounded batches; controls have a separate task
+  and a ten-second lease. The JS writer retains at most one outstanding control
+  frame plus one pending stop, not a promise per input event.
+- Naming maps are capped at 32,768 entries / 8 MiB with retained-string accounting.
+  Only earlier names yield candidates. TTL is 30 seconds of event QPC; it bounds
+  reuse of evidence, not a correctness claim. Unknown/preopened paths stay null;
+  later names do not backfill reads. Rebind conflict, object/key disagreement,
+  Cleanup/Close, out-of-order events, query failure, observed loss, decoding or
+  ingress loss reset the whole map epoch. Close/cleanup with both pointers known
+  and neither present in the maps can be ignored; a matching or incomplete close
+  resets the epoch. This conservative lifecycle strategy
+  may leave many reads unresolved under machine-wide churn.
+- Roots are lexical retention boundaries. Only selected paths are emitted, raw
+  object/key addresses never leave the collector. Root selection does not establish
+  reparse target identity or reduce machine-wide kernel cost. No file contents,
+  command lines, environment values or API keys are collected.
+  Reads with unresolved paths are sampled at up to ten per second of receipt time;
+  omitted samples contribute to `filtered`, separately from overflow `dropped`.
+  This sample is not an activity count. Selected-path candidates are not sampled.
+- Header PID and issuing TID remain candidates. At most 100 fresh limited-query
+  process handle probes per second retain full creation FILETIME and the actual
+  QPC observation interval, without caching birth time. This later observation
+  cannot prove the earlier event issuer; agent and instanceId remain null.
+- Main retains at most 256 diagnostic records / 1 MiB including UTF-16 storage
+  estimates. Eviction has its own counter. Stop/failure clears this ring. At most
+  32 ended summaries retain reasons, loss maxima, ready clock/buffers, final sampled
+  counters and stop reason; an omitted-summary count records older eviction.
+  EOF is not a stop acknowledgement. Stop timeout, wrong request IDs, stale frames
+  and failed process exit cannot certify cleanup. Failure never auto-relaunches.
+
+## Current evidence and limits
+
+See [backend implementation record](../../docs/roadmap/etw-file-backend.md).
+The local C# build/formatter, self-tests and process checks are separate from the
+repository's five CI contexts, which do not build this new .NET project.
+The new provider's narrow live smoke passed, including a scoped Read/header-PID
+candidate and owned stop. Its application queues dropped 12,061 of 88,772 events despite
+zero native ETW losses; this is a degraded diagnostic backend, not loss-free capture.
+The aggregate retains all earlier attempts, including the failed first one. Independent
+absence witnessing and protected collector-crash recovery remain unfinished.
+Warm mmap, Fast I/O and the remaining B1/E4–E8 coverage questions remain open.

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -43,6 +43,7 @@ const logger = require('./logger');
 const tray = require('./tray-icon');
 const ipc = require('./ipc-handlers');
 let updates;
+let etwFile;
 const { createBatcher } = require('./ipc-batcher');
 // Pure domain modules — no I/O, no Electron, no timers — so they cost nothing to load
 // on the fast path to a visible window. `file-access-batching` must be here rather than
@@ -224,6 +225,7 @@ function getAppHealth() {
   if (typeof platform.getSnapshotHealth === 'function') {
     records.push(platform.getSnapshotHealth());
   }
+  if (etwFile) records.push(etwFile.getHealth());
   const derived = appHealth.deriveAppHealth({
     bootPhase: true,
     capabilities,
@@ -829,6 +831,7 @@ app.whenReady().then(() => {
     isMonitoringPaused: () => monitoringPaused,
     setMonitoringPaused: (v) => {
       monitoringPaused = v;
+      etwFile?.setPaused(v);
     },
     stopScanIntervals: () => {
       if (scanLoop) scanLoop.stopScanIntervals();
@@ -847,6 +850,10 @@ app.whenReady().then(() => {
     getAgentCount: () => latestAgents.length,
   });
   createWindow();
+  etwFile = require('./platform/etw-file-runtime').createRuntime({
+    app,
+    powerMonitor: require('electron').powerMonitor,
+  });
   // Block B5 — the OS sleep gap. `powerMonitor` is usable only after `ready`, which is
   // where this runs; the module is injected the emitter and a clock and owns the rest.
   // On resume one `observation-gap` audit record explains the hole in the JSONL, ahead
@@ -891,6 +898,7 @@ app.whenReady().then(() => {
     tray.createTray();
     // Load heavy modules AFTER window is visible
     setImmediate(() => initDeferredSubsystems(userData));
+    etwFile.start();
   });
   globalShortcut.register('CommandOrControl+Shift+T', () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
@@ -900,6 +908,7 @@ app.whenReady().then(() => {
 });
 
 app.on('before-quit', () => {
+  etwFile?.dispose();
   updates?.dispose();
   if (oomIntervalId) {
     clearInterval(oomIntervalId);
@@ -930,6 +939,15 @@ app.on('quit', () => {
 /** @internal Inject the file-watcher module, normally set by loadDeferredModules (for tests). */
 function _setWatcherForTest(mod) {
   watcher = mod;
+}
+
+/** @internal Inject the optional ETW runtime without launching a collector.
+ * @param {Object|undefined} mod - Health/diagnostic owner.
+ * @returns {void}
+ * @since v0.14.2
+ */
+function _setEtwFileForTest(mod) {
+  etwFile = mod;
 }
 
 /**
@@ -1019,6 +1037,7 @@ module.exports = {
   getStats,
   getAppHealth,
   _setWatcherForTest,
+  _setEtwFileForTest,
   _setScannerForTest,
   _setScanLoopForTest,
   _setSequenceEngineForTest,

--- a/src/main/platform/etw-file-health.js
+++ b/src/main/platform/etw-file-health.js
@@ -150,7 +150,7 @@ function withTelemetry(state, sample, now) {
 function reduceSession(state, message, now) {
   time(now);
   validateMessage(message, state);
-  if (['start', 'stop'].includes(message.t)) error('wrong-direction');
+  if (['start', 'stop', 'ping'].includes(message.t)) error('wrong-direction');
   if (BigInt(message.seq) <= BigInt(state.lastSeq)) error('sequence-replayed');
   if (state.phase === 'failed' || state.phase === 'stopped') error('session-terminal');
   if (message.t === 'hello' && (state.helloSeen || state.lastSeq !== '0'))

--- a/src/main/platform/etw-file-protocol.js
+++ b/src/main/platform/etw-file-protocol.js
@@ -146,6 +146,7 @@ const messageData = {
   health: telemetry,
   heartbeat: telemetry,
   stop: shape({ requestId: id }),
+  ping: shape({}),
   stopped: shape({
     requestId: id,
     drained: oneOf(true, false),

--- a/src/main/platform/etw-file-runtime.js
+++ b/src/main/platform/etw-file-runtime.js
@@ -1,0 +1,82 @@
+/** @file Explicit development-only ETW startup. Diagnostic paths stay in main memory. */
+'use strict';
+const path = require('node:path');
+const fs = require('node:fs');
+const { spawn } = require('node:child_process');
+const { createSupervisor } = require('./etw-file-supervisor');
+
+/** Attach the optional backend to application lifetime without adding renderer IPC.
+ * Packaged enablement awaits provenance, crash-recovery and live admission gates.
+ * @param {Object} options - app, powerMonitor, argv and optional process test seams.
+ * @returns {Object} Sensor runtime; no filesystem activity is routed downstream.
+ * @since v0.14.2
+ */
+function createRuntime({
+  app,
+  powerMonitor,
+  argv = process.argv,
+  platform = process.platform,
+  spawnProcess = spawn,
+  exists = fs.existsSync,
+}) {
+  const prefix = '--etw-file-diagnostic-root=';
+  const roots = argv.filter((value) => value.startsWith(prefix));
+  const root = roots[0]?.slice(prefix.length);
+  const executable = path.resolve(
+    __dirname,
+    '../../../sidecar/etw-file/bin/Release/net10.0-windows/EtwFile.exe',
+  );
+  const sensor = createSupervisor({
+    spawnBroker: (launchId, sessionId) =>
+      spawnProcess(executable, ['broker', launchId, sessionId, root], {
+        windowsHide: true,
+        shell: false,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      }),
+  });
+  const validRoot =
+    typeof root === 'string' &&
+    /^[A-Za-z]:\\[^\\]/.test(root) &&
+    root.length <= 1024 &&
+    !/[\p{Cc}/]/u.test(root) &&
+    !root.slice(3).includes(':') &&
+    root
+      .split('\\')
+      .slice(1)
+      .every((part) => part !== '.' && part !== '..' && !/[. ]$/.test(part));
+  let permitted = false;
+  if (platform !== 'win32') sensor.setUnavailable('UNSUPPORTED', 'windows-only');
+  else if (roots.length === 0) sensor.setUnavailable('DISABLED', 'diagnostic-opt-in-required');
+  else if (app.isPackaged) sensor.setUnavailable('DISABLED', 'deployment-gates-pending');
+  else if (roots.length !== 1 || !validRoot)
+    sensor.setUnavailable('FAILED', 'invalid-diagnostic-root');
+  else if (!exists(executable)) sensor.setUnavailable('FAILED', 'diagnostic-broker-missing');
+  else permitted = true;
+  let paused = false,
+    suspended = false;
+  const onSuspend = () => {
+    suspended = true;
+    sensor.stop('suspend');
+  };
+  const onResume = () => {
+    suspended = false;
+  }; // Explicit restart only; never another surprise UAC.
+  powerMonitor.on('suspend', onSuspend);
+  powerMonitor.on('resume', onResume);
+  return {
+    start: () => permitted && !paused && !suspended && sensor.start(),
+    restart: () => permitted && !paused && !suspended && sensor.restart(),
+    setPaused(value) {
+      paused = value;
+      if (paused) sensor.stop('pause');
+    },
+    getHealth: sensor.getHealth,
+    getDiagnostics: sensor.getDiagnostics,
+    dispose() {
+      powerMonitor.removeListener('suspend', onSuspend);
+      powerMonitor.removeListener('resume', onResume);
+      sensor.dispose();
+    },
+  };
+}
+module.exports = { createRuntime };

--- a/src/main/platform/etw-file-supervisor.js
+++ b/src/main/platform/etw-file-supervisor.js
@@ -1,0 +1,296 @@
+/** @file Bounded diagnostic ETW transport owner; never emits FileEvents. */
+'use strict';
+const { randomUUID } = require('node:crypto');
+const { performance } = require('node:perf_hooks');
+const wire = require('./etw-file-protocol');
+const model = require('./etw-file-health');
+const health = require('../sensor-health');
+
+/** Own one broker at a time, with explicit retry and no elevated kill or replay.
+ * @param {Object} deps - spawnBroker, optional clocks/ID factory for deterministic tests.
+ * @returns {Object} Lifecycle, health and local-only diagnostic snapshot methods.
+ * @since v0.14.2
+ */
+function createSupervisor({
+  spawnBroker,
+  now = Date.now,
+  mono = () => performance.now(),
+  id = randomUUID,
+}) {
+  let current = null,
+    child = null,
+    timer = null,
+    decoder = null;
+  let startedAt = 0,
+    receivedAt = 0,
+    stopAt = null,
+    startRequest = null,
+    stopRequest = null;
+  let sent = 0n,
+    pendingWrite = false,
+    writeAt = 0,
+    closed = true,
+    disposed = false;
+  let restartRequested = false,
+    unsafe = false,
+    receivedReady = false;
+  let stopSent = false,
+    failedAt = null;
+  let stopReason = null;
+  let capture = null;
+  let ring = [],
+    ringBytes = 0,
+    ringDropped = 0,
+    summaries = [],
+    omittedSummaries = 0;
+  let idle = { ...health.createSensorHealth('etw-file'), state: 'DISABLED' };
+
+  function clearRing() {
+    ring = [];
+    ringBytes = 0;
+  }
+  function fail(code) {
+    if (!current || current.phase === 'failed') return;
+    current = model.failSession(current, now(), code);
+    failedAt = mono();
+    unsafe = receivedReady; // Once capture existed, missing cleanup forbids a new capture.
+    restartRequested = false;
+    clearRing();
+    child?.stdin.destroy(); // Broker EOF and collector lease own cleanup.
+  }
+  function send(t, data) {
+    if (!child || closed || pendingWrite) return false;
+    const bytes = wire.encodeFrame({
+      t,
+      proto: wire.PROTOCOL,
+      launchId: current.launchId,
+      sessionId: current.sessionId,
+      seq: String(++sent),
+      data,
+    });
+    pendingWrite = true;
+    writeAt = mono();
+    const target = child;
+    try {
+      target.stdin.write(bytes, (error) => {
+        if (child !== target) return;
+        pendingWrite = false;
+        if (error) return fail('consumer-failed');
+        flushStop();
+      });
+    } catch {
+      fail('protocol-failed');
+      return false;
+    }
+    return true;
+  }
+  function flushStop() {
+    if (stopAt !== null && !stopSent && current?.phase === 'running' && !pendingWrite) {
+      stopSent = true;
+      send('stop', { requestId: stopRequest });
+    }
+  }
+  function accept(message) {
+    if (message.t === 'ready' && message.data.requestId !== startRequest)
+      throw new Error('request');
+    if (message.t === 'stopped' && message.data.requestId !== stopRequest)
+      throw new Error('request');
+    current = model.reduceSession(current, message, now());
+    receivedAt = mono();
+    if (message.t === 'hello') {
+      if (stopAt !== null) {
+        child.stdin.end();
+        return;
+      }
+      startRequest = id();
+      if (!send('start', { requestId: startRequest, profile: wire.PROFILE, buffersMiB: 16 }))
+        throw new Error('write-busy');
+    }
+    if (message.t === 'ready') {
+      receivedReady = true;
+      capture = structuredClone({
+        buffers: message.data.buffers,
+        frequency: message.data.frequency,
+        clock: message.data.clock,
+      });
+    }
+    if (current.phase === 'failed') {
+      failedAt = mono();
+      unsafe = true;
+      child.stdin.destroy();
+      clearRing();
+    }
+    if (message.t === 'observations' && stopAt === null) {
+      for (const record of message.data.records) {
+        // Account retained UTF-16 strings as well as JSON bytes and entry overhead.
+        const copy = structuredClone(record);
+        const bytes = 1024 + Buffer.byteLength(JSON.stringify(copy)) + (copy.path?.length || 0) * 2;
+        while (ring.length && (ring.length >= 256 || ringBytes + bytes > 1024 * 1024)) {
+          ringBytes -= ring.shift().bytes;
+          ringDropped++;
+        }
+        ring.push({ record: copy, bytes });
+        ringBytes += bytes;
+      }
+    }
+    if (message.t === 'stopped') {
+      clearRing();
+      child.stdin.end();
+    }
+  }
+  function tick() {
+    if (!child || closed) return;
+    const elapsed = mono();
+    if (failedAt !== null) {
+      if (elapsed - failedAt > 15000) {
+        child.kill();
+        failedAt = Infinity;
+      }
+      return;
+    }
+    if (pendingWrite && elapsed - writeAt > 5000) return fail('consumer-failed');
+    if (stopAt !== null && elapsed - stopAt > 10000) return fail('stop-unverified');
+    if (current.phase === 'starting' && elapsed - startedAt > 130000) return fail('launch-failed');
+    if (current.phase === 'running' && elapsed - receivedAt > 10000) return fail('lease-expired');
+    if (current.phase === 'running' && stopAt === null) send('ping', {});
+  }
+  function finish(target, code) {
+    if (target !== child || closed) return;
+    closed = true;
+    clearInterval(timer);
+    timer = null;
+    if (current.phase !== 'stopped' || code !== 0) {
+      current = model.failSession(current, now(), 'stream-ended');
+      // Even pre-ready failure could follow successful enable and a lost ready.
+      unsafe = true;
+    }
+    summaries.push({
+      launchId: current.launchId,
+      sessionId: current.sessionId,
+      endedAt: now(),
+      phase: current.phase,
+      reasons: [...current.reasons],
+      maxima: { ...current.maxima },
+      capture,
+      finalCounters: structuredClone(current.latest?.counters || null),
+      finalTotals: structuredClone(current.latest?.totals || null),
+      ringDropped,
+      stopReason,
+      exitCode: code,
+      stopVerified: current.phase === 'stopped' && code === 0,
+    });
+    if (summaries.length > 32) {
+      summaries.shift();
+      omittedSummaries++;
+    }
+    child = null;
+    clearRing();
+    if (restartRequested && !unsafe && !disposed) {
+      restartRequested = false;
+      start();
+    }
+  }
+  function start() {
+    if (disposed || child || unsafe) return false;
+    current = model.createSession(id(), id());
+    startRequest = null;
+    stopRequest = null;
+    stopAt = null;
+    stopReason = null;
+    capture = null;
+    sent = 0n;
+    pendingWrite = false;
+    receivedReady = false;
+    ringDropped = 0;
+    stopSent = false;
+    failedAt = null;
+    clearRing();
+    startedAt = receivedAt = mono();
+    closed = false;
+    try {
+      child = spawnBroker(current.launchId, current.sessionId);
+    } catch {
+      current = model.failSession(current, now(), 'launch-failed');
+      closed = true;
+      return false;
+    }
+    const target = child;
+    decoder = wire.createFrameDecoder({ ...current, onMessage: accept });
+    const reader = decoder;
+    target.stdout.on('data', (bytes) => {
+      if (target !== child || closed) return;
+      try {
+        reader.push(bytes);
+      } catch {
+        fail('protocol-failed');
+      }
+    });
+    target.stdout.on('end', () => {
+      if (target !== child || closed) return;
+      try {
+        reader.end();
+      } catch {
+        fail('protocol-failed');
+      }
+      if (current.phase !== 'stopped') fail('stream-ended');
+    });
+    target.stdout.on('error', () => {
+      if (target === child) fail('stream-ended');
+    });
+    target.stdin.on('error', () => {
+      if (target === child && current.phase !== 'stopped') fail('stream-ended');
+    });
+    target.on('error', () => {
+      if (target === child) fail('launch-failed');
+    });
+    target.on('close', (code) => finish(target, code));
+    timer = setInterval(tick, 2000);
+    timer.unref?.();
+    return true;
+  }
+  function stop(reason = 'operator-stop') {
+    if (!['operator-stop', 'pause', 'suspend', 'restart', 'shutdown'].includes(reason))
+      throw new Error('etw-file:invalid-stop-reason');
+    restartRequested = false;
+    clearRing();
+    if (!child || stopAt !== null || current.phase === 'stopped') return;
+    stopAt = mono();
+    stopRequest = id();
+    stopReason = reason;
+    if (current.phase !== 'running') child.stdin.end();
+    else flushStop();
+  }
+  return {
+    start,
+    stop,
+    tick,
+    restart() {
+      stop('restart');
+      restartRequested = true;
+      if (!child && !unsafe) {
+        restartRequested = false;
+        return start();
+      }
+      return false;
+    },
+    dispose() {
+      disposed = true;
+      stop('shutdown');
+    },
+    setUnavailable(state, detail) {
+      idle = { ...idle, state, detail };
+    },
+    getHealth: () => structuredClone(current?.record || idle),
+    getDiagnostics: () => ({
+      records: ring.map((v) => structuredClone(v.record)),
+      ringBytes,
+      ringDropped,
+      summaries: structuredClone(summaries),
+      omittedSummaries,
+      restartBlocked: unsafe,
+      phase: current?.phase || 'disabled',
+      pendingBytes: decoder?.allocatedBytes() || 0,
+    }),
+  };
+}
+module.exports = { createSupervisor };

--- a/tests/main/main-etw-health.test.js
+++ b/tests/main/main-etw-health.test.js
@@ -1,0 +1,48 @@
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { installShims, createHarness } from './helpers/health-umbrella-harness.js';
+import supervisor from '../../src/main/platform/etw-file-supervisor.js';
+
+const shims = installShims();
+let h;
+afterAll(() => shims.restore());
+afterEach(async () => {
+  h?.main._setEtwFileForTest(undefined);
+  await h?.tearDown();
+});
+describe('ETW leaf in the actual application composer', () => {
+  it('includes the optional disabled sensor without reducing process coverage', async () => {
+    h = createHarness(shims);
+    await h.bringUp();
+    const sensor = supervisor.createSupervisor({
+      spawnBroker: () => {
+        throw new Error('must-not-launch');
+      },
+    });
+    h.main._setEtwFileForTest(sensor);
+    const health = h.health();
+    expect(health.sensors.byId['etw-file'].state).toBe('DISABLED');
+    expect(health.state).toBe('HEALTHY');
+    expect(health.populationReliable).toBe(true);
+    sensor.dispose();
+  });
+  it('reports failed diagnostic capture without poisoning population or exposing paths', async () => {
+    h = createHarness(shims);
+    await h.bringUp();
+    const before = h.auditTypes();
+    const sensor = supervisor.createSupervisor({
+      spawnBroker: () => {
+        throw new Error('private path');
+      },
+    });
+    sensor.start();
+    h.main._setEtwFileForTest(sensor);
+    const stats = h.stats();
+    expect(stats.appHealth.state).toBe('DEGRADED');
+    expect(stats.appHealth.populationReliable).toBe(true);
+    expect(stats.appHealth.sensors.byId['etw-file'].lastError).toBe('launch-failed');
+    expect(JSON.stringify(stats)).not.toContain('private path');
+    expect(stats).not.toHaveProperty('etwObservations');
+    expect(h.auditTypes()).toEqual(before);
+    sensor.dispose();
+  });
+});

--- a/tests/main/platform/etw-file-supervisor.test.js
+++ b/tests/main/platform/etw-file-supervisor.test.js
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import supervisor from '../../../src/main/platform/etw-file-supervisor.js';
+import runtime from '../../../src/main/platform/etw-file-runtime.js';
+import { message, observation, rawFrame, telemetry } from './etw-file-fixtures.js';
+
+const sensors = [];
+afterEach(() => {
+  for (const sensor of sensors.splice(0)) sensor.dispose();
+  vi.useRealTimers();
+});
+function harness() {
+  vi.useFakeTimers();
+  let time = 0,
+    nextId = 0;
+  const children = [];
+  const spawnBroker = vi.fn((launchId, sessionId) => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stdin = new EventEmitter();
+    child.stdin.destroy = vi.fn();
+    child.stdin.end = vi.fn();
+    child.kill = vi.fn();
+    child.writes = [];
+    child.callbacks = [];
+    child.stdin.write = vi.fn((bytes, callback) => {
+      child.writes.push(JSON.parse(bytes.subarray(4).toString()));
+      child.callbacks.push(callback);
+      return false;
+    });
+    child.flush = () => {
+      while (child.callbacks.length) child.callbacks.shift()();
+    };
+    child.message = (type, seq, data) => {
+      const value = { ...message(type, String(seq), data), launchId, sessionId };
+      child.stdout.emit('data', rawFrame(value));
+    };
+    children.push(child);
+    return child;
+  });
+  const sensor = supervisor.createSupervisor({
+    spawnBroker,
+    now: () => time,
+    mono: () => time,
+    id: () => `id-${++nextId}`,
+  });
+  sensors.push(sensor);
+  function running() {
+    sensor.start();
+    const child = children.at(-1);
+    child.message('hello', 1);
+    child.flush();
+    const ready = message('ready').data;
+    ready.requestId = child.writes[0].data.requestId;
+    child.message('ready', 2, ready);
+    return child;
+  }
+  function stop(child, seq = 3) {
+    sensor.stop();
+    child.flush();
+    const stopped = message('stopped').data;
+    stopped.requestId = child.writes.at(-1).data.requestId;
+    stopped.finalEventSeq = '999999';
+    child.message('stopped', seq, stopped);
+    child.stdout.emit('end');
+    child.emit('close', 0);
+  }
+  return {
+    sensor,
+    spawnBroker,
+    children,
+    running,
+    stop,
+    advance: (ms) => {
+      time += ms;
+      sensor.tick();
+    },
+  };
+}
+
+describe('ETW diagnostic supervisor', () => {
+  it('does not start implicitly and publishes diagnostic degradation after ready', () => {
+    const h = harness();
+    expect(h.spawnBroker).not.toHaveBeenCalled();
+    expect(h.sensor.getHealth().state).toBe('DISABLED');
+    h.running();
+    expect(h.sensor.getHealth().state).toBe('DEGRADED');
+    expect(h.sensor.start()).toBe(false);
+  });
+  it('requires ready to acknowledge this start request', () => {
+    const h = harness();
+    h.sensor.start();
+    const child = h.children[0];
+    child.message('hello', 1);
+    child.flush();
+    child.message('ready', 2);
+    expect(h.sensor.getHealth().state).toBe('FAILED');
+  });
+  it('requires stopped to acknowledge this stop request', () => {
+    const h = harness();
+    const child = h.running();
+    child.message('stopped', 3);
+    expect(h.sensor.getHealth().state).toBe('FAILED');
+  });
+  it('retains only 256 records and accounts local ring eviction', () => {
+    const h = harness();
+    const child = h.running();
+    for (let i = 0; i < 400; i++)
+      child.message('observations', i + 3, { records: [observation({ eventSeq: String(i + 1) })] });
+    const data = h.sensor.getDiagnostics();
+    expect(data.records).toHaveLength(256);
+    expect(data.ringDropped).toBe(144);
+    data.records[0].path = 'mutation';
+    expect(h.sensor.getDiagnostics().records[0].path).toBeNull();
+  });
+  it('also bounds long retained UTF-16 paths by bytes', () => {
+    const h = harness();
+    const child = h.running();
+    for (let i = 0; i < 50; i++)
+      child.message('observations', i + 3, {
+        records: [
+          observation({
+            eventSeq: String(i + 1),
+            path: `C:\\fixture\\${'a'.repeat(32000)}`,
+            pathEvidence: 'candidate-object',
+          }),
+        ],
+      });
+    const result = h.sensor.getDiagnostics();
+    expect(result.ringBytes).toBeLessThanOrEqual(1024 * 1024);
+    expect(result.records.length).toBeLessThan(20);
+    expect(result.ringDropped).toBeGreaterThan(0);
+  });
+  it('EOF cannot stand in for stop and erases candidate evidence', () => {
+    const h = harness();
+    const child = h.running();
+    child.message('observations', 3);
+    child.stdout.emit('end');
+    child.emit('close', 0);
+    expect(h.sensor.getHealth().state).toBe('FAILED');
+    expect(h.sensor.getDiagnostics().records).toEqual([]);
+    expect(h.sensor.start()).toBe(false);
+    expect(h.sensor.getDiagnostics().summaries[0].stopVerified).toBe(false);
+  });
+  it('retains losses in ended summary across a fresh session', () => {
+    const h = harness();
+    const child = h.running();
+    const sample = telemetry();
+    sample.counters.eventsLost = '7';
+    child.message('health', 3, sample);
+    h.stop(child, 4);
+    expect(h.sensor.getDiagnostics().summaries[0].maxima.eventsLost).toBe('7');
+    h.running();
+    expect(h.sensor.getHealth().lossCount).toBe(0);
+    expect(h.sensor.getDiagnostics().summaries[0].maxima.eventsLost).toBe('7');
+  });
+  it('ignores callbacks belonging to a previous broker', () => {
+    const h = harness();
+    const old = h.running();
+    h.stop(old);
+    const fresh = h.running();
+    old.message('error', 5);
+    old.emit('close', 2);
+    expect(h.sensor.getHealth().state).toBe('DEGRADED');
+    fresh.message('observations', 3);
+    expect(h.sensor.getDiagnostics().records).toHaveLength(1);
+  });
+  it('rejects frames claiming a foreign session even on the current stream', () => {
+    const h = harness();
+    const child = h.running();
+    child.stdout.emit('data', rawFrame(message('observations', '3')));
+    expect(h.sensor.getHealth().state).toBe('FAILED');
+  });
+  it('queues one stop behind a blocked control write without growing promises', () => {
+    const h = harness();
+    const child = h.running();
+    h.advance(2000);
+    h.sensor.stop();
+    h.sensor.stop();
+    expect(child.writes.filter((v) => v.t === 'stop')).toHaveLength(0);
+    child.flush();
+    expect(child.writes.filter((v) => v.t === 'stop')).toHaveLength(1);
+  });
+  it('fails a blocked write and only terminates its normal broker after cleanup grace', () => {
+    const h = harness();
+    const child = h.running();
+    h.advance(2000);
+    h.advance(5001);
+    expect(h.sensor.getHealth().state).toBe('FAILED');
+    expect(child.kill).not.toHaveBeenCalled();
+    h.advance(15001);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(h.spawnBroker).toHaveBeenCalledTimes(1);
+  });
+  it('heartbeat expiry is independent of successful outbound pings', () => {
+    const h = harness();
+    const child = h.running();
+    h.advance(2000);
+    child.flush();
+    h.advance(8001);
+    expect(h.sensor.getHealth().lastError).toBe('lease-expired');
+  });
+  it('launch deadline does not repeat UAC', () => {
+    const h = harness();
+    h.sensor.start();
+    h.advance(130001);
+    expect(h.sensor.getHealth().lastError).toBe('launch-failed');
+    expect(h.spawnBroker).toHaveBeenCalledTimes(1);
+  });
+  it('stop timeout blocks restart and clears diagnostic data', () => {
+    const h = harness();
+    const child = h.running();
+    h.sensor.restart();
+    child.flush();
+    h.advance(10001);
+    child.emit('close', 2);
+    expect(h.spawnBroker).toHaveBeenCalledTimes(1);
+    expect(h.sensor.getDiagnostics().restartBlocked).toBe(true);
+  });
+  it('explicit restart waits for terminal and successful broker exit', () => {
+    const h = harness();
+    const child = h.running();
+    h.sensor.restart();
+    child.flush();
+    const data = message('stopped').data;
+    data.requestId = child.writes.at(-1).data.requestId;
+    child.message('stopped', 3, data);
+    expect(h.spawnBroker).toHaveBeenCalledTimes(1);
+    child.emit('close', 0);
+    expect(h.spawnBroker).toHaveBeenCalledTimes(2);
+    expect(h.spawnBroker.mock.calls[0]).not.toEqual(h.spawnBroker.mock.calls[1]);
+  });
+  it('bounds ended summaries and makes truncation explicit', () => {
+    const h = harness();
+    for (let i = 0; i < 40; i++) h.stop(h.running());
+    expect(h.sensor.getDiagnostics().summaries).toHaveLength(32);
+    expect(h.sensor.getDiagnostics().omittedSummaries).toBe(8);
+  });
+  it('rejects confirmed fields at the only diagnostic ingress', () => {
+    const h = harness();
+    const child = h.running();
+    child.message('observations', 3, {
+      records: [observation({ agent: 'invented-agent', instanceId: '71:1000' })],
+    });
+    expect(h.sensor.getDiagnostics().records).toEqual([]);
+    expect(h.sensor.getHealth().state).toBe('FAILED');
+  });
+});
+
+describe('ETW backend runtime gate', () => {
+  function make(options = {}) {
+    const powerMonitor = new EventEmitter(),
+      spawnProcess = vi.fn();
+    const sensor = runtime.createRuntime({
+      app: { isPackaged: false },
+      powerMonitor,
+      platform: 'win32',
+      argv: [],
+      exists: () => true,
+      spawnProcess,
+      ...options,
+    });
+    sensors.push(sensor);
+    return { sensor, powerMonitor, spawnProcess };
+  }
+  it.each([
+    [{}, 'DISABLED'],
+    [{ platform: 'linux' }, 'UNSUPPORTED'],
+    [{ app: { isPackaged: true }, argv: ['--etw-file-diagnostic-root=C:\\fixture'] }, 'DISABLED'],
+    [{ argv: ['--etw-file-diagnostic-root=C:\\'] }, 'FAILED'],
+    [{ argv: ['--etw-file-diagnostic-root=C:\\fixture'], exists: () => false }, 'FAILED'],
+  ])('does not elevate when gates fail (%j)', (options, state) => {
+    const { sensor, spawnProcess } = make(options);
+    expect(sensor.start()).toBe(false);
+    expect(sensor.getHealth().state).toBe(state);
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+  it('does not auto-launch on resume or unpause; removes power listeners', () => {
+    const { sensor, powerMonitor, spawnProcess } = make({
+      argv: ['--etw-file-diagnostic-root=C:\\fixture'],
+    });
+    powerMonitor.emit('suspend');
+    expect(sensor.start()).toBe(false);
+    powerMonitor.emit('resume');
+    sensor.setPaused(true);
+    sensor.setPaused(false);
+    expect(spawnProcess).not.toHaveBeenCalled();
+    sensor.dispose();
+    expect(powerMonitor.listenerCount('suspend')).toBe(0);
+    expect(powerMonitor.listenerCount('resume')).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds an opt-in development Kernel-File collector and connects its diagnostic health to Electron main. The normal broker authenticates an elevated collector; bounded ingress/output queues, conservative path maps, uncached candidate FILETIME observations and a JS supervisor handle framing, losses, lease expiry, explicit stop/restart and ended-session summaries.

Capture requires a selected local root. Packaged enablement is blocked, and observations stay in bounded main-process memory with null agent/instanceId. They never enter FileEvent, audit, risk, baseline or sequence consumers; no frontend or IPC channel changes are included. Pause/suspend/quit request stop; resume does not trigger UAC automatically. Sleep testing remains deferred.

Local validation: clean-checkout renderer build, format, lint (31 existing warnings), TypeScript/Svelte, 2928 passing tests and 4 skips with two workers, witness/sequence gates, counts, production npm audit and transitive NuGet audit. C# Release/formatter, 22 self-tests and three real normal-token process cases passed. The first unconstrained local coverage run exhausted memory and lacked Electron dist; installing the existing binary and bounding workers resolved it without source changes.

Five short live attempts are retained in the evidence aggregate. Final matching-binary smoke passed a selected-file Read/header-PID candidate, actual 256 × 64 KiB buffers, known zero native losses and owned stop/child exit 0. Application queues still dropped 12061 of 88772 events; this remains a degraded diagnostic backend. Event-time authoritative attribution, independent absence witnessing, protected collector-crash recovery, deployment trust and sustained transport admission remain open. Existing CI does not build the new .NET project; its checks are recorded local evidence.
