### PR TITLE
fix(ui): restore reviewed Observatory layout and visual behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+- Restore the reviewed Observatory layout after the first integration simplified it: compact workspace navigation, six-part summary, radar activity cards, assessment columns, permission profiles, catalog rows, report summary and settings rows. Fix dark-theme artwork, stacked checkboxes and hidden active tabs.
 - Replace the desktop shell with the shared Observatory Svelte interface: instance radar, workspaces, linked detail history, activity charts, audit, rules, catalog, analysis and settings.
 - Preserve unreliable populations and missing measurements; show failed/degraded sensors and keep process actions tied to stamped identity.
 - Fix same-timestamp audit pagination, custom catalog import persistence, permission draft resets and native folder error reporting.

--- a/frontend/observatory/App.svelte
+++ b/frontend/observatory/App.svelte
@@ -29,7 +29,7 @@
     ['network', 'Network', 'network'],
     ['rules', 'Rules & permissions', 'shield'],
     ['database', 'Agent catalog', 'database'],
-    ['analysis', 'AI analysis', 'spark'],
+    ['analysis', 'AI analysis', 'shield'],
     ['reports', 'Reports', 'report'],
     ['audit', 'Audit', 'history'],
     ['stats', 'Statistics', 'chart'],
@@ -96,7 +96,12 @@
     commands = false;
     const ticket = ++navigationRevision;
     await tick();
