### PR TITLE
fix(ui): clarify radar groups and separate monitoring panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+- Simplify Monitoring with numbered radar markers, one agent roster and a separate details panel. Collapse individual processes, separate summary cards and remove repeated charts from this view. Keep the selected agent when closing a detail dialog with Escape.
 - Show one row per agent in tables, resource charts and token summaries, with individual processes inside the agent overview. Aggregate complete measurements without replacing unknown values with zero.
 - Preserve the template's neutral surfaces in high contrast, strengthen text and controls, and make the ordinary theme toggle leave high contrast. Keep Settings synchronized with toolbar changes and prevent late startup settings from undoing a theme choice.
 - Use the approved Observatory template styles and markup throughout the desktop: radar and linked resources, activity charts, permissions, catalog, analysis, reports, settings and dialogs. Retire the superseded layout and design guidance.

--- a/OBSERVATORY-INTEGRATION.md
+++ b/OBSERVATORY-INTEGRATION.md
@@ -2,6 +2,12 @@
 
 The earlier integrations passed functional gates but did not preserve the reviewed template closely enough. Their validation below is historical evidence, not visual approval of the current interface.
 
+## Radar clarity follow-up — 2026-09-09
+
+The requested refinement removes repeated product labels and side charts from Monitoring. Compact numbered radar markers map to one agent roster; the selected group's risk, combined usage and latest activity occupy a separate panel. Individual processes are expandable and retain their stamped identities. Summary cards have separate boundaries, and per-agent resource bars remain in Statistics. Closing a detail dialog with Escape preserves the radar selection.
+
+The original twelve reference stylesheets remain unchanged; the intentional refinement lives in styles/radar-clarity.css. Browser checks cover marker collisions, roster alignment, collapsed process controls and dialog selection across 264 view/theme/scale combinations. Additional narrow-window checks include 900 px at 150% scale. The coverage suite passed 2866 tests with 4 skipped across 160 files. The packaged Windows app passed eleven workspaces with 25 observed processes, unique radar groups, settings restart and six exports. All 114 packaged renderer files match the final build. The deployed app displayed three unique agent groups without overlapping markers or labels; settings remained unchanged. These checks verify behavior and geometry; they do not constitute user visual approval.
+
 ## Agent grouping and theme follow-up — 2026-09-09
 
 The radar grouped processes, but agent tables, resource bars, token summaries and activity filters still repeated product names. They now show one entry per agent. Product details expose the individual stamped processes; a group itself has no process-control target. CPU/RAM and token totals remain unknown when member measurements are incomplete, file totals count distinct retained paths, and risk is the highest member score.

--- a/frontend/observatory/App.svelte
+++ b/frontend/observatory/App.svelte
@@ -177,6 +177,7 @@
   });
   function keydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
+      if (detail || document.querySelector('dialog[open]')) return;
       commands = false;
       selected = null;
       return;
@@ -350,7 +351,7 @@
                   ? 'Observation unavailable / stale'
                   : telemetry.scanning
                     ? 'Scanning'
-                    : 'Monitoring'}</span
+                    : 'Live'}</span
           >
         </div>
         <div class="page-actions">

--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -5,6 +5,7 @@ The approved visual source is preserved in reference/ui/ and reference/DESIGN.md
 Preserve the template's composition, hierarchy, spacing, typography, artwork, controls, radar and dialogs while connecting real telemetry through runtime/host.ts. Runtime behavior is implemented in Svelte; simulated observations must never enter a desktop build.
 
 Live-data adaptations:
+- The requested radar clarity pass replaces repeated side charts and long in-circle labels with compact numbered markers and one roster. Selected-agent details form a separate panel; process selection is expandable. The monitoring screen has separate summary cards and one activity chart; per-agent resource bars remain in Statistics. `styles/radar-clarity.css` records this intentional refinement after the preserved template cascade.
 - Radar, agent tables and resource charts group processes by agent identity. Radar pages four groups at a time. Product rows open an overview; its process list and the radar instance selector open explicitly chosen stamped processes. Distance represents risk, as in the template.
 - Group usage totals require every member to be measured; risk is the highest member score, Files counts distinct retained paths, and Network counts observed connections. Product grouping never supplies a process action identity.
 - High contrast keeps the template's neutral surfaces and strengthens text, focus and interactive boundaries. The toolbar theme toggle returns to ordinary light/dark, matching the template; high contrast is selected explicitly in Settings.

--- a/frontend/observatory/components/Monitoring.svelte
+++ b/frontend/observatory/components/Monitoring.svelte
@@ -3,7 +3,6 @@
   import { radarGroups } from '../runtime/radar';
   import Radar from './Radar.svelte';
   import ActivityChart from './ActivityChart.svelte';
-  import ResourceUsage from './ResourceUsage.svelte';
   import Agents from './Agents.svelte';
   import Timeline from './Timeline.svelte';
   import Icon from './Icon.svelte';
@@ -36,7 +35,7 @@
 </script>
 
 <div hidden={mode !== 'overview'}>
-  <div class="summary">
+  <div class="summary monitoring-summary">
     <div class="summary-stat">
       <span>Agents</span><strong
         >{telemetry.ready ? groups.length : '—'}<small
@@ -80,12 +79,8 @@
     </div>
   </div>
   <Radar {telemetry} bind:selected {inspect} />
