### PR TITLE
fix(radar): restore file and network resource layers

### DIFF
--- a/frontend/observatory/components/DetailSummary.svelte
+++ b/frontend/observatory/components/DetailSummary.svelte
@@ -3,6 +3,7 @@
   import { radarGroups, groupResource, displayMeasure } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
+  import { networkAddress } from '../runtime/radar-resources';
   let { row, telemetry }: { row: RecordData; telemetry: Telemetry } = $props();
   let name = $derived(String(row.name ?? row.displayName ?? row.agent ?? 'Observation'));
   let group = $derived(radarGroups(instances(telemetry)).find((g) => g.key === row.agentGroupKey));
@@ -102,7 +103,9 @@
     <dt>{row.file ? 'Action' : 'State'}</dt>
     <dd>{String(row.action ?? row.state ?? 'Unknown')}</dd>
     <dt>Resource</dt>
-    <dd><code>{String(row.file ?? row.domain ?? row.remoteIp)}</code></dd>
+    <dd>
+      <code>{row.file ? String(row.file) : networkAddress(row) || 'Unavailable'}</code>
+    </dd>
     {#if row.remotePort}<dt>Port</dt>
       <dd>{String(row.remotePort)}</dd>{/if}
     <dt>Attribution</dt>

--- a/frontend/observatory/components/Radar.svelte
+++ b/frontend/observatory/components/Radar.svelte
@@ -7,6 +7,7 @@
   import RadarInspector from './RadarInspector.svelte';
   import RadarLinks from './RadarLinks.svelte';
   import { reveal } from '../runtime/motion';
+  import { radarResources } from '../runtime/radar-resources';
   let {
     telemetry,
     selected = $bindable(null),
@@ -20,6 +21,7 @@
   let groups = $derived(radarGroups(agents));
   let page = $state(0);
   let layer = $state('radar');
+  let resourcePage = $state(0);
   let pages = $derived(Math.max(1, Math.ceil(groups.length / 4)));
   let plotted = $derived(
     groups.slice(Math.min(page, pages - 1) * 4, Math.min(page, pages - 1) * 4 + 4),
@@ -28,22 +30,20 @@
   let chosenGroup = $derived(
     groups.find((g) => g.members.some((a) => !!selected && a.instanceId === selected)),
   );
-  let linked = $derived(
-    (layer === 'files' ? telemetry.events : telemetry.network)
-      .filter(
-        (e) =>
-          !chosenGroup ||
-          chosenGroup.members.some((a) => !!e.instanceId && a.instanceId === e.instanceId),
-      )
-      .slice(0, 2)
-      .map((e) => ({
-        row: e as unknown as RecordData,
-        group:
-          plotted.find((g) =>
-            g.members.some((a) => !!e.instanceId && a.instanceId === e.instanceId),
-          )?.key ?? null,
-      })),
-  );
+  let resources = $derived(radarResources(telemetry, layer, plotted, chosenGroup));
+  let resourcePages = $derived(Math.max(1, Math.ceil(resources.length / 2)));
+  let resourceIndex = $derived(Math.min(resourcePage, resourcePages - 1));
+  let linked = $derived(resources.slice(resourceIndex * 2, resourceIndex * 2 + 2));
+  $effect(() => {
+    layer;
+    selected;
+    page;
+    resourcePage = 0;
+  });
+  function changePage(offset: number) {
+    page = Math.max(0, Math.min(pages - 1, page + offset));
+    selected = null;
+  }
   function select(g: RadarGroup) {
     selected =
       g.members.find((a) => a.instanceId === selected)?.instanceId ??
@@ -81,6 +81,38 @@
           >{/each}
       </div>
     </div>
+    {#if layer !== 'radar'}
+      <div class="radar-resource-toolbar">
+        <div class="resource-scope">
+          <strong>{chosenGroup?.name ?? 'All agents on this page'}</strong>
+          <span
+            >{resources.length} unique {layer === 'files' ? 'files' : 'endpoints'} · {telemetry.stale
+              ? 'Last reliable snapshot'
+              : layer === 'files'
+                ? 'Observed this session'
+                : 'Current snapshot'}</span
+          >
+        </div>
+        {#if chosenGroup}<button class="text-button" onclick={() => (selected = null)}
+            >Show all agents</button
+          >{/if}
+        {#if resourcePages > 1}<div class="radar-pages resource-pages" aria-label="Resource pages">
+            <button
+              aria-label="Previous radar resources"
+              disabled={resourceIndex === 0}
+              onclick={() => (resourcePage = resourceIndex - 1)}><Icon name="arrowLeft" /></button
+            >
+            <span
+              >{resourceIndex * 2 + 1}–{Math.min(resources.length, resourceIndex * 2 + 2)} / {resources.length}</span
+            >
+            <button
+              aria-label="Next radar resources"
+              disabled={resourceIndex >= resourcePages - 1}
+              onclick={() => (resourcePage = resourceIndex + 1)}><Icon name="chevron" /></button
+            >
+          </div>{/if}
+      </div>
+    {/if}
     <div id="radar-body">
       <div class="radar-workspace">
         <div class="radar-stage" class:stale={telemetry.stale} data-layer={layer}>
@@ -117,10 +149,16 @@
                 >
               </button>{/each}
           </div>
-          {#if !groups.length}<p class="radar-message">
+          {#if !groups.length && layer === 'radar'}<p class="radar-message">
               {telemetry.ready ? 'No agents in this snapshot' : 'Waiting for a reliable scan'}
             </p>{/if}
-          {#if layer !== 'radar'}<RadarLinks rows={linked} {layer} {inspect} />{/if}
+          {#if layer !== 'radar'}<RadarLinks
+              rows={linked}
+              {layer}
+              {inspect}
+              ready={telemetry.ready}
+              scoped={!!chosenGroup}
+            />{/if}
           <div class="radar-scale">Select a marker or an agent in the list</div>
         </div>
         <aside class="radar-roster" aria-label="Observed agents">
@@ -150,12 +188,14 @@
         >
       </div>
       {#if pages > 1}<div class="radar-pages">
-          <button aria-label="Previous radar agents" disabled={page === 0} onclick={() => page--}
-            ><Icon name="arrowLeft" /></button
+          <button
+            aria-label="Previous radar agents"
+            disabled={page === 0}
+            onclick={() => changePage(-1)}><Icon name="arrowLeft" /></button
           ><span>{Math.min(page, pages - 1) + 1}/{pages}</span><button
             aria-label="Next radar agents"
             disabled={page >= pages - 1}
-            onclick={() => page++}><Icon name="chevron" /></button
+            onclick={() => changePage(1)}><Icon name="chevron" /></button
           >
         </div>{/if}
     </div>

--- a/frontend/observatory/components/RadarLinks.svelte
+++ b/frontend/observatory/components/RadarLinks.svelte
@@ -1,20 +1,26 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import type { RecordData } from '../runtime/host';
+  import type { RadarResource } from '../runtime/radar-resources';
+  import Icon from './Icon.svelte';
   let {
     rows,
     layer,
     inspect,
+    ready,
+    scoped,
   }: {
-    rows: { row: RecordData; group: string | null }[];
+    rows: RadarResource[];
     layer: string;
     inspect: (title: string, row: RecordData) => void;
+    ready: boolean;
+    scoped: boolean;
   } = $props();
   let svg: SVGSVGElement;
   let stage: HTMLElement | null = null;
   function align(): void {
     if (!stage || !svg) return;
-    const bounds = stage.getBoundingClientRect();
+    const bounds = svg.getBoundingClientRect();
     if (!bounds.width || !bounds.height) return;
     svg.setAttribute('viewBox', `0 0 ${bounds.width} ${bounds.height}`);
     const routes = svg.querySelectorAll('g');
@@ -39,7 +45,6 @@
       route.querySelector('path')?.setAttribute('d', path);
       route.querySelector('animateMotion')?.setAttribute('path', path);
     });
-    svg.setCurrentTime?.(svg.getCurrentTime?.() || 0);
     svg.dataset.routes = 'ready';
   }
   $effect(() => {
@@ -52,10 +57,10 @@
     const resize = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(align);
     if (stage) resize?.observe(stage);
     const app = stage?.closest('.observatory-app');
-    const media = matchMedia('(prefers-reduced-motion: reduce)');
+    const media = window.matchMedia?.('(prefers-reduced-motion: reduce)');
     const syncMotion = () => {
       const frozen =
-        media.matches ||
+        media?.matches ||
         document.documentElement.dataset.motion === 'reduce' ||
         app?.classList.contains('paused') ||
         stage?.classList.contains('stale');
@@ -69,20 +74,26 @@
     });
     if (app) observer.observe(app, { attributes: true, attributeFilter: ['class'] });
     if (stage) observer.observe(stage, { attributes: true, attributeFilter: ['class'] });
-    media.addEventListener('change', syncMotion);
+    media?.addEventListener('change', syncMotion);
     align();
     syncMotion();
     return () => {
       resize?.disconnect();
       observer.disconnect();
-      media.removeEventListener('change', syncMotion);
+      media?.removeEventListener('change', syncMotion);
       stage = null;
     };
   });
 </script>
 
-<svg bind:this={svg} class="radar-links" aria-hidden="true" data-routes="pending">
-  {#each rows as entry, i (entry.row)}<g
+<svg
+  bind:this={svg}
+  class="radar-links"
+  aria-hidden="true"
+  data-routes="pending"
+  preserveAspectRatio="none"
+>
+  {#each rows as entry, i (entry.key)}<g data-resource-key={entry.key}
       ><path /><circle r="2" opacity="0"
         ><animateMotion dur={`${4 + i}s`} repeatCount="indefinite" /><animate
           attributeName="opacity"
@@ -94,28 +105,101 @@
       ></g
     >{/each}
 </svg>
-{#each rows as entry, i (entry.row)}<button
+{#each rows as entry, i (entry.key)}<button
     class="resource-node"
     data-route-index={i}
-    title={String(entry.row.file ?? entry.row.domain ?? entry.row.remoteIp ?? '')}
+    data-resource-key={entry.key}
+    data-resource-group={entry.group}
+    title={entry.address}
     onclick={() =>
       inspect(layer === 'files' ? 'File observation' : 'Network observation', entry.row)}
-    >{String(entry.row.file ?? entry.row.domain ?? entry.row.remoteIp ?? 'Observation')
-      .split(/[/\\]/)
-      .pop()}</button
-  >{:else}<p class="resource-empty">
-    No {layer === 'files' ? 'file observations' : 'connections'} for this selection
-  </p>{/each}
+    ><span class="resource-title"
+      ><Icon name={layer === 'files' ? 'file' : 'network'} /><strong>{entry.label}</strong><span
+        class="resource-count">{entry.count}×</span
+      ></span
+    >
+    <span class="resource-detail">{entry.detail}</span>
+    <span class="resource-owner">{entry.name} · {entry.attribution}</span></button
+  >{:else}<div class="resource-empty" role="status">
+    <Icon name={layer === 'files' ? 'folder' : 'network'} />
+    <strong
+      >{ready
+        ? `No ${layer === 'files' ? 'file observations' : 'connections'}${scoped ? ' for this agent' : ' on this page'}`
+        : 'Waiting for a reliable scan'}</strong
+    >
+    <span
+      >{scoped
+        ? 'Choose another agent or show all agents.'
+        : layer === 'files'
+          ? 'Recorded file activity will appear here.'
+          : 'Observed endpoints will appear here.'}</span
+    >
+  </div>{/each}
 
 <style>
   .resource-empty {
     position: absolute;
-    bottom: 12px;
-    padding: 0 12px;
-    width: 100%;
+    inset: auto 16px 16px;
+    padding: 14px;
+    display: grid;
+    justify-items: center;
+    gap: 6px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--panel);
     text-align: center;
-    font-size: 11px;
+    font-size: calc(11px * var(--ui-scale));
     color: var(--muted);
     pointer-events: none;
+  }
+  :global(.radar-stage) .resource-node {
+    display: grid;
+    gap: 4px;
+    width: min(300px, calc(100% - 32px));
+    max-width: calc(100% - 32px);
+    padding: 10px 12px;
+    text-align: left;
+    color: var(--ink);
+    border-color: var(--strong-border);
+    box-shadow: 0 2px 6px #0001;
+    animation: resource-arrive 220ms ease-out;
+  }
+  .resource-title {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+  }
+  .resource-title strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .resource-title :global(svg) {
+    flex: none;
+  }
+  .resource-count {
+    margin-left: auto;
+    color: var(--muted);
+    font-size: calc(10px * var(--ui-scale));
+  }
+  .resource-detail,
+  .resource-owner {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--muted);
+    font-size: calc(10px * var(--ui-scale));
+  }
+  .resource-owner {
+    padding-top: 4px;
+    border-top: 1px solid var(--border);
+  }
+  @keyframes resource-arrive {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 </style>

--- a/frontend/observatory/runtime/radar-resources.ts
+++ b/frontend/observatory/runtime/radar-resources.ts
@@ -1,0 +1,97 @@
+import type { Telemetry, RecordData } from './host';
+import type { RadarGroup } from './radar';
+
+export interface RadarResource {
+  key: string;
+  row: RecordData;
+  group: string | null;
+  name: string;
+  label: string;
+  address: string;
+  detail: string;
+  count: number;
+  attribution: string;
+}
+
+/** Format an observed endpoint, falling back to its IP when DNS is empty.
+ * @param row Connection metadata @returns Address with an optional port @since 0.14.1
+ */
+export function networkAddress(row: RecordData): string {
+  const host = String(row.domain || '').trim() || String(row.remoteIp || '').trim();
+  const port = typeof row.remotePort === 'number' && row.remotePort > 0 ? row.remotePort : null;
+  return host ? `${host.includes(':') ? `[${host}]` : host}${port ? `:${port}` : ''}` : '';
+}
+
+/** Collect unique resources, keeping exact process attribution and the newest file evidence.
+ * @param state Observed telemetry @param layer Resource layer @param plotted Visible agent groups
+ * @param chosen Selected group @returns Resources available on this radar page @since 0.14.1
+ */
+export function radarResources(
+  state: Telemetry,
+  layer: string,
+  plotted: RadarGroup[],
+  chosen?: RadarGroup,
+): RadarResource[] {
+  const owners = new Map(
+    plotted.flatMap((g) =>
+      g.members.filter((a) => a.instanceId).map((a) => [a.instanceId, g] as const),
+    ),
+  );
+  const allIds = new Set(state.agents.map((a) => a.instanceId).filter(Boolean));
+  const resources = new Map<string, RadarResource>();
+  const source = layer === 'files' ? state.events : state.network;
+  for (const entry of source) {
+    const row = entry as unknown as RecordData;
+    const evidence = row.attribution as { status?: string } | undefined;
+    if (row.selfAccess === true) continue;
+    const owner = evidence?.status === 'unattributed' ? undefined : owners.get(entry.instanceId);
+    if (chosen && owner?.key !== chosen.key) continue;
+    // Other radar pages have their own resources. Historical/unknown owners stay unlinked.
+    if (!chosen && !owner && entry.instanceId && allIds.has(entry.instanceId)) continue;
+    const file = String(row.file || '').trim();
+    const ip = String(row.remoteIp || '').trim();
+    const domain = String(row.domain || '').trim();
+    const port = typeof row.remotePort === 'number' && row.remotePort > 0 ? row.remotePort : null;
+    const address = layer === 'files' ? file : networkAddress(row);
+    if (!address) continue;
+    const status = owner
+      ? evidence?.status === 'inferred'
+        ? 'Indirect attribution'
+        : evidence?.status === 'confirmed'
+          ? 'Confirmed'
+          : 'Recorded owner'
+      : 'No current agent link';
+    // Ports and distinct IPs remain distinct even when reverse DNS returns the same name.
+    const identity =
+      layer === 'files' ? file.replaceAll('\\', '/') : `${ip || domain}:${port ?? ''}`;
+    const key = JSON.stringify([owner?.key ?? entry.instanceId ?? null, identity]);
+    const existing = resources.get(key);
+    if (existing) {
+      existing.count++;
+      if (existing.attribution !== status) existing.attribution = 'Mixed attribution';
+      if (Number(row.timestamp || 0) > Number(existing.row.timestamp || 0)) existing.row = row;
+      continue;
+    }
+    resources.set(key, {
+      key,
+      row,
+      group: owner?.key ?? null,
+      name: owner?.name ?? 'Unlinked observation',
+      label: layer === 'files' ? file.split(/[/\\]/).filter(Boolean).pop() || file : address,
+      address,
+      detail:
+        layer === 'files'
+          ? file
+          : [domain && ip !== domain ? ip : '', row.state].filter(Boolean).join(' · '),
+      count: 1,
+      attribution: status,
+    });
+  }
+  return [...resources.values()].sort((a, b) =>
+    layer === 'files'
+      ? Number(b.row.timestamp || 0) - Number(a.row.timestamp || 0) || a.key.localeCompare(b.key)
+      : a.name.localeCompare(b.name) ||
+        a.address.localeCompare(b.address) ||
+        a.key.localeCompare(b.key),
+  );
+}

--- a/frontend/observatory/styles/radar-clarity.css
+++ b/frontend/observatory/styles/radar-clarity.css
@@ -44,6 +44,34 @@
   container-type: inline-size;
   background: var(--bg);
 }
+.radar-clarity .radar-stage:not([data-layer='radar']) {
+  min-height: calc(400px + 90px * var(--ui-scale));
+}
+.radar-clarity .radar-stage:not([data-layer='radar']) .radar-scale {
+  display: none;
+}
+.radar-resource-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel-head);
+  font-size: calc(11px * var(--ui-scale));
+}
+.resource-scope {
+  display: grid;
+  gap: 4px;
+  margin-right: auto;
+}
+.resource-scope span {
+  color: var(--muted);
+}
+.resource-pages {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
 .radar-clarity .radar-dial {
   width: min(280px, calc(100cqw - 48px));
   height: min(280px, calc(100cqw - 48px));

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -5,6 +5,7 @@ import { resolve, sep, extname } from 'node:path';
 import { chromium } from 'playwright';
 import { createHash } from 'node:crypto';
 import { checkMotion } from './motion-check.mjs';
+import { checkResourceLayers } from './resource-layer-check.mjs';
 
 const repo = process.cwd();
 const designRoot = resolve(repo, 'frontend/observatory');
@@ -365,6 +366,7 @@ try {
   assert.equal(await page.evaluate(() => window.bridgeCalls), 0);
   await checkMotion(page);
   await page.close();
+  await checkResourceLayers(browser, base + '/desktop/', out);
   const desktop = await browser.newPage();
   desktop.on('pageerror', (e) => errors.push(e.message));
   await desktop.goto(base + '/desktop/');

--- a/frontend/observatory/tests/electron-smoke.mjs
+++ b/frontend/observatory/tests/electron-smoke.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { _electron as electron } from 'playwright';
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { checkResourceGeometry } from './resource-layer-check.mjs';
 const root = process.cwd();
 const out = resolve(
   root,
@@ -67,6 +68,24 @@ try {
     1,
     'closing agent details clears the radar selection',
   );
+  for (const layer of ['Files', 'Network']) {
+    await window.locator('.radar-layers').getByRole('button', { name: layer, exact: true }).click();
+    const all = window.getByRole('button', { name: 'Show all agents', exact: true });
+    if (await all.isVisible()) await all.click();
+    await window.mouse.move(0, 0);
+    await checkResourceGeometry(window);
+    // Check every endpoint currently visible to the native sensors, including empty DNS.
+    const next = window.getByLabel('Next radar resources');
+    while ((await next.isVisible()) && (await next.isEnabled())) {
+      await next.click();
+      await window.mouse.move(0, 0);
+      await checkResourceGeometry(window);
+    }
+    await window
+      .locator('.radar-panel')
+      .screenshot({ path: resolve(out, `radar-${layer.toLowerCase()}.png`) });
+  }
+  await window.locator('.radar-layers').getByRole('button', { name: 'Radar', exact: true }).click();
   const stats = await window.evaluate(async () => {
     const stats = await window.aegis.getStats();
     return { agents: stats.currentAgents, health: stats.appHealth, gap: stats.observationGap };

--- a/frontend/observatory/tests/resource-layer-check.mjs
+++ b/frontend/observatory/tests/resource-layer-check.mjs
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+/** Check resource routes against rendered anchors after motion, resizing and data refresh.
+ * @param {import('playwright').Page} page Observatory page @returns {Promise<void>} Verified geometry @since 0.14.1
+ */
+export async function checkResourceGeometry(page) {
+  await page.waitForFunction(
+    () => document.querySelector('.radar-links')?.dataset.routes === 'ready',
+  );
+  await page.waitForTimeout(350);
+  const issues = await page.locator('.radar-stage').evaluate((stage) => {
+    const issues = [];
+    const svg = stage.querySelector('.radar-links');
+    const bounds = stage.getBoundingClientRect();
+    const nodes = [...stage.querySelectorAll('.resource-node')];
+    const center = (r) => ({ x: r.x + r.width / 2, y: r.y + r.height / 2 });
+    for (const node of nodes) {
+      const box = node.getBoundingClientRect();
+      if (
+        box.left < bounds.left ||
+        box.right > bounds.right + 1 ||
+        box.top < bounds.top ||
+        box.bottom > bounds.bottom + 1
+      )
+        issues.push('resource outside stage');
+      if (!node.querySelector('strong')?.textContent.trim()) issues.push('empty resource label');
+      const route = [...svg.querySelectorAll('g')].find(
+        (g) => g.dataset.resourceKey === node.dataset.resourceKey,
+      );
+      const marker = [...stage.querySelectorAll('.radar-blip')].find(
+        (m) => m.dataset.group === node.dataset.resourceGroup,
+      );
+      if (!marker) {
+        if (getComputedStyle(route).display !== 'none')
+          issues.push('unattributed resource has a route');
+        continue;
+      }
+      for (const other of stage.querySelectorAll('.radar-blip')) {
+        const b = other.getBoundingClientRect();
+        if (box.left < b.right && box.right > b.left && box.top < b.bottom && box.bottom > b.top)
+          issues.push('resource overlaps marker');
+      }
+      const path = route.querySelector('path');
+      const matrix = path.getScreenCTM();
+      const start = path.getPointAtLength(0).matrixTransform(matrix);
+      const end = path.getPointAtLength(path.getTotalLength()).matrixTransform(matrix);
+      const dot = center(marker.querySelector('.blip-dot').getBoundingClientRect());
+      const resource = center(box);
+      if (Math.hypot(start.x - dot.x, start.y - dot.y) > 1.5)
+        issues.push('route detached from marker');
+      if (Math.hypot(end.x - resource.x, end.y - resource.y) > 1.5)
+        issues.push('route detached from resource');
+    }
+    return issues;
+  });
+  assert.deepEqual(issues, [], 'resource layer geometry');
+}
+
+/** Exercise populated desktop resource layers through an isolated bridge fixture.
+ * @param {import('playwright').Browser} browser Browser @param {string} url Desktop build URL
+ * @param {string} out Screenshot directory @returns {Promise<void>} Regression assertions @since 0.14.1
+ */
+export async function checkResourceLayers(browser, url, out) {
+  const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  try {
+    await page.addInitScript(() => {
+      const listeners = {};
+      window.resourceFixture = listeners;
+      window.aegis = new Proxy(
+        {},
+        {
+          get: (_, method) => {
+            if (method.startsWith('on'))
+              return (cb) => {
+                listeners[method] = cb;
+                return () => delete listeners[method];
+              };
+            return async () =>
+              method === 'getSettings'
+                ? { darkMode: true, uiScale: 1 }
+                : method === 'getAppVersion'
+                  ? 'Test'
+                  : method === 'getFalsePositives'
+                    ? []
+                    : {};
+          },
+        },
+      );
+    });
+    await page.goto(url);
+    await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
+    await page.evaluate(() => {
+      const agents = ['Claude Code', 'Codex', 'Cursor', 'Ollama', 'Zeta'].map((agent, i) => ({
+        agent,
+        pid: 100 + i,
+        process: 'agent.exe',
+        instanceId: `resource-test:${i}`,
+        instanceIdSource: 'os',
+      }));
+      window.resourceAgents = agents;
+      window.resourceStats = {
+        appHealth: { populationReliable: true, identityDegraded: false, state: 'HEALTHY' },
+        observationGap: { state: 'NONE' },
+      };
+      window.resourceFixture.onScanBatch({ agents, stats: window.resourceStats });
+      window.resourceFixture.onNetworkUpdate([
+        ...[443, 443, 80, 8080, 8443].map((remotePort) => ({
+          instanceId: agents[0].instanceId,
+          domain: '',
+          remoteIp: '192.0.2.10',
+          remotePort,
+          state: 'Established',
+        })),
+        { instanceId: agents[4].instanceId, domain: '', remoteIp: '2001:db8::1', remotePort: 443 },
+      ]);
+      window.resourceFixture.onFileAccess(
+        Array.from({ length: 8 }, (_, i) => ({
+          instanceId: agents[0].instanceId,
+          file: `X:/Fixture/project-${i % 4}/settings.json`,
+          timestamp: Date.now() - i * 1000,
+          attribution: { status: 'inferred' },
+          action: 'modified',
+        })),
+      );
+    });
+    const layer = (name) =>
+      page.locator('.radar-layers').getByRole('button', { name, exact: true });
+    await layer('Network').click();
+    assert.match(await page.locator('.resource-scope').innerText(), /4 unique endpoints/);
+    await page.locator('.resource-node').first().click();
+    await page.getByRole('dialog').waitFor();
+    assert.match(await page.locator('.details-grid').innerText(), /192\.0\.2\.10:\d+/);
+    await page.keyboard.press('Escape');
+    await page.getByRole('dialog').waitFor({ state: 'hidden' });
+    await page.mouse.move(0, 0);
+    for (const size of [
+      { width: 1200, height: 800 },
+      { width: 900, height: 700 },
+      { width: 1779, height: 1146 },
+    ]) {
+      await page.setViewportSize(size);
+      for (const scale of [1, 1.5]) {
+        await page.evaluate(
+          (scale) => document.documentElement.style.setProperty('--ui-scale', String(scale)),
+          scale,
+        );
+        for (const theme of ['dark', 'light', 'dark-hc', 'light-hc']) {
+          await page.evaluate((theme) => (document.documentElement.dataset.theme = theme), theme);
+          for (const name of ['Files', 'Network']) {
+            await layer(name).click();
+            await checkResourceGeometry(page);
+            await page.getByLabel('Next radar resources').click();
+            await checkResourceGeometry(page);
+          }
+        }
+      }
+    }
+    await page.locator('.radar-stage').screenshot({ path: resolve(out, 'resources-network.png') });
+    // Same identities with new objects must not recreate resource nodes or detach routes.
+    const first = await page.locator('.resource-node').first().elementHandle();
+    await page.evaluate(() =>
+      window.resourceFixture.onScanBatch({
+        agents: structuredClone(window.resourceAgents),
+        stats: window.resourceStats,
+      }),
+    );
+    await checkResourceGeometry(page);
+    assert(await first.evaluate((node) => node.isConnected), 'scan recreated unchanged resources');
+    await page.getByLabel('Next radar agents').click();
+    await checkResourceGeometry(page);
+    assert.match(await page.locator('.resource-node').innerText(), /\[2001:db8::1\]:443/);
+    await layer('Files').click();
+    assert.match(
+      await page.locator('.resource-empty').innerText(),
+      /No file observations on this page/,
+    );
+    await page.getByLabel('Previous radar agents').click();
+    await checkResourceGeometry(page);
+    await page.locator('.radar-stage').screenshot({ path: resolve(out, 'resources-files.png') });
+    await page.evaluate(() =>
+      window.resourceFixture.onStatsUpdate({ appHealth: { populationReliable: false } }),
+    );
+    await page.waitForFunction(() => document.querySelector('.radar-links').animationsPaused());
+    assert.match(await page.locator('.resource-scope').innerText(), /Last reliable snapshot/);
+    assert.deepEqual(errors, []);
+    console.log(
+      'Resource layers: 48 theme/scale/viewport combinations, all pages, exact route anchors, empty DNS, deduplication, refreshed identities, details and stale motion passed.',
+    );
+  } finally {
+    await page.close();
+  }
+}

--- a/tests/renderer/components/ObservatoryRadarResources.test.js
+++ b/tests/renderer/components/ObservatoryRadarResources.test.js
@@ -1,0 +1,84 @@
+import { expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/svelte';
+import Radar from '../../../frontend/observatory/components/Radar.svelte';
+import DetailSummary from '../../../frontend/observatory/components/DetailSummary.svelte';
+import { emptyTelemetry } from '../../../frontend/observatory/runtime/host';
+
+const agents = ['Alpha', 'Beta', 'Delta', 'Gamma', 'Zeta'].map((agent, i) => ({
+  agent,
+  pid: i + 1,
+  process: 'agent.exe',
+  instanceId: `${i}:live`,
+  instanceIdSource: 'os',
+}));
+const events = Array.from({ length: 7 }, (_, i) => ({
+  file: `X:/project/file-${i}.ts`,
+  instanceId: i < 6 ? '0:live' : '4:live',
+  timestamp: i,
+  attribution: { status: 'confirmed' },
+}));
+
+it('pages through every unique file, opens the recorded observation and resets scope across agent pages', async () => {
+  const inspect = vi.fn();
+  const mounted = render(Radar, {
+    telemetry: { ...emptyTelemetry(), ready: true, stale: false, agents, events },
+    selected: '0:live',
+    inspect,
+  });
+  await fireEvent.click(
+    within(screen.getByLabelText('Radar layer')).getByRole('button', {
+      name: 'Files',
+      exact: true,
+    }),
+  );
+  expect(screen.getByText(/6 unique files/)).toBeInTheDocument();
+  await fireEvent.click(
+    within(mounted.container.querySelector('.radar-stage')).getByRole('button', {
+      name: /file-5.ts/,
+    }),
+  );
+  expect(inspect).toHaveBeenLastCalledWith('File observation', events[5]);
+  await fireEvent.click(screen.getByLabelText('Next radar resources'));
+  await fireEvent.click(screen.getByLabelText('Next radar resources'));
+  expect(screen.getByRole('button', { name: /file-0.ts/ })).toBeInTheDocument();
+  expect(screen.getByLabelText('Next radar resources')).toBeDisabled();
+  await fireEvent.click(screen.getByLabelText('Next radar agents'));
+  expect(screen.getByText('All agents on this page')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /file-6.ts/ })).toBeInTheDocument();
+  expect(mounted.container.querySelectorAll('.radar-blip[aria-pressed="true"]')).toHaveLength(0);
+});
+
+it('explains an empty selected agent and allows showing other agents without losing the layer', async () => {
+  render(Radar, {
+    telemetry: { ...emptyTelemetry(), ready: true, stale: false, agents, events },
+    selected: '1:live',
+    inspect: vi.fn(),
+  });
+  await fireEvent.click(
+    within(screen.getByLabelText('Radar layer')).getByRole('button', {
+      name: 'Files',
+      exact: true,
+    }),
+  );
+  expect(screen.getByRole('status')).toHaveTextContent('No file observations for this agent');
+  await fireEvent.click(screen.getByRole('button', { name: 'Show all agents' }));
+  expect(screen.getByRole('button', { name: /file-5.ts/ })).toBeInTheDocument();
+});
+
+it('shows the endpoint in both the radar and its detail view when DNS is empty', async () => {
+  const row = { instanceId: '0:live', domain: '', remoteIp: '192.0.2.8', remotePort: 443 };
+  const telemetry = { ...emptyTelemetry(), ready: true, stale: false, agents, network: [row] };
+  const inspect = vi.fn();
+  const mounted = render(Radar, { telemetry, selected: null, inspect });
+  await fireEvent.click(
+    within(screen.getByLabelText('Radar layer')).getByRole('button', {
+      name: 'Network',
+      exact: true,
+    }),
+  );
+  await fireEvent.click(screen.getByRole('button', { name: /192.0.2.8:443/ }));
+  expect(inspect).toHaveBeenCalledWith('Network observation', row);
+  mounted.unmount();
+  render(DetailSummary, { row, telemetry });
+  expect(screen.getByText('192.0.2.8:443')).toBeInTheDocument();
+});

--- a/tests/renderer/components/ObservatoryTheme.test.js
+++ b/tests/renderer/components/ObservatoryTheme.test.js
@@ -7,10 +7,10 @@ it('leaves high contrast through the ordinary theme toggle and persists the ordi
   localStorage.setItem('aegis-theme', 'light-hc');
   render(App, { host: null });
   await waitFor(() => expect(document.documentElement.dataset.theme).toBe('light-hc'));
-  await fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+  await fireEvent.click(screen.getByLabelText('Toggle theme', { selector: 'button' }));
   expect(document.documentElement.dataset.theme).toBe('dark');
   expect(localStorage.getItem('aegis-theme')).toBe('dark');
-  await fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+  await fireEvent.click(screen.getByLabelText('Toggle theme', { selector: 'button' }));
   expect(document.documentElement.dataset.theme).toBe('light');
 });
 
@@ -22,7 +22,7 @@ it('does not let delayed settings overwrite a theme chosen while the app starts'
   });
   const host = { getSettings: () => pending };
   render(App, { host });
-  await fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+  await fireEvent.click(screen.getByLabelText('Toggle theme', { selector: 'button' }));
   expect(document.documentElement.dataset.theme).toBe('light');
   resolveSettings({ darkMode: true, uiScale: 1 });
   await pending;

--- a/tests/renderer/observatory-radar-resources.test.js
+++ b/tests/renderer/observatory-radar-resources.test.js
@@ -1,0 +1,98 @@
+import { expect, it } from 'vitest';
+import { emptyTelemetry, instances } from '../../frontend/observatory/runtime/host';
+import { radarGroups } from '../../frontend/observatory/runtime/radar';
+import { radarResources } from '../../frontend/observatory/runtime/radar-resources';
+
+const agent = (pid, name = 'Codex') => ({
+  agent: name,
+  pid,
+  process: 'agent.exe',
+  instanceId: `${pid}:now`,
+  instanceIdSource: 'os',
+});
+const file = (path, timestamp, pid = 1) => ({
+  instanceId: `${pid}:now`,
+  file: path,
+  timestamp,
+  attribution: { status: 'confirmed' },
+});
+const connection = (overrides = {}) => ({
+  instanceId: '1:now',
+  domain: '',
+  remoteIp: '192.0.2.8',
+  remotePort: 443,
+  state: 'Established',
+  ...overrides,
+});
+
+it('deduplicates files across grouped processes, retains newest evidence and distinct paths', () => {
+  const state = {
+    ...emptyTelemetry(),
+    agents: [agent(1), agent(2)],
+    events: [
+      file('X:/a/config.ts', 2),
+      file('X:\\a\\config.ts', 9, 2),
+      file('X:/b/config.ts', 3),
+      { ...file('X:/self', 5), selfAccess: true },
+    ],
+  };
+  const rows = radarResources(state, 'files', radarGroups(instances(state)));
+  expect(rows).toHaveLength(2);
+  expect(rows[0]).toMatchObject({ label: 'config.ts', count: 2, group: 'Codex' });
+  expect(rows[0].row).toBe(state.events[1]);
+  expect(rows.map((r) => r.key)).toHaveLength(new Set(rows.map((r) => r.key)).size);
+});
+
+it('renders empty DNS as IP and port, distinguishing ports and IPv6 without duplicate sockets', () => {
+  const state = {
+    ...emptyTelemetry(),
+    agents: [agent(1), agent(2)],
+    network: [
+      connection(),
+      connection({ instanceId: '2:now' }),
+      connection({ remotePort: 80 }),
+      connection({ remoteIp: '2001:db8::1' }),
+      connection({ remoteIp: '', domain: '' }),
+    ],
+  };
+  const rows = radarResources(state, 'network', radarGroups(instances(state)));
+  expect(rows.map((r) => r.label)).toEqual(
+    expect.arrayContaining(['192.0.2.8:443', '192.0.2.8:80', '[2001:db8::1]:443']),
+  );
+  expect(rows).toHaveLength(3);
+  expect(rows.find((r) => r.label === '192.0.2.8:443').count).toBe(2);
+});
+
+it('only links exact current instances and scopes resources to the visible radar page', () => {
+  const state = {
+    ...emptyTelemetry(),
+    agents: [agent(1), agent(2, 'Cursor')],
+    events: [
+      file('X:/current', 1),
+      file('X:/other-page', 2, 2),
+      { ...file('X:/old', 3), instanceId: '1:old', agent: 'Codex', pid: 1 },
+      { ...file('X:/unknown', 4), instanceId: null, agent: 'Codex', pid: 1 },
+    ],
+  };
+  const groups = radarGroups(instances(state));
+  const rows = radarResources(state, 'files', [groups[0]]);
+  expect(rows).toHaveLength(3);
+  expect(rows.filter((r) => r.group)).toHaveLength(1);
+  expect(rows.filter((r) => !r.group).every((r) => r.attribution === 'No current agent link')).toBe(
+    true,
+  );
+  expect(radarResources(state, 'files', [groups[0]], groups[0]).map((r) => r.label)).toEqual([
+    'current',
+  ]);
+});
+
+it('does not turn inferred file ownership into confirmed attribution', () => {
+  const state = {
+    ...emptyTelemetry(),
+    agents: [agent(1)],
+    events: [{ ...file('X:/config', 1), attribution: { status: 'inferred' } }],
+  };
+  expect(radarResources(state, 'files', radarGroups(instances(state)))[0].attribution).toBe(
+    'Indirect attribution',
+  );
+});


### PR DESCRIPTION
The radar rendered empty buttons for connections without DNS names and silently stopped after two observations. Repeated observations could hide other resources, and connection paths were measured during the resource entrance translation.

Files and Network now show labelled resource cards, IP/port fallback, grouped observation counts, explicit agent scope and resource pagination. Links use exact current process identities; historical or unattributed records remain unlinked. Changing agent pages clears an off-page selection. Resource anchors stay aligned after motion, resize and scan refresh. Endpoint details use the same address formatter.

Validation: all repository gates passed; 162 test files, 2873 passing tests and 4 existing skips. Both renderer builds passed. Browser checks cover 264 existing view combinations plus 48 populated resource-layer combinations, all resource pages, DNS fallback, exact route geometry, selection, details and stale motion. Packaged Windows smoke passed with real sensors, all 11 workspaces, settings persistence and six export handlers. The existing theme regression test now finds the labelled toolbar button directly, avoiding a slow whole-tree accessibility query under coverage without increasing its timeout.

No backend, IPC, dependency, version or release changes.