-    if (ticket === navigationRevision) workspace.scrollTop = scrolls[next] ?? 0;
+    if (ticket === navigationRevision) {
+      workspace.scrollTop = scrolls[next] ?? 0;
+      document
+        .querySelector('.workspace-tabs > .active')
+        ?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
   }
   function back(delta: number) {
     const next = historyIndex + delta;
@@ -197,11 +202,16 @@
       </div>
     </div>
     <nav aria-label="Main navigation">
-      {#each views as [id, label, icon] (id)}<button
+      {#each views.filter((row) => row[0] !== 'settings') as [id, label, icon] (id)}
+        {#if id === 'rules' || id === 'analysis'}<div class="nav-divider"></div>{/if}<button
           class="nav"
+          aria-label={label}
           class:active={view === id}
           aria-current={view === id ? 'page' : undefined}
-          onclick={() => navigate(id)}><Icon name={icon} /><span>{label}</span></button
+          onclick={() => navigate(id)}
+          ><Icon name={icon} /><span>{label}</span>{#if id === 'agents'}<small class="count"
+              >{telemetry.ready ? telemetry.agents.length : '—'}</small
+            >{/if}</button
         >{/each}
     </nav>
     <div class="sidebar-bottom">
@@ -217,24 +227,18 @@
           ></span
         ></button
       >
+      <button
+        class="nav"
+        class:active={view === 'settings'}
+        aria-current={view === 'settings' ? 'page' : undefined}
+        onclick={() => navigate('settings')}><Icon name="settings" /><span>Settings</span></button
+      >
       <div class="sidebar-foot">{preview ? 'Preview · simulated data' : 'Local observations'}</div>
     </div>
   </aside>
   <div class="shell">
     <header class="topbar">
-      <div class="toolbar">
-        <button
-          class="icon-button"
-          aria-label="Back"
-          disabled={historyIndex === 0}
-          onclick={() => back(-1)}>←</button
-        ><button
-          class="icon-button"
-          aria-label="Forward"
-          disabled={historyIndex >= history.length - 1}
-          onclick={() => back(1)}>→</button
-        ><span class="breadcrumb">Workspace / <strong>{title}</strong></span>
-      </div>
+      <div class="breadcrumb">Workstation<span>/</span><strong>{title}</strong></div>
       <div class="top-actions">
         <button class="command-trigger" onclick={() => (commands = !commands)}
           ><Icon name="search" />Commands<kbd>Ctrl K</kbd></button
@@ -243,24 +247,43 @@
         >
       </div>
     </header>
-    <div class="workspace-tabs" aria-label="Open workspaces">
-      {#each tabs as tab (tab)}<div class:active={view === tab}>
-          <button onclick={() => navigate(tab)}>{views.find((row) => row[0] === tab)?.[1]}</button
-          >{#if tab !== 'overview'}<button
-              aria-label={`Close ${tab}`}
-              onclick={() => {
-                tabs = tabs.filter((item) => item !== tab);
-                if (view === tab) void navigate('overview');
-              }}>×</button
-            >{/if}
-        </div>{/each}
+    <div class="workspace-navigation">
+      <div class="history-controls">
+        <button
+          class="history-arrow"
+          aria-label="Back"
+          disabled={historyIndex === 0}
+          onclick={() => back(-1)}><Icon name="arrowLeft" /></button
+        ><button
+          class="history-arrow"
+          aria-label="Forward"
+          disabled={historyIndex >= history.length - 1}
+          onclick={() => back(1)}><Icon name="chevron" /></button
+        >
+      </div>
+      <div class="workspace-tabs" aria-label="Open workspaces">
+        {#each tabs as tab (tab)}<div class:active={view === tab}>
+            <button onclick={() => navigate(tab)}
+              ><Icon name={views.find((row) => row[0] === tab)?.[2] ?? 'file'} />{views.find(
+                (row) => row[0] === tab,
+              )?.[1]}</button
+            >{#if tab !== 'overview'}<button
+                aria-label={`Close ${tab}`}
+                onclick={() => {
+                  tabs = tabs.filter((item) => item !== tab);
+                  if (view === tab) void navigate('overview');
+                }}>×</button
+              >{/if}
+          </div>{/each}
+      </div>
     </div>
-    <main id="main" tabindex="-1" bind:this={workspace}>
+    <main class:analysis-view={view === 'analysis'} id="main" tabindex="-1" bind:this={workspace}>
       <div class="page-head">
         <div class="page-title">
+          <Icon name={views.find((row) => row[0] === view)?.[2] ?? 'file'} />
           <h1>{title}</h1>
           <span class="live-badge"
-            >{preview
+            ><Icon name="activity" />{preview
               ? 'Demo'
               : telemetry.stale
                 ? 'Observation unavailable / stale'
@@ -297,17 +320,17 @@
       {#if tabs.includes('database')}<div hidden={view !== 'database'}>
           <Catalog {host} {inspect} />
         </div>{/if}
-      {#if tabs.includes('analysis')}<div hidden={view !== 'analysis'}>
+      {#if tabs.includes('analysis')}<div class="analysis-container" hidden={view !== 'analysis'}>
           <Analysis {host} {telemetry} visible={view === 'analysis'} {preview} />
         </div>{/if}
       {#if tabs.includes('reports')}<div hidden={view !== 'reports'}>
-          <Reports {host} {inspect} />
+          <Reports {host} {inspect} {telemetry} {navigate} />
         </div>{/if}
       {#if tabs.includes('audit')}<div hidden={view !== 'audit'}>
-          <Reports {host} audit {inspect} />
+          <Reports {host} audit {inspect} {telemetry} {navigate} />
         </div>{/if}
       {#if tabs.includes('settings')}<div hidden={view !== 'settings'}>
-          <Settings {host} {appearance} />
+          <Settings {host} {appearance} {navigate} />
         </div>{/if}
       <div hidden={view !== 'stats'}><Statistics {telemetry} {inspect} /></div>
     </main>
@@ -364,10 +387,7 @@
     height: 100dvh;
     min-height: 0;
   }
-  .sidebar {
-    overflow: auto;
-    padding-top: 18px;
-  }
+
   .shell {
     min-height: 0;
     height: 100dvh;
@@ -375,37 +395,13 @@
     flex-direction: column;
   }
   .topbar,
-  footer,
-  .workspace-tabs {
+  footer {
     flex-shrink: 0;
   }
   main {
     overflow: auto;
     min-height: 0;
     flex: 1;
-  }
-  .workspace-tabs {
-    display: flex;
-    overflow-x: auto;
-    gap: 6px;
-    padding: 8px 16px;
-    border-bottom: 1px solid var(--border);
-  }
-  .workspace-tabs > div {
-    display: flex;
-    flex-shrink: 0;
-    border: 1px solid transparent;
-    border-radius: 8px;
-  }
-  .workspace-tabs > div.active {
-    background: var(--raised);
-    border-color: var(--strong-border);
-  }
-  .workspace-tabs button {
-    padding: 5px 8px;
-    background: transparent;
-    color: var(--muted);
-    border: 0;
   }
   .health-banner {
     padding: 12px 16px;
@@ -478,21 +474,19 @@
     background: var(--raised);
     border-color: var(--strong-border);
   }
-  @media (max-width: 1000px) {
-    .observatory-app {
-      grid-template-columns: 170px minmax(0, 1fr);
-    }
-    .sidebar {
-      padding: 14px 8px;
-    }
-    .breadcrumb {
-      display: none;
-    }
-    footer {
-      flex-wrap: wrap;
-    }
-    .version {
-      display: none;
+  .analysis-view {
+    display: flex;
+    flex-direction: column;
+  }
+  .analysis-container {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  @media (max-width: 850px) {
+    .analysis-container {
+      min-height: 500px;
     }
   }
 </style>

--- a/frontend/observatory/VALIDATION.md
+++ b/frontend/observatory/VALIDATION.md
@@ -1,5 +1,9 @@
 # Integration validation
 
+The initial integration's functional checks did not establish visual fidelity to the reviewed dialogs-14 prototype. The subsequent visual repair compares the rendered reference at 1200×800 against the shared Svelte entry. Browser checks now assert the 184 px sidebar, 44 px workspace history row, summary position, radar/inspector alignment, assessment column proportions, checkbox alignment and active-tab visibility. Each of the eleven workspaces is captured for inspection. Radar layer changes and clearing selection must retain the sweep element.
+
+The repair keeps real backend semantics: unobserved measurements remain unavailable, process identities stay stamped, provider requests require an explicit action, and unavailable demo-only actions are not enabled. Provider configuration is a collapsible panel, and raw observation fields remain available under a metadata disclosure in details.
+
 See ../../OBSERVATORY-INTEGRATION.md for current status and the complete migration matrix. The preparation-only validation is superseded.
 
 Validated so far: production and preview builds; 132 browser view/viewport/theme/scale combinations; explicit unavailable desktop bridge; zero real bridge calls from preview; no preview identities in production JavaScript; isolated-profile Electron startup with reliable real process observations and all 11 workspaces; TypeScript and Svelte diagnostics.

--- a/frontend/observatory/components/ActivityChart.svelte
+++ b/frontend/observatory/components/ActivityChart.svelte
@@ -108,7 +108,7 @@
     height: var(--height);
     min-height: 1px;
     border-radius: 3px 3px 0 0;
-    background: var(--green);
+    background: var(--muted);
   }
   .activity-chart {
     margin-bottom: 12px;

--- a/frontend/observatory/components/AgentLogo.svelte
+++ b/frontend/observatory/components/AgentLogo.svelte
@@ -1,20 +1,29 @@
 <script lang="ts">
-  import { logo } from '../runtime/artwork';
+  import { logo, invertOnDark } from '../runtime/artwork';
   import Icon from './Icon.svelte';
-  let { id = '', name = '' }: { id?: string; name?: string } = $props();
+  let { id = '', name = '', size = 24 }: { id?: string; name?: string; size?: number } = $props();
   let src = $derived(logo(id || name.toLowerCase().replaceAll(' ', '-')));
 </script>
 
-<span class="agent-mark"
-  >{#if src}<img {src} alt="" width="24" height="24" />{:else}<Icon name="agents" />{/if}</span
+<span class="agent-mark" style={`--logo-size:${size}px`}
+  >{#if src}<img
+      {src}
+      class:invert-dark={invertOnDark(src)}
+      alt=""
+      width={size}
+      height={size}
+    />{:else}<Icon name="agents" />{/if}</span
 >
 
 <style>
+  :global(:root[data-theme^='dark']) .invert-dark {
+    filter: invert(1);
+  }
   .agent-mark {
     display: inline-flex;
     flex-shrink: 0;
-    width: 32px;
-    height: 32px;
+    width: calc(var(--logo-size) * var(--ui-scale));
+    height: calc(var(--logo-size) * var(--ui-scale));
     align-items: center;
     justify-content: center;
   }

--- a/frontend/observatory/components/Analysis.svelte
+++ b/frontend/observatory/components/Analysis.svelte
@@ -9,6 +9,9 @@
     type Telemetry,
   } from '../runtime/host';
   import Action from './Action.svelte';
+  import Icon from './Icon.svelte';
+  import AgentLogo from './AgentLogo.svelte';
+  import Metadata from './Metadata.svelte';
   let {
     host,
     telemetry,
@@ -28,6 +31,8 @@
   let alive = true;
   let generation = 0;
   let section = $state('summary');
+  let showProvider = $state(false);
+  let reportTitle = $state('Activity assessment');
   let names = $derived([...new Set(telemetry.agents.map((a) => a.agent))]);
   onMount(() => {
     invoke(host, 'getSettings')
@@ -62,6 +67,7 @@
       totalAgents: telemetry.stats.currentAgents,
       totalNet: telemetry.network.length,
     };
+    const title = reportTitle.trim() || 'Activity assessment';
     const result = confirmed(
       await invoke(
         host,
@@ -81,7 +87,7 @@
       }
     }
     if (!Object.keys(structured).length) structured = result;
-    report = { ...structured, scope, counts, createdAt: new Date().toISOString() };
+    report = { ...structured, title, scope, counts, createdAt: new Date().toISOString() };
     history = [report, ...history].slice(0, 20);
   }
   function strings(value: unknown) {
@@ -90,119 +96,385 @@
 </script>
 
 <div class="analysis-workspace">
-  <section class="panel">
-    <div class="panel-head">
-      <h2>AI analysis</h2>
-      <span>Anthropic</span>
+  <section class="panel analysis-provider">
+    <div class="provider-name">
+      <AgentLogo name="Claude Code" size={32} />
+      <div>
+        <strong>Anthropic</strong><small
+          >{preview
+            ? 'Preview · provider calls disabled'
+            : configured
+              ? 'API key saved · verified on first analysis'
+              : 'Not connected'}</small
+        >
+      </div>
     </div>
-    <div class="inset form-stack">
-      <p>
-        {configured
-          ? 'API key saved. Connection is verified when analysis runs.'
-          : 'Add your API key to enable analysis.'}
-      </p>
-      {#if error}<p role="alert">{error}</p>{/if}
+    <div class="toolbar">
+      <button class="button" onclick={() => (showProvider = !showProvider)}
+        ><Icon name="settings" />{configured
+          ? 'Connection settings'
+          : 'Connect AI analysis'}</button
+      ><Action disabled={preview || !configured || (mode === 'agent' && !agent)} action={analyze}
+        ><Icon name="play" />Run analysis</Action
+      >
+    </div>
+  </section>
+  {#if showProvider}<section class="panel inset provider-settings">
       <label
         >New API key<input
           disabled={preview}
           type="password"
           autocomplete="off"
           bind:value={key}
-          placeholder="Never stored in browser history"
+          placeholder="Anthropic API key"
         /></label
       >
       <div class="toolbar">
         <Action disabled={preview || !key.trim()} action={() => saveKey()}>Save key</Action
-        >{#if configured}<Action action={() => saveKey(true)}>Remove key</Action>{/if}
-      </div>
-      <label
-        >Scope<select bind:value={mode}
-          ><option value="session">Session</option><option value="agent"
-            >Agent name · all matching instances</option
-          ></select
-        ></label
-      >
-      {#if mode === 'agent'}<label
-          >Agent<select bind:value={agent}
-            ><option value="">Select an agent</option>{#each names as name (name)}<option
-                >{name}</option
-              >{/each}</select
-          ></label
-        >{/if}
-      <p class="muted">
-        This sends recorded activity metadata to the provider and may incur API charges.
-      </p>
-      <Action disabled={preview || !configured || (mode === 'agent' && !agent)} action={analyze}
-        >Run analysis</Action
-      >
-    </div>
-  </section>
-  <section class="panel analysis-report">
-    <div class="panel-head">
-      <h2>{String(report?.scope ?? 'Report')}</h2>
-      <span>{String(report?.createdAt ?? '')}</span>
-    </div>
-    <div class="toolbar inset" aria-label="Report sections">
-      {#each ['summary', 'findings', 'recommendations', 'history'] as tab (tab)}<button
+        >{#if configured}<Action action={() => saveKey(true)}>Remove key</Action>{/if}<button
           class="button"
-          class:active={section === tab}
-          onclick={() => (section = tab)}>{tab}</button
-        >{/each}
-    </div>
-    <div class="inset report-body">
-      {#if section === 'history'}{#each history as previous (previous)}<button
-            class="history-row"
-            onclick={() => {
-              report = previous;
-              section = 'summary';
-            }}>{String(previous.scope)} · {String(previous.createdAt)}</button
-          >{:else}<p>No reports in this window.</p>{/each}
-      {:else if !report}<p class="muted">
-          Run an analysis to review the provider's findings. No report has been generated.
-        </p>
-      {:else if section === 'summary'}<span class="badge"
-          >{String(report.riskRating ?? report.riskLevel ?? 'UNKNOWN')}</span
+          onclick={() => {
+            showProvider = false;
+            key = '';
+          }}>Close settings</button
         >
-        <p class="report-text">{String(report.summary ?? 'No summary returned')}</p>
-        <p>{String(report.riskJustification ?? '')}</p>
-        <Action action={async () => confirmed(await invoke(host, 'openThreatReport', report))}
-          >Open report</Action
+      </div>
+      <small>Connection is verified when analysis runs.</small>
+    </section>{/if}
+  {#if error}<p role="alert">{error}</p>{/if}
+  <div class="analysis-layout">
+    <section class="panel analysis-config">
+      <div class="panel-head"><h2><Icon name="settings" />New assessment</h2></div>
+      <div class="config-body form-stack">
+        <label
+          >Scope<select bind:value={mode}
+            ><option value="session">Entire session</option><option value="agent"
+              >Agent · all matching instances</option
+            ></select
+          ></label
         >
-      {:else}<ul>
-          {#each strings(report[section]) as item, i (i)}<li>{item}</li>{:else}<li>
-              No items returned.
-            </li>{/each}
-        </ul>{/if}
-    </div>
-  </section>
+        {#if mode === 'agent'}<label
+            >Agent<select bind:value={agent}
+              ><option value="">Select an agent</option>{#each names as name (name)}<option
+                  >{name}</option
+                >{/each}</select
+            ></label
+          >{/if}
+        <div class="scope-details">
+          <small>Evidence scope</small>
+          <p>Recorded session metadata</p>
+          <small>File observations, connections and agent activity supplied by AEGIS.</small>
+        </div>
+        <label>Report title<input bind:value={reportTitle} maxlength="160" /></label>
+        <p class="muted">Changes apply to the next run.</p>
+        <div class="provider-note">
+          <Icon name="shield" />
+          <p>Analysis sends recorded activity metadata to Anthropic and may incur API charges.</p>
+        </div>
+      </div>
+    </section>
+    <section class="panel analysis-report">
+      <div class="report-tabs" aria-label="Report sections">
+        {#each [['summary', 'Report', 'report'], ['evidence', 'Evidence', 'file'], ['history', 'History', 'history']] as [id, title, icon] (id)}<button
+            aria-pressed={section === id}
+            onclick={() => (section = id)}><Icon name={icon} />{title}</button
+          >{/each}
+      </div>
+      <div class="report-body">
+        <div hidden={section !== 'summary'} class="report-section">
+          {#if !report}<div class="analysis-empty">
+              <Icon name="report" />
+              <h2>Review agent activity</h2>
+              <p>
+                Choose a scope and run an assessment. Review findings alongside their recorded
+                evidence.
+              </p>
+              <ol>
+                <li><span>1</span>Choose a session or an agent</li>
+                <li><span>2</span>Review the selected metadata</li>
+                <li><span>3</span>Assess findings and export the report</li>
+              </ol>
+              <small
+                >{preview
+                  ? 'Provider calls are disabled in this preview.'
+                  : 'Connect Anthropic to create your first assessment.'}</small
+              >
+            </div>
+          {:else}<article class="analysis-document">
+              <div class="document-meta">
+                <small>ANTHROPIC ASSESSMENT</small><span class="badge"
+                  >{String(report.riskRating ?? report.riskLevel ?? 'UNKNOWN')}</span
+                >
+              </div>
+              <h2>{String(report.title)}</h2>
+              <small>{String(report.scope)} · {String(report.createdAt)}</small>
+              <p class="report-text">{String(report.summary ?? 'No summary returned')}</p>
+              <p>{String(report.riskJustification ?? '')}</p>
+              <h3><Icon name="shield" />Findings</h3>
+              <ol>
+                {#each strings(report.findings) as item, i (i)}<li>{item}</li>{:else}<li>
+                    No findings returned.
+                  </li>{/each}
+              </ol>
+              <h3><Icon name="check" />Recommended checks</h3>
+              <ol>
+                {#each strings(report.recommendations) as item, i (i)}<li>{item}</li>{:else}<li>
+                    No recommendations returned.
+                  </li>{/each}
+              </ol>
+              <Action action={async () => confirmed(await invoke(host, 'openThreatReport', report))}
+                ><Icon name="report" />Open report</Action
+              >
+            </article>{/if}
+        </div>
+        <div hidden={section !== 'evidence'} class="report-section inset">
+          {#if report}<h2>Recorded scope</h2>
+            <p class="muted">Counters captured when this assessment was requested.</p>
+            <Metadata value={record(report.counts)} />{:else}<div class="analysis-empty">
+              <Icon name="file" />
+              <h2>No assessment yet</h2>
+              <p>Evidence information appears after an analysis completes.</p>
+            </div>{/if}
+        </div>
+        <div hidden={section !== 'history'} class="report-section inset">
+          {#each history as previous (previous)}<button
+              class="history-row"
+              onclick={() => {
+                report = previous;
+                section = 'summary';
+              }}
+              ><Icon name="report" /><span
+                ><strong>{String(previous.title)}</strong><small
+                  >{String(previous.scope)} · {String(previous.createdAt)}</small
+                ></span
+              ><Icon name="chevron" /></button
+            >{:else}<div class="analysis-empty">
+              <Icon name="history" />
+              <h2>No assessments yet</h2>
+              <p>Your completed assessments will appear here.</p>
+            </div>{/each}
+        </div>
+      </div>
+    </section>
+  </div>
 </div>
 
 <style>
   .analysis-workspace {
-    display: grid;
-    grid-template-columns: minmax(250px, 0.8fr) minmax(0, 1.6fr);
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
     gap: 12px;
-    align-items: start;
+  }
+  .analysis-workspace > .panel {
+    margin-top: 0;
+  }
+  .analysis-provider {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    flex-shrink: 0;
+  }
+  .provider-name {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .provider-name small {
+    display: block;
+    margin-top: 3px;
+    color: var(--muted);
+  }
+  .provider-settings {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .provider-settings label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .analysis-layout {
+    display: grid;
+    grid-template-columns: minmax(calc(240px * var(--ui-scale)), 0.75fr) minmax(0, 2fr);
+    gap: 12px;
+    flex: 1;
+    min-height: 0;
+  }
+  .analysis-layout > .panel {
+    margin-top: 0;
+    min-height: 0;
+  }
+  .analysis-config,
+  .analysis-report {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .panel-head {
+    flex-shrink: 0;
+  }
+  .config-body {
+    padding: 14px;
+    overflow: auto;
+    min-height: 0;
+    font-size: calc(12px * var(--ui-scale));
+  }
+  .config-body label {
+    font-weight: 600;
+  }
+  .config-body input,
+  .config-body select {
+    font-weight: 400;
+  }
+  .scope-details {
+    border-block: 1px solid var(--border);
+    padding-block: 12px;
+  }
+  .scope-details small {
+    color: var(--muted);
+  }
+  .provider-note {
+    display: flex;
+    gap: 8px;
+    border-top: 1px solid var(--border);
+    padding-top: 12px;
+    color: var(--muted);
+  }
+  .report-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .report-tabs button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-size: calc(12px * var(--ui-scale));
+    color: var(--muted);
+  }
+  .report-tabs button[aria-pressed='true'] {
+    background: var(--selection);
+    border-color: var(--selection-border);
+    color: var(--ink);
   }
   .report-body {
-    min-height: 280px;
+    display: flex;
+    min-height: 0;
+    flex: 1;
+  }
+  .report-section {
+    overflow: auto;
+    flex: 1;
+    min-width: 0;
     overflow-wrap: anywhere;
+  }
+  .analysis-empty,
+  .analysis-document {
+    padding: 20px;
+  }
+  .analysis-empty :global(> .icon) {
+    width: 32px;
+    height: 32px;
+    color: var(--muted);
+    margin-bottom: 24px;
+  }
+  .analysis-empty h2,
+  .analysis-document h2 {
+    font-size: calc(22px * var(--ui-scale));
+    margin-bottom: 12px;
+  }
+  .analysis-empty p {
+    max-width: 65ch;
+  }
+  .analysis-empty small {
+    color: var(--muted);
+  }
+  .analysis-empty ol {
+    list-style: none;
+    padding: 0;
+    margin: 20px 0;
+  }
+  .analysis-empty li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 10px 0;
+  }
+  .analysis-empty li span {
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--border);
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .document-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+    color: var(--muted);
   }
   .report-text {
     white-space: pre-wrap;
+    margin: 20px 0;
+  }
+  .analysis-document h3 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 20px 0 10px;
+  }
+  .analysis-document li {
+    margin-block: 10px;
   }
   .history-row {
-    display: block;
-    background: var(--panel);
-    color: var(--ink);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
     padding: 12px;
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    margin-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
   }
-  @media (max-width: 1050px) {
-    .analysis-workspace {
-      grid-template-columns: minmax(0, 1fr);
+  .history-row span {
+    flex: 1;
+  }
+  .history-row small {
+    display: block;
+    color: var(--muted);
+  }
+  @media (max-width: 950px) {
+    .analysis-layout {
+      grid-template-columns: minmax(200px, 0.8fr) minmax(0, 1.5fr);
+    }
+    .analysis-provider {
+      flex-wrap: wrap;
+    }
+  }
+  @media (max-width: 800px) {
+    .analysis-layout {
+      grid-template-columns: 1fr;
+      overflow: auto;
+    }
+    .analysis-config,
+    .analysis-report {
+      min-height: 350px;
     }
   }
 </style>

--- a/frontend/observatory/components/Catalog.svelte
+++ b/frontend/observatory/components/Catalog.svelte
@@ -12,6 +12,8 @@
   } from '../../../src/renderer/lib/utils/agent-crud-utils';
   import Action from './Action.svelte';
   import AgentLogo from './AgentLogo.svelte';
+  import Icon from './Icon.svelte';
+  let category = $state('');
   let { host, inspect }: { host: Host | null; inspect: (title: string, row: RecordData) => void } =
     $props();
   let base = $state<RecordData[]>([]);
@@ -26,8 +28,10 @@
     [
       ...base.map((row) => ({ ...row, custom: false })),
       ...custom.map((row) => ({ ...row, custom: true })),
-    ].filter((row) =>
-      JSON.stringify(row).toLowerCase().includes(query.toLowerCase()),
+    ].filter(
+      (row) =>
+        (!category || record(row).category === category) &&
+        JSON.stringify(row).toLowerCase().includes(query.toLowerCase()),
     ) as RecordData[],
   );
   async function load() {
@@ -75,28 +79,31 @@
   }
 </script>
 
+<div class="catalog-toolbar">
+  <input
+    type="search"
+    aria-label="Search catalog"
+    bind:value={query}
+    placeholder="Name, signature or vendor…"
+  /><label
+    >Category <select aria-label="Catalog category" bind:value={category}
+      ><option value="">All categories</option>{#each CATEGORIES as [id, title] (id)}<option
+          value={id}>{title}</option
+        >{/each}</select
+    ></label
+  ><span class="toolbar-spacer"></span><button
+    class="button"
+    onclick={() => {
+      form = createEmptyForm();
+      editing = null;
+      showForm = true;
+    }}><Icon name="plus" />Add agent</button
+  ><Action action={importAgents}>Import</Action><Action
+    action={async () => confirmed(await invoke(host, 'exportAgentDatabase'))}>Export</Action
+  >
+</div>
+
 <section class="panel">
-  <div class="panel-head">
-    <h2>Agent catalog</h2>
-    <span>{base.length} bundled · {custom.length} custom</span>
-  </div>
-  <div class="toolbar inset">
-    <input
-      type="search"
-      aria-label="Search catalog"
-      bind:value={query}
-      placeholder="Name, signature or vendor…"
-    /><button
-      class="button"
-      onclick={() => {
-        form = createEmptyForm();
-        editing = null;
-        showForm = true;
-      }}>Add agent</button
-    ><Action action={importAgents}>Import</Action><Action
-      action={async () => confirmed(await invoke(host, 'exportAgentDatabase'))}>Export</Action
-    >
-  </div>
   {#if error}<p role="alert" class="inset">{error}</p>{/if}
   {#if showForm}<div class="inset form-stack editor">
       <h3>{editing ? 'Edit custom agent' : 'Add custom agent'}</h3>
@@ -121,7 +128,9 @@
   <div class="table-scroll">
     <table>
       <thead
-        ><tr><th>Agent</th><th>Vendor / category</th><th>Process signatures</th><th>Actions</th></tr
+        ><tr
+          ><th>Agent</th><th>Category</th><th>Process signatures</th><th>Risk</th><th>Actions</th
+          ></tr
         ></thead
       ><tbody
         >{#each rows as row (String(row.id))}<tr
@@ -129,12 +138,37 @@
               ><button
                 class="text-link identity"
                 onclick={() => inspect(String(row.displayName), row)}
-                ><AgentLogo id={String(row.id)} />{String(row.displayName)}</button
-              ><small>{row.custom ? 'Custom' : 'Bundled'}</small></td
-            ><td>{String(row.vendor ?? '')}<small>{String(row.category ?? '')}</small></td><td
-              >{Array.isArray(row.names) ? row.names.join(', ') : 'Unavailable'}</td
+                ><AgentLogo id={String(row.id)} /><span
+                  ><strong>{String(row.displayName)}</strong><small
+                    >{String(row.vendor ?? (row.custom ? 'Custom' : 'Bundled'))}</small
+                  ></span
+                ></button
+              ></td
+            ><td>{String(row.category ?? '')}</td><td
+              ><div class="signature-list">
+                {#each Array.isArray(row.names) ? row.names.slice(0, 3) : [] as name (name)}<button
+                    class="text-link"
+                    onclick={() =>
+                      inspect('Process signature', { signature: name, agent: row.displayName })}
+                    >{String(name)}</button
+                  >{/each}{#if Array.isArray(row.names) && row.names.length > 3}<button
+                    class="text-link"
+                    onclick={() => inspect(String(row.displayName), row)}
+                    >+{row.names.length - 3} more</button
+                  >{/if}
+              </div></td
+            ><td
+              ><span
+                class="badge"
+                class:high={row.riskProfile === 'high'}
+                class:medium={row.riskProfile === 'medium'}
+                >{String(row.riskProfile ?? 'Unknown')}</span
+              ></td
             ><td
               ><div class="toolbar">
+                <button class="button" onclick={() => inspect(String(row.displayName), row)}
+                  ><Icon name="chevron" />Details</button
+                >
                 {#if row.website}<Action
                     action={async () =>
                       confirmed(await invoke(host, 'openExternalUrl', row.website))}>Website</Action
@@ -156,7 +190,46 @@
   </div>
 </section>
 
+<p class="catalog-count muted">{base.length} bundled · {custom.length} custom</p>
+
 <style>
+  .catalog-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+  }
+  .catalog-toolbar input {
+    width: 265px;
+  }
+  .catalog-toolbar label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: calc(11px * var(--ui-scale));
+  }
+  .toolbar-spacer {
+    flex: 1;
+  }
+  .signature-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 16px;
+  }
+  .identity {
+    text-decoration: none;
+    text-align: left;
+  }
+  .identity small {
+    margin-top: 3px;
+    font-weight: 400;
+  }
+  .catalog-count {
+    font-size: 11px;
+    margin-top: 12px;
+  }
+
   .identity {
     display: flex;
     align-items: center;

--- a/frontend/observatory/components/DetailSummary.svelte
+++ b/frontend/observatory/components/DetailSummary.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { measured, record, type RecordData, type Telemetry } from '../runtime/host';
+  import AgentLogo from './AgentLogo.svelte';
+  import Icon from './Icon.svelte';
+  let { row, telemetry }: { row: RecordData; telemetry: Telemetry } = $props();
+  let name = $derived(String(row.name ?? row.displayName ?? row.agent ?? 'Observation'));
+  let resources = $derived(
+    typeof row.instanceId === 'string'
+      ? telemetry.resources.find((r) => r.instanceId === row.instanceId)
+      : undefined,
+  );
+  const metric = (value: unknown, unit = '') =>
+    measured(value) === null ? 'Unavailable' : `${Number(value).toFixed(1)}${unit}`;
+</script>
+
+{#if row.process || row.displayName}
+  <div class="entity-heading">
+    <AgentLogo {name} id={String(row.id ?? '')} size={36} />
+    <div>
+      <h2>{name}</h2>
+      <small>{String(row.vendor ?? row.process ?? '')}{row.pid ? ` · PID ${row.pid}` : ''}</small>
+    </div>
+  </div>
+  {#if row.description}<p class="description">{String(row.description)}</p>{/if}
+  <div class="entity-metrics">
+    <div>
+      <small>Exposure risk</small><strong
+        >{String(row.riskScore ?? row.riskProfile ?? 'Unavailable')}{row.riskScore !== undefined
+          ? '/100'
+          : ''}</strong
+      >
+    </div>
+    <div>
+      <small>{row.process ? 'CPU' : 'Category'}</small><strong
+        >{row.process ? metric(resources?.cpu, '%') : String(row.category ?? 'Unavailable')}</strong
+      >
+    </div>
+    <div>
+      <small>{row.process ? 'Memory' : 'Source'}</small><strong
+        >{row.process ? metric(resources?.memMb, ' MB') : row.custom ? 'Custom' : 'Bundled'}</strong
+      >
+    </div>
+  </div>
+  {#if row.process}<dl>
+      <dt>Behaviour anomaly</dt>
+      <dd>{String(row.anomalyScore ?? 'Unavailable')}/100</dd>
+      <dt>Working directory</dt>
+      <dd>{String(row.cwd ?? 'Unavailable')}</dd>
+      <dt>Instance</dt>
+      <dd>{String(row.instanceId ?? 'Identity unavailable')}</dd>
+    </dl>{/if}
+{:else if row.file || row.remoteIp || row.domain}
+  <div class="entity-heading">
+    <Icon name={row.file ? 'file' : 'network'} />
+    <div>
+      <h2>{row.file ? 'File observation' : 'Network observation'}</h2>
+      <small>{String(row.source ?? 'Source unavailable')}</small>
+    </div>
+  </div>
+  <dl>
+    <dt>Resource</dt>
+    <dd>{String(row.file ?? row.domain ?? row.remoteIp)}</dd>
+    <dt>Agent</dt>
+    <dd>{String(row.agent ?? 'Unattributed')}</dd>
+    <dt>Time</dt>
+    <dd>{row.timestamp ? new Date(Number(row.timestamp)).toLocaleString() : 'Unavailable'}</dd>
+    <dt>Attribution</dt>
+    <dd>{String(record(row.attribution).status ?? 'Unavailable')}</dd>
+  </dl>
+{/if}
+
+<style>
+  .entity-heading {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .entity-heading h2 {
+    font-size: 18px;
+  }
+  .entity-heading small {
+    display: block;
+    color: var(--muted);
+    margin-top: 4px;
+  }
+  .entity-metrics {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+    border-block: 1px solid var(--border);
+    padding-block: 16px;
+    margin-bottom: 16px;
+  }
+  .entity-metrics small,
+  .entity-metrics strong {
+    display: block;
+    overflow-wrap: anywhere;
+  }
+  .entity-metrics small {
+    color: var(--muted);
+  }
+  .entity-metrics strong {
+    font-size: 16px;
+    margin-top: 6px;
+  }
+  .description {
+    color: var(--muted);
+    margin-bottom: 16px;
+  }
+  dl {
+    display: grid;
+    grid-template-columns: 120px minmax(0, 1fr);
+    gap: 10px 16px;
+    font-size: 12px;
+  }
+  dt {
+    color: var(--muted);
+  }
+  dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+  @media (max-width: 650px) {
+    dl {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/observatory/components/Details.svelte
+++ b/frontend/observatory/components/Details.svelte
@@ -17,6 +17,7 @@
   import EntityLinks from './EntityLinks.svelte';
   import Metadata from './Metadata.svelte';
   import Icon from './Icon.svelte';
+  import DetailSummary from './DetailSummary.svelte';
   let {
     host,
     telemetry,
@@ -105,8 +106,18 @@
     >
   </div>
   <div class="detail-body" tabindex="-1" bind:this={body}>
-    {#if current}<Metadata value={current.row} />
+    {#if current}<DetailSummary row={current.row} {telemetry} />
       <EntityLinks row={current.row} {telemetry} {navigate} />
+      <details
+        class="all-metadata"
+        open={!current.row.process &&
+          !current.row.displayName &&
+          !current.row.file &&
+          !current.row.remoteIp &&
+          !current.row.domain}
+      >
+        <summary>All observation metadata</summary><Metadata value={current.row} />
+      </details>
       {#if current.row.process}<h3>Alert watchlist</h3>
         <Action action={loadWatch}>Refresh watchlist</Action>{#each watch as entry (entry)}<div
             class="toolbar"
@@ -190,6 +201,16 @@
 </dialog>
 
 <style>
+  .all-metadata {
+    border-top: 1px solid var(--border);
+    margin: 16px 0;
+    padding-top: 12px;
+  }
+  summary {
+    cursor: pointer;
+    color: var(--muted);
+    font-size: 12px;
+  }
   dialog {
     padding: 0;
     width: min(920px, calc(100vw - 32px));

--- a/frontend/observatory/components/Monitoring.svelte
+++ b/frontend/observatory/components/Monitoring.svelte
@@ -3,7 +3,9 @@
   import { isAnomalyAlert } from '../../../src/renderer/lib/utils/anomaly-toast-tracker';
   import { RISK_BAND_HIGH_MIN } from '../../../src/renderer/lib/utils/trust-badge-utils';
   import AgentLogo from './AgentLogo.svelte';
-  import Icon from './Icon.svelte';
+  import Radar from './Radar.svelte';
+  import ActivityChart from './ActivityChart.svelte';
+  import ResourceUsage from './ResourceUsage.svelte';
   let {
     telemetry,
     selected = $bindable(null),
@@ -16,7 +18,15 @@
     mode?: string;
   } = $props();
   let agents = $derived(instances(telemetry));
-  let chosen = $derived(selected ? agents.find((a) => a.instanceId === selected) : undefined);
+  let end = $derived(
+    Math.max(telemetry.lastScan ?? 0, ...telemetry.events.map((e) => e.timestamp)),
+  );
+  let recent = $derived(telemetry.events.filter((e) => e.timestamp > end - 60000));
+  let tokenTotal = $derived(
+    telemetry.tokens.length && telemetry.tokens.every((t) => measured(t.totalTokens) !== null)
+      ? telemetry.tokens.reduce((sum, t) => sum + Number(t.totalTokens), 0)
+      : null,
+  );
   let query = $state('');
   let filtered = $derived(
     agents.filter((a) =>
@@ -29,18 +39,6 @@
   function value(n: number | null, suffix = '') {
     return n === null ? 'Unavailable' : `${n.toFixed(1)}${suffix}`;
   }
-  function position(index: number) {
-    const ring = index < 8 ? Math.min(8, agents.length) : Math.min(4, agents.length - 8);
-    const angle = ((index < 8 ? index : index - 8) / ring) * Math.PI * 2 - Math.PI / 2;
-    const radius = index < 8 ? 142 : 68;
-    return (
-      'left:calc(50% + ' +
-      Math.cos(angle) * radius +
-      'px);top:calc(50% + ' +
-      Math.sin(angle) * radius +
-      'px)'
-    );
-  }
   $effect(() => {
     if (!telemetry.stale && selected && !agents.some((a) => a.instanceId === selected))
       selected = null;
@@ -50,101 +48,49 @@
 <div hidden={mode !== 'overview'}>
   <div class="summary-strip">
     <div>
-      <small>Observed instances</small><strong>{telemetry.ready ? agents.length : '—'}</strong>
+      <small>Agents</small><strong>{telemetry.ready ? agents.length : '—'}</strong>
+      <p>Current process snapshot</p>
     </div>
     <div>
-      <small>File observations · session</small><strong
-        >{String(telemetry.stats.totalFiles ?? '—')}</strong
+      <small>Average risk</small><strong
+        >{agents.length
+          ? Math.round(agents.reduce((sum, a) => sum + a.riskScore, 0) / agents.length)
+          : '—'}<small>/100</small></strong
       >
+      <p>Highest: {agents.length ? Math.max(...agents.map((a) => a.riskScore)) : '—'}</p>
     </div>
     <div>
-      <small>Sensitive · session</small><strong>{String(telemetry.stats.aiSensitive ?? '—')}</strong
-      >
+      <small>Events / min</small><strong>{telemetry.ready ? recent.length : '—'}</strong>
+      <p>{telemetry.events.length} retained</p>
     </div>
     <div>
-      <small>Network · snapshot</small><strong
-        >{telemetry.ready ? telemetry.network.length : '—'}</strong
+      <small>Sensitive events</small><strong class="attention"
+        >{String(telemetry.stats.aiSensitive ?? '—')}</strong
       >
+      <p>File events · session</p>
+    </div>
+    <div>
+      <small>Connections</small><strong>{telemetry.ready ? telemetry.network.length : '—'}</strong>
+      <p>Current snapshot</p>
+    </div>
+    <div>
+      <small>Tokens</small><strong
+        >{tokenTotal === null
+          ? '—'
+          : Intl.NumberFormat('en', { notation: 'compact' }).format(tokenTotal)}</strong
+      >
+      <p>
+        {tokenTotal === null ? 'No measurement' : `${telemetry.tokens.length} reported sources`}
+      </p>
     </div>
   </div>
-  <div class="monitor-grid">
-    <section class="panel radar-panel">
-      <div class="panel-head">
-        <h2>Agent radar</h2>
-        <span>{telemetry.stale ? 'Last observation · stale' : 'Live observations'}</span>
-      </div>
-      <div class="radar-stage" class:stale={telemetry.stale}>
-        <button
-          class="radar-empty"
-          aria-label="Clear radar selection"
-          onclick={() => (selected = null)}
-        ></button>
-        <div class="radar-dial" aria-hidden="true">
-          <div class="dial-grid"></div>
-          <div class="dial-ticks"></div>
-          <div class="dial-sweep"></div>
-          <div class="radar-center"><Icon name="shield" /></div>
-        </div>
-        {#each agents.filter((a) => a.instanceId).slice(0, 12) as agent, index (agent.instanceId)}
-          <button
-            class="radar-point"
-            class:selected={selected === agent.instanceId}
-            style={position(index)}
-            aria-label={`Select ${agent.name}, PID ${agent.pid}`}
-            aria-pressed={selected === agent.instanceId}
-            onclick={() => (selected = agent.instanceId)}
-            onkeydown={(event) => {
-              if (event.key === 'Escape') selected = null;
-            }}
-          >
-            <AgentLogo name={agent.name} /><small>PID {agent.pid}</small>
-          </button>
-        {/each}
-        {#if !agents.length}<p class="radar-message">
-            {telemetry.ready
-              ? 'No agents in the last reliable scan'
-              : 'Waiting for the first reliable scan'}
-          </p>{/if}
-      </div>
-      <div class="inset muted">
-        Showing up to 12 instances. All observed processes appear in the table below. Distance does
-        not represent risk.
-      </div>
-    </section>
-    <section class="panel inspector">
-      <div class="panel-head"><h2>Instance inspector</h2></div>
-      <div class="inset">
-        {#if chosen}<div class="identity">
-            <AgentLogo name={chosen.name} />
-            <h3>{chosen.name}</h3>
-          </div>
-          <p class="mono">{chosen.instanceId}</p>
-          <dl>
-            <dt>Exposure risk</dt>
-            <dd>{chosen.riskScore}/100 · {chosen.trustGrade}</dd>
-            <dt>Behaviour anomaly</dt>
-            <dd>{chosen.anomalyScore}/100</dd>
-            <dt>CPU / memory</dt>
-            <dd>
-              {value(metric(chosen.instanceId, 'cpu'), '%')} / {value(
-                metric(chosen.instanceId, 'memMb'),
-                ' MB',
-              )}
-            </dd>
-            <dt>Working directory</dt>
-            <dd>{chosen.cwd ?? 'Unavailable'}</dd>
-          </dl>
-          <button
-            class="button"
-            onclick={() => inspect(chosen.name, chosen as unknown as RecordData)}
-            >Open instance details</button
-          >{:else}<Icon name="agents" />
-          <h3>Select an instance</h3>
-          <p class="muted">
-            Choose a radar marker or a row below to inspect its observations and available actions.
-          </p>{/if}
-      </div>
-    </section>
+  <Radar {telemetry} bind:selected {inspect} />
+  <div class="activity-grid">
+    <ActivityChart
+      events={telemetry.events}
+      observedAt={telemetry.lastScan}
+      {inspect}
+    /><ResourceUsage {telemetry} {inspect} />
   </div>
 </div>
 
@@ -202,129 +148,73 @@
 </section>
 
 <style>
+  .activity-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(260px, 1fr);
+    gap: 12px;
+    margin-bottom: 12px;
+    align-items: start;
+  }
+  @media (max-width: 1000px) {
+    .activity-grid {
+      grid-template-columns: 1fr;
+    }
+  }
   .anomaly-alert {
     color: var(--red);
   }
   .summary-strip {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 12px;
-    margin-bottom: 12px;
-  }
-  .summary-strip > div {
-    background: var(--panel);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 16px;
-  }
-  .summary-strip strong {
-    display: block;
-    font-size: 28px;
-    font-weight: 550;
-  }
-  .summary-strip small {
-    color: var(--muted);
-  }
-  .monitor-grid > .panel {
-    margin-top: 0;
-  }
-  .monitor-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(230px, 30%);
-    gap: 12px;
-    margin-bottom: 12px;
-  }
-  .radar-stage {
-    position: relative;
-    min-height: 380px;
-    height: 380px;
-    overflow: hidden;
-  }
-  .radar-empty {
-    position: absolute;
-    inset: 0;
-    border: 0;
-    background: transparent;
-    width: 100%;
-  }
-  .radar-dial {
-    pointer-events: none;
-  }
-  .dial-sweep {
-    animation: sweep 12s linear infinite;
-  }
-  .stale .dial-sweep {
-    animation-play-state: paused;
-  }
-  .radar-point {
-    position: absolute;
-    transform: translate(-50%, -50%);
-    display: flex;
-    gap: 4px;
-    align-items: center;
-    background: var(--panel);
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 10px;
+    padding: 12px;
+    margin-bottom: 14px;
+    background: var(--sidebar);
     border: 1px solid var(--border);
     border-radius: 8px;
-    color: var(--ink);
-    padding: 4px;
-    max-width: 78px;
-    flex-direction: column;
   }
-  .radar-point.selected {
-    border-color: var(--strong-border);
-    background: var(--raised);
+  .summary-strip > div {
+    min-width: 0;
+    padding-left: 10px;
+    border-left: 1px solid var(--border);
   }
-  .radar-message {
-    position: absolute;
-    bottom: 12px;
-    text-align: center;
-    width: 100%;
-    pointer-events: none;
+  .summary-strip > div:first-child {
+    border-left: 0;
+    padding-left: 0;
+  }
+  .summary-strip strong {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 4px;
+    font-size: calc(23px * var(--ui-scale));
+    font-weight: 500;
+    line-height: 1.3;
+    margin: 6px 0 3px;
+  }
+  .summary-strip small,
+  .summary-strip p {
+    font-size: calc(11px * var(--ui-scale));
     color: var(--muted);
+    overflow-wrap: anywhere;
   }
-  .identity,
+  .attention {
+    color: var(--amber);
+  }
   .agent-link {
     display: flex;
     align-items: center;
     gap: 8px;
-  }
-  .agent-link {
-    background: transparent;
-    color: var(--ink);
-    border: 0;
     padding: 0;
     text-align: left;
   }
-  dt {
-    color: var(--muted);
-    margin-top: 12px;
-  }
-  dd {
-    margin: 0;
-    overflow-wrap: anywhere;
-  }
-  .mono {
-    overflow-wrap: anywhere;
-  }
-  @keyframes sweep {
-    to {
-      transform: rotate(360deg);
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .dial-sweep {
-      animation: none;
-    }
-  }
-  @media (max-width: 1080px) {
-    .monitor-grid > .panel {
-      margin-top: 0;
-    }
-    .monitor-grid {
-      grid-template-columns: minmax(0, 1fr);
-    }
+  @media (max-width: 950px) {
     .summary-strip {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+    .summary-strip > div:nth-child(4) {
+      border-left: 0;
+      padding-left: 0;
     }
   }
 </style>

--- a/frontend/observatory/components/Radar.svelte
+++ b/frontend/observatory/components/Radar.svelte
@@ -1,0 +1,594 @@
+<script lang="ts">
+  import { instances, measured, type Telemetry, type RecordData } from '../runtime/host';
+  import { activityBins } from '../runtime/activity';
+  import AgentLogo from './AgentLogo.svelte';
+  import Icon from './Icon.svelte';
+  let {
+    telemetry,
+    selected = $bindable(null),
+    inspect,
+  }: {
+    telemetry: Telemetry;
+    selected: string | null;
+    inspect: (title: string, row: RecordData) => void;
+  } = $props();
+  let agents = $derived(instances(telemetry));
+  let plotted = $derived(agents.filter((a) => a.instanceId).slice(0, 12));
+  let chosen = $derived(selected ? agents.find((a) => a.instanceId === selected) : undefined);
+  let layer = $state('radar');
+  let end = $derived(
+    Math.max(telemetry.lastScan ?? 0, ...telemetry.events.map((e) => e.timestamp)) + 1,
+  );
+  let chosenEvents = $derived(
+    selected ? telemetry.events.filter((e) => e.instanceId === selected) : [],
+  );
+  let latest = $derived([...chosenEvents].sort((a, b) => b.timestamp - a.timestamp)[0]);
+  let linked = $derived(
+    (layer === 'files' ? telemetry.events : telemetry.network)
+      .filter((e) => !selected || e.instanceId === selected)
+      .slice(0, 2) as unknown as RecordData[],
+  );
+  function resource(id: string | null, key: string) {
+    return id ? measured(telemetry.resources.find((r) => r.instanceId === id)?.[key]) : null;
+  }
+  function value(n: number | null, suffix = '') {
+    return n === null ? '—' : `${n.toFixed(1)}${suffix}`;
+  }
+  function position(index: number) {
+    const angle = (index / Math.max(4, plotted.length)) * Math.PI * 2 - Math.PI * 0.7;
+    return { x: 50 + Math.cos(angle) * 34, y: 50 + Math.sin(angle) * 34 };
+  }
+  function band(score: number) {
+    return score >= 66 ? 'High' : score >= 35 ? 'Medium' : 'Low';
+  }
+  function openChosen() {
+    if (chosen) inspect(chosen.name, chosen as unknown as RecordData);
+  }
+</script>
+
+<div class="overview-grid">
+  <section class="panel radar-panel">
+    <div class="panel-head">
+      <div>
+        <h2><Icon name="radar" />Agent radar</h2>
+        <p>Risk and active instances</p>
+      </div>
+      <div class="segmented" aria-label="Radar layer">
+        {#each [['radar', 'Radar', 'radar'], ['files', 'Files', 'folder'], ['network', 'Network', 'network']] as [id, title, icon] (id)}<button
+            aria-pressed={layer === id}
+            onclick={() => (layer = id)}><Icon name={icon} />{title}</button
+          >{/each}
+      </div>
+    </div>
+    <div class="radar-body">
+      <div class="radar-workspace">
+        <div class="radar-stage" class:stale={telemetry.stale}>
+          <button
+            class="radar-empty"
+            aria-label="Clear radar selection"
+            onclick={() => (selected = null)}
+          ></button>
+          <div class="radar-coordinate">
+            {telemetry.stale ? 'Observation unavailable' : 'Processes visible'}<br />Local
+            monitoring
+          </div>
+          <div class="radar-dial">
+            <div class="dial-grid"></div>
+            <div class="dial-ticks"></div>
+            <div class="dial-sweep"></div>
+            <span class="bearing north">0°</span><span class="bearing east">90°</span><span
+              class="bearing south">180°</span
+            ><span class="bearing west">270°</span>
+            <div class="radar-center"><Icon name="shield" /></div>
+            {#each plotted as agent, index (agent.instanceId)}{@const point = position(index)}
+              <button
+                class="radar-point"
+                class:label-left={point.x < 50}
+                class:dense={plotted.length > 6}
+                aria-pressed={selected === agent.instanceId}
+                style={`left:${point.x}%;top:${point.y}%`}
+                aria-label={`Select ${agent.name}, PID ${agent.pid}`}
+                onclick={() => (selected = agent.instanceId)}
+                onkeydown={(e) => {
+                  if (e.key === 'Escape') selected = null;
+                }}
+              >
+                <AgentLogo name={agent.name} size={18} /><span
+                  ><strong>{agent.name}</strong><small
+                    >{plotted.length > 6 ? `PID ${agent.pid}` : `${agent.riskScore} / 100`}</small
+                  ></span
+                >
+              </button>
+            {/each}
+          </div>
+          {#if !agents.length}<p class="radar-message">
+              {telemetry.ready
+                ? 'No agents in the last reliable scan'
+                : 'Waiting for the first reliable scan'}
+            </p>{/if}
+          {#if layer !== 'radar'}<div class="layer-resources">
+              {#each linked as row (row)}<button
+                  class="button"
+                  onclick={() =>
+                    inspect(layer === 'files' ? 'File observation' : 'Network observation', row)}
+                  ><Icon name={layer === 'files' ? 'file' : 'network'} /><span
+                    >{String(row.file ?? row.domain ?? row.remoteIp ?? 'Observation')}</span
+                  ></button
+                >{:else}<small
+                  >No {layer === 'files' ? 'file observations' : 'connections'} for this selection.</small
+                >{/each}
+            </div>{/if}
+        </div>
+        <div class="radar-cards" aria-label="Agent activity">
+          {#each plotted as agent (agent.instanceId)}{@const events = telemetry.events.filter(
+              (e) => e.instanceId === agent.instanceId,
+            )}{@const bins = activityBins(events, end, 300000, 10)}{@const max = Math.max(
+              1,
+              ...bins.map((bin) => bin.events.length),
+            )}
+            <article class="radar-agent-card">
+              <button
+                class="radar-agent-title"
+                aria-pressed={selected === agent.instanceId}
+                onclick={() => (selected = agent.instanceId)}
+                ><AgentLogo name={agent.name} size={20} /><span>{agent.name}</span><b
+                  >{agent.riskScore}</b
+                ></button
+              >
+              <div class="radar-agent-metrics">
+                <span>CPU <b>{value(resource(agent.instanceId, 'cpu'), '%')}</b></span><span
+                  >RAM <b>{value(resource(agent.instanceId, 'memMb'), ' MB')}</b></span
+                >
+              </div>
+              <button
+                class="radar-mini-chart"
+                aria-label={`Recent activity for ${agent.name}, PID ${agent.pid}`}
+                onclick={() =>
+                  inspect('Activity interval', {
+                    instanceId: agent.instanceId,
+                    observations: bins.flatMap((bin) => bin.events),
+                  })}
+              >
+                <svg viewBox="0 0 200 24" preserveAspectRatio="none" aria-hidden="true"
+                  >{#each bins as bin, i (i)}<rect
+                      x={i * 20}
+                      y={24 - (bin.events.length / max) * 24}
+                      width="14"
+                      height={Math.max(1, (bin.events.length / max) * 24)}
+                      rx="1"
+                    />{/each}</svg
+                >
+                <small>{bins.reduce((sum, bin) => sum + bin.events.length, 0)} events · 5 min</small
+                >
+              </button>
+              <button
+                class="text-link radar-agent-foot"
+                onclick={() => inspect(agent.name, agent as unknown as RecordData)}
+                ><Icon name="cpu" />PID {agent.pid}</button
+              >
+            </article>
+          {/each}
+        </div>
+      </div>
+    </div>
+    <div class="radar-bottom">
+      <span>Up to 12 instances · distance does not encode risk</span><button
+        disabled={!chosen}
+        onclick={openChosen}>Open selected agent</button
+      >
+    </div>
+  </section>
+  <section class="panel inspector">
+    <div class="inspector-title">
+      <span>Selected instance</span><button
+        disabled={!chosen}
+        aria-label="Open selected instance"
+        onclick={openChosen}><Icon name="chevron" /></button
+      >
+    </div>
+    {#if chosen}
+      <div class="agent-identity">
+        <AgentLogo name={chosen.name} size={32} />
+        <div>
+          <button class="text-link" onclick={openChosen}>{chosen.name}</button><small
+            >PID {chosen.pid}</small
+          >
+        </div>
+      </div>
+      <div class="inspector-risk">
+        <div>
+          <small>Risk</small><span
+            class="badge"
+            class:high={chosen.riskScore >= 66}
+            class:medium={chosen.riskScore >= 35 && chosen.riskScore < 66}
+            >{band(chosen.riskScore)}</span
+          >
+        </div>
+        <strong>{chosen.riskScore}<small>/100</small></strong>
+      </div>
+      <div class="risk-track">
+        <i
+          style={`transform:scaleX(${chosen.riskScore / 100});background:var(--${chosen.riskScore >= 66 ? 'red' : chosen.riskScore >= 35 ? 'amber' : 'muted'})`}
+        ></i>
+      </div>
+      <div class="inspector-metrics">
+        <div>
+          <strong>{value(resource(chosen.instanceId, 'cpu'), '%')}</strong><small>CPU</small>
+        </div>
+        <div>
+          <strong>{value(resource(chosen.instanceId, 'memMb'))}</strong><small>RAM, MB</small>
+        </div>
+        <div><strong>{chosenEvents.length}</strong><small>events</small></div>
+      </div>
+      {#if latest}<div class="finding">
+          <small
+            ><Icon name="file" />{latest.sensitive ? 'Needs review' : 'Latest observation'} · {new Date(
+              latest.timestamp,
+            ).toLocaleTimeString()}</small
+          ><button
+            class="text-link"
+            onclick={() => inspect('File observation', latest as unknown as RecordData)}
+            >{latest.file.split(/[/\\]/).pop()}</button
+          >
+          <p>{latest.action ?? 'File observation'}</p>
+        </div>
+        <p class="attribution">
+          Attribution: {String(latest.attribution?.status ?? 'unavailable')}. {latest.attribution
+            ?.status === 'confirmed'
+            ? 'See observation details for evidence.'
+            : 'A specific process action is unconfirmed.'}
+        </p>{:else}<p class="muted">No retained file observations for this instance.</p>{/if}
+      <dl>
+        <dt>Behaviour anomaly</dt>
+        <dd>{chosen.anomalyScore}/100</dd>
+        <dt>Working directory</dt>
+        <dd>{chosen.cwd ?? 'Unavailable'}</dd>
+      </dl>
+      <div class="toolbar">
+        <button class="button" onclick={openChosen}>Process details</button>{#if latest}<button
+            class="button"
+            onclick={() => inspect('File observation', latest as unknown as RecordData)}
+            >Review event</button
+          >{/if}
+      </div>
+    {:else}<div class="radar-no-selection">
+        <Icon name="agents" />
+        <h3>Select an instance</h3>
+        <p>
+          Choose a radar marker or an activity card to inspect its observations and available
+          actions.
+        </p>
+      </div>{/if}
+  </section>
+</div>
+
+<style>
+  .overview-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) clamp(240px, 24vw, 300px);
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+  .overview-grid > .panel {
+    margin-top: 0;
+  }
+  .radar-panel {
+    display: flex;
+    flex-direction: column;
+    height: calc(640px + (var(--ui-scale) - 1) * 340px);
+  }
+  .radar-body {
+    flex: 1;
+    min-height: 0;
+    container-type: inline-size;
+  }
+  .radar-workspace {
+    height: 100%;
+    display: grid;
+    grid-template-rows: minmax(240px, 1fr) auto;
+  }
+  .radar-stage {
+    min-height: 0;
+    container-type: size;
+  }
+  .radar-dial {
+    width: min(300px, calc(100cqh - 72px), calc(100cqw - 120px));
+    height: min(300px, calc(100cqh - 72px), calc(100cqw - 120px));
+    pointer-events: none;
+  }
+  .dial-sweep {
+    animation: sweep 9s linear infinite;
+  }
+  .stale .dial-sweep {
+    animation-play-state: paused;
+  }
+  .radar-empty {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+  .radar-coordinate {
+    left: 12px;
+    top: 7px;
+    font-size: calc(10px * var(--ui-scale));
+  }
+  .bearing {
+    font-size: 9px;
+  }
+  .radar-point {
+    pointer-events: auto;
+    position: absolute;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: var(--bg);
+    transform: translate(-14px, -50%);
+    text-align: left;
+    white-space: nowrap;
+  }
+  .radar-point.label-left {
+    flex-direction: row-reverse;
+    text-align: right;
+    transform: translate(calc(-100% + 14px), -50%);
+  }
+  .radar-point strong,
+  .radar-point small {
+    display: block;
+    font-size: calc(10px * var(--ui-scale));
+  }
+  .radar-point small {
+    color: var(--muted);
+  }
+  .radar-point[aria-pressed='true'],
+  .radar-agent-title[aria-pressed='true'] {
+    background: var(--selection);
+    border-color: var(--selection-border);
+  }
+  .radar-point.dense span {
+    display: none;
+  }
+  .radar-point.dense:hover span,
+  .radar-point.dense:focus span {
+    display: block;
+  }
+  .radar-message {
+    position: absolute;
+    bottom: 12px;
+    width: 100%;
+    text-align: center;
+    pointer-events: none;
+    font-size: 12px;
+  }
+  .radar-cards {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    max-height: 300px;
+    overflow: auto;
+    background: var(--panel);
+    border-top: 1px solid var(--border);
+  }
+  .radar-agent-card {
+    min-width: 0;
+    padding: 12px 10px;
+    border-bottom: 1px solid var(--border);
+  }
+  .radar-agent-card:nth-child(even) {
+    border-left: 1px solid var(--border);
+  }
+  .radar-agent-title {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    font-size: calc(11px * var(--ui-scale));
+    text-align: left;
+  }
+  .radar-agent-title > span {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .radar-agent-metrics {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 4px;
+    color: var(--muted);
+    margin-top: 8px;
+    font-size: calc(10px * var(--ui-scale));
+  }
+  .radar-agent-metrics b {
+    color: var(--ink);
+  }
+  .radar-mini-chart {
+    width: 100%;
+    padding: 6px 0 0;
+    color: var(--muted);
+    text-align: left;
+  }
+  .radar-mini-chart svg {
+    display: block;
+    width: 100%;
+    height: 24px;
+  }
+  .radar-mini-chart rect {
+    fill: currentColor;
+    opacity: 0.65;
+  }
+  .radar-mini-chart small,
+  .radar-agent-foot {
+    font-size: calc(10px * var(--ui-scale));
+  }
+  .radar-agent-foot {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-top: 4px;
+  }
+  .layer-resources {
+    position: absolute;
+    inset: auto 12px 8px;
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .layer-resources button {
+    max-width: 48%;
+  }
+  .layer-resources span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .radar-bottom {
+    flex-wrap: wrap;
+    padding: 8px 12px;
+  }
+  .inspector {
+    padding: 12px;
+    height: calc(640px + (var(--ui-scale) - 1) * 340px);
+    overflow: auto;
+    background: var(--inspector);
+  }
+  .inspector-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 10px;
+    margin-bottom: 16px;
+    font-size: calc(11px * var(--ui-scale));
+    color: var(--muted);
+  }
+  .agent-identity {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .agent-identity small {
+    display: block;
+    color: var(--muted);
+    margin-top: 4px;
+  }
+  .inspector-risk {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .inspector-risk small {
+    display: block;
+    color: var(--muted);
+  }
+  .inspector-risk strong {
+    font-size: 20px;
+  }
+  .inspector-risk strong small {
+    display: inline;
+  }
+  .risk-track {
+    height: 3px;
+    background: var(--border);
+    margin: 8px 0 14px;
+  }
+  .risk-track i {
+    display: block;
+    height: 100%;
+    transform-origin: left;
+  }
+  .inspector-metrics {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .inspector-metrics strong,
+  .inspector-metrics small {
+    display: block;
+  }
+  .inspector-metrics small {
+    color: var(--muted);
+  }
+  .finding {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px;
+  }
+  .finding small {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+    color: var(--muted);
+    margin-bottom: 8px;
+  }
+  .finding p,
+  .attribution {
+    font-size: calc(11px * var(--ui-scale));
+    color: var(--muted);
+    margin: 8px 0;
+  }
+  dl {
+    font-size: calc(11px * var(--ui-scale));
+  }
+  dt {
+    color: var(--muted);
+    margin-top: 10px;
+  }
+  dd {
+    margin: 3px 0 0;
+    overflow-wrap: anywhere;
+  }
+  .radar-no-selection {
+    margin: 28px 0;
+    color: var(--muted);
+  }
+  .radar-no-selection h3 {
+    margin: 14px 0 8px;
+    color: var(--ink);
+  }
+  .radar-no-selection p {
+    font-size: calc(12px * var(--ui-scale));
+  }
+  @container (min-width: 760px) {
+    .radar-workspace {
+      grid-template-columns: minmax(180px, 1fr) minmax(360px, 2fr);
+      grid-template-rows: 1fr;
+    }
+    .radar-cards {
+      grid-template-columns: 1fr;
+      max-height: none;
+      border-top: 0;
+      border-left: 1px solid var(--border);
+    }
+    .radar-agent-card:nth-child(even) {
+      border-left: 0;
+    }
+  }
+  @media (max-width: 950px) {
+    .overview-grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
+    .inspector {
+      height: auto;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dial-sweep {
+      animation: none;
+    }
+  }
+  @keyframes sweep {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/frontend/observatory/components/Reports.svelte
+++ b/frontend/observatory/components/Reports.svelte
@@ -2,13 +2,20 @@
   import { onMount } from 'svelte';
   import { confirmed, invoke, record, records, type Host, type RecordData } from '../runtime/host';
   import Action from './Action.svelte';
+  import Icon from './Icon.svelte';
+  import AgentLogo from './AgentLogo.svelte';
+  import { instances, type Telemetry } from '../runtime/host';
   import Metadata from './Metadata.svelte';
   let {
     host,
     audit = false,
     inspect,
+    telemetry,
+    navigate,
   }: {
     host: Host | null;
+    telemetry: Telemetry;
+    navigate: (view: string) => void;
     audit?: boolean;
     inspect: (title: string, row: RecordData) => void;
   } = $props();
@@ -122,34 +129,127 @@
     </div>
   </section>
 {:else}
-  <section class="panel">
-    <div class="panel-head">
-      <h2>Export observations</h2>
-      <span>Native exports & printable report</span>
-    </div>
-    <div class="export-grid inset">
-      {#each exports as [method, label] (method)}<div class="export-card">
-          <h3>{label}</h3>
-          <p class="muted">
-            {method === 'generateReport'
-              ? 'Open a generated HTML report in your default application.'
-              : 'Export recorded observations to a file you choose.'}
-          </p>
-          <Action action={async () => confirmed(await invoke(host, method))}>Export</Action>
-        </div>{/each}
-    </div>
-  </section>
+  <div class="notice">
+    <Icon name="shield" /><span>AI assessments have their own workspace.</span><button
+      class="button"
+      onclick={() => navigate('analysis')}><Icon name="chevron" />Open AI analysis</button
+    >
+  </div>
+  <div class="report-grid">
+    <section class="panel">
+      <div class="panel-head">
+        <div>
+          <h2><Icon name="report" />Session summary</h2>
+          <p>Current observations</p>
+        </div>
+      </div>
+      <div class="inline-stats">
+        <div>
+          <strong>{String(telemetry.stats.totalFiles ?? '—')}</strong><small
+            >file observations</small
+          >
+        </div>
+        <div>
+          <strong>{String(telemetry.stats.aiSensitive ?? '—')}</strong><small>sensitive</small>
+        </div>
+        <div>
+          <strong>{telemetry.ready ? instances(telemetry).length : '—'}</strong><small
+            >instances</small
+          >
+        </div>
+      </div>
+      <div class="table-scroll">
+        <table>
+          <thead><tr><th>Agent</th><th>PID</th><th>Risk</th><th>Grade</th></tr></thead><tbody
+            >{#each instances(telemetry) as agent (agent.instanceId ?? agent)}<tr
+                ><td
+                  ><button
+                    class="report-agent"
+                    onclick={() => inspect(agent.name, agent as unknown as RecordData)}
+                    ><AgentLogo name={agent.name} />{agent.name}</button
+                  ></td
+                ><td>{agent.pid}</td><td>{agent.riskScore}/100</td><td
+                  ><span class="badge">{agent.trustGrade}</span></td
+                ></tr
+              >{:else}<tr><td colspan="4">No observed instances</td></tr>{/each}</tbody
+          >
+        </table>
+      </div>
+    </section>
+    <section class="panel">
+      <div class="panel-head">
+        <div>
+          <h2><Icon name="download" />Export observations</h2>
+          <p>Native exports & printable report</p>
+        </div>
+      </div>
+      <div class="export-grid inset">
+        {#each exports as [method, label] (method)}<div class="export-card">
+            <h3>{label}</h3>
+            <Action action={async () => confirmed(await invoke(host, method))}
+              ><Icon name="download" />Export</Action
+            >
+          </div>{/each}
+      </div>
+      <div class="inset">
+        <p class="notice">
+          <Icon name="file" />Exports contain recorded metadata and omit the provider key.
+        </p>
+      </div>
+    </section>
+  </div>
 {/if}
 
 <style>
+  .report-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+    gap: 12px;
+    align-items: start;
+  }
+  .report-grid > .panel {
+    margin-top: 0;
+  }
+  .notice > span {
+    flex: 1;
+  }
+  .inline-stats {
+    display: flex;
+    gap: 24px;
+    padding: 16px;
+  }
+  .inline-stats strong {
+    display: block;
+    font-size: 24px;
+  }
+  .inline-stats small {
+    color: var(--muted);
+  }
+  .report-agent {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-align: left;
+    padding: 0;
+  }
+  .export-card h3 {
+    margin-bottom: 8px;
+    font-size: 11px;
+  }
+  @media (max-width: 1000px) {
+    .report-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
   .export-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 12px;
   }
   .export-card {
     border: 1px solid var(--border);
     border-radius: 8px;
-    padding: 16px;
+    padding: 12px;
   }
 </style>

--- a/frontend/observatory/components/ResourceUsage.svelte
+++ b/frontend/observatory/components/ResourceUsage.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import { instances, measured, type RecordData, type Telemetry } from '../runtime/host';
+  import AgentLogo from './AgentLogo.svelte';
+  import Icon from './Icon.svelte';
+  let {
+    telemetry,
+    inspect,
+  }: { telemetry: Telemetry; inspect: (title: string, row: RecordData) => void } = $props();
+  let mode = $state('cpu');
+  let agents = $derived(instances(telemetry));
+  let maximum = $derived(
+    mode === 'cpu' ? 100 : Math.max(1, ...telemetry.resources.map((r) => measured(r.memMb) ?? 0)),
+  );
+</script>
+
+<section class="panel usage-panel">
+  <div class="panel-head">
+    <div>
+      <h2><Icon name="chart" />Agent usage</h2>
+      <p>Current process snapshot</p>
+    </div>
+    <div class="segmented">
+      <button aria-pressed={mode === 'cpu'} onclick={() => (mode = 'cpu')}>CPU</button><button
+        aria-pressed={mode === 'memMb'}
+        onclick={() => (mode = 'memMb')}>RAM</button
+      >
+    </div>
+  </div>
+  <div class="usage-body">
+    {#each agents as agent (agent.instanceId ?? agent)}{@const sample = agent.instanceId
+        ? telemetry.resources.find((r) => r.instanceId === agent.instanceId)
+        : undefined}{@const value = measured(sample?.[mode])}<button
+        class="usage-row"
+        onclick={() => inspect(agent.name, agent as unknown as RecordData)}
+        ><span class="usage-identity"
+          ><AgentLogo name={agent.name} size={20} /><span
+            >{agent.name}<small>PID {agent.pid}</small></span
+          ><strong
+            >{value === null ? '—' : value.toFixed(1)}{value === null
+              ? ''
+              : mode === 'cpu'
+                ? '%'
+                : ' MB'}</strong
+          ></span
+        ><span class="track"
+          ><span style={`transform:scaleX(${Math.min(1, (value ?? 0) / maximum)})`}></span></span
+        ></button
+      >{:else}<p class="muted">No process measurements available.</p>{/each}
+  </div>
+  <p class="usage-caption">
+    {mode === 'cpu'
+      ? 'Percentage of total CPU capacity.'
+      : 'Memory relative to the largest measured process.'} — means unavailable.
+  </p>
+</section>
+
+<style>
+  .usage-panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    margin-top: 0;
+  }
+  .usage-body {
+    max-height: 280px;
+    overflow: auto;
+    padding: 10px 16px;
+  }
+  .usage-row {
+    width: 100%;
+    padding: 8px 0;
+    text-align: left;
+  }
+  .usage-identity {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: calc(11px * var(--ui-scale));
+  }
+  .usage-identity > span {
+    flex: 1;
+  }
+  .usage-identity small {
+    display: block;
+    color: var(--muted);
+  }
+  .track {
+    display: block;
+    height: 4px;
+    border-radius: 3px;
+    background: var(--border);
+    margin-top: 8px;
+    overflow: hidden;
+  }
+  .track > span {
+    display: block;
+    height: 100%;
+    background: var(--muted);
+    transform-origin: left;
+    transition: transform 280ms ease;
+  }
+  .usage-caption {
+    padding: 12px 16px;
+    color: var(--muted);
+    font-size: calc(11px * var(--ui-scale));
+    margin-top: auto;
+  }
+</style>

--- a/frontend/observatory/components/Rules.svelte
+++ b/frontend/observatory/components/Rules.svelte
@@ -11,6 +11,23 @@
     type Telemetry,
   } from '../runtime/host';
   import Action from './Action.svelte';
+  import Icon from './Icon.svelte';
+  import AgentLogo from './AgentLogo.svelte';
+  let section = $state('permissions');
+  const profiles: Record<string, [string, string]> = {
+    paranoid: ['bell', 'Alert on every category'],
+    strict: ['shield', 'More alerts for risky actions'],
+    balanced: ['balance', 'Monitor every category'],
+    developer: ['terminal', 'Fewer notifications'],
+  };
+  const labels: Record<string, [string, string, string]> = {
+    filesystem: ['folder', 'File system', 'Read and write files'],
+    sensitive: ['key', 'Sensitive files', '.env, SSH keys, cloud configuration'],
+    network: ['network', 'Network', 'Outbound connections'],
+    terminal: ['terminal', 'Terminal', 'Commands and child processes'],
+    clipboard: ['clipboard', 'Clipboard', 'Clipboard policy category'],
+    screen: ['monitor', 'Screen', 'Screen capture policy category'],
+  };
   let { host, telemetry }: { host: Host | null; telemetry: Telemetry } = $props();
   let permissions = $state<RecordData>({});
   let rules = $state<RecordData[]>([]);
@@ -105,52 +122,80 @@
   }
 </script>
 
-<section class="panel">
-  <div class="panel-head">
-    <h2>Rules & permissions</h2>
-    <Action action={load}>Refresh</Action>
+<div class="section-tabs">
+  <button aria-pressed={section === 'permissions'} onclick={() => (section = 'permissions')}
+    ><Icon name="shield" />Agent permissions</button
+  ><button aria-pressed={section === 'rules'} onclick={() => (section = 'rules')}
+    ><Icon name="file" />Detection rules <small>{rules.length}</small></button
+  >
+</div>
+<div hidden={section !== 'permissions'}>
+  <p class="notice">
+    <Icon name="shield" />Profiles control monitoring responses. Policy labels do not establish that
+    an action was blocked.
+  </p>
+  {#if error}<p role="alert">{error}</p>{/if}
+  <div class="preset-grid">
+    {#each Object.entries(presets) as [name, values] (name)}<button
+        class="preset"
+        aria-label={name}
+        data-profile={name}
+        disabled={!target}
+        aria-pressed={!!target && categories.every((cat, i) => draft[cat] === values[i])}
+        onclick={() => (draft = Object.fromEntries(categories.map((cat, i) => [cat, values[i]])))}
+        ><span
+          ><Icon name={profiles[name][0]} /><strong>{name}</strong
+          >{#if target && categories.every((cat, i) => draft[cat] === values[i])}<Icon
+              name="check"
+            />{/if}</span
+        ><small>{profiles[name][1]}</small></button
+      >{/each}
   </div>
-  <div class="inset form-stack">
-    {#if error}<p role="alert">{error}</p>{/if}
-    <div class="toolbar">
-      <label
-        >Scope<select bind:value={scope} onchange={() => (target = '')}
-          ><option value="agent">Agent defaults</option><option value="instance"
-            >Project / parent override</option
+  <div class="target-toolbar">
+    <label
+      >Agent <AgentLogo name={scope === 'agent' ? target : (chosen?.name ?? '')} size={22} /><select
+        aria-label="Target"
+        bind:value={target}
+        ><option value="">Select…</option>{#each options as option (option.key)}<option
+            value={option.key}>{option.label}</option
+          >{/each}</select
+      ></label
+    ><label
+      ><Icon name="cpu" />Apply to
+      <select aria-label="Scope" bind:value={scope} onchange={() => (target = '')}
+        ><option value="agent">Agent defaults</option><option value="instance"
+          >Project / parent override</option
+        ></select
+      ></label
+    ><Action action={load}>Refresh</Action>
+  </div>
+  <section class="panel">
+    <div class="panel-head">
+      <div>
+        <h2>
+          <AgentLogo name={scope === 'agent' ? target : (chosen?.name ?? '')} />{scope === 'agent'
+            ? target || 'Select an agent'
+            : chosen?.name || 'Select an instance'}
+        </h2>
+        <p>
+          {scope === 'agent'
+            ? 'Rules by agent name'
+            : 'Rules by agent, working directory and parent editor'}
+        </p>
+      </div>
+    </div>
+    {#each categories as category (category)}<label class="permission-row"
+        ><span
+          ><Icon name={labels[category][0]} /><span
+            ><strong>{labels[category][1]}</strong><small>{labels[category][2]}</small></span
+          ></span
+        ><select aria-label={labels[category][1]} disabled={!target} bind:value={draft[category]}
+          ><option value="allow">Allow</option><option value="monitor">Monitor</option><option
+            value="block">Block</option
           ></select
         ></label
-      ><label
-        >Target<select bind:value={target}
-          ><option value="">Select…</option>{#each options as option (option.key)}<option
-              value={option.key}>{option.label}</option
-            >{/each}</select
-        ></label
-      >
-    </div>
-    <p class="muted">
-      Project overrides persist by agent, working directory and parent editor. Instances sharing
-      that context share permissions. Permission categories reflect the backend's supported policy.
-    </p>
-    <div class="preset-grid">
-      {#each Object.entries(presets) as [name, values] (name)}<button
-          class="button"
-          disabled={!target}
-          class:active={categories.every((cat, i) => draft[cat] === values[i])}
-          aria-pressed={categories.every((cat, i) => draft[cat] === values[i])}
-          onclick={() => (draft = Object.fromEntries(categories.map((cat, i) => [cat, values[i]])))}
-          >{name}</button
-        >{/each}
-    </div>
-    <div class="permission-grid">
-      {#each categories as category (category)}<label
-          >{category}<select disabled={!target} bind:value={draft[category]}
-            ><option value="allow">Allow</option><option value="monitor">Monitor</option><option
-              value="block">Block</option
-            ></select
-          ></label
-        >{/each}
-    </div>
-    <div class="toolbar">
+      >{/each}
+    <div class="toolbar inset">
       <Action disabled={!loaded || !target} action={save}>Save permissions</Action><Action
         action={async () => {
           await invoke(host, 'resetPermissionsToDefaults');
@@ -158,9 +203,13 @@
         }}>Reset all to defaults</Action
       >
     </div>
-  </div>
-</section>
-<section class="panel">
+  </section>
+  <p class="policy-note">
+    Project overrides persist by agent, working directory and parent editor. Instances sharing that
+    context share permissions.
+  </p>
+</div>
+<section class="panel" hidden={section !== 'rules'}>
   <div class="panel-head">
     <h2>Loaded detection rules</h2>
     <Action
@@ -190,11 +239,97 @@
   .preset-grid {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 8px;
-  }
-  .permission-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     gap: 12px;
+    margin-bottom: 12px;
+  }
+  .preset {
+    padding: 16px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--panel);
+    text-align: left;
+    --profile-color: var(--muted);
+  }
+  .preset span {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    margin-bottom: 12px;
+  }
+  .preset strong {
+    flex: 1;
+    text-transform: capitalize;
+    font-size: calc(12px * var(--ui-scale));
+  }
+  .preset :global(.icon) {
+    color: var(--profile-color);
+    width: 21px;
+    height: 21px;
+  }
+  .preset[data-profile='paranoid'] {
+    --profile-color: var(--red);
+  }
+  .preset[data-profile='strict'] {
+    --profile-color: var(--amber);
+  }
+  .preset[data-profile='balanced'] {
+    --profile-color: var(--green);
+  }
+  .preset[data-profile='developer'] {
+    --profile-color: var(--ice);
+  }
+  .preset[aria-pressed='true'] {
+    background: var(--raised);
+    border-color: var(--profile-color);
+    box-shadow: inset 0 0 0 1px var(--profile-color);
+  }
+  .target-toolbar,
+  .target-toolbar label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    font-size: calc(11px * var(--ui-scale));
+  }
+  .target-toolbar {
+    margin-bottom: 12px;
+    gap: 12px;
+  }
+  .target-toolbar select {
+    max-width: 280px;
+  }
+  .permission-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  .permission-row > span {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .permission-row strong {
+    font-size: calc(12px * var(--ui-scale));
+  }
+  .permission-row small {
+    display: block;
+    color: var(--muted);
+    margin-top: 3px;
+  }
+  .permission-row select {
+    min-width: 140px;
+  }
+  .policy-note {
+    margin-top: 12px;
+    color: var(--muted);
+    font-size: 11px;
+  }
+  @media (max-width: 1000px) {
+    .preset-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
 </style>

--- a/frontend/observatory/components/Settings.svelte
+++ b/frontend/observatory/components/Settings.svelte
@@ -2,11 +2,17 @@
   import { onMount } from 'svelte';
   import { confirmed, invoke, record, type Host, type RecordData } from '../runtime/host';
   import Action from './Action.svelte';
+  import Icon from './Icon.svelte';
+  import AgentLogo from './AgentLogo.svelte';
   let {
     host,
     appearance,
-  }: { host: Host | null; appearance: (dark: boolean, scale: number, contrast?: boolean) => void } =
-    $props();
+    navigate,
+  }: {
+    host: Host | null;
+    appearance: (dark: boolean, scale: number, contrast?: boolean) => void;
+    navigate: (view: string) => void;
+  } = $props();
   let form = $state<RecordData>({});
   let loaded = $state(false);
   let error = $state('');
@@ -97,7 +103,7 @@
 {#if error}<p role="alert">{error}</p>{/if}
 <div class="settings-grid">
   <section class="panel">
-    <div class="panel-head"><h2>Appearance & monitoring</h2></div>
+    <div class="panel-head"><h2><Icon name="sun" />Appearance</h2></div>
     <div class="inset form-stack">
       <label
         >Theme <select bind:value={form.darkMode}
@@ -117,6 +123,7 @@
         ><input type="checkbox" bind:checked={motion} />Interface motion (respects system
         preference)</label
       >
+      <div class="settings-section-title"><h2><Icon name="radar" />Monitoring</h2></div>
       <label
         >Scan interval (seconds) <input
           type="number"
@@ -140,16 +147,18 @@
         >Ignored directories · one per line<textarea rows="4" bind:value={ignored}
         ></textarea></label
       >
-      <div class="toolbar">
-        <Action disabled={!loaded} action={save}>Save settings</Action><Action action={load}
-          >Restore saved values</Action
-        >
-      </div>
     </div>
   </section>
   <div class="form-stack">
+    <section class="panel inset">
+      <h2 class="analysis-heading"><AgentLogo name="Claude Code" />Anthropic analysis</h2>
+      <p class="muted">Connect Anthropic and review assessments in the AI analysis workspace.</p>
+      <button class="button" onclick={() => navigate('analysis')}
+        ><Icon name="shield" />Open AI analysis</button
+      >
+    </section>
     <section class="panel">
-      <div class="panel-head"><h2>Application updates</h2></div>
+      <div class="panel-head"><h2><Icon name="refresh" />Application updates</h2></div>
       <div class="inset">
         <p role="status">{String(updates.status ?? 'Loading')} {String(updates.version ?? '')}</p>
         {#if updates.error}<p role="alert">
@@ -172,7 +181,7 @@
       </div>
     </section>
     <section class="panel">
-      <div class="panel-head"><h2>Configuration</h2></div>
+      <div class="panel-head"><h2><Icon name="settings" />Configuration</h2></div>
       <div class="inset form-stack">
         <Action action={async () => confirmed(await invoke(host, 'testNotification'))}
           >Send test notification</Action
@@ -193,7 +202,62 @@
   </div>
 </div>
 
+<div class="settings-save">
+  <Action action={load}>Restore saved values</Action><Action disabled={!loaded} action={save}
+    ><Icon name="check" />Save settings</Action
+  >
+</div>
+
 <style>
+  .settings-grid :global(.panel + .panel) {
+    margin-top: 0;
+  }
+  .settings-grid .form-stack > label {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    font-size: calc(12px * var(--ui-scale));
+    min-height: 44px;
+    gap: 12px;
+  }
+  .settings-grid label > select,
+  .settings-grid label > input:not([type='checkbox']) {
+    max-width: 55%;
+  }
+  .settings-grid .form-stack > label:has(textarea) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .settings-grid .check-row input {
+    order: 1;
+  }
+  .settings-section-title {
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
+    margin-top: 8px;
+  }
+  .settings-section-title h2,
+  .analysis-heading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .analysis-heading {
+    margin-bottom: 16px;
+  }
+  .settings-save {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    position: sticky;
+    bottom: -16px;
+    background: var(--bg);
+    padding: 12px 0;
+    margin-top: 12px;
+    border-top: 1px solid var(--border);
+    z-index: 2;
+  }
+
   .settings-grid {
     display: grid;
     grid-template-columns: minmax(0, 1.25fr) minmax(260px, 1fr);
@@ -205,7 +269,7 @@
     align-items: center;
     gap: 8px;
   }
-  @media (max-width: 1050px) {
+  @media (max-width: 950px) {
     .settings-grid {
       grid-template-columns: minmax(0, 1fr);
     }

--- a/frontend/observatory/components/Statistics.svelte
+++ b/frontend/observatory/components/Statistics.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { measured, record, type Telemetry, type RecordData } from '../runtime/host';
+  import { instances, measured, record, type Telemetry, type RecordData } from '../runtime/host';
+  import ResourceUsage from './ResourceUsage.svelte';
   import Metadata from './Metadata.svelte';
   let {
     telemetry,
@@ -7,6 +8,7 @@
   }: { telemetry: Telemetry; inspect: (title: string, row: RecordData) => void } = $props();
   let samples = $state<{ at: number; cpu: number | null; mem: number | null }[]>([]);
   let lastAt = 0;
+  let agents = $derived(instances(telemetry));
   let tokenOnly = $derived(
     telemetry.tokens.filter(
       (token) =>
@@ -68,7 +70,13 @@
                   (t) =>
                     typeof resource.instanceId === 'string' && t.instanceId === resource.instanceId,
                 )}<tr
-            ><td>{String(resource.instanceId ?? `Unattributed sample · PID ${resource.pid}`)}</td
+            ><td
+              >{agents.find(
+                (a) =>
+                  typeof resource.instanceId === 'string' && a.instanceId === resource.instanceId,
+              )?.name ?? 'Unattributed sample'}<small
+                >{String(resource.instanceId ?? `PID ${resource.pid}`)}</small
+              ></td
             ><td>{measured(resource.cpu) ?? 'Unavailable'}</td><td
               >{measured(resource.memMb) ?? 'Unavailable'}</td
             ><td>{resource.gpu ? JSON.stringify(resource.gpu) : 'Unavailable'}</td><td
@@ -84,29 +92,32 @@
 <section class="panel">
   <div class="panel-head"><h2>Monitoring counters & delivery</h2></div>
   <div class="inset">
-    <Metadata
-      value={{
-        ...telemetry.stats,
-        rendererRetention: {
-          evicted: telemetry.evicted,
-          sensitiveEvicted: telemetry.retainedEvicted,
-        },
-        aegisProcess: telemetry.own,
-      }}
-    />
+    <details>
+      <summary>View monitoring counters and delivery metadata</summary><Metadata
+        value={{
+          ...telemetry.stats,
+          rendererRetention: {
+            evicted: telemetry.evicted,
+            sensitiveEvicted: telemetry.retainedEvicted,
+          },
+          aegisProcess: telemetry.own,
+        }}
+      />
+    </details>
   </div>
 </section>
+<ResourceUsage {telemetry} {inspect} />
 
 <style>
   .chart {
     height: 180px;
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(60, minmax(0, 1fr));
     align-items: stretch;
     gap: 3px;
   }
   .chart button {
     position: relative;
-    flex: 1;
     min-width: 3px;
     background: transparent;
     border: 0;
@@ -119,7 +130,7 @@
     left: 0;
     right: 0;
     height: var(--height);
-    background: var(--green);
+    background: var(--muted);
     border-radius: 3px 3px 0 0;
   }
 </style>

--- a/frontend/observatory/runtime/artwork.ts
+++ b/frontend/observatory/runtime/artwork.ts
@@ -103,9 +103,13 @@ const artwork: Record<string, string> = {
 export function logo(id: string): string | null {
   const special: Record<string, string> = {
     'claude-code': 'claude.png',
+    'claude-desktop': 'claude.png',
+    'claude-computer-use': 'claude.png',
     'openai-codex': 'codex.png',
+    'openai-codex-cli': 'codex.png',
     codex: 'codex.png',
     cursor: 'cursor.png',
+    'cursor-ai': 'cursor.png',
     ollama: 'ollama.png',
   };
   return special[id]
@@ -113,4 +117,17 @@ export function logo(id: string): string | null {
     : artwork[id]
       ? 'assets/agents/catalog/' + artwork[id]
       : null;
+}
+
+/** Identify monochrome artwork that needs a light variant on dark surfaces.
+ * @param source Bundled asset path @returns Whether dark theme should invert it @since 0.14.1
+ */
+export function invertOnDark(source: string | null): boolean {
+  return [
+    'ollama.png',
+    'github-copilot.svg',
+    'zed-ai.png',
+    'void-editor.png',
+    'kilo-code.png',
+  ].some((file) => source?.endsWith('/' + file));
 }

--- a/frontend/observatory/runtime/icons.ts
+++ b/frontend/observatory/runtime/icons.ts
@@ -1,5 +1,6 @@
 /** Fixed Observatory vector elements. Host strings never become markup. */
 export const icons: Record<string, { tag: string; attrs: Record<string, string> }[]> = {
+  arrowLeft: [{ tag: 'path', attrs: { d: 'm15 5-7 7 7 7' } }],
   terminal: [{ tag: 'path', attrs: { d: 'm4 6 5 6-5 6m8 0h8' } }],
   balance: [
     { tag: 'path', attrs: { d: 'M12 3v18M6 21h12M4 7h16M5 7l-4 8h8L5 7Zm14 0-4 8h8l-4-8Z' } },

--- a/frontend/observatory/styles/layout.css
+++ b/frontend/observatory/styles/layout.css
@@ -1,26 +1,31 @@
 .app {
   display: grid;
-  grid-template-columns: 204px minmax(0, 1fr);
+  grid-template-columns: calc(184px + (var(--ui-scale) - 1) * 96px) minmax(0, 1fr);
   background: var(--bg);
 }
 .sidebar {
   background: var(--sidebar);
   border-right: 1px solid var(--border);
-  padding: 18px 12px;
+  padding: 16px 10px 10px;
+  min-height: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   min-width: 0;
 }
 .brand {
   color: var(--ink);
-  font-size: 22px;
+  font-size: calc(20px * var(--ui-scale));
   font-weight: 650;
   text-decoration: none;
   display: flex;
   align-items: center;
   gap: 8px;
+  padding-inline: 5px;
+  flex-shrink: 0;
 }
 .version {
+  display: none;
   font-size: 10px;
   color: var(--muted);
 }
@@ -28,9 +33,11 @@
   display: flex;
   gap: 10px;
   align-items: center;
-  padding: 16px 4px;
+  padding: 12px 5px;
   border-block: 1px solid var(--border);
-  margin: 18px 0;
+  margin: 16px 0 10px;
+  flex-shrink: 0;
+  font-size: calc(11px * var(--ui-scale));
 }
 .machine small {
   display: block;
@@ -41,31 +48,51 @@ nav {
   flex-direction: column;
   gap: 4px;
 }
+.sidebar nav {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 3px;
+  margin: 0 -3px;
+}
+.nav-divider {
+  border-top: 1px solid var(--border);
+  margin: 8px;
+  flex-shrink: 0;
+}
+.nav .count {
+  margin-left: auto;
+  border-radius: 5px;
+  padding: 0 5px;
+  background: var(--raised);
+}
 .nav {
   display: flex;
   gap: 10px;
   align-items: center;
   width: 100%;
-  min-height: 38px;
+  min-height: 36px;
+  flex-shrink: 0;
+  font-size: calc(12px * var(--ui-scale));
   text-align: left;
   background: transparent;
   color: var(--muted);
   border: 1px solid transparent;
   border-radius: 8px;
-  padding: 8px;
+  padding: 7px;
 }
 .nav:hover {
   background: var(--hover);
   color: var(--ink);
 }
 .nav.active {
-  background: var(--raised);
-  border-color: var(--strong-border);
+  background: var(--selection);
   color: var(--ink);
 }
 .sidebar-bottom {
   margin-top: auto;
-  padding-top: 20px;
+  padding-top: 10px;
+  flex-shrink: 0;
 }
 .sensor-mini {
   display: flex;
@@ -76,7 +103,9 @@ nav {
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 12px;
+  padding: 9px 7px;
+  font-size: calc(12px * var(--ui-scale));
+  margin-bottom: 7px;
   width: 100%;
 }
 .sensor-mini small {
@@ -86,14 +115,16 @@ nav {
 .sidebar-foot {
   color: var(--muted);
   font-size: 11px;
-  padding: 12px 4px 0;
+  padding: 8px 4px 0;
 }
 .topbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 10px 16px;
+  padding: 6px 16px;
+  min-height: 46px;
+  font-size: calc(11px * var(--ui-scale));
   border-bottom: 1px solid var(--border);
   background: var(--sidebar);
 }
@@ -101,6 +132,20 @@ nav {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--muted);
+}
+.breadcrumb strong {
+  color: var(--ink);
+  font-weight: 400;
+}
+.command-trigger {
+  background: transparent;
+  border-color: transparent;
 }
 .icon-button,
 .button,
@@ -113,8 +158,9 @@ nav {
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 8px;
-  min-height: 34px;
+  min-height: 32px;
   padding: 7px 11px;
+  font-size: calc(11px * var(--ui-scale));
 }
 .icon-button {
   min-width: 34px;
@@ -133,27 +179,108 @@ kbd {
   padding: 1px 4px;
 }
 main {
-  padding: 16px;
+  padding: 0 16px 16px;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+}
+.workspace-navigation {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 44px;
+  flex-shrink: 0;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+  min-width: 0;
+}
+.history-controls {
+  display: flex;
+  gap: 2px;
+  padding-right: 12px;
+  border-right: 1px solid var(--border);
+}
+.history-arrow {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  border-radius: 6px;
+}
+.history-arrow:hover:not(:disabled) {
+  background: var(--raised);
+}
+.workspace-tabs {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  height: 100%;
+  align-items: center;
+}
+.workspace-tabs > div {
+  display: flex;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+  border-radius: 7px;
+}
+.workspace-tabs > div.active {
+  background: var(--selection);
+  border-color: var(--selection-border);
+}
+.workspace-tabs button {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 11px;
+  font-size: calc(11px * var(--ui-scale));
+  white-space: nowrap;
+}
+.workspace-tabs button + button {
+  padding-inline: 6px;
+}
+.workspace-tabs .icon {
+  width: 14px;
+  height: 14px;
 }
 .page-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 16px;
+  margin: 0 -16px 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  min-height: 58px;
+  flex-shrink: 0;
+  background: var(--bg);
 }
 .page-title {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 .live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   color: var(--muted);
-  font-size: 12px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 3px 7px;
+  font-size: calc(11px * var(--ui-scale));
+}
+h1 {
+  font-size: calc(21px * var(--ui-scale));
+}
+.page-title > .icon {
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+}
+.page-actions {
+  display: flex;
+  gap: 8px;
 }
 .panel {
   background: var(--panel);
@@ -162,6 +289,8 @@ main {
   min-width: 0;
 }
 .panel-head {
+  background: var(--panel-head);
+  border-radius: 11px 11px 0 0;
   padding: 12px 16px;
   border-bottom: 1px solid var(--border);
   display: flex;
@@ -169,6 +298,81 @@ main {
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+}
+.panel-head h2 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.panel-head p {
+  color: var(--muted);
+  font-size: calc(11px * var(--ui-scale));
+  margin-top: 3px;
+}
+.segmented {
+  display: inline-flex;
+  flex-wrap: wrap;
+  background: var(--bg);
+  padding: 3px;
+  border-radius: 8px;
+  gap: 2px;
+}
+.segmented button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 9px;
+  min-height: 27px;
+  font-size: calc(11px * var(--ui-scale));
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--muted);
+}
+.segmented button[aria-pressed='true'] {
+  background: var(--selection);
+  border-color: var(--selection-border);
+  color: var(--ink);
+}
+.segmented .icon {
+  width: 14px;
+  height: 14px;
+}
+.badge.medium {
+  color: var(--amber);
+  border-color: var(--amber);
+}
+.section-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.section-tabs button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--muted);
+  font-size: calc(12px * var(--ui-scale));
+}
+.section-tabs button[aria-pressed='true'] {
+  background: var(--selection);
+  border-color: var(--selection-border);
+  color: var(--ink);
+}
+.notice {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: calc(11px * var(--ui-scale));
 }
 .panel-head > span {
   color: var(--muted);
@@ -199,8 +403,8 @@ th {
 }
 td {
   border-top: 1px solid var(--border);
-  padding: 12px 14px;
-  vertical-align: top;
+  padding: 10px 12px;
+  vertical-align: middle;
 }
 tr:hover td {
   background: color-mix(in srgb, var(--raised) 40%, transparent);
@@ -222,15 +426,46 @@ tr.selected td {
   border-color: var(--red);
 }
 footer {
+  min-height: 30px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 12px;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border-top: 1px solid var(--border);
   background: var(--sidebar);
   color: var(--muted);
   font-size: 11px;
+}
+@media (max-width: 1100px) {
+  .app {
+    grid-template-columns: 164px minmax(0, 1fr);
+  }
+  .command-trigger kbd {
+    display: none;
+  }
+}
+@media (max-height: 700px) {
+  .machine {
+    display: none;
+  }
+  .brand {
+    margin-bottom: 12px;
+  }
+  .sensor-mini small {
+    display: none;
+  }
+}
+@media (max-width: 850px) {
+  .breadcrumb {
+    display: none;
+  }
+  .topbar {
+    justify-content: flex-end;
+  }
+  footer {
+    flex-wrap: wrap;
+  }
 }
 footer button {
   display: flex;

--- a/frontend/observatory/styles/theme.css
+++ b/frontend/observatory/styles/theme.css
@@ -81,7 +81,9 @@
   box-sizing: border-box;
 }
 html {
-  scrollbar-gutter: stable;
+  height: 100%;
+  overflow: hidden;
+  scrollbar-gutter: auto;
 }
 body {
   margin: 0;
@@ -234,4 +236,30 @@ code {
   animation: none !important;
   transition: none !important;
   scroll-behavior: auto !important;
+}
+
+/* Selection and status palette from the reviewed Observatory prototype. */
+:root {
+  --selection: #41454a;
+  --selection-border: #797f86;
+  --amber: #ffbd3e;
+  --amber-bg: #312719;
+  --red: #ff6262;
+  --red-bg: #321f22;
+  --green: #4bc68b;
+  --green-bg: #1e3027;
+}
+:root[data-theme^='light'] {
+  --selection: #fff;
+  --selection-border: #92989e;
+  --amber: #975200;
+  --amber-bg: #fff4db;
+  --red: #bd242e;
+  --red-bg: #fff0f0;
+  --green: #16734a;
+  --green-bg: #e8f5ed;
+}
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--strong-border) transparent;
 }

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -72,6 +72,46 @@ try {
   await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
   await page.getByRole('button', { name: 'Select Claude Code, PID 10000', exact: true }).waitFor();
   assert.equal(await page.evaluate(() => window.bridgeCalls), 0);
+  // Measured from the reviewed dialogs-14 prototype at 1200x800. These checks
+  // catch a functioning renderer that has silently replaced the approved layout.
+  const geometry = await page.evaluate(() => {
+    const rect = (selector) => {
+      const r = document.querySelector(selector).getBoundingClientRect();
+      return { x: r.x, y: r.y, width: r.width, height: r.height };
+    };
+    return {
+      sidebar: rect('.sidebar'),
+      topbar: rect('.topbar'),
+      history: rect('.workspace-navigation'),
+      summary: rect('.summary-strip'),
+      radar: rect('.radar-panel'),
+      inspector: rect('.inspector'),
+    };
+  });
+  assert.equal(geometry.sidebar.width, 184, 'prototype sidebar density');
+  assert(Math.abs(geometry.topbar.height - 46) <= 2, 'prototype toolbar height');
+  assert.equal(geometry.history.height, 44, 'prototype workspace history row');
+  assert(Math.abs(geometry.summary.y - 160) <= 4, 'prototype summary position');
+  assert(Math.abs(geometry.radar.y - geometry.inspector.y) < 1, 'inspector aligns with radar');
+  assert.equal(await page.locator('.summary-strip > div').count(), 6);
+  assert.equal(await page.locator('.radar-agent-card').count(), 4);
+  const sweep = await page.locator('.dial-sweep').elementHandle();
+  await page.getByRole('button', { name: 'Select Claude Code, PID 10000', exact: true }).click();
+  await page.getByRole('button', { name: 'Files', exact: true }).click();
+  await page.getByRole('button', { name: 'Radar', exact: true }).click();
+  assert(
+    await sweep.evaluate((node) => node === document.querySelector('.dial-sweep')),
+    'layer switch recreates sweep',
+  );
+  await page
+    .getByRole('button', { name: 'Clear radar selection', exact: true })
+    .click({ position: { x: 10, y: 70 } });
+  assert.equal(await page.locator('.radar-point[aria-pressed="true"]').count(), 0);
+  assert(
+    await sweep.evaluate((node) => node === document.querySelector('.dial-sweep')),
+    'clearing selection recreates sweep',
+  );
+  await writeFile(resolve(out, 'prototype-geometry.json'), JSON.stringify(geometry, null, 2));
   const views = [
     'Monitoring',
     'Agents',
@@ -100,11 +140,14 @@ try {
         await page.evaluate((theme) => (document.documentElement.dataset.theme = theme), theme);
         await page.emulateMedia({ reducedMotion: scale === 1.5 ? 'reduce' : 'no-preference' });
         for (const view of views) {
-          await page
-            .getByRole('navigation', { name: 'Main navigation' })
-            .getByRole('button', { name: view, exact: true })
-            .click();
+          await page.locator('.sidebar').getByRole('button', { name: view, exact: true }).click();
           await page.getByRole('heading', { name: view, exact: true, level: 1 }).waitFor();
+          const activeTabVisible = await page.evaluate(() => {
+            const strip = document.querySelector('.workspace-tabs').getBoundingClientRect();
+            const tab = document.querySelector('.workspace-tabs > .active').getBoundingClientRect();
+            return tab.left >= strip.left - 2 && tab.right <= strip.right + 2;
+          });
+          assert(activeTabVisible, `active workspace tab hidden: ${view} ${size.width} ${scale}`);
           const overflow = await page.evaluate(
             () => document.documentElement.scrollWidth > innerWidth + 2,
           );
@@ -113,6 +156,42 @@ try {
             false,
             `document overflow: ${view} ${size.width} ${scale} ${theme}`,
           );
+          if (size.width === 1200 && scale === 1 && theme === 'dark') {
+            await page.screenshot({ path: resolve(out, `workspace-${views.indexOf(view)}.png`) });
+            if (view === 'AI analysis') {
+              const panels = await page.evaluate(() => {
+                const config = document.querySelector('.analysis-config').getBoundingClientRect();
+                const report = document.querySelector('.analysis-report').getBoundingClientRect();
+                return {
+                  aligned: Math.abs(config.y - report.y) < 1,
+                  configWidth: config.width,
+                  reportWidth: report.width,
+                  bottom: report.bottom,
+                };
+              });
+              assert(
+                panels.aligned && panels.reportWidth > panels.configWidth * 2,
+                'prototype assessment columns',
+              );
+              assert(panels.bottom <= 770, 'assessment report extends under footer');
+            }
+            if (view === 'Settings') {
+              const row = await page
+                .locator('.check-row')
+                .first()
+                .evaluate((row) => ({
+                  direction: getComputedStyle(row).flexDirection,
+                  checkbox: row.querySelector('input').getBoundingClientRect().x,
+                  label: row.getBoundingClientRect().x,
+                }));
+              assert.equal(
+                row.direction,
+                'row',
+                'checkbox form styles regressed to stacked labels',
+              );
+              assert(row.checkbox > row.label + 100, 'checkbox is not aligned on right');
+            }
+          }
         }
       }
     }
@@ -122,10 +201,7 @@ try {
     document.documentElement.style.setProperty('--ui-scale', '1');
     document.documentElement.dataset.theme = 'dark';
   });
-  await page
-    .getByRole('navigation')
-    .getByRole('button', { name: 'Monitoring', exact: true })
-    .click();
+  await page.locator('.sidebar').getByRole('button', { name: 'Monitoring', exact: true }).click();
   await page.emulateMedia({ reducedMotion: 'no-preference' });
   const frameIntervals = await page.evaluate(
     () =>
@@ -159,7 +235,7 @@ try {
   );
   await page.screenshot({ path: resolve(out, 'monitoring.png') });
   await page.getByRole('button', { name: 'Select Claude Code, PID 10000', exact: true }).click();
-  await page.getByRole('button', { name: 'Open instance details', exact: true }).click();
+  await page.getByRole('button', { name: 'Process details', exact: true }).click();
   const dialog = page.getByRole('dialog');
   await dialog.waitFor();
   await page.screenshot({ path: resolve(out, 'instance.png') });

--- a/frontend/observatory/tests/electron-smoke.mjs
+++ b/frontend/observatory/tests/electron-smoke.mjs
@@ -68,10 +68,7 @@ try {
     'Statistics',
     'Settings',
   ]) {
-    await window
-      .getByRole('navigation', { name: 'Main navigation' })
-      .getByRole('button', { name, exact: true })
-      .click();
+    await window.locator('.sidebar').getByRole('button', { name, exact: true }).click();
     await window.getByRole('heading', { level: 1, name, exact: true }).waitFor();
   }
   await window.getByLabel('Scan interval (seconds)').fill('20');
@@ -127,10 +124,7 @@ try {
     await window.evaluate(async () => (await window.aegis.getSettings()).anthropicApiKey),
     sentinel,
   );
-  await window
-    .getByRole('navigation')
-    .getByRole('button', { name: 'Monitoring', exact: true })
-    .click();
+  await window.locator('.sidebar').getByRole('button', { name: 'Monitoring', exact: true }).click();
   await window.screenshot({ path: resolve(out, 'desktop.png') });
   const hardening = await app.evaluate(({ BrowserWindow }) => {
     const prefs = BrowserWindow.getAllWindows()[0].webContents.getLastWebPreferences();

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -37,7 +37,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (frontend/observatory/) — Svelte 5 + Vite 7
-17 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
+20 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
 
 App.svelte owns workspace tabs, history and the host connection. Monitoring shows stamped instances; Events and ActivityChart show retained evidence; Details and EntityLinks connect observations; Rules, Catalog, Analysis, Reports, Statistics and Settings expose host actions. SensorStatus renders effective sensor IDs; Notifications tracks anomaly crossings.
 

--- a/tests/renderer/components/Observatory.test.js
+++ b/tests/renderer/components/Observatory.test.js
@@ -38,11 +38,11 @@ describe('Observatory production components', () => {
       inspect,
     });
     await fireEvent.click(screen.getByRole('button', { name: 'Select Claude Code, PID 102' }));
-    await fireEvent.click(screen.getByRole('button', { name: 'Open instance details' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Process details' }));
     expect(inspect.mock.calls[0][1].instanceId).toBe('102:1');
     expect(screen.queryByText('99.9%')).toBeNull();
     await fireEvent.click(screen.getByRole('button', { name: 'Clear radar selection' }));
-    expect(screen.queryByRole('button', { name: 'Open instance details' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Process details' })).toBeNull();
   });
 
   it('preserves permission drafts across new snapshots and preserves other project overrides on save', async () => {
@@ -59,7 +59,7 @@ describe('Observatory production components', () => {
     await fireEvent.change(screen.getByLabelText('Target'), { target: { value: 'Claude Code' } });
     await fireEvent.click(screen.getByRole('button', { name: 'strict', exact: true }));
     await mounted.rerender({ host, telemetry: telemetry() });
-    expect(screen.getByLabelText('network')).toHaveValue('block');
+    expect(screen.getByLabelText('Network')).toHaveValue('block');
     await fireEvent.click(screen.getByRole('button', { name: 'Save permissions' }));
     await waitFor(() => expect(host.saveAgentPermissions).toHaveBeenCalled());
     expect(host.saveAgentPermissions.mock.calls[0][0]).toMatchObject({
@@ -82,7 +82,7 @@ describe('Observatory production components', () => {
       saveSettings: vi.fn(async () => ({ success: false, error: 'Disk full' })),
     };
     const appearance = vi.fn();
-    const { container } = render(Settings, { host, appearance });
+    const { container } = render(Settings, { host, appearance, navigate: noOp });
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Save settings' })).toBeEnabled(),
     );
@@ -111,11 +111,12 @@ describe('Observatory production components', () => {
       downloadUpdate: vi.fn(async () => ({ status: 'downloading' })),
       installUpdate: vi.fn(async () => ({ status: 'ready' })),
     };
-    const { container } = render(Settings, { host, appearance: noOp });
+    const { container } = render(Settings, { host, appearance: noOp, navigate: noOp });
+    expect(await screen.findByText('<img src=x onerror=alert(1)>')).toBeInTheDocument();
     await fireEvent.click(await screen.findByRole('button', { name: 'Download update' }));
     expect(host.downloadUpdate).toHaveBeenCalledOnce();
     expect(host.installUpdate).not.toHaveBeenCalled();
-    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('img[src="x"], img[onerror]')).toBeNull();
     push({ status: 'ready' });
     await fireEvent.click(await screen.findByRole('button', { name: 'Install and restart' }));
     expect(host.installUpdate).toHaveBeenCalledOnce();
@@ -135,7 +136,7 @@ describe('Observatory production components', () => {
         .mockResolvedValueOnce(page)
         .mockResolvedValueOnce([{ timestamp, eventId: 100, type: 'file-access' }]),
     };
-    render(Reports, { host, audit: true, inspect: noOp });
+    render(Reports, { host, audit: true, inspect: noOp, telemetry: telemetry(), navigate: noOp });
     await screen.findByText('99');
     const older = screen.getByText('Load older entries');
     await fireEvent.click(older);
@@ -145,7 +146,12 @@ describe('Observatory production components', () => {
   });
 
   it('keeps cancelled exports visible as incomplete', async () => {
-    render(Reports, { host: { exportLog: async () => ({ success: false }) }, inspect: noOp });
+    render(Reports, {
+      host: { exportLog: async () => ({ success: false }) },
+      inspect: noOp,
+      telemetry: telemetry(),
+      navigate: noOp,
+    });
     await fireEvent.click(screen.getAllByRole('button', { name: 'Export', exact: true })[0]);
     expect(await screen.findByRole('alert')).toHaveTextContent('cancelled');
     expect(screen.queryByText('Completed')).toBeNull();
@@ -162,6 +168,7 @@ describe('Observatory production components', () => {
     const mounted = render(Analysis, { host, telemetry: telemetry(), visible: true });
     await waitFor(() => expect(screen.getByRole('button', { name: 'Run analysis' })).toBeEnabled());
     expect(host.analyzeSession).not.toHaveBeenCalled();
+    await fireEvent.click(screen.getByRole('button', { name: 'Connection settings' }));
     await fireEvent.input(screen.getByLabelText('New API key'), {
       target: { value: 'unsaved-secret' },
     });
@@ -169,7 +176,7 @@ describe('Observatory production components', () => {
     expect(screen.getByLabelText('New API key')).toHaveValue('');
     await fireEvent.click(screen.getByRole('button', { name: 'Run analysis' }));
     expect(await screen.findByText('<img src=x>')).toBeInTheDocument();
-    expect(mounted.container.querySelector('img')).toBeNull();
+    expect(mounted.container.querySelector('img[src="x"], img[onerror]')).toBeNull();
     expect(mounted.container.innerHTML).not.toContain('stored-secret');
   });
 


### PR DESCRIPTION
The first Observatory integration changed the reviewed prototype's layout. This restores its compact navigation and summary strip, radar activity cards and inspector, assessment columns, permission profiles, catalog rows, report summary and settings alignment while keeping the real host integration.

Also fixes hidden active tabs, dark artwork and missing Cursor/Codex aliases, vertically stacked checkboxes and full-width single resource samples. Observation metadata stays available in detail disclosures.

Validation: 2851 passing tests (4 skipped); type checks, lint, formatting, witness/sequence gates and production dependency audit; 132 browser viewport/theme/scale cases. Browser assertions compare measured prototype geometry, checkbox alignment, assessment proportions, active-tab visibility and radar element stability.

The Windows package passed an isolated-profile Electron smoke with 22 observed instances, all eleven workspaces, six real export handlers and settings persistence across restart. No paid provider request or intervention against user processes was performed. The installer was built locally without publishing a release.
