### PR TITLE
fix(ui): group agent processes and correct theme behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+- Show one row per agent in tables, resource charts and token summaries, with individual processes inside the agent overview. Aggregate complete measurements without replacing unknown values with zero.
+- Preserve the template's neutral surfaces in high contrast, strengthen text and controls, and make the ordinary theme toggle leave high contrast. Keep Settings synchronized with toolbar changes and prevent late startup settings from undoing a theme choice.
 - Use the approved Observatory template styles and markup throughout the desktop: radar and linked resources, activity charts, permissions, catalog, analysis, reports, settings and dialogs. Retire the superseded layout and design guidance.
 - Group multiple observed processes on the radar with an explicit instance selector; retain stable scan animation, view pause, detail history and keyboard focus.
 - Fix unavailable process controls on enriched rows, stale stop confirmations, external website commands, cramped permission labels and long event lists in process details.

--- a/OBSERVATORY-INTEGRATION.md
+++ b/OBSERVATORY-INTEGRATION.md
@@ -2,6 +2,14 @@
 
 The earlier integrations passed functional gates but did not preserve the reviewed template closely enough. Their validation below is historical evidence, not visual approval of the current interface.
 
+## Agent grouping and theme follow-up — 2026-09-09
+
+The radar grouped processes, but agent tables, resource bars, token summaries and activity filters still repeated product names. They now show one entry per agent. Product details expose the individual stamped processes; a group itself has no process-control target. CPU/RAM and token totals remain unknown when member measurements are incomplete, file totals count distinct retained paths, and risk is the highest member score.
+
+High contrast retains the template's neutral surfaces and strengthens text, focus and interactive boundaries. The toolbar and keyboard theme toggles leave high contrast, matching the reference interaction. Settings follows toolbar theme changes without losing other drafts, and delayed startup settings cannot overwrite a new theme choice. The initial renderer surface is light, matching the host default; saved choices still take precedence.
+
+Validation: 159 test files, 2864 passed and 4 skipped with coverage; both renderer builds; 264 browser viewport/theme/scale combinations including all four themes, high-contrast readability and theme persistence; repository type, Svelte, format, lint, witness, sequence and inventory checks. The packaged Windows app exercised 25 real processes, unique product rows, group details, all eleven workspaces, settings restart and six exports. All 114 packaged renderer files match the final build byte for byte. Native macOS/Linux and paid provider requests remain outside this check.
+
 ## Template restoration — 2026-09-09
 
 Working branch: codex/observatory-template-restoration, based on 09bdc9b. The approved template is preserved in frontend/observatory/reference/; its twelve stylesheets are used directly in their source order. Superseded theme/layout styles were removed. Local project design/context skills and the UI agent instructions no longer direct work toward the retired designs.

--- a/frontend/observatory/App.svelte
+++ b/frontend/observatory/App.svelte
@@ -40,6 +40,7 @@
   let paused = $state(false);
   let held = $state(emptyTelemetry());
   let displayTelemetry = $derived(paused ? held : telemetry);