-  <div class="dashboard-grid">
-    <ActivityChart
-      events={telemetry.events}
-      observedAt={telemetry.lastScan}
-      {inspect}
-    /><ResourceUsage {telemetry} {inspect} />
+  <div class="monitoring-activity">
+    <ActivityChart events={telemetry.events} observedAt={telemetry.lastScan} {inspect} />
   </div>
   <div class="overview-bottom">
     <Timeline {telemetry} {inspect} />

--- a/frontend/observatory/components/Radar.svelte
+++ b/frontend/observatory/components/Radar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { instances, type Telemetry, type RecordData } from '../runtime/host';
-  import { radarGroups, groupActivity, riskBand, type RadarGroup } from '../runtime/radar';
+  import { radarGroups, groupRecord, riskBand, type RadarGroup } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   import RadarSummary from './RadarSummary.svelte';
@@ -27,18 +27,13 @@
   let chosenGroup = $derived(
     groups.find((g) => g.members.some((a) => !!selected && a.instanceId === selected)),
   );
-  let end = $derived(
-    Math.max(telemetry.lastScan ?? 0, ...telemetry.events.map((e) => e.timestamp)) + 1,
-  );
-  let maximum = $derived(
-    Math.max(
-      1,
-      ...plotted.flatMap((g) => groupActivity(g, telemetry, end).map((b) => b.events.length)),
-    ),
-  );
   let linked = $derived(
     (layer === 'files' ? telemetry.events : telemetry.network)
-      .filter((e) => !selected || e.instanceId === selected)
+      .filter(
+        (e) =>
+          !chosenGroup ||
+          chosenGroup.members.some((a) => !!e.instanceId && a.instanceId === e.instanceId),
+      )
       .slice(0, 2)
       .map((e) => ({
         row: e as unknown as RecordData,
@@ -53,10 +48,12 @@
       g.members.find((a) => a.instanceId === selected)?.instanceId ??
       g.members.find((a) => a.instanceId)?.instanceId ??
       null;
+    if (!selected) inspect(g.name, groupRecord(g));
   }
   function position(g: RadarGroup, i: number) {
-    const angle = [312, 142, 65, 225][i];
-    const r = 22 + g.risk * 0.24;
+    const count = plotted.length;
+    const angle = count === 3 ? i * 120 : 45 + i * (360 / Math.max(2, count));
+    const r = 27 + g.risk * 0.19;
     return {
       x: 50 + Math.sin((angle * Math.PI) / 180) * r,
       y: 50 - Math.cos((angle * Math.PI) / 180) * r,
@@ -65,12 +62,12 @@
   }
 </script>
 
-<div class="overview-grid">
+<div class="overview-grid radar-clarity">
   <section class="panel radar-panel">
     <div class="panel-head">
       <div>
         <h2><Icon name="radar" />Agent radar</h2>
-        <p>Risk and active instances</p>
+        <p>One marker per agent · risk rises toward the edge</p>
       </div>
       <div class="segmented" aria-label="Radar layer">
         {#each [['radar', 'Radar', 'radar'], ['files', 'Files', 'folder'], ['network', 'Network', 'network']] as [id, title, icon] (id)}<button
@@ -81,17 +78,6 @@
     </div>
     <div id="radar-body">
       <div class="radar-workspace">
-        <aside class="radar-info radar-info-left" aria-label="Agent activity, left">
-          {#each plotted.slice(0, 2) as group (group.key)}<RadarSummary
-              {group}
-              {telemetry}
-              {end}
-              {maximum}
-              {selected}
-              {select}
-              {inspect}
-            />{/each}
-        </aside>
         <div class="radar-stage" class:stale={telemetry.stale} data-layer={layer}>
           <button
             class="radar-empty"
@@ -99,22 +85,19 @@
             onclick={() => (selected = null)}
           ></button>
           <div class="radar-coordinate">
-            {telemetry.stale ? 'Sensor unavailable' : 'Processes visible'}<br />Local monitoring
+            {telemetry.stale ? 'Last reliable snapshot' : 'Live observation'}
           </div>
           <div class="radar-dial">
             <div class="dial-grid"></div>
             <div class="dial-ticks"></div>
             <div class="dial-sweep"></div>
-            <span class="bearing north">0°</span><span class="bearing east">90°</span><span
-              class="bearing south">180°</span
-            ><span class="bearing west">270°</span>
             <div class="radar-center"><Icon name="shield" /></div>
             {#each plotted as group, i (group.key)}{@const point = position(group, i)}<button
                 class={`radar-blip ${riskBand(group.risk)}`}
-                class:label-left={point.x < 50}
                 data-group={group.key}
                 style={`left:${point.x}%;top:${point.y}%;--echo-delay:${point.angle / 40 - 9}s`}
                 aria-label={`Select ${group.name}, ${group.members.length} processes, risk ${group.risk}`}
+                title={`${group.name} · ${group.members.length} processes · risk ${group.risk}/100`}
                 aria-pressed={group === chosenGroup}
                 onclick={() => select(group)}
                 onkeydown={(e) => {
@@ -122,12 +105,10 @@
                 }}
               >
                 <span class="blip-dot"
-                  ><AgentLogo id={group.key} name={group.name} size={18} /></span
-                ><span class="blip-meta"
-                  ><strong>{group.name}</strong><small
-                    >{group.risk} / 100{#if group.members.length > 1}
-                      · {group.members.length} processes{/if}</small
-                  ></span
+                  ><AgentLogo id={group.key} name={group.name} size={24} /></span
+                >
+                <span class="marker-number" aria-hidden="true"
+                  >{Math.min(page, pages - 1) * 4 + i + 1}</span
                 >
               </button>{/each}
           </div>
@@ -135,18 +116,25 @@
               {telemetry.ready ? 'No agents in this snapshot' : 'Waiting for a reliable scan'}
             </p>{/if}
           {#if layer !== 'radar'}<RadarLinks rows={linked} {layer} {inspect} />{/if}
-          <div class="radar-scale">Farther from center:<br />higher risk</div>
+          <div class="radar-scale">Select a marker or an agent in the list</div>
         </div>
-        <aside class="radar-info radar-info-right" aria-label="Agent activity, right">
-          {#each plotted.slice(2, 4) as group (group.key)}<RadarSummary
-              {group}
-              {telemetry}
-              {end}
-              {maximum}
-              {selected}
-              {select}
-              {inspect}
-            />{/each}
+        <aside class="radar-roster" aria-label="Observed agents">
+          <div class="roster-heading">
+            <h3>Agents</h3>
+            <span>{groups.length}</span>
+          </div>
+          <div class="roster-items">
+            {#each plotted as group, i (group.key)}<RadarSummary
+                {group}
+                ordinal={Math.min(page, pages - 1) * 4 + i + 1}
+                {selected}
+                {select}
+              />{/each}
+          </div>
+          {#if !groups.length}<p class="entity-note">
+              {telemetry.ready ? 'No agents observed.' : 'Waiting for a scan.'}
+            </p>{/if}
+          <p class="roster-note">{agents.length} processes grouped by agent</p>
         </aside>
       </div>
     </div>
@@ -165,12 +153,6 @@
             onclick={() => page++}><Icon name="chevron" /></button
           >
         </div>{/if}
-      <button
-        id="open-selected-agent"
-        disabled={!chosen}
-        onclick={() => chosen && inspect(chosen.name, chosen as unknown as RecordData)}
-        >Open selected agent</button
-      >
     </div>
   </section>
   <RadarInspector {chosen} group={chosenGroup} {telemetry} bind:selected {inspect} />

--- a/frontend/observatory/components/RadarInspector.svelte
+++ b/frontend/observatory/components/RadarInspector.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { measured, record, type Telemetry, type RecordData } from '../runtime/host';
+  import { record, type Telemetry, type RecordData } from '../runtime/host';
   import {
+    groupResource,
+    groupRecord,
     displayMeasure,
     riskBand,
     type RadarGroup,
@@ -21,125 +23,111 @@
     selected: string | null;
     inspect: (title: string, row: RecordData) => void;
   } = $props();
-  let events = $derived(
-    chosen?.instanceId ? telemetry.events.filter((e) => e.instanceId === chosen.instanceId) : [],
-  );
+  let processOptions = $state(false);
+  let previousGroup: string | undefined;
+  $effect(() => {
+    if (group?.key !== previousGroup) {
+      previousGroup = group?.key;
+      processOptions = false;
+    }
+  });
+  let ids = $derived(new Set(group?.members.map((a) => a.instanceId).filter(Boolean)));
+  let events = $derived(telemetry.events.filter((e) => e.instanceId && ids.has(e.instanceId)));
   let latest = $derived([...events].sort((a, b) => b.timestamp - a.timestamp)[0]);
-  function resource(key: string) {
-    return telemetry.stale || !chosen?.instanceId
-      ? null
-      : measured(telemetry.resources.find((r) => r.instanceId === chosen?.instanceId)?.[key]);
+  function openGroup() {
+    if (group) inspect(group.name, groupRecord(group));
   }
-  function open() {
+  function openProcess() {
     if (chosen) inspect(chosen.name, chosen as unknown as RecordData);
   }
 </script>
 
 <aside class="panel inspector" id="inspector">
   <div class="inspector-title">
-    <span>Selected instance</span>{#if chosen}<button
-        aria-label="Open selected instance"
-        onclick={open}><Icon name="chevron" /></button
-      >{/if}
+    <h2><Icon name="agents" />Agent details</h2>
+    <span class="detail-status"
+      >{group ? (telemetry.stale ? 'Last snapshot' : 'Selected') : 'No selection'}</span
+    >
   </div>
-  {#if chosen}
+  {#if group}
     <div class="agent-identity">
-      <AgentLogo id={chosen.agent} name={chosen.name} size={32} />
+      <AgentLogo id={group.key} name={group.name} size={32} />
       <div>
-        <button class="entity-link" onclick={open}>{chosen.name}</button><small class="mono"
-          >PID {chosen.pid}</small
+        <button class="entity-link" onclick={openGroup}>{group.name}</button><small
+          >{group.members.length}
+          {group.members.length === 1 ? 'process' : 'processes'} combined</small
         >
       </div>
     </div>
-    {#if group && group.members.length > 1}<label class="instance-picker"
-        ><span>Process · {group.members.length} observed</span><select
-          aria-label="Selected process"
-          bind:value={selected}
-          >{#each group.members.filter((a) => a.instanceId) as a (a.instanceId)}<option
-              value={a.instanceId}
-              >PID {a.pid} · {a.projectName ?? a.process} · risk {a.riskScore}</option
-            >{/each}</select
-        ></label
-      >{/if}
-    <div class="inspector-risk">
-      <div>
-        <span>Risk</span><span class={`badge ${riskBand(chosen.riskScore)}`}
-          >{riskBand(chosen.riskScore)}</span
-        >
-      </div>
-      <span class={`risk-value ${riskBand(chosen.riskScore)}`}
-        >{chosen.riskScore}<small>/100</small></span
-      >
-    </div>
-    <div class="risk-track">
-      <i
-        style={`transform:scaleX(${chosen.riskScore / 100});background:var(--${chosen.riskScore < 35 ? 'green' : chosen.riskScore < 66 ? 'amber' : 'red'})`}
-      ></i>
-    </div>
-    <div class="inspector-metrics">
-      <div><strong>{displayMeasure(resource('cpu'), '%')}</strong><span>CPU</span></div>
-      <div><strong>{displayMeasure(resource('memMb'))}</strong><span>RAM, MB</span></div>
-      <div><strong>{events.length}</strong><span>events</span></div>
-    </div>
-    {#if latest}<div class="finding" class:ordinary={!latest.sensitive}>
+    <section class="inspector-block" aria-label="Agent risk">
+      <div class="inspector-risk">
         <div>
-          <Icon name="file" /><span>{latest.sensitive ? 'Needs review' : 'Latest action'}</span
-          ><time>{new Date(latest.timestamp).toLocaleTimeString()}</time>
+          <span>Highest process risk</span><span class={`badge ${riskBand(group.risk)}`}
+            >{riskBand(group.risk)}</span
+          >
         </div>
-        <button
-          class="entity-link"
-          onclick={() => inspect('File observation', latest as unknown as RecordData)}
-          >{latest.file.split(/[/\\]/).pop()}</button
-        >
-        <p>{latest.action ?? 'File change observed.'}</p>
+        <span class={`risk-value ${riskBand(group.risk)}`}>{group.risk}<small>/100</small></span>
       </div>
-      <div class="attribution-line">
-        <Icon name="link" /><span
-          >{record(latest.attribution).status === 'confirmed'
-            ? 'Process instance confirmed.'
-            : 'Indirect attribution. A specific process action is unconfirmed.'}</span
-        >
-      </div>{:else}<p class="entity-note">No retained file observations for this instance.</p>{/if}
-    <div class="toolbar">
-      {#if latest}<button
-          class="button"
-          onclick={() => inspect('File observation', latest as unknown as RecordData)}
-          >Review</button
-        >{/if}<button class="button" onclick={open}>Process</button>
-    </div>
-    <div class="inspector-secondary"><span>Behaviour anomaly: {chosen.anomalyScore}/100</span></div>
-    <p class="entity-note">{chosen.projectName ?? chosen.cwd ?? 'Working directory unavailable'}</p>
+      <div class="risk-track">
+        <i
+          style={`transform:scaleX(${group.risk / 100});background:var(--${group.risk < 35 ? 'green' : group.risk < 66 ? 'amber' : 'red'})`}
+        ></i>
+      </div>
+    </section>
+    <section class="inspector-block" aria-label="Combined agent usage">
+      <h3>Combined usage</h3>
+      <div class="inspector-metrics">
+        <div>
+          <strong>{displayMeasure(groupResource(group, telemetry, 'cpu'), '%')}</strong><span
+            >CPU</span
+          >
+        </div>
+        <div>
+          <strong>{displayMeasure(groupResource(group, telemetry, 'memMb'))}</strong><span
+            >RAM, MB</span
+          >
+        </div>
+        <div><strong>{events.length}</strong><span>events</span></div>
+      </div>
+    </section>
+    <section class="inspector-block" aria-label="Recent agent activity">
+      <h3>Latest activity</h3>
+      {#if latest}<div class="finding" class:ordinary={!latest.sensitive}>
+          <div>
+            <Icon name="file" /><span>{latest.sensitive ? 'Needs review' : 'File event'}</span><time
+              >{new Date(latest.timestamp).toLocaleTimeString()}</time
+            >
+          </div>
+          <button
+            class="entity-link"
+            onclick={() => inspect('File observation', latest as unknown as RecordData)}
+            >{latest.file.split(/[/\\]/).pop()}</button
+          >
+          <p>{latest.action ?? 'File change observed.'}</p>
+          {#if record(latest.attribution).status !== 'confirmed'}<small>Indirect attribution</small
+            >{/if}
+        </div>{:else}<p class="entity-note">No retained file events for this agent.</p>{/if}
+    </section>
+    <button class="button inspector-open" onclick={openGroup}
+      >Open agent<Icon name="chevron" /></button
+    >
+    <details class="process-options" bind:open={processOptions}>
+      <summary>Individual processes <span>{group.members.length}</span></summary>
+      <label class="instance-picker"
+        ><span>Choose a process</span><select aria-label="Selected process" bind:value={selected}>
+          {#each group.members.filter((a) => a.instanceId) as a (a.instanceId)}<option
+              value={a.instanceId}
+              >PID {a.pid}{a.projectName ? ' · ' + a.projectName : ''} · risk {a.riskScore}</option
+            >{/each}
+        </select></label
+      >
+      <button class="button" onclick={openProcess} disabled={!chosen}>Process</button>
+    </details>
   {:else}
     <div class="radar-no-selection">
       <Icon name="radar" />
-      <h3>No agent selected</h3>
-      <p>Select a marker or an agent card to inspect its process.</p>
+      <h3>Choose an agent</h3>
+      <p>Select a marker or a row in the agent list. Its risk, usage and activity appear here.</p>
     </div>
-    <div class="inspector-metrics">
-      <div>
-        <strong>{telemetry.ready ? telemetry.agents.length : '—'}</strong><span
-          >active processes</span
-        >
-      </div>
-      <div><strong>{telemetry.network.length}</strong><span>connections</span></div>
-    </div>
-    <p class="entity-note">Click empty radar space or press Escape to clear a selection.</p>
   {/if}
 </aside>
-
-<style>
-  .instance-picker {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    font-size: calc(11px * var(--ui-scale));
-    margin-bottom: 12px;
-  }
-  .instance-picker select {
-    width: 100%;
-    padding: 6px;
-  }
-  .badge {
-    text-transform: capitalize;
-  }
-</style>

--- a/frontend/observatory/components/RadarSummary.svelte
+++ b/frontend/observatory/components/RadarSummary.svelte
@@ -1,81 +1,31 @@
 <script lang="ts">
-  import type { RecordData, Telemetry } from '../runtime/host';
-  import {
-    groupActivity,
-    groupResource,
-    groupRecord,
-    displayMeasure,
-    type RadarGroup,
-  } from '../runtime/radar';
+  import { riskBand, type RadarGroup } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   let {
     group,
-    telemetry,
-    end,
-    maximum,
+    ordinal,
     selected,
     select,
-    inspect,
   }: {
     group: RadarGroup;
-    telemetry: Telemetry;
-    end: number;
-    maximum: number;
+    ordinal: number;
     selected: string | null;
-    select: (g: RadarGroup) => void;
-    inspect: (title: string, row: RecordData) => void;
+    select: (group: RadarGroup) => void;
   } = $props();
-  let bins = $derived(groupActivity(group, telemetry, end));
-  let chosen = $derived(group.members.find((a) => a.instanceId === selected));
+  let chosen = $derived(group.members.some((a) => !!selected && a.instanceId === selected));
 </script>
 
-<section class="radar-agent-card">
-  <button
-    class="radar-agent-title"
-    aria-pressed={!!chosen}
-    title={`Select ${group.name}`}
-    onclick={() => select(group)}
+<button class="radar-agent-card" aria-pressed={chosen} onclick={() => select(group)}>
+  <span class="roster-number" aria-hidden="true">{ordinal}</span>
+  <AgentLogo id={group.key} name={group.name} size={24} />
+  <span class="roster-identity"
+    ><strong>{group.name}</strong><small
+      >{group.members.length} {group.members.length === 1 ? 'process' : 'processes'}</small
+    ></span
   >
-    <AgentLogo id={group.key} name={group.name} size={20} /><span>{group.name}</span><span
-      class="risk-value">{group.risk}<small>/100</small></span
-    >
-  </button>
-  <div class="radar-agent-metrics">
-    <span>CPU <b>{displayMeasure(groupResource(group, telemetry, 'cpu'), '%')}</b></span><span
-      >RAM <b>{displayMeasure(groupResource(group, telemetry, 'memMb'), ' MB')}</b></span
-    >
-  </div>
-  <button
-    class="radar-mini-chart"
-    aria-label={`Recent activity for ${group.name}`}
-    onclick={() =>
-      inspect(group.name + ' activity', {
-        observations: bins.flatMap((b) => b.events),
-        from: new Date(end - 300000).toISOString(),
-        to: new Date(end).toISOString(),
-      })}
+  <span class={`roster-risk ${riskBand(group.risk)}`} title="Highest process risk"
+    >{group.risk}<small>risk</small></span
   >
-    <svg viewBox="0 0 120 24" preserveAspectRatio="none" aria-hidden="true"
-      >{#each bins as bin, i (i)}<rect
-          x={i * 12}
-          y="0"
-          width="8"
-          height="24"
-          rx="1"
-          style={`transform:scaleY(${bin.events.length / maximum})`}
-        />{/each}</svg
-    >
-    <span
-      ><span>{bins.reduce((sum, b) => sum + b.events.length, 0)} events · 5 min</span><Icon
-        name="chevron"
-      /></span
-    >
-  </button>
-  <div class="radar-agent-foot">
-    <button class="entity-link" onclick={() => inspect(group.name, groupRecord(group))}
-      ><Icon name="cpu" />{group.members.length}
-      {group.members.length === 1 ? 'process' : 'processes'}<Icon name="chevron" /></button
-    >
-  </div>
-</section>
+  <Icon name="chevron" />
+</button>

--- a/frontend/observatory/styles.ts
+++ b/frontend/observatory/styles.ts
@@ -10,4 +10,5 @@ import './styles/identity.css';
 import './styles/analysis.css';
 import './styles/polish.css';
 import './styles/dialogs.css';
+import './styles/radar-clarity.css';
 import './styles/desktop.css';

--- a/frontend/observatory/styles/radar-clarity.css
+++ b/frontend/observatory/styles/radar-clarity.css
@@ -1,0 +1,310 @@
+/* Requested clarity pass: one roster, compact markers, distinct information panels. */
+.summary.monitoring-summary {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, calc(130px * var(--ui-scale))), 1fr));
+  gap: 10px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+.monitoring-summary > .summary-stat {
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+}
+.radar-clarity {
+  gap: 16px;
+  align-items: start;
+}
+.radar-clarity .radar-panel,
+.radar-clarity .inspector {
+  height: auto;
+  border: 1px solid var(--strong-border);
+  border-radius: 12px;
+}
+.radar-clarity .radar-panel > .panel-head {
+  padding: 16px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+.radar-clarity #radar-body {
+  display: block;
+  flex: none;
+}
+.radar-clarity .radar-workspace {
+  display: grid;
+  height: auto;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto;
+}
+.radar-clarity .radar-stage {
+  grid-column: auto;
+  grid-row: auto;
+  min-height: 340px;
+  container-type: inline-size;
+  background: var(--bg);
+}
+.radar-clarity .radar-dial {
+  width: min(280px, calc(100cqw - 48px));
+  height: min(280px, calc(100cqw - 48px));
+}
+.radar-clarity .radar-coordinate {
+  top: 14px;
+  left: 16px;
+  color: var(--muted);
+}
+.radar-clarity .radar-scale {
+  display: block;
+  bottom: 12px;
+  left: 12px;
+  right: 12px;
+  text-align: center;
+  max-width: none;
+  font-size: calc(10px * var(--ui-scale));
+  color: var(--muted);
+}
+.radar-clarity .radar-blip {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  min-height: 44px;
+  padding: 0;
+  transform: translate(-50%, -50%);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--panel);
+  box-shadow: 0 2px 5px #0001;
+}
+.radar-clarity .radar-blip.low {
+  border-color: var(--green);
+}
+.radar-clarity .radar-blip.medium {
+  border-color: var(--amber);
+}
+.radar-clarity .radar-blip.high {
+  border-color: var(--red);
+}
+.radar-clarity .radar-blip[aria-pressed='true'] {
+  border: 2px solid var(--ink);
+  box-shadow: 0 0 0 4px var(--selection-border);
+  background: var(--selection);
+}
+.radar-clarity .blip-dot {
+  --marker-size: 24px;
+  width: 24px;
+  height: 24px;
+}
+.radar-clarity .blip-dot::after {
+  display: none;
+}
+.marker-number {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  display: grid;
+  place-items: center;
+  width: 19px;
+  height: 19px;
+  border-radius: 50%;
+  background: var(--ink);
+  color: var(--panel);
+  border: 2px solid var(--panel);
+  font-size: 10px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.radar-roster {
+  padding: 14px;
+  background: var(--panel);
+  border-top: 1px solid var(--border);
+  min-width: 0;
+}
+.roster-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+.roster-heading > span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.roster-items {
+  display: grid;
+  gap: 8px;
+}
+.radar-roster .radar-agent-card {
+  display: grid;
+  grid-template-columns: 16px 24px minmax(0, 1fr) auto 12px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 64px;
+  padding: 10px;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+.radar-roster .radar-agent-card:hover {
+  background: var(--hover);
+}
+.radar-roster .radar-agent-card[aria-pressed='true'] {
+  background: var(--selection);
+  border-color: var(--selection-border);
+  box-shadow: inset 3px 0 0 var(--ink);
+}
+.roster-number {
+  color: var(--muted);
+  font-size: 11px;
+}
+.roster-identity {
+  min-width: 0;
+}
+.radar-clarity .radar-roster .agent-mark,
+.radar-clarity .blip-dot .agent-mark {
+  width: 24px;
+  height: 24px;
+}
+.radar-roster .agent-mark img {
+  width: 100%;
+  height: 100%;
+}
+.roster-identity strong {
+  display: block;
+  font-size: calc(12px * var(--ui-scale));
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.roster-identity small,
+.roster-risk small {
+  display: block;
+  color: var(--muted);
+  font-size: calc(10px * var(--ui-scale));
+}
+.roster-risk {
+  font-size: calc(14px * var(--ui-scale));
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+.radar-roster .radar-agent-card > .icon {
+  width: 12px;
+  height: 12px;
+}
+.roster-note {
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: calc(10px * var(--ui-scale));
+}
+.radar-clarity .radar-bottom {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--panel);
+}
+.radar-clarity .inspector {
+  padding: 16px;
+  overflow: visible;
+  background: var(--panel);
+}
+.radar-clarity .inspector-title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-bottom: 12px;
+  margin-bottom: 16px;
+}
+.inspector-title h2 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.detail-status {
+  color: var(--muted);
+  font-size: 10px;
+}
+.radar-clarity .agent-identity {
+  margin-bottom: 0;
+}
+.radar-clarity .agent-identity > div {
+  min-width: 0;
+}
+.radar-clarity .agent-identity .entity-link {
+  overflow-wrap: anywhere;
+}
+.inspector-block {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.inspector-block h3 {
+  margin-bottom: 10px;
+  color: var(--muted);
+}
+.radar-clarity .inspector-metrics {
+  margin-bottom: 0;
+}
+.radar-clarity .inspector-metrics > div {
+  padding: 10px 6px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+.inspector-open {
+  margin-top: 18px;
+  width: 100%;
+  justify-content: space-between;
+}
+.process-options {
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.process-options summary {
+  cursor: pointer;
+  font-size: calc(11px * var(--ui-scale));
+}
+.process-options summary > span {
+  float: right;
+  color: var(--muted);
+}
+.process-options .instance-picker {
+  display: grid;
+  gap: 7px;
+  font-size: 11px;
+  margin: 12px 0;
+}
+.process-options select {
+  width: 100%;
+  padding: 7px;
+}
+.monitoring-activity {
+  margin-top: 20px;
+}
+.monitoring-activity .panel-head {
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+@container (min-width: 620px) {
+  .radar-clarity .radar-workspace {
+    grid-template-columns: minmax(0, 1fr) minmax(235px, 0.82fr);
+  }
+  .radar-clarity .radar-stage {
+    min-height: 380px;
+  }
+  .radar-roster {
+    border-top: 0;
+    border-left: 1px solid var(--border);
+  }
+}
+@media (max-width: 1100px) {
+  .summary.monitoring-summary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .overview-grid.radar-clarity {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/frontend/observatory/tests/capture-template.mjs
+++ b/frontend/observatory/tests/capture-template.mjs
@@ -63,6 +63,7 @@ try {
   const route = await page.locator('.radar-links path').first().getAttribute('d');
   assert(route && !route.includes('NaN'));
   await shot('desktop-radar-files');
+  await page.getByText(/Individual processes/).click();
   await page.getByRole('button', { name: 'Process', exact: true }).click();
   await page.getByRole('dialog').waitFor();
   await shot('desktop-process');

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -20,7 +20,7 @@ const imports = [
 ].map((match) => match[1]);
 assert.deepEqual(
   imports,
-  [...reference.stylesheetOrder, 'styles/desktop.css'],
+  [...reference.stylesheetOrder, 'styles/radar-clarity.css', 'styles/desktop.css'],
   'approved cascade order',
 );
 
@@ -187,6 +187,43 @@ try {
           await page.locator('.sidebar').getByRole('button', { name: view, exact: true }).click();
           await page.getByRole('heading', { name: view, exact: true, level: 1 }).waitFor();
           await page.waitForFunction(() => !document.documentElement.dataset.transitionSurface);
+          if (view === 'Monitoring') {
+            const radar = await page.evaluate(() => {
+              const rect = (n) => n.getBoundingClientRect();
+              const points = [...document.querySelectorAll('.radar-blip')].map(rect);
+              const stage = rect(document.querySelector('.radar-stage'));
+              const overlaps = (a, b) =>
+                a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+              const cards = [...document.querySelectorAll('.radar-agent-card')];
+              return {
+                collisions: points.some((p, i) => points.slice(i + 1).some((q) => overlaps(p, q))),
+                clipped: points.some(
+                  (p) =>
+                    p.left < stage.left ||
+                    p.right > stage.right ||
+                    p.top < stage.top ||
+                    p.bottom > stage.bottom,
+                ),
+                crowdedLogos: cards.some(
+                  (card) =>
+                    rect(card.querySelector('.agent-mark')).right >
+                    rect(card.querySelector('.roster-identity')).left - 3,
+                ),
+                rosterCount: cards.length,
+                markerCount: points.length,
+                repeatedPanels: document.querySelectorAll('.radar-info, .radar-mini-chart').length,
+              };
+            });
+            assert.equal(radar.collisions, false, `radar marker collision: ${size.width} ${scale}`);
+            assert.equal(radar.clipped, false, `clipped radar marker: ${size.width} ${scale}`);
+            assert.equal(
+              radar.crowdedLogos,
+              false,
+              `roster logo overlaps name: ${size.width} ${scale}`,
+            );
+            assert.equal(radar.rosterCount, radar.markerCount);
+            assert.equal(radar.repeatedPanels, 0, 'repeated agent panels returned');
+          }
           const activeTabVisible = await page.evaluate(() => {
             const strip = document.querySelector('.workspace-tabs').getBoundingClientRect();
             const tab = document.querySelector('.workspace-tabs > .active').getBoundingClientRect();
@@ -301,6 +338,12 @@ try {
   );
   await page.screenshot({ path: resolve(out, 'monitoring.png') });
   await page.getByRole('button', { name: /Select Claude Code, 1 processes/ }).click();
+  assert.equal(
+    await page.getByRole('button', { name: 'Process', exact: true }).isVisible(),
+    false,
+    'individual processes are expanded by default',
+  );
+  await page.getByText(/Individual processes/).click();
   await page.getByRole('button', { name: 'Process', exact: true }).click();
   const dialog = page.getByRole('dialog');
   await dialog.waitFor();
@@ -308,6 +351,11 @@ try {
   assert.equal(await page.locator('button button, button a').count(), 0);
   await page.keyboard.press('Escape');
   await dialog.waitFor({ state: 'hidden' });
+  assert.equal(
+    await page.locator('.radar-blip[aria-pressed="true"]').count(),
+    1,
+    'closing details cleared radar selection',
+  );
   assert.equal(await page.evaluate(() => window.bridgeCalls), 0);
   await page.close();
   const desktop = await browser.newPage();

--- a/frontend/observatory/tests/electron-smoke.mjs
+++ b/frontend/observatory/tests/electron-smoke.mjs
@@ -50,6 +50,23 @@ try {
   const visibleAgentGroups = Number.parseInt(
     await window.locator('.summary-stat strong').first().innerText(),
   );
+  const rosterNames = await window
+    .locator('.radar-roster .roster-identity strong')
+    .allTextContents();
+  assert.equal(rosterNames.length, Math.min(4, visibleAgentGroups));
+  assert.equal(rosterNames.length, new Set(rosterNames).size, 'radar repeats product names');
+  assert.equal(await window.locator('.radar-blip').count(), rosterNames.length);
+  assert.equal(await window.locator('.radar-info, .radar-mini-chart').count(), 0);
+  await window.locator('.radar-agent-card').first().click();
+  await window.getByRole('button', { name: 'Open agent', exact: true }).click();
+  await window.getByText('Agent overview', { exact: true }).waitFor();
+  await window.keyboard.press('Escape');
+  await window.getByRole('dialog').waitFor({ state: 'hidden' });
+  assert.equal(
+    await window.locator('.radar-blip[aria-pressed="true"]').count(),
+    1,
+    'closing agent details clears the radar selection',
+  );
   const stats = await window.evaluate(async () => {
     const stats = await window.aegis.getStats();
     return { agents: stats.currentAgents, health: stats.appHealth, gap: stats.observationGap };

--- a/tests/renderer/components/Observatory.test.js
+++ b/tests/renderer/components/Observatory.test.js
@@ -38,6 +38,7 @@ describe('Observatory production components', () => {
       inspect,
     });
     await fireEvent.click(screen.getByRole('button', { name: /Select Claude Code, 3 processes/ }));
+    await fireEvent.click(screen.getByText(/Individual processes/));
     await fireEvent.change(screen.getByLabelText('Selected process'), {
       target: { value: '102:1' },
     });

--- a/tests/renderer/components/ObservatoryRadarClarity.test.js
+++ b/tests/renderer/components/ObservatoryRadarClarity.test.js
@@ -1,0 +1,75 @@
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/svelte';
+import Radar from '../../../frontend/observatory/components/Radar.svelte';
+import { emptyTelemetry } from '../../../frontend/observatory/runtime/host';
+
+const process = (pid, agent = 'ChatGPT Desktop') => ({
+  agent,
+  process: 'agent.exe',
+  pid,
+  instanceId: `${pid}:live`,
+  instanceIdSource: 'os',
+});
+it('shows one roster entry and compact marker per agent while grouping many processes', async () => {
+  const inspect = vi.fn();
+  const state = {
+    ...emptyTelemetry(),
+    ready: true,
+    stale: false,
+    agents: [
+      ...Array.from({ length: 11 }, (_, i) => process(i + 1)),
+      process(20, 'OpenAI Codex CLI'),
+    ],
+    resources: Array.from({ length: 11 }, (_, i) => ({
+      instanceId: `${i + 1}:live`,
+      cpu: 1,
+      memMb: 20,
+    })),
+  };
+  const mounted = render(Radar, { telemetry: state, selected: null, inspect });
+  expect(mounted.container.querySelectorAll('.radar-agent-card')).toHaveLength(2);
+  expect(mounted.container.querySelectorAll('.radar-blip')).toHaveLength(2);
+  expect(mounted.container.querySelector('.radar-stage')).not.toHaveTextContent('ChatGPT Desktop');
+  expect(screen.getAllByText('ChatGPT Desktop', { exact: true })).toHaveLength(1);
+  await fireEvent.click(
+    within(screen.getByLabelText('Observed agents')).getByRole('button', {
+      name: /ChatGPT Desktop/,
+    }),
+  );
+  expect(screen.getByText('11.0%')).toBeInTheDocument();
+  // jsdom exposes descendants of closed details to role queries; browser QA checks visibility.
+  expect(mounted.container.querySelector('.process-options').open).toBe(false);
+  await fireEvent.click(screen.getByRole('button', { name: 'Open agent', exact: true }));
+  expect(inspect).toHaveBeenCalledWith('ChatGPT Desktop', {
+    agentGroupKey: 'ChatGPT Desktop',
+    name: 'ChatGPT Desktop',
+  });
+  await fireEvent.click(screen.getByText(/Individual processes/));
+  await fireEvent.change(screen.getByLabelText('Selected process'), {
+    target: { value: '11:live' },
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Process', exact: true }));
+  expect(inspect.mock.calls.at(-1)[1].instanceId).toBe('11:live');
+  await mounted.rerender({ telemetry: { ...state, agents: [...state.agents, process(30)] } });
+  expect(mounted.container.querySelectorAll('.radar-agent-card')).toHaveLength(2);
+  expect(screen.queryByText('11.0%')).toBeNull();
+});
+
+it('opens metadata for an unstamped agent without inventing a process identity', async () => {
+  const inspect = vi.fn();
+  render(Radar, {
+    telemetry: {
+      ...emptyTelemetry(),
+      ready: true,
+      stale: false,
+      agents: [{ ...process(0), instanceId: null }],
+    },
+    selected: null,
+    inspect,
+  });
+  await fireEvent.click(screen.getByRole('button', { name: /Select ChatGPT Desktop,/ }));
+  expect(inspect.mock.calls[0][1]).toEqual({
+    agentGroupKey: 'ChatGPT Desktop',
+    name: 'ChatGPT Desktop',
+  });
+});


### PR DESCRIPTION
Monitoring repeated each product across long radar labels, side charts and resource bars, obscuring the distinction between agents and their processes. The radar now uses compact numbered markers and one roster. A separate panel shows the selected group's risk, combined usage and activity, with individual stamped processes behind an expandable control.

Separate summary cards and one activity chart make the screen's sections clearer. Per-agent resource bars remain in Statistics. Closing a detail dialog with Escape keeps the radar selection. The original twelve reference stylesheets remain unchanged; the requested visual refinement is applied after them.

Validation: all ten repository checks passed, including 160 test files with 2866 passed and 4 skipped; lint has 75 warnings and no errors. Browser checks passed 264 view/theme/scale combinations, including marker collisions, roster alignment, collapsed process controls and Escape selection. Additional narrow-window checks covered 900 px at 150% scale. The packaged Windows application exercised 25 real processes, unique radar groups, eleven workspaces, settings restart and six exports. All 114 packaged renderer files match the final build. The deployed application also passed geometry checks with the existing user profile and preserved its settings.

Native macOS/Linux behavior and paid provider requests were not exercised. No release tag, version change or published binary is included.