+  const agentCount = $derived(new Set(displayTelemetry.agents.map((agent) => agent.agent)).size);
   const healthCaption = $derived(
     record(telemetry.stats.appHealth).state === 'HEALTHY'
       ? 'Monitoring available'
@@ -69,13 +70,14 @@
   let detail = $state<{ title: string; row: RecordData } | null>(null);
   let version = $state('');
   const savedTheme = localStorage.getItem('aegis-theme');
-  let dark = $state(savedTheme ? savedTheme.startsWith('dark') : true);
+  let dark = $state(savedTheme ? savedTheme.startsWith('dark') : false);
   let contrast = $state(localStorage.getItem('aegis-theme')?.endsWith('-hc') ?? false);
   let scale = $state(1);
   let commands = $state(false);
   let commandQuery = $state('');
   let commandDialog: HTMLDialogElement;
   let navigationRevision = 0;
+  let themeChanged = false;
   $effect(() => {
     if (commands && !commandDialog?.open) commandDialog?.showModal();
     else if (!commands && commandDialog?.open) commandDialog.close();
@@ -85,9 +87,15 @@
     detail = { title, row };
   }
   function appearance(nextDark: boolean, nextScale: number, highContrast = contrast) {
+    themeChanged = true;
     contrast = highContrast;
     dark = nextDark;
     scale = nextScale;
+  }
+  function toggleTheme() {
+    themeChanged = true;
+    dark = !dark;
+    contrast = false;
   }
   $effect(() => {
     const theme = (dark ? 'dark' : 'light') + (contrast ? '-hc' : '');
@@ -141,7 +149,7 @@
     });
     connection = stop;
     const unsubscribe = host?.onToggleTheme
-      ? Reflect.apply(host.onToggleTheme, host, [() => (dark = !dark)])
+      ? Reflect.apply(host.onToggleTheme, host, [toggleTheme])
       : undefined;
     invoke(host, 'getAppVersion')
       .then((value) => {
@@ -152,10 +160,10 @@
       .then((value) => {
         if (alive) {
           const settings = record(value);
-          appearance(
-            savedTheme ? savedTheme.startsWith('dark') : settings.darkMode === true,
-            Number(settings.uiScale ?? 1),
-          );
+          if (!themeChanged) {
+            dark = savedTheme ? savedTheme.startsWith('dark') : settings.darkMode === true;
+            scale = Number(settings.uiScale ?? 1);
+          }
         }
       })
       .catch(() => {});
@@ -200,7 +208,7 @@
     )
       return;
     if (event.key === 's') void navigate('settings');
-    if (event.key === 't') dark = !dark;
+    if (event.key === 't') toggleTheme();
     const keys: Record<string, string> = {
       '1': 'overview',
       '2': 'events',
@@ -237,7 +245,7 @@
           aria-current={view === id ? 'page' : undefined}
           onclick={() => navigate(id)}
           ><Icon name={icon} /><span>{label}</span>{#if id === 'agents'}<small class="count"
-              >{telemetry.ready ? telemetry.agents.length : '—'}</small
+              >{displayTelemetry.ready ? agentCount : '—'}</small
             >{/if}</button
         >{/each}
     </nav>
@@ -268,7 +276,7 @@
       <div class="top-actions">
         <button class="command-trigger" onclick={() => (commands = !commands)}
           ><Icon name="search" />Commands<kbd>Ctrl K</kbd></button
-        ><button class="icon-button" aria-label="Toggle theme" onclick={() => (dark = !dark)}
+        ><button class="icon-button" aria-label="Toggle theme" onclick={toggleTheme}
           ><Icon name="sun" /></button
         >
         <button class="icon-button" aria-label="Open settings" onclick={() => navigate('settings')}
@@ -395,7 +403,12 @@
             <Reports {host} audit {inspect} telemetry={displayTelemetry} {navigate} />
           </div>{/if}
         {#if tabs.includes('settings')}<div hidden={view !== 'settings'}>
-            <Settings {host} {appearance} {navigate} />
+            <Settings
+              {host}
+              {appearance}
+              {navigate}
+              currentTheme={(dark ? 'dark' : 'light') + (contrast ? '-hc' : '')}
+            />
           </div>{/if}
         <div hidden={view !== 'stats'}><Statistics telemetry={displayTelemetry} {inspect} /></div>
       </div>

--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -5,7 +5,9 @@ The approved visual source is preserved in reference/ui/ and reference/DESIGN.md
 Preserve the template's composition, hierarchy, spacing, typography, artwork, controls, radar and dialogs while connecting real telemetry through runtime/host.ts. Runtime behavior is implemented in Svelte; simulated observations must never enter a desktop build.
 
 Live-data adaptations:
-- Radar groups processes by agent identity and pages four groups at a time. A group opens an explicitly chosen stamped process; process counts and the instance selector make grouping visible. Distance represents risk, as in the template.
+- Radar, agent tables and resource charts group processes by agent identity. Radar pages four groups at a time. Product rows open an overview; its process list and the radar instance selector open explicitly chosen stamped processes. Distance represents risk, as in the template.
+- Group usage totals require every member to be measured; risk is the highest member score, Files counts distinct retained paths, and Network counts observed connections. Product grouping never supplies a process action identity.
+- High contrast keeps the template's neutral surfaces and strengthens text, focus and interactive boundaries. The toolbar theme toggle returns to ordinary light/dark, matching the template; high contrast is selected explicitly in Settings.
 - An unavailable measurement is shown as a dash. Sensor outages pause the sweep and disable process control.
 - API configuration and analysis controls reflect supported host capabilities. A retained report is labeled with its actual evidence scope.
 - Settings and policy drafts survive view navigation; failed saves retain inputs. Unsaved provider keys are cleared when their dialog or workspace closes.

--- a/frontend/observatory/components/ActivityChart.svelte
+++ b/frontend/observatory/components/ActivityChart.svelte
@@ -14,15 +14,13 @@
   } = $props();
   let period = $state(15 * 60000),
     type = $state('all'),
-    instance = $state(''),
+    agent = $state(''),
     hover = $state<number | null>(null),
     focus = $state(0);
   let end = $derived(Math.max(observedAt ?? 0, ...events.map((e) => e.timestamp)) + 1);
   let bins = $derived(
     activityBins(
-      events.filter(
-        (e) => (!instance || e.instanceId === instance) && (type === 'all' || e.sensitive),
-      ),
+      events.filter((e) => (!agent || e.agent === agent) && (type === 'all' || e.sensitive)),
       end,
       period,
     ),
@@ -30,9 +28,7 @@
   let maximum = $derived(
     Math.max(5, Math.ceil(Math.max(1, ...bins.map((b) => b.events.length)) / 5) * 5),
   );
-  let identities = $derived([
-    ...new Map(events.filter((e) => e.instanceId).map((e) => [e.instanceId!, e.agent])).entries(),
-  ]);
+  let names = $derived([...new Set(events.map((e) => e.agent).filter(Boolean))].sort());
   function caption(i: number) {
     const b = bins[i];
     return `${new Date(b.start).toLocaleTimeString()}–${new Date(b.end).toLocaleTimeString()} · ${b.events.length} observations`;
@@ -68,9 +64,9 @@
       ><option value="all">All file events</option><option value="sensitive"
         >Sensitive events</option
       ></select
-    ><select aria-label="Chart agent" bind:value={instance}
-      ><option value="">All instances</option>{#each identities as [id, name] (id)}<option
-          value={id}>{name ?? 'Unknown'} · {id.split(':').at(-1)}</option
+    ><select aria-label="Chart agent" bind:value={agent}
+      ><option value="">All agents</option>{#each names as name (name)}<option value={name}
+          >{name}</option
         >{/each}</select
     >
   </div>

--- a/frontend/observatory/components/Agents.svelte
+++ b/frontend/observatory/components/Agents.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
-  import { instances, measured, type RecordData, type Telemetry } from '../runtime/host';
-  import { riskBand } from '../runtime/radar';
+  import { instances, type RecordData, type Telemetry } from '../runtime/host';
+  import {
+    radarGroups,
+    groupResource,
+    groupEvidence,
+    groupRecord,
+    riskBand,
+  } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   let {
@@ -8,26 +14,27 @@
     inspect,
   }: { telemetry: Telemetry; inspect: (title: string, row: RecordData) => void } = $props();
   let query = $state(''),
-    sort = $state('riskScore'),
+    sort = $state('risk'),
     descending = $state(true);
-  function metric(id: string | null, key: string) {
-    return !id || telemetry.stale
-      ? null
-      : measured(telemetry.resources.find((r) => r.instanceId === id)?.[key]);
-  }
   let agents = $derived(
-    instances(telemetry)
+    radarGroups(instances(telemetry))
       .filter((a) =>
-        `${a.name} ${a.pid} ${a.cwd ?? ''}`.toLowerCase().includes(query.toLowerCase()),
+        `${a.name} ${a.members.map((m) => `${m.pid} ${m.cwd ?? ''}`).join(' ')}`
+          .toLowerCase()
+          .includes(query.toLowerCase()),
       )
+      .map((a) => ({
+        ...a,
+        ...groupEvidence(a, telemetry),
+        cpu: groupResource(a, telemetry, 'cpu'),
+        memMb: groupResource(a, telemetry, 'memMb'),
+      }))
       .sort(
         (a, b) =>
           (sort === 'name'
             ? a.name.localeCompare(b.name)
-            : sort === 'cpu' || sort === 'memMb'
-              ? (metric(a.instanceId, sort) ?? -1) - (metric(b.instanceId, sort) ?? -1)
-              : Number((a as unknown as RecordData)[sort]) -
-                Number((b as unknown as RecordData)[sort])) * (descending ? -1 : 1),
+            : Number((a as unknown as RecordData)[sort] ?? -1) -
+              Number((b as unknown as RecordData)[sort] ?? -1)) * (descending ? -1 : 1),
       ),
   );
 </script>
@@ -36,21 +43,23 @@
   <label class="search-field"
     ><Icon name="search" /><input
       type="search"
-      aria-label="Search instances"
+      aria-label="Search agents"
       placeholder="Find agent, PID or project"
       bind:value={query}
     /></label
   ><label
     >Sort by<select bind:value={sort}
-      ><option value="riskScore">Risk</option><option value="name">Name</option><option value="cpu"
+      ><option value="risk">Risk</option><option value="name">Name</option><option value="cpu"
         >CPU</option
-      ><option value="memMb">RAM</option><option value="fileCount">Files</option><option
-        value="networkCount">Network</option
+      ><option value="memMb">RAM</option><option value="files">Files</option><option value="network"
+        >Network</option
       ></select
     ></label
   ><button class="button" onclick={() => (descending = !descending)}
     >{descending ? 'Descending' : 'Ascending'}</button
-  ><span class="spacer"></span><span class="filter-count">{agents.length} instances</span>
+  ><span class="spacer"></span><span class="filter-count"
+    >{agents.length} agents · {agents.reduce((sum, a) => sum + a.members.length, 0)} processes</span
+  >
 </div>
 <section class="panel">
   <div class="table-wrap">
@@ -62,44 +71,34 @@
           ><th>Tokens</th><th>Cost</th><th>Latest event</th><th></th></tr
         ></thead
       ><tbody>
-        {#each agents as a (a.instanceId ?? a)}{@const token = telemetry.tokens.find(
-            (t) => !!a.instanceId && t.instanceId === a.instanceId,
-          )}{@const latest = telemetry.events
-            .filter((e) => !!a.instanceId && e.instanceId === a.instanceId)
-            .sort((x, y) => y.timestamp - x.timestamp)[0]}<tr class="agent-instance-row"
+        {#each agents as a (a.key)}<tr class="agent-group-row"
             ><td
-              ><button
-                class="table-agent"
-                onclick={() => inspect(a.name, a as unknown as RecordData)}
-                ><AgentLogo id={a.agent} name={a.name} /><strong>{a.name}</strong></button
-              ><button
-                class="entity-link mono"
-                onclick={() => inspect(a.name, a as unknown as RecordData)}>PID {a.pid}</button
+              ><button class="table-agent" onclick={() => inspect(a.name, groupRecord(a))}
+                ><AgentLogo id={a.key} name={a.name} /><strong>{a.name}</strong></button
+              ><button class="entity-link" onclick={() => inspect(a.name, groupRecord(a))}
+                >{a.members.length}
+                {a.members.length === 1 ? 'process' : 'processes'}<Icon name="chevron" /></button
               ></td
             ><td><span class="badge low">{telemetry.stale ? 'Last snapshot' : 'Active'}</span></td
             ><td
-              ><span class={`risk-value ${riskBand(a.riskScore)}`}
-                >{a.riskScore}<small>/100</small></span
+              ><span
+                class={`risk-value ${riskBand(a.risk)}`}
+                title="Highest risk among this agent's processes">{a.risk}<small>/100</small></span
               ></td
-            ><td class="mono">{metric(a.instanceId, 'cpu')?.toFixed(1) ?? '—'}%</td><td class="mono"
-              >{metric(a.instanceId, 'memMb')?.toFixed(1) ?? '—'} MB</td
-            ><td>{a.fileCount}</td><td>{a.networkCount}</td><td
-              >{measured(token?.totalTokens)?.toLocaleString() ?? '—'}</td
+            ><td class="mono">{a.cpu === null ? '—' : a.cpu.toFixed(1) + '%'}</td><td class="mono"
+              >{a.memMb === null ? '—' : a.memMb.toFixed(1) + ' MB'}</td
+            ><td>{a.files}</td><td>{a.network}</td><td>{a.tokens?.toLocaleString() ?? '—'}</td><td
+              >{a.cost === null ? '—' : '$' + a.cost.toFixed(2)}</td
+            ><td class="mono"
+              >{a.latest === null ? '—' : new Date(a.latest).toLocaleTimeString()}</td
             ><td
-              >{measured(token?.costUsd) === null
-                ? '—'
-                : '$' + Number(token?.costUsd).toFixed(2)}</td
-            ><td class="mono">{latest ? new Date(latest.timestamp).toLocaleTimeString() : '—'}</td
-            ><td
-              ><button
-                class="text-button"
-                onclick={() => inspect(a.name, a as unknown as RecordData)}
+              ><button class="text-button" onclick={() => inspect(a.name, groupRecord(a))}
                 >Open<Icon name="chevron" /></button
               ></td
             ></tr
           >{:else}<tr
             ><td colspan="11"
-              >{telemetry.ready ? 'No matching instances.' : 'Waiting for scan data.'}</td
+              >{telemetry.ready ? 'No matching agents.' : 'Waiting for scan data.'}</td
             ></tr
           >{/each}
       </tbody>
@@ -107,6 +106,6 @@
   </div>
 </section>
 <div class="notice" style="margin-top:18px">
-  <Icon name="cpu" />Usage is per process instance. A dash means no measurement is available. Token
-  costs are estimates.
+  <Icon name="cpu" />One row per agent. Usage combines its processes; risk shows the highest process
+  score. A dash means the total is incomplete. Open an agent to inspect individual processes.
 </div>

--- a/frontend/observatory/components/DetailSummary.svelte
+++ b/frontend/observatory/components/DetailSummary.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import { measured, record, type RecordData, type Telemetry } from '../runtime/host';
+  import { instances, measured, record, type RecordData, type Telemetry } from '../runtime/host';
+  import { radarGroups, groupResource, displayMeasure } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   let { row, telemetry }: { row: RecordData; telemetry: Telemetry } = $props();
   let name = $derived(String(row.name ?? row.displayName ?? row.agent ?? 'Observation'));
+  let group = $derived(radarGroups(instances(telemetry)).find((g) => g.key === row.agentGroupKey));
   let resources = $derived(
     typeof row.instanceId === 'string'
       ? telemetry.resources.find((r) => r.instanceId === row.instanceId)
@@ -14,7 +16,34 @@
   }
 </script>
 
-{#if row.process}
+{#if row.agentGroupKey}
+  <div class="agent-identity">
+    <AgentLogo {name} id={String(row.agentGroupKey)} size={32} />
+    <div>
+      <strong>{name}</strong><small
+        >{group
+          ? `${group.members.length} observed processes`
+          : 'Not in the latest snapshot'}</small
+      >
+    </div>
+  </div>
+  {#if group}
+    <dl class="details-grid">
+      <dt>Status</dt>
+      <dd>{telemetry.stale ? 'Last reliable snapshot' : 'Active'}</dd>
+      <dt>Highest process risk</dt>
+      <dd><span class="risk-value">{group.risk}<small>/100</small></span></dd>
+      <dt>Combined CPU</dt>
+      <dd>{displayMeasure(groupResource(group, telemetry, 'cpu'), '%')}</dd>
+      <dt>Combined RAM</dt>
+      <dd>{displayMeasure(groupResource(group, telemetry, 'memMb'), ' MB')}</dd>
+    </dl>
+    <p class="entity-note">
+      These processes belong to the same agent. Choose a process to see its own activity and
+      controls.
+    </p>
+  {/if}
+{:else if row.process}
   <div class="agent-identity">
     <AgentLogo {name} size={32} />
     <div>

--- a/frontend/observatory/components/Details.svelte
+++ b/frontend/observatory/components/Details.svelte
@@ -137,11 +137,13 @@
     </div>
     <div>
       <span class="muted" id="modal-caption"
-        >{current?.row.process
-          ? 'Agent instance'
-          : current?.row.displayName
-            ? 'Agent catalog'
-            : 'Recorded metadata'}</span
+        >{current?.row.agentGroupKey
+          ? 'Agent overview'
+          : current?.row.process
+            ? 'Agent instance'
+            : current?.row.displayName
+              ? 'Agent catalog'
+              : 'Recorded metadata'}</span
       >
       <h2 id="modal-title" tabindex="-1">{current?.title ?? 'Details'}</h2>
     </div>
@@ -150,13 +152,16 @@
     >
   </div>
   <div id="modal-body" tabindex="-1" bind:this={body}>
-    {#if current}<div class:agent-detail-grid={!!current.row.process}>
+    {#if current}<div
+        class:agent-detail-grid={!!current.row.process || !!current.row.agentGroupKey}
+      >
         <div><DetailSummary row={current.row} {telemetry} /></div>
         <div><EntityLinks row={current.row} {telemetry} {navigate} /></div>
       </div>
       <details
         class="all-metadata"
         open={!current.row.process &&
+          !current.row.agentGroupKey &&
           !current.row.displayName &&
           !current.row.file &&
           !current.row.remoteIp &&

--- a/frontend/observatory/components/EntityLinks.svelte
+++ b/frontend/observatory/components/EntityLinks.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { instances, record, type Telemetry, type RecordData } from '../runtime/host';
+  import { radarGroups } from '../runtime/radar';
   import Icon from './Icon.svelte';
   let {
     row,
@@ -17,7 +18,9 @@
       .slice(0, 30),
   );
   let siblings = $derived(
-    instances(telemetry).filter((a) => row.process && a.name === String(row.name ?? row.agent)),
+    row.agentGroupKey
+      ? (radarGroups(instances(telemetry)).find((g) => g.key === row.agentGroupKey)?.members ?? [])
+      : instances(telemetry).filter((a) => row.process && a.name === String(row.name ?? row.agent)),
   );
   let path = $derived(
     typeof row.file === 'string' ? row.file : typeof row.cwd === 'string' ? row.cwd : '',
@@ -27,15 +30,20 @@
   );
 </script>
 
-{#if row.process}
-  <h3>Process instances</h3>
+{#if row.process || row.agentGroupKey}
+  <h3>
+    {row.agentGroupKey ? 'Processes' : 'Process instances'}
+    <span class="muted">{siblings.length}</span>
+  </h3>
   {#each siblings as a (a.instanceId ?? a)}<div class="process-row">
       <div>
         <button
           class="entity-link"
           onclick={() => navigate(a.name + ' · PID ' + a.pid, a as unknown as RecordData)}
           ><Icon name="cpu" />PID {a.pid}</button
-        ><small>{a.process}</small>
+        ><small>{a.process}</small>{#if a.cwd}<small class="process-project" title={a.cwd}
+            >{a.cwd}</small
+          >{/if}
       </div>
       <button
         class="text-button"
@@ -43,6 +51,8 @@
         >Open<Icon name="chevron" /></button
       >
     </div>{/each}
+{/if}
+{#if row.process}
   <h3 class="section-title">Recent events</h3>
   {#each related.slice(0, 4) as e (e)}<button
       class="recent-event"
@@ -94,6 +104,15 @@
   .process-row small {
     display: block;
     color: var(--muted);
+  }
+  .process-row > div {
+    min-width: 0;
+  }
+  .process-project {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 220px;
   }
   .entity-parent {
     margin-top: 16px;

--- a/frontend/observatory/components/RadarSummary.svelte
+++ b/frontend/observatory/components/RadarSummary.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import type { RecordData, Telemetry } from '../runtime/host';
-  import { groupActivity, groupResource, displayMeasure, type RadarGroup } from '../runtime/radar';
+  import {
+    groupActivity,
+    groupResource,
+    groupRecord,
+    displayMeasure,
+    type RadarGroup,
+  } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   let {
@@ -22,7 +28,6 @@
   } = $props();
   let bins = $derived(groupActivity(group, telemetry, end));
   let chosen = $derived(group.members.find((a) => a.instanceId === selected));
-  let primary = $derived(chosen ?? group.members[0]);
 </script>
 
 <section class="radar-agent-card">
@@ -68,10 +73,9 @@
     >
   </button>
   <div class="radar-agent-foot">
-    <button
-      class="entity-link"
-      onclick={() => inspect(primary.name, primary as unknown as RecordData)}
-      ><Icon name="cpu" />PID {primary.pid}</button
-    ><span>{group.members.length} {group.members.length === 1 ? 'process' : 'processes'}</span>
+    <button class="entity-link" onclick={() => inspect(group.name, groupRecord(group))}
+      ><Icon name="cpu" />{group.members.length}
+      {group.members.length === 1 ? 'process' : 'processes'}<Icon name="chevron" /></button
+    >
   </div>
 </section>

--- a/frontend/observatory/components/ResourceUsage.svelte
+++ b/frontend/observatory/components/ResourceUsage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { instances, measured, type RecordData, type Telemetry } from '../runtime/host';
+  import { instances, type RecordData, type Telemetry } from '../runtime/host';
+  import { radarGroups, groupResource, groupRecord } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   let {
@@ -7,9 +8,11 @@
     inspect,
   }: { telemetry: Telemetry; inspect: (title: string, row: RecordData) => void } = $props();
   let mode = $state('cpu');
-  let agents = $derived(instances(telemetry));
+  let agents = $derived(radarGroups(instances(telemetry)));
   let maximum = $derived(
-    mode === 'cpu' ? 100 : Math.max(1, ...telemetry.resources.map((r) => measured(r.memMb) ?? 0)),
+    mode === 'cpu'
+      ? 100
+      : Math.max(1, ...agents.map((g) => groupResource(g, telemetry, 'memMb') ?? 0)),
   );
 </script>
 
@@ -17,7 +20,7 @@
   <div class="panel-head">
     <div>
       <h2><Icon name="chart" />Agent usage</h2>
-      <p>Current process snapshot</p>
+      <p>Combined usage across each agent's processes</p>
     </div>
     <div class="segmented">
       <button aria-pressed={mode === 'cpu'} onclick={() => (mode = 'cpu')}>CPU</button><button
@@ -27,17 +30,16 @@
     </div>
   </div>
   <div class="resource-bars">
-    {#each agents as a (a.instanceId ?? a)}{@const value = telemetry.stale
-        ? null
-        : measured(
-            telemetry.resources.find((r) => !!a.instanceId && r.instanceId === a.instanceId)?.[
-              mode
-            ],
-          )}<button class="usage-row" onclick={() => inspect(a.name, a as unknown as RecordData)}
-        ><AgentLogo id={a.agent} name={a.name} /><span class="usage-body"
+    {#each agents as a (a.key)}{@const value = groupResource(a, telemetry, mode)}<button
+        class="usage-row"
+        onclick={() => inspect(a.name, groupRecord(a))}
+        ><AgentLogo id={a.key} name={a.name} /><span class="usage-body"
           ><span class="usage-heading"
-            ><strong>{a.name}</strong><span
-              >{value === null ? '—' : value.toFixed(1) + (mode === 'cpu' ? '%' : ' MB')}</span
+            ><strong
+              >{a.name}<small
+                >{a.members.length} {a.members.length === 1 ? 'process' : 'processes'}</small
+              ></strong
+            ><span>{value === null ? '—' : value.toFixed(1) + (mode === 'cpu' ? '%' : ' MB')}</span
             ></span
           ><span class="usage-track"
             ><span style={`transform:scaleX(${Math.min(1, (value ?? 0) / maximum)})`}></span></span
@@ -48,7 +50,7 @@
   <p class="chart-footnote">
     {mode === 'cpu'
       ? 'Percentage of total CPU capacity.'
-      : 'Bar length is relative to the largest process.'} Open an agent for process details.
+      : 'Bar length is relative to the largest agent total.'} Open an agent for its processes.
   </p>
 </section>
 
@@ -59,5 +61,11 @@
   }
   .resource-chart {
     align-self: stretch;
+  }
+  .usage-heading strong small {
+    display: block;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 400;
   }
 </style>

--- a/frontend/observatory/components/Settings.svelte
+++ b/frontend/observatory/components/Settings.svelte
@@ -8,10 +8,12 @@
     host,
     appearance,
     navigate,
+    currentTheme = null,
   }: {
     host: Host | null;
     appearance: (dark: boolean, scale: number, contrast?: boolean) => void;
     navigate: (view: string) => void;
+    currentTheme?: string | null;
   } = $props();
   let form = $state<RecordData>({});
   let loaded = $state(false);
@@ -22,6 +24,14 @@
   let patterns = $state('');
   let ignored = $state('');
   let alive = true;
+  let previousTheme: string | null = null;
+  $effect(() => {
+    if (loaded && currentTheme && currentTheme !== previousTheme) {
+      previousTheme = currentTheme;
+      form.darkMode = currentTheme.startsWith('dark');
+      contrast = currentTheme.endsWith('-hc');
+    }
+  });
   async function load() {
     const settings = record(await invoke(host, 'getSettings'));
     if (!alive) return;

--- a/frontend/observatory/components/Statistics.svelte
+++ b/frontend/observatory/components/Statistics.svelte
@@ -5,6 +5,7 @@
   import Agents from './Agents.svelte';
   import Icon from './Icon.svelte';
   import Metadata from './Metadata.svelte';
+  import { radarGroups, groupEvidence, groupRecord } from '../runtime/radar';
   let {
     telemetry,
     inspect,
@@ -12,6 +13,15 @@
   let samples = $state<{ at: number; cpu: number | null; mem: number | null }[]>([]);
   let lastAt = 0;
   let agents = $derived(instances(telemetry));
+  let tokenGroups = $derived(
+    radarGroups(agents)
+      .filter((g) =>
+        g.members.some(
+          (a) => a.instanceId && telemetry.tokens.some((t) => t.instanceId === a.instanceId),
+        ),
+      )
+      .map((g) => ({ ...g, ...groupEvidence(g, telemetry) })),
+  );
   const sum = (key: string) =>
     telemetry.resources.length && telemetry.resources.every((r) => measured(r[key]) !== null)
       ? telemetry.resources.reduce((total, r) => total + Number(r[key]), 0)
@@ -36,30 +46,29 @@
   <div class="panel-head">
     <div>
       <h2><Icon name="chart" />Tokens and estimated cost</h2>
-      <p>From supported agent logs</p>
+      <p>Combined by agent, from supported logs</p>
     </div>
   </div>
   <div class="table-wrap">
     <table>
       <thead><tr><th>Source</th><th>Tokens</th><th>Estimate</th></tr></thead><tbody
-        >{#each telemetry.tokens as token (token)}<tr
+        >{#each tokenGroups as group (group.key)}<tr
             ><td
-              >{agents.find((a) => !!token.instanceId && a.instanceId === token.instanceId)?.name ??
-                'Unattributed sample'}<small
-                >{String(token.instanceId ?? 'No process identity')}</small
-              ></td
+              ><button class="entity-link" onclick={() => inspect(group.name, groupRecord(group))}
+                >{group.name}</button
+              ><small>{group.members.length} processes</small></td
             ><td
-              >{measured(token.totalTokens)?.toLocaleString() ?? '—'}{measured(
-                token.totalTokens,
-              ) === null
-                ? ''
-                : token.estimated
-                  ? ' (estimated)'
-                  : ' (measured)'}</td
-            ><td
-              >{measured(token.costUsd) === null ? '—' : '$' + Number(token.costUsd).toFixed(2)}</td
+              >{group.tokens === null
+                ? '—'
+                : `${group.tokens.toLocaleString()} (${group.estimated ? 'estimated' : 'measured'})`}</td
+            ><td>{group.cost === null ? '—' : '$' + group.cost.toFixed(2)}</td></tr
+          >{:else}<tr
+            ><td colspan="3"
+              >{telemetry.tokens.length
+                ? 'No complete current agent attribution. See source samples below.'
+                : 'No token measurements are available.'}</td
             ></tr
-          >{:else}<tr><td colspan="3">No token measurements are available.</td></tr>{/each}</tbody
+          >{/each}</tbody
       >
     </table>
   </div>
@@ -67,6 +76,14 @@
     AEGIS resource usage is shown separately in the footer.
   </div>
 </section>
+{#if telemetry.tokens.length}<details class="diagnostics">
+    <summary>Token source samples · {telemetry.tokens.length}</summary>
+    <p class="muted">
+      A dash in an agent total means one or more processes have no measurement. Individual source
+      values and estimate flags are retained here.
+    </p>
+    <Metadata value={telemetry.tokens} />
+  </details>{/if}
 <details class="diagnostics">
   <summary>Resource history and delivery details</summary>
 

--- a/frontend/observatory/index.html
+++ b/frontend/observatory/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/frontend/observatory/runtime/radar.ts
+++ b/frontend/observatory/runtime/radar.ts
@@ -1,4 +1,4 @@
-import { instances, measured, type Telemetry } from './host';
+import { instances, measured, type Telemetry, type RecordData } from './host';
 import { activityBins } from './activity';
 export type ObservedInstance = ReturnType<typeof instances>[number];
 export interface RadarGroup {
@@ -34,6 +34,42 @@ export function groupResource(group: RadarGroup, state: Telemetry, key: string):
   return state.stale || values.some((v) => v === null)
     ? null
     : values.reduce<number>((sum, v) => sum + (v ?? 0), 0);
+}
+/** Open a product overview without implying a process action target. @param group Product group @returns Detail request @since 0.14.1 */
+export function groupRecord(group: RadarGroup): RecordData {
+  return { agentGroupKey: group.key, name: group.name };
+}
+interface GroupEvidence {
+  files: number;
+  network: number;
+  latest: number | null;
+  tokens: number | null;
+  cost: number | null;
+  estimated: boolean;
+}
+/** Roll up exact-identity observations and complete token measurements. @param group Product group @param state Telemetry @returns Group evidence @since 0.14.1 */
+export function groupEvidence(group: RadarGroup, state: Telemetry): GroupEvidence {
+  const ids = new Set(group.members.map((a) => a.instanceId).filter(Boolean));
+  const events = state.events.filter((e) => e.instanceId && ids.has(e.instanceId));
+  const tokens = group.members.map((a) =>
+    a.instanceId ? state.tokens.find((t) => t.instanceId === a.instanceId) : undefined,
+  );
+  const tokenSum = (key: string): number | null =>
+    tokens.length && tokens.every((t) => measured(t?.[key]) !== null)
+      ? tokens.reduce((total, t) => total + Number(t?.[key]), 0)
+      : null;
+  return {
+    files: new Set(
+      events
+        .filter((e) => !e.selfAccess && e.attribution?.status !== 'unattributed')
+        .map((e) => e.file),
+    ).size,
+    network: state.network.filter((n) => n.instanceId && ids.has(n.instanceId)).length,
+    latest: events.reduce<number | null>((latest, e) => Math.max(latest ?? 0, e.timestamp), null),
+    tokens: tokenSum('totalTokens'),
+    cost: tokenSum('costUsd'),
+    estimated: tokens.some((t) => t?.estimated === true),
+  };
 }
 /** Read group activity on one shared timeline. @param group Group @param state Telemetry @param end Interval end @returns Bins @since 0.14.1 */
 export function groupActivity(group: RadarGroup, state: Telemetry, end: number) {

--- a/frontend/observatory/styles/desktop.css
+++ b/frontend/observatory/styles/desktop.css
@@ -1,4 +1,30 @@
-/* Host integration only; composition comes from the approved template styles. */
+/* Desktop integration and requested refinements; composition comes from the approved template. */
+/* Higher contrast strengthens text and controls without outlining every panel. */
+:root[data-theme='dark-hc'] {
+  --bg: #171819;
+  --sidebar: #1d1e20;
+  --panel: #202224;
+  --ink: #f6f6f3;
+  --muted: #d1d3cf;
+  --faint: #b9bdb7;
+  --border: #45494c;
+  --strong-border: #8c928c;
+  --focus: #eff3ec;
+}
+:root[data-theme='light-hc'] {
+  --bg: #f0f0ee;
+  --sidebar: #e8e8e5;
+  --panel: #fafaf8;
+  --ink: #181c17;
+  --muted: #384034;
+  --faint: #47513f;
+  --border: #b7bdb2;
+  --strong-border: #697362;
+  --focus: #273722;
+}
+:root[data-theme$='-hc'] :is(input, select, textarea, .button, .segmented) {
+  border-color: var(--strong-border);
+}
 .inset {
   padding: var(--panel-inset);
 }

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -155,8 +155,33 @@ try {
         (scale) => document.documentElement.style.setProperty('--ui-scale', String(scale)),
         scale,
       );
-      for (const theme of ['dark', 'light']) {
+      for (const theme of ['dark', 'light', 'dark-hc', 'light-hc']) {
         await page.evaluate((theme) => (document.documentElement.dataset.theme = theme), theme);
+        if (theme.endsWith('-hc')) {
+          const contrast = await page.evaluate(() => {
+            const style = getComputedStyle(document.documentElement);
+            const luminance = (token) => {
+              const hex = style.getPropertyValue(token).trim().replace('#', '');
+              const channels = [0, 2, 4]
+                .map((i) => parseInt(hex.slice(i, i + 2), 16) / 255)
+                .map((n) => (n <= 0.04045 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4));
+              return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+            };
+            const ratio = (a, b) => (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+            return {
+              text: ratio(luminance('--muted'), luminance('--panel')),
+              controls: ratio(luminance('--strong-border'), luminance('--bg')),
+              background: style.getPropertyValue('--bg').trim(),
+            };
+          });
+          assert(contrast.text >= 7, 'high contrast secondary text is below 7:1');
+          assert(contrast.controls >= 3, 'high contrast controls are below 3:1');
+          assert.equal(
+            contrast.background,
+            theme.startsWith('dark') ? '#171819' : '#f0f0ee',
+            'high contrast replaced the template surfaces',
+          );
+        }
         await page.emulateMedia({ reducedMotion: scale === 1.5 ? 'reduce' : 'no-preference' });
         for (const view of views) {
           await page.locator('.sidebar').getByRole('button', { name: view, exact: true }).click();
@@ -176,6 +201,13 @@ try {
             false,
             `document overflow: ${view} ${size.width} ${scale} ${theme}`,
           );
+          if (
+            size.width === 1200 &&
+            scale === 1 &&
+            ['Monitoring', 'Agents', 'Settings'].includes(view)
+          ) {
+            await page.screenshot({ path: resolve(out, `${theme}-${view.toLowerCase()}.png`) });
+          }
           if (size.width === 1200 && scale === 1 && theme === 'dark') {
             await page.screenshot({ path: resolve(out, `workspace-${views.indexOf(view)}.png`) });
             if (view === 'AI analysis') {
@@ -217,6 +249,20 @@ try {
     }
   }
   await page.setViewportSize({ width: 1200, height: 800 });
+  await page.evaluate(() => document.documentElement.style.setProperty('--ui-scale', '1'));
+  await page.locator('.sidebar').getByRole('button', { name: 'Settings', exact: true }).click();
+  await page.getByLabel('Theme', { exact: true }).selectOption('light-hc');
+  await page.getByRole('button', { name: 'Save settings', exact: true }).click();
+  await page.getByText('Completed', { exact: true }).waitFor();
+  await page.reload();
+  await page.getByRole('heading', { name: 'Monitoring', level: 1, exact: true }).waitFor();
+  assert.equal(await page.evaluate(() => document.documentElement.dataset.theme), 'light-hc');
+  await page.getByRole('button', { name: 'Toggle theme', exact: true }).click();
+  assert.equal(await page.evaluate(() => document.documentElement.dataset.theme), 'dark');
+  await page.locator('.sidebar').getByRole('button', { name: 'Settings', exact: true }).click();
+  assert.equal(await page.getByLabel('Theme', { exact: true }).inputValue(), 'dark');
+  await page.getByRole('button', { name: 'Toggle theme', exact: true }).click();
+  assert.equal(await page.getByLabel('Theme', { exact: true }).inputValue(), 'light');
   await page.evaluate(() => {
     document.documentElement.style.setProperty('--ui-scale', '1');
     document.documentElement.dataset.theme = 'dark';
@@ -272,7 +318,7 @@ try {
   await desktop.close();
   assert.deepEqual(errors, [], 'browser runtime errors');
   console.log(
-    'Shared Svelte preview: 132 viewport/theme/scale view checks; isolated bridge; dialog; desktop unavailable state; production fixture exclusion passed.',
+    'Shared Svelte preview: 264 viewport/theme/scale view checks; four themes; theme persistence and ordinary toggle; isolated bridge; dialog; desktop unavailable state; production fixture exclusion passed.',
   );
 } finally {
   await browser.close();

--- a/frontend/observatory/tests/electron-smoke.mjs
+++ b/frontend/observatory/tests/electron-smoke.mjs
@@ -70,7 +70,24 @@ try {
   ]) {
     await window.locator('.sidebar').getByRole('button', { name, exact: true }).click();
     await window.getByRole('heading', { level: 1, name, exact: true }).waitFor();
+    if (name === 'Agents') {
+      const names = await window.locator('.agent-group-row:visible .table-agent').allTextContents();
+      assert(names.length > 0, 'real agent groups are missing');
+      assert.equal(names.length, new Set(names).size, 'agent table repeats the same product');
+      assert.equal(
+        await window.locator('.sidebar .count').innerText(),
+        String(names.length),
+        'navigation counts processes as agents',
+      );
+      await window.locator('.agent-group-row:visible .table-agent').first().click();
+      await window.getByText('Agent overview', { exact: true }).waitFor();
+      assert.equal(await window.getByRole('button', { name: 'Suspend', exact: true }).count(), 0);
+      assert((await window.locator('#modal .process-row').count()) > 0, 'group lost its processes');
+      await window.keyboard.press('Escape');
+      await window.getByRole('dialog').waitFor({ state: 'hidden' });
+    }
   }
+  await window.getByLabel('Theme', { exact: true }).selectOption('light-hc');
   await window.getByLabel('Scan interval (seconds)').evaluate((input) => {
     input.value = '20';
     input.dispatchEvent(new Event('input', { bubbles: true }));
@@ -81,6 +98,11 @@ try {
     await window.evaluate(async () => (await window.aegis.getSettings()).scanIntervalSec),
     20,
   );
+  assert.equal(await window.evaluate(() => localStorage.getItem('aegis-theme')), 'light-hc');
+  await window.getByRole('button', { name: 'Toggle theme', exact: true }).click();
+  assert.equal(await window.getByLabel('Theme', { exact: true }).inputValue(), 'dark');
+  await window.getByRole('button', { name: 'Toggle theme', exact: true }).click();
+  assert.equal(await window.getByLabel('Theme', { exact: true }).inputValue(), 'light');
 
   // Only the disposable profile receives this sentinel. No provider request is made.
   const sentinel = 'observatory-test-key-never-export';

--- a/tests/renderer/components/ObservatoryGroups.test.js
+++ b/tests/renderer/components/ObservatoryGroups.test.js
@@ -1,0 +1,109 @@
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/svelte';
+import { emptyTelemetry, instances } from '../../../frontend/observatory/runtime/host';
+import {
+  radarGroups,
+  groupEvidence,
+  groupRecord,
+} from '../../../frontend/observatory/runtime/radar';
+import Agents from '../../../frontend/observatory/components/Agents.svelte';
+import ResourceUsage from '../../../frontend/observatory/components/ResourceUsage.svelte';
+import Details from '../../../frontend/observatory/components/Details.svelte';
+import ActivityChart from '../../../frontend/observatory/components/ActivityChart.svelte';
+
+const agent = (pid, name = 'Claude Code') => ({
+  agent: name,
+  pid,
+  process: 'claude.exe',
+  instanceId: `${pid}:live`,
+  instanceIdSource: 'os',
+  cwd: `X:/project-${pid}`,
+});
+const state = () => ({
+  ...emptyTelemetry(),
+  ready: true,
+  stale: false,
+  agents: [agent(10), agent(20), agent(30, 'Cursor')],
+  resources: [
+    { instanceId: '10:live', cpu: 2, memMb: 100 },
+    { instanceId: '20:live', cpu: 3, memMb: 200 },
+  ],
+  events: [
+    { instanceId: '10:live', agent: 'Claude Code', file: 'X:/shared', timestamp: 100 },
+    { instanceId: '20:live', agent: 'Claude Code', file: 'X:/shared', timestamp: 200 },
+    { instanceId: null, agent: 'Claude Code', file: 'X:/unknown', timestamp: 300 },
+  ],
+  tokens: [{ instanceId: '10:live', totalTokens: 50, costUsd: 0.1 }],
+});
+
+it('renders one row per product, aggregates complete resources and keeps a PID search at product scope', async () => {
+  const inspect = vi.fn();
+  const mounted = render(Agents, { telemetry: state(), inspect });
+  expect(mounted.container.querySelectorAll('.agent-group-row')).toHaveLength(2);
+  const claude = screen.getByRole('button', { name: 'Claude Code', exact: true }).closest('tr');
+  expect(within(claude).getByText('5.0%')).toBeInTheDocument();
+  expect(within(claude).getByText('300.0 MB')).toBeInTheDocument();
+  expect(within(claude).getByRole('button', { name: '2 processes' })).toBeInTheDocument();
+  await fireEvent.input(screen.getByLabelText('Search agents'), {
+    target: { value: 'project-20' },
+  });
+  expect(mounted.container.querySelectorAll('.agent-group-row')).toHaveLength(1);
+  expect(screen.getByText('5.0%')).toBeInTheDocument();
+  await fireEvent.click(screen.getByRole('button', { name: 'Open', exact: true }));
+  expect(inspect).toHaveBeenCalledWith('Claude Code', {
+    agentGroupKey: 'Claude Code',
+    name: 'Claude Code',
+  });
+  await mounted.rerender({ telemetry: { ...state(), stale: true } });
+  expect(screen.queryByText('5.0%')).toBeNull();
+});
+
+it('does not repeat product usage bars or fabricate missing measurements', async () => {
+  const inspect = vi.fn();
+  const { container } = render(ResourceUsage, { telemetry: state(), inspect });
+  expect(container.querySelectorAll('.usage-row')).toHaveLength(2);
+  expect(screen.getByText('5.0%')).toBeInTheDocument();
+  expect(screen.getByText('—')).toBeInTheDocument();
+  await fireEvent.click(screen.getByRole('button', { name: /Claude Code/ }));
+  expect(inspect.mock.calls[0][1]).not.toHaveProperty('instanceId');
+});
+
+it('keeps missing-identity observations out of product totals and incomplete tokens unknown', () => {
+  const s = state();
+  const group = radarGroups(instances(s)).find((g) => g.name === 'Claude Code');
+  expect(groupEvidence(group, s)).toMatchObject({
+    files: 1,
+    latest: 200,
+    tokens: null,
+    cost: null,
+  });
+  s.tokens.push({ instanceId: '20:live', totalTokens: 70, costUsd: 0.2 });
+  expect(groupEvidence(group, s).tokens).toBe(120);
+});
+
+it('opens the group without process controls and resolves a chosen member to its own stamped identity', async () => {
+  const host = { suspendProcess: vi.fn(async () => ({ success: true })) };
+  const group = radarGroups(instances(state())).find((g) => g.name === 'Claude Code');
+  render(Details, {
+    host,
+    telemetry: state(),
+    request: { title: group.name, row: groupRecord(group) },
+    close: vi.fn(),
+    refreshFalsePositives: vi.fn(),
+  });
+  await screen.findByText('Agent overview');
+  expect(screen.queryByRole('button', { name: 'Suspend', exact: true })).toBeNull();
+  await fireEvent.click(screen.getByRole('button', { name: 'PID 20', exact: true }));
+  await fireEvent.click(await screen.findByRole('button', { name: 'Suspend', exact: true }));
+  await waitFor(() =>
+    expect(host.suspendProcess).toHaveBeenCalledWith({ pid: 20, instanceId: '20:live' }),
+  );
+});
+
+it('offers one activity filter for the same product across multiple processes', async () => {
+  render(ActivityChart, { props: { events: state().events, observedAt: 1000, inspect: vi.fn() } });
+  const select = screen.getByLabelText('Chart agent');
+  expect(within(select).getAllByRole('option')).toHaveLength(2);
+  await fireEvent.change(select, { target: { value: 'Claude Code' } });
+  expect(screen.getByText('3')).toBeInTheDocument();
+});

--- a/tests/renderer/components/ObservatoryTheme.test.js
+++ b/tests/renderer/components/ObservatoryTheme.test.js
@@ -1,0 +1,51 @@
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import App from '../../../frontend/observatory/App.svelte';
+import Settings from '../../../frontend/observatory/components/Settings.svelte';
+
+it('leaves high contrast through the ordinary theme toggle and persists the ordinary theme', async () => {
+  localStorage.setItem('aegis-theme', 'light-hc');
+  render(App, { host: null });
+  await waitFor(() => expect(document.documentElement.dataset.theme).toBe('light-hc'));
+  await fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+  expect(document.documentElement.dataset.theme).toBe('dark');
+  expect(localStorage.getItem('aegis-theme')).toBe('dark');
+  await fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+  expect(document.documentElement.dataset.theme).toBe('light');
+});
+
+it('does not let delayed settings overwrite a theme chosen while the app starts', async () => {
+  localStorage.setItem('aegis-theme', 'dark-hc');
+  let resolveSettings;
+  const pending = new Promise((resolve) => {
+    resolveSettings = resolve;
+  });
+  const host = { getSettings: () => pending };
+  render(App, { host });
+  await fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+  expect(document.documentElement.dataset.theme).toBe('light');
+  resolveSettings({ darkMode: true, uiScale: 1 });
+  await pending;
+  await waitFor(() => expect(localStorage.getItem('aegis-theme')).toBe('light'));
+});
+
+it('updates the settings theme after a toolbar change without losing other draft settings', async () => {
+  localStorage.setItem('aegis-theme', 'dark-hc');
+  const host = {
+    getSettings: async () => ({ darkMode: true, scanIntervalSec: 10, uiScale: 1 }),
+    getUpdateStatus: async () => ({}),
+  };
+  const mounted = render(Settings, {
+    host,
+    appearance: vi.fn(),
+    navigate: vi.fn(),
+    currentTheme: 'dark-hc',
+  });
+  await waitFor(() => expect(screen.getByLabelText('Theme')).toHaveValue('dark-hc'));
+  await fireEvent.input(screen.getByLabelText('Scan interval (seconds)'), {
+    target: { value: '23' },
+  });
+  await mounted.rerender({ currentTheme: 'light' });
+  expect(screen.getByLabelText('Theme')).toHaveValue('light');
+  expect(screen.getByLabelText('Scan interval (seconds)')).toHaveValue('23');
+});


### PR DESCRIPTION
Agents with several processes appeared repeatedly in the agent table and resource charts. These views, navigation counts, activity filters and token summaries now group by product. An agent overview exposes individual stamped processes, while process commands still require an exact live identity. Resource totals remain unknown when measurements are incomplete.

The ordinary theme toggle now leaves high contrast, as the template does. Settings follows toolbar theme changes without discarding other draft values, and delayed startup settings cannot undo a new choice. High contrast preserves the template's neutral surfaces and strengthens text and controls instead of outlining every panel.

Validation: 159 test files (2864 passed, 4 skipped), both builds, TypeScript/Svelte checks, format/lint, inventory and mutation gates, dependency audit, and 264 browser combinations across four themes. The packaged Windows app was checked with 25 real processes, unique product rows, group details, all eleven workspaces, settings restart and six exports. No paid provider requests or interventions against user processes were used.
