### PR TITLE
fix(charts): separate source clocks and correct live graph history

### DIFF
--- a/frontend/observatory/App.svelte
+++ b/frontend/observatory/App.svelte
@@ -404,6 +404,7 @@
               bind:selected
               {inspect}
               mode={view}
+              {paused}
               {navigate}
             />
           </div>

--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -23,3 +23,5 @@ Live-data adaptations:
 - Process activity groups retained files and connections with access to each observation. Evidence has its own Attributes tab; resource delivery diagnostics use named expandable fields.
 
 Visual verification uses the preserved source at the same viewport, scale, theme and state. Passing tests alone must not be reported as proof that the interface matches the template.
+
+Graph correctness: source-specific receipt clocks govern sparse history; resource, token, network and own-process updates never provide denominators for another source. Charts use fixed one/three/five-minute windows, visible measured subtotals and coverage, explicit missing-data breaks, and actual-point inspection. Histograms age by wall time and freeze with the view. Source delivery timestamps are not OS measurement timestamps.

--- a/frontend/observatory/components/ActivityChart.svelte
+++ b/frontend/observatory/components/ActivityChart.svelte
@@ -1,23 +1,45 @@
 <script lang="ts">
-  import { activityBins } from '../runtime/activity';
+  import { activityBins, activityTimeLabel } from '../runtime/activity';
   import type { FileEvent } from '../../../src/shared/types';
   import type { RecordData } from '../runtime/host';
   import Icon from './Icon.svelte';
   let {
     events,
     observedAt,
+    paused = false,
+    stale = false,
     inspect,
   }: {
     events: FileEvent[];
     observedAt: number | null;
-    inspect: (title: string, row: RecordData) => void;
+    paused?: boolean;
+    stale?: boolean;
+    inspect: (_title: string, _row: RecordData) => void;
   } = $props();
   let period = $state(15 * 60000),
     type = $state('all'),
     agent = $state(''),
     hover = $state<number | null>(null),
     focus = $state(0);
-  let end = $derived(Math.max(observedAt ?? 0, ...events.map((e) => e.timestamp)) + 1);
+  let focused = $state(false);
+  let now = $state(Date.now());
+  $effect(() => {
+    if (paused || stale) return;
+    now = Date.now();
+    const timer = setInterval(() => {
+      now = Date.now();
+    }, 1000);
+    return () => clearInterval(timer);
+  });
+  $effect(() => {
+    period;
+    type;
+    agent;
+    hover = null;
+    focused = false;
+  });
+  let end = $derived(now + 1);
+  let selection = $derived(hover ?? (focused ? focus : null));
   let bins = $derived(
     activityBins(
       events.filter((e) => (!agent || e.agent === agent) && (type === 'all' || e.sensitive)),
@@ -31,7 +53,7 @@
   let names = $derived([...new Set(events.map((e) => e.agent).filter(Boolean))].sort());
   function caption(i: number) {
     const b = bins[i];
-    return `${new Date(b.start).toLocaleTimeString()}–${new Date(b.end).toLocaleTimeString()} · ${b.events.length} observations`;
+    return `${activityTimeLabel(b.start, true)}–${activityTimeLabel(b.end, true)} · ${b.events.length} observations`;
   }
   function keys(e: KeyboardEvent, i: number) {
     if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) return;
@@ -40,8 +62,8 @@
       e.key === 'Home'
         ? 0
         : e.key === 'End'
-          ? 23
-          : Math.max(0, Math.min(23, i + (e.key === 'ArrowRight' ? 1 : -1)));
+          ? bins.length - 1
+          : Math.max(0, Math.min(bins.length - 1, i + (e.key === 'ArrowRight' ? 1 : -1)));
     (e.currentTarget as HTMLElement).parentElement
       ?.querySelectorAll<HTMLButtonElement>('button')
       .item(focus)
@@ -71,10 +93,16 @@
     >
   </div>
   <div class="chart-reading">
-    <strong>{bins.reduce((sum, b) => sum + b.events.length, 0)}</strong><span>events in period</span
-    ><span class="chart-max">Scale 0–{maximum}</span>
+    <strong>{bins.reduce((sum, b) => sum + b.events.length, 0)}</strong><span
+      >retained events in period</span
+    ><span class="chart-max">Scale 0–{maximum} / interval</span>
   </div>
-  <div class="activity-plot" role="group" aria-label="File activity histogram">
+  <div
+    class="activity-plot"
+    role="group"
+    aria-label="File activity histogram"
+    onpointerleave={() => (hover = null)}
+  >
     {#each bins as bin, i (i)}<button
         class="chart-bucket"
         tabindex={focus === i ? 0 : -1}
@@ -83,8 +111,9 @@
         onpointerenter={() => (hover = i)}
         onfocus={() => {
           focus = i;
-          hover = i;
+          focused = true;
         }}
+        onblur={() => (focused = false)}
         onkeydown={(e) => keys(e, i)}
         onclick={() =>
           inspect('Activity interval', {
@@ -98,11 +127,17 @@
       >{/each}
   </div>
   <div class="chart-axis">
-    <span>{new Date(end - period).toLocaleTimeString().slice(0, 5)}</span><span
-      >{new Date(end).toLocaleTimeString().slice(0, 5)}</span
-    >
+    <span>{activityTimeLabel(end - period)}</span><span>{activityTimeLabel(end - 1)}</span>
   </div>
   <div class="chart-readout">
-    {hover === null ? 'Select an interval to inspect its events.' : caption(hover)}
+    {selection === null
+      ? observedAt === null && !events.length
+        ? 'Waiting for observations.'
+        : paused
+          ? 'View paused · retained window frozen.'
+          : stale
+            ? 'Observation unavailable · retained window frozen.'
+            : 'Select an interval to inspect its events.'
+      : caption(selection)}
   </div>
 </section>

--- a/frontend/observatory/components/Monitoring.svelte
+++ b/frontend/observatory/components/Monitoring.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { instances, measured, type Telemetry, type RecordData } from '../runtime/host';
   import { radarGroups } from '../runtime/radar';
   import Radar from './Radar.svelte';
@@ -17,19 +18,29 @@
     inspect,
     mode = 'overview',
     navigate,
+    paused = false,
   }: {
     telemetry: Telemetry;
     selected: string | null;
     inspect: (title: string, row: RecordData) => void;
     mode?: string;
+    paused?: boolean;
     navigate?: (_view: string) => void | Promise<void>;
   } = $props();
   let agents = $derived(instances(telemetry)),
     groups = $derived(radarGroups(agents));
-  let end = $derived(
-    Math.max(telemetry.lastScan ?? 0, ...telemetry.events.map((e) => e.timestamp)),
+  let now = $state(Date.now());
+  onMount(() => {
+    const timer = setInterval(() => {
+      if (!paused && !telemetry.stale) now = Date.now();
+    }, 1000);
+    return () => clearInterval(timer);
+  });
+  let recent = $derived(
+    telemetry.events.filter(
+      (e) => Number.isFinite(e.timestamp) && e.timestamp > now - 60000 && e.timestamp <= now,
+    ),
   );
-  let recent = $derived(telemetry.events.filter((e) => e.timestamp > end - 60000));
   let tokenTotal = $derived(
     telemetry.tokens.length && telemetry.tokens.every((t) => measured(t.totalTokens) !== null)
       ? telemetry.tokens.reduce((sum, t) => sum + Number(t.totalTokens), 0)
@@ -87,10 +98,16 @@
   </div>
   <Radar {telemetry} bind:selected {inspect} />
   <div class="monitoring-activity">
-    <ActivityChart events={telemetry.events} observedAt={telemetry.lastScan} {inspect} />
+    <ActivityChart
+      events={telemetry.events}
+      observedAt={telemetry.lastScan}
+      {inspect}
+      {paused}
+      stale={telemetry.stale}
+    />
   </div>
   <div class="overview-bottom">
-    <Timeline {telemetry} {inspect} />
+    <Timeline {telemetry} {inspect} {paused} />
     <section class="panel recent-panel">
       <div class="panel-head">
         <h2><Icon name="activity" />Recent events</h2>

--- a/frontend/observatory/components/ResourceUsage.svelte
+++ b/frontend/observatory/components/ResourceUsage.svelte
@@ -1,18 +1,20 @@
 <script lang="ts">
   import { instances, type RecordData, type Telemetry } from '../runtime/host';
-  import { radarGroups, groupResource, groupRecord } from '../runtime/radar';
+  import { radarGroups, groupRecord } from '../runtime/radar';
+  import { measuredGroupResource } from '../runtime/resources';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   let {
     telemetry,
     inspect,
   }: { telemetry: Telemetry; inspect: (title: string, row: RecordData) => void } = $props();
-  let mode = $state('cpu');
+  let mode = $state<'cpu' | 'memMb'>('cpu');
   let agents = $derived(radarGroups(instances(telemetry)));
+  let readings = $derived(
+    agents.map((group) => ({ group, ...measuredGroupResource(group, telemetry, mode) })),
+  );
   let maximum = $derived(
-    mode === 'cpu'
-      ? 100
-      : Math.max(1, ...agents.map((g) => groupResource(g, telemetry, 'memMb') ?? 0)),
+    mode === 'cpu' ? 100 : Math.max(0, ...readings.map((reading) => reading.value ?? 0)) || 1,
   );
 </script>
 
@@ -20,7 +22,7 @@
   <div class="panel-head">
     <div>
       <h2><Icon name="chart" />Agent usage</h2>
-      <p>Combined usage across each agent's processes</p>
+      <p>Latest delivered measurements</p>
     </div>
     <div class="segmented">
       <button aria-pressed={mode === 'cpu'} onclick={() => (mode = 'cpu')}>CPU</button><button
@@ -30,18 +32,25 @@
     </div>
   </div>
   <div class="resource-bars">
-    {#each agents as a (a.key)}{@const value = groupResource(a, telemetry, mode)}<button
-        class="usage-row"
-        onclick={() => inspect(a.name, groupRecord(a))}
+    {#each readings as reading (reading.group.key)}{@const a = reading.group}{@const value =
+        reading.value}<button class="usage-row" onclick={() => inspect(a.name, groupRecord(a))}
         ><AgentLogo id={a.key} name={a.name} /><span class="usage-body"
           ><span class="usage-heading"
             ><strong
               >{a.name}<small
-                >{a.members.length} {a.members.length === 1 ? 'process' : 'processes'}</small
+                >{telemetry.stale || !telemetry.ready
+                  ? 'Readings paused'
+                  : reading.measured + '/' + reading.total + ' processes measured'}{value !==
+                  null && reading.measured < reading.total
+                  ? ' · partial'
+                  : ''}</small
               ></strong
             ><span>{value === null ? '—' : value.toFixed(1) + (mode === 'cpu' ? '%' : ' MB')}</span
             ></span
-          ><span class="usage-track"
+          ><span
+            class="usage-track"
+            class:partial={value !== null && reading.measured < reading.total}
+            class:unavailable={value === null}
             ><span style={`transform:scaleX(${Math.min(1, (value ?? 0) / maximum)})`}></span></span
           ></span
         ><Icon name="chevron" /></button
@@ -50,7 +59,10 @@
   <p class="chart-footnote">
     {mode === 'cpu'
       ? 'Percentage of total CPU capacity.'
-      : 'Bar length is relative to the largest agent total.'} Open an agent for its processes.
+      : 'Bar length is relative to the largest measured agent subtotal.'} Coverage identifies missing
+    processes; partial readings exclude them. {#if telemetry.resourcesAt !== null && Number.isFinite(telemetry.resourcesAt)}Received
+      {new Date(telemetry.resourcesAt).toLocaleTimeString()}.
+    {/if}Open an agent for its processes.
   </p>
 </section>
 
@@ -58,6 +70,12 @@
   .resource-bars {
     max-height: 286px;
     overflow: auto;
+  }
+  .usage-track.partial > span {
+    background-image: repeating-linear-gradient(135deg, transparent 0 5px, var(--panel) 5px 7px);
+  }
+  .usage-track.unavailable {
+    opacity: 0.45;
   }
   .resource-chart {
     align-self: stretch;

--- a/frontend/observatory/components/Statistics.svelte
+++ b/frontend/observatory/components/Statistics.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { instances, record, type Telemetry, type RecordData } from '../runtime/host';
   import { radarGroups, groupRecord, riskBand } from '../runtime/radar';
   import {
@@ -39,6 +39,14 @@
     activity: 'fileRate',
     tokens: 'tokens',
     sensors: 'ownCpu',
+  });
+  let now = $state(Date.now());
+  let historyPeriod = $state(60000);
+  onMount(() => {
+    const timer = setInterval(() => {
+      if (!paused && !telemetry.stale) now = Date.now();
+    }, 1000);
+    return () => clearInterval(timer);
   });
   let history = createStatisticsHistory();
   let samples = $state<StatisticsSample[]>([]);
@@ -85,9 +93,10 @@
   );
   let health = $derived(record(telemetry.stats.appHealth));
   $effect(() => {
-    const current = telemetry;
+    const current = paused ? { ...telemetry, stale: true } : telemetry;
+    const interruptedAt = paused ? Date.now() : undefined;
     untrack(() => {
-      const next = observeStatistics(history, current);
+      const next = observeStatistics(history, current, interruptedAt);
       if (next !== history) {
         history = next;
         samples = next.samples;
@@ -107,21 +116,6 @@
 </script>
 
 <div class="statistics-workspace">
-  <section class="statistics-heading" aria-label="Statistics coverage">
-    <div>
-      <h2>Performance & observation</h2>
-      <p>A focused view of your agents, their activity and AEGIS itself.</p>
-    </div>
-    <div class="live-state">
-      <span class:stale={telemetry.stale || paused}></span>{paused
-        ? 'View paused'
-        : telemetry.stale
-          ? 'Last reliable data'
-          : telemetry.ready
-            ? 'Live observations'
-            : 'Waiting for data'}
-    </div>
-  </section>
   <div class="stats-navigation">
     <SectionTabs
       tabs={statisticsTabs}
@@ -144,7 +138,7 @@
             >{section === 'sensors'
               ? 'AEGIS main process · ' + String(health.state || 'Starting').toLowerCase()
               : section === 'tokens'
-                ? 'Supported agent logs · complete totals only'
+                ? 'Supported agent logs · measured coverage'
                 : section === 'activity'
                   ? 'Observed activity · counts and rates'
                   : 'Agent processes · ' +
@@ -153,11 +147,20 @@
                     telemetry.agents.length +
                     ' resource samples'}</span
           >
-          <span>{samples.length} / 120 samples · this window</span>
+          <span class="live-state"
+            >{paused
+              ? 'View paused · '
+              : telemetry.stale
+                ? 'Last observation · '
+                : ''}{samples.length} source updates · up to 5 minutes</span
+          >
         </div>
         <StatsChart
           {samples}
           {metrics}
+          {now}
+          {paused}
+          bind:period={historyPeriod}
           bind:selected={selected[section]}
           stale={telemetry.stale || paused}
         />
@@ -181,7 +184,13 @@
             <ResourceUsage {telemetry} {inspect} />
             <Agents {telemetry} {inspect} />
           {:else if section === 'activity'}
-            <ActivityChart events={telemetry.events} observedAt={telemetry.lastScan} {inspect} />
+            <ActivityChart
+              events={telemetry.events}
+              observedAt={telemetry.lastScan}
+              {inspect}
+              {paused}
+              stale={telemetry.stale}
+            />
             <div class="distribution-grid">
               <StatsDistribution
                 title="Connection identity"
@@ -217,44 +226,6 @@
 <style>
   .statistics-workspace {
     min-width: 0;
-  }
-  .statistics-heading {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 14px;
-    margin-bottom: 18px;
-  }
-  h2 {
-    margin: 0;
-    font-size: 18px;
-    font-weight: 550;
-    letter-spacing: -0.4px;
-  }
-  .statistics-heading p {
-    color: var(--muted);
-    font-size: 12px;
-    margin: 6px 0 0;
-    line-height: 1.5;
-  }
-  .live-state {
-    display: flex;
-    gap: 7px;
-    align-items: center;
-    font-size: 11px;
-    color: var(--muted);
-  }
-  .live-state > span {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: var(--green);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 12%, transparent);
-  }
-  .live-state > span.stale {
-    background: var(--muted);
-    box-shadow: none;
   }
   .stats-navigation {
     position: sticky;

--- a/frontend/observatory/components/StatsChart.svelte
+++ b/frontend/observatory/components/StatsChart.svelte
@@ -1,176 +1,186 @@
 <script lang="ts">
   import type { StatisticsSample } from '../runtime/statistics-history';
-  import { statisticsPaths } from '../runtime/statistics-history';
+  import { metricObservations, plotGeometry, plotMaximum } from '../runtime/statistics-plot';
   import { statisticsValue, type StatsMetric } from '../runtime/statistics-metrics';
+  import StatsPlot from './StatsPlot.svelte';
   let {
     samples,
     metrics,
     selected = $bindable('cpu'),
+    period = $bindable(60000),
     stale = false,
+    paused = false,
+    now,
   }: {
     samples: StatisticsSample[];
     metrics: StatsMetric[];
     selected?: string;
+    period?: number;
     stale?: boolean;
+    paused?: boolean;
+    now?: number;
   } = $props();
-  let cursor = $state<number | null>(null);
-  let period = $state(120);
+  let pinnedAt = $state<number | null>(null),
+    hoverAt = $state<number | null>(null);
   let metric = $derived(metrics.find((m) => m.id === selected) ?? metrics[0]);
-  let visible = $derived(samples.slice(-period));
-  let latest = $derived(visible.at(-1));
+  let end = $derived(now ?? samples.at(-1)?.at ?? Date.now());
+  let start = $derived(end - period);
+  let observations = $derived(metricObservations(samples, metric.id, start, end));
+  let latest = $derived(
+    metricObservations(samples, metric.id, -Infinity, end)
+      .filter((s) => !paused || typeof s.values[metric.id] === 'number')
+      .at(-1),
+  );
+  let inspecting = $derived(hoverAt ?? pinnedAt);
   let focused = $derived(
-    cursor === null ? latest : (visible.find((s) => s.at === cursor) ?? latest),
+    inspecting === null ? latest : (observations.find((s) => s.at === inspecting) ?? latest),
   );
-  let maximum = $derived(
-    Math.max(metric.floor ?? 1, ...visible.map((s) => s.values[metric.id] ?? 0)) *
-      (metric.floor ? 1 : 1.08),
+  let coverage = $derived(focused?.coverage?.[metric.id]);
+  let values = $derived(
+    observations
+      .map((s) => s.values[metric.id])
+      .filter((n): n is number => typeof n === 'number' && Number.isFinite(n)),
   );
-  let measuredValues = $derived(
-    visible.map((s) => s.values[metric.id]).filter((n): n is number => typeof n === 'number'),
-  );
-  let average = $derived(
-    measuredValues.length
-      ? measuredValues.reduce((a, b) => a + b, 0) / measuredValues.length
-      : null,
-  );
+  let maximum = $derived(plotMaximum(values, metric.floor));
+  let average = $derived(values.length ? values.reduce((a, b) => a + b, 0) / values.length : null);
+  $effect(() => {
+    if (pinnedAt !== null && !observations.some((s) => s.at === pinnedAt)) pinnedAt = null;
+  });
   function choose(id: string): void {
     selected = id;
-    cursor = null;
+    pinnedAt = null;
+    hoverAt = null;
   }
   function time(at: number | undefined): string {
-    return at ? new Date(at).toLocaleTimeString() : 'Waiting for a sample';
+    return at === undefined
+      ? 'Waiting for this source'
+      : new Date(at).toLocaleTimeString(undefined, {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        });
   }
 </script>
 
 <section class="panel monitor" aria-label="Live performance monitor">
   <div class="metric-rail" aria-label="Performance metrics">
     {#each metrics as item (item.id)}
-      {@const max = Math.max(item.floor ?? 1, ...visible.map((s) => s.values[item.id] ?? 0))}
+      {@const series = metricObservations(samples, item.id, start, end)}
+      {@const current = metricObservations(samples, item.id, -Infinity, end)
+        .filter((s) => !paused || typeof s.values[item.id] === 'number')
+        .at(-1)}
+      {@const geometry = plotGeometry(
+        series,
+        item.id,
+        start,
+        end,
+        plotMaximum(
+          series.map((s) => s.values[item.id]),
+          item.floor,
+        ),
+      )}
       <button
         class:selected={metric.id === item.id}
         aria-pressed={metric.id === item.id}
         onclick={() => choose(item.id)}
       >
-        <svg viewBox="0 0 600 164" preserveAspectRatio="none" aria-hidden="true">
-          {#each statisticsPaths(visible, item.id, max) as path, index (index)}<path
-              d={path}
-            />{/each}
+        <svg viewBox="0 0 600 160" preserveAspectRatio="none" aria-hidden="true">
+          {#each geometry.paths as path, i (i)}<path d={path} />{/each}
+          {#each geometry.points as point, i (i)}<circle cx={point.x} cy={point.y} r="3" />{/each}
         </svg>
         <span
           ><strong>{item.label}</strong><small
-            >{statisticsValue(latest?.values[item.id], item.unit)}</small
-          ></span
-        >
+            >{statisticsValue(current?.values[item.id], item.unit)}</small
+          >
+          {#if current?.coverage?.[item.id] && current.coverage[item.id].measured < current.coverage[item.id].total}<em
+              >Partial coverage</em
+            >{/if}
+        </span>
       </button>
     {/each}
   </div>
   <div class="monitor-detail">
     <header>
       <div>
-        <p class="eyebrow">Performance history</p>
         <h2>{metric.label}</h2>
+        <p class="measurement-status">
+          {stale
+            ? 'View held'
+            : inspecting === null
+              ? 'Latest measurement'
+              : 'Selected measurement'} · {time(focused?.at)}
+        </p>
       </div>
-      <div class="current">
-        <strong>{statisticsValue(focused?.values[metric.id], metric.unit)}</strong><small
-          >{cursor !== null
-            ? 'Selected observation'
-            : stale
-              ? 'Last reliable observation'
-              : 'Latest observation'}</small
-        >
-      </div>
+      <strong class="current">{statisticsValue(focused?.values[metric.id], metric.unit)}</strong>
     </header>
-    <div
-      class="plot"
-      role="img"
-      aria-label={metric.label +
-        ' history, ' +
-        measuredValues.length +
-        ' measured samples. Current value ' +
-        statisticsValue(focused?.values[metric.id], metric.unit)}
-    >
-      <div class="plot-top">
-        <span>{statisticsValue(maximum, metric.unit)}</span><span
-          >{stale ? 'Observation paused' : 'Observed samples'}</span
-        >
-      </div>
-      <svg viewBox="0 0 600 164" preserveAspectRatio="none" aria-hidden="true">
-        {#each [4, 42.5, 81, 119.5, 158] as y (y)}<line x1="2" x2="598" y1={y} y2={y} />{/each}
-        {#each [2, 101, 200, 300, 400, 499, 598] as x (x)}<line
-            x1={x}
-            x2={x}
-            y1="4"
-            y2="158"
-          />{/each}
-        {#each statisticsPaths(visible, metric.id, maximum) as path, index (index)}<path
-            d={path}
-          />{/each}
-        {#if focused && visible.length}
-          {@const x =
-            2 + ((focused.at - visible[0].at) / Math.max(1, latest!.at - visible[0].at)) * 596}
-          <line class="cursor" x1={x} x2={x} y1="4" y2="158" />
-          {#if typeof focused.values[metric.id] === 'number'}
-            <circle
-              cx={x}
-              cy={158 - Math.min(1, focused.values[metric.id]! / maximum) * 154}
-              r="3.5"
-            />
-          {/if}
-        {/if}
-      </svg>
-      {#if !measuredValues.length}<div class="plot-empty">
-          <strong>Waiting for measured data</strong><span
-            >Missing or incomplete measurements appear as gaps.</span
-          >
-        </div>{/if}
-      <div class="plot-times">
-        <span>{time(visible[0]?.at)}</span><span>{time(latest?.at)}</span>
-      </div>
+    <div class="monitor-tools">
+      <label
+        >Time window<select aria-label="Performance history length" bind:value={period}
+          ><option value={60000}>1 minute</option><option value={180000}>3 minutes</option><option
+            value={300000}>5 minutes</option
+          ></select
+        ></label
+      >
+      <span>{values.length} measured points</span>
     </div>
+    {#if coverage}<p class="coverage" class:partial={coverage.measured < coverage.total}>
+        {coverage.measured < coverage.total ? 'Measured subtotal' : 'Measured total'} · {coverage.measured}
+        / {coverage.total} processes
+      </p>{/if}
+    <StatsPlot
+      {observations}
+      {metric}
+      {start}
+      {end}
+      {maximum}
+      held={stale}
+      focusedAt={focused?.at ?? null}
+      hover={(at) => (hoverAt = at)}
+    />
     <div class="scrubber">
-      <label for={'stats-sample-' + metric.id}>Sample</label>
+      <label for={'stats-sample-' + metric.id}>Inspect</label>
       <input
         id={'stats-sample-' + metric.id}
         type="range"
         min="0"
-        max={Math.max(0, visible.length - 1)}
-        value={Math.max(0, focused ? visible.indexOf(focused) : 0)}
-        disabled={visible.length < 2}
+        max={Math.max(0, observations.length - 1)}
+        value={Math.max(0, focused ? observations.indexOf(focused) : observations.length - 1)}
+        disabled={observations.length < 2}
         aria-valuetext={time(focused?.at) +
           ', ' +
           statisticsValue(focused?.values[metric.id], metric.unit)}
-        oninput={(event) => (cursor = visible[Number(event.currentTarget.value)]?.at ?? null)}
+        oninput={(event) =>
+          (pinnedAt = observations[Number(event.currentTarget.value)]?.at ?? null)}
       />
-      <button class="button" aria-pressed={cursor === null} onclick={() => (cursor = null)}
-        >Latest</button
+      <button
+        class="button"
+        aria-pressed={pinnedAt === null}
+        onclick={() => {
+          pinnedAt = null;
+          hoverAt = null;
+        }}>Latest</button
       >
     </div>
     <div class="monitor-summary">
-      <div><span>Average</span><strong>{statisticsValue(average, metric.unit)}</strong></div>
+      <div><span>Sample average</span><strong>{statisticsValue(average, metric.unit)}</strong></div>
       <div>
         <span>Peak</span><strong
-          >{statisticsValue(
-            measuredValues.length ? Math.max(...measuredValues) : null,
-            metric.unit,
-          )}</strong
+          >{statisticsValue(values.length ? Math.max(...values) : null, metric.unit)}</strong
         >
       </div>
-      <label
-        >History<select aria-label="Performance history length" bind:value={period}
-          ><option value={30}>30 samples</option><option value={60}>60 samples</option><option
-            value={120}>120 samples</option
-          ></select
-        ></label
-      >
+      <p>Each point is a delivered measurement. Gaps mean unavailable data.</p>
     </div>
-    <p class="metric-description">{metric.description}</p>
+    <details class="metric-help">
+      <summary>About this metric</summary>
+      <p>{metric.description}</p>
+    </details>
   </div>
 </section>
 
 <style>
   .monitor {
     display: grid;
-    grid-template-columns: 190px minmax(0, 1fr);
+    grid-template-columns: 180px minmax(0, 1fr);
     overflow: hidden;
   }
   .metric-rail {
@@ -203,11 +213,12 @@
     border-color: var(--selection-border);
   }
   .metric-rail svg {
-    width: 50px;
+    width: 46px;
     height: 34px;
     flex-shrink: 0;
     border: 1px solid var(--border);
     background: var(--panel);
+    overflow: visible;
   }
   .metric-rail span {
     min-width: 0;
@@ -222,117 +233,85 @@
   .metric-rail small {
     font-variant-numeric: tabular-nums;
     color: var(--muted);
+    font-size: 11px;
+  }
+  .metric-rail em {
+    color: var(--amber);
+    font-size: 9px;
+    font-style: normal;
   }
   path {
     fill: none;
     stroke: var(--green);
-    stroke-width: 2;
+    stroke-width: 1.5;
     vector-effect: non-scaling-stroke;
     stroke-linecap: round;
-    stroke-linejoin: round;
+  }
+  circle {
+    fill: var(--green);
   }
   .monitor-detail {
     min-width: 0;
-    padding: 20px;
+    padding: 18px;
   }
   header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: start;
     gap: 12px;
-    margin-bottom: 20px;
+    margin-bottom: 14px;
   }
   h2 {
-    margin: 5px 0 0;
+    margin: 0;
     font-size: 20px;
-    letter-spacing: -0.5px;
+    letter-spacing: -0.4px;
   }
-  .eyebrow {
+  .measurement-status {
     color: var(--muted);
     font-size: 10px;
-    margin: 0;
-    text-transform: uppercase;
-    letter-spacing: 0.09em;
+    margin: 7px 0 0;
   }
   .current {
-    display: grid;
-    gap: 4px;
-    text-align: right;
-  }
-  .current strong {
-    font-size: 25px;
+    font-size: 26px;
     font-weight: 500;
     font-variant-numeric: tabular-nums;
-    letter-spacing: -0.8px;
+    text-align: right;
   }
-  .current small {
-    font-size: 10px;
-    color: var(--muted);
-  }
-  .plot {
-    position: relative;
-  }
-  .plot svg {
-    width: 100%;
-    height: 180px;
-    display: block;
-    overflow: visible;
-  }
-  .plot line {
-    stroke: var(--border);
-    vector-effect: non-scaling-stroke;
-  }
-  .plot .cursor {
-    stroke: var(--muted);
-    stroke-dasharray: 3 4;
-    opacity: 0.55;
-  }
-  .plot circle {
-    fill: var(--green);
-    stroke: var(--panel);
-    stroke-width: 2;
-    vector-effect: non-scaling-stroke;
-  }
-  .plot-top,
-  .plot-times {
+  .monitor-tools {
     display: flex;
     justify-content: space-between;
-    gap: 10px;
-    font-size: 10px;
-    color: var(--muted);
-    font-variant-numeric: tabular-nums;
-  }
-  .plot-top {
-    margin-bottom: 8px;
-  }
-  .plot-times {
-    margin-top: 8px;
-  }
-  .plot-empty {
-    position: absolute;
-    inset: 25% 10% 25%;
-    display: grid;
-    align-content: center;
-    text-align: center;
+    align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
-    padding: 12px;
-    border: 1px solid var(--border);
-    background: var(--panel);
-    border-radius: 8px;
-    font-size: 12px;
-  }
-  .plot-empty span {
     color: var(--muted);
+    font-size: 10px;
+    margin: 0 0 12px;
+  }
+  .monitor-tools label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  select {
+    padding: 5px;
+    max-width: 140px;
     font-size: 11px;
-    line-height: 1.5;
+  }
+  .coverage {
+    margin: 0 0 14px;
+    font-size: 11px;
+    color: var(--muted);
+  }
+  .coverage.partial {
+    color: var(--amber);
   }
   .scrubber {
     display: flex;
     align-items: center;
     gap: 10px;
     margin-top: 12px;
-    font-size: 11px;
     color: var(--muted);
+    font-size: 11px;
   }
   .scrubber input {
     min-width: 30px;
@@ -342,52 +321,64 @@
     accent-color: var(--green);
   }
   .scrubber .button {
-    font-size: 11px;
-    padding: 5px 9px;
     min-height: 28px;
+    padding: 5px 9px;
+    font-size: 11px;
   }
   .monitor-summary {
     display: flex;
-    flex-wrap: wrap;
-    gap: 18px;
+    gap: 20px;
     border-top: 1px solid var(--border);
-    padding-top: 14px;
-    margin-top: 14px;
+    margin-top: 12px;
+    padding-top: 12px;
+    align-items: start;
   }
   .monitor-summary div {
     display: grid;
     gap: 5px;
   }
-  .monitor-summary span,
-  .monitor-summary label {
-    font-size: 10px;
+  .monitor-summary span {
     color: var(--muted);
+    font-size: 10px;
+    white-space: nowrap;
   }
   .monitor-summary strong {
     font-size: 13px;
     font-weight: 550;
     font-variant-numeric: tabular-nums;
   }
-  .monitor-summary label {
-    margin-left: auto;
-    display: flex;
-    gap: 8px;
-    align-items: center;
-  }
-  select {
-    padding: 5px;
-    font-size: 11px;
-    max-width: 140px;
-  }
-  .metric-description {
-    font-size: 11px;
-    line-height: 1.6;
+  .monitor-summary p {
+    margin: 0 0 0 auto;
+    max-width: 200px;
     color: var(--muted);
-    margin: 14px 0 0;
+    font-size: 10px;
+    line-height: 1.6;
+  }
+  .metric-help {
+    margin-top: 12px;
+    color: var(--muted);
+    font-size: 11px;
+  }
+  .metric-help summary {
+    cursor: pointer;
+  }
+  .metric-help p {
+    margin: 10px 0 0;
+    line-height: 1.6;
   }
   @media (max-width: 1000px) {
     .monitor {
-      grid-template-columns: 155px minmax(0, 1fr);
+      grid-template-columns: minmax(0, 1fr);
+    }
+    .metric-rail {
+      flex-direction: row;
+      overflow-x: auto;
+      border-right: 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .metric-rail button {
+      flex: 0 0 142px;
+      padding: 8px;
     }
     .metric-rail svg {
       width: 32px;
@@ -397,26 +388,14 @@
     }
   }
   @media (max-width: 720px) {
-    .monitor {
-      grid-template-columns: minmax(0, 1fr);
-    }
-    .metric-rail {
-      flex-direction: row;
-      overflow: auto;
-      border-right: 0;
-      border-bottom: 1px solid var(--border);
-    }
-    .metric-rail button {
-      min-width: 145px;
-    }
-    .plot svg {
-      height: 160px;
-    }
-    .current strong {
-      font-size: 21px;
+    .monitor-summary p {
+      display: none;
     }
     h2 {
       font-size: 18px;
+    }
+    .current {
+      font-size: 22px;
     }
   }
   @media (prefers-reduced-motion: reduce) {

--- a/frontend/observatory/components/StatsPlot.svelte
+++ b/frontend/observatory/components/StatsPlot.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import type { StatisticsSample } from '../runtime/statistics-history';
+  import { nearestObservation, plotGeometry, plotX } from '../runtime/statistics-plot';
+  import type { StatsMetric } from '../runtime/statistics-metrics';
+  let {
+    observations,
+    metric,
+    start,
+    end,
+    maximum,
+    held = false,
+    focusedAt,
+    hover,
+  }: {
+    observations: StatisticsSample[];
+    metric: StatsMetric;
+    start: number;
+    end: number;
+    maximum: number;
+    held?: boolean;
+    focusedAt: number | null;
+    hover: (_at: number | null) => void;
+  } = $props();
+  let stepped = $derived(
+    [
+      'processes',
+      'products',
+      'connections',
+      'tokens',
+      'input',
+      'output',
+      'cost',
+      'evictions',
+      'risk',
+    ].includes(metric.id),
+  );
+  let geometry = $derived(plotGeometry(observations, metric.id, start, end, maximum, stepped));
+  let focus = $derived(
+    focusedAt === null ? undefined : geometry.points.find((p) => p.at === focusedAt),
+  );
+  function point(event: PointerEvent) {
+    const box =
+      event.currentTarget instanceof Element ? event.currentTarget.getBoundingClientRect() : null;
+    if (!box) return;
+    const at =
+      start + Math.max(0, Math.min(1, (event.clientX - box.left) / box.width)) * (end - start);
+    hover(nearestObservation(observations, at)?.at ?? null);
+  }
+  function ago(fraction: number): string {
+    const seconds = Math.round(((end - start) * fraction) / 1000);
+    return seconds >= 60
+      ? (seconds / 60).toLocaleString(undefined, { maximumFractionDigits: 1 }) + ' min'
+      : seconds + ' s';
+  }
+</script>
+
+<div
+  class="plot"
+  role="img"
+  aria-label={metric.label +
+    ' history, ' +
+    geometry.points.length +
+    ' measured samples; ' +
+    Math.round((end - start) / 1000) +
+    ' seconds'}
+>
+  <div class="axis-values" aria-hidden="true">
+    {#each [1, 0.75, 0.5, 0.25, 0] as fraction (fraction)}<span
+        >{(maximum * fraction).toLocaleString(undefined, { maximumFractionDigits: 2 }) +
+          (metric.unit ? ' ' + metric.unit : '')}</span
+      >{/each}
+  </div>
+  <div class="plot-area">
+    <svg
+      viewBox="0 0 600 160"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      onpointermove={point}
+      onpointerleave={() => hover(null)}
+    >
+      {#each [0, 40, 80, 120, 160] as y (y)}<line x1="0" x2="600" y1={y} y2={y} />{/each}
+      {#each [0, 150, 300, 450, 600] as x (x)}<line x1={x} x2={x} y1="0" y2="160" />{/each}
+      {#each geometry.paths as path, i (i)}<path d={path} />{/each}
+      {#each geometry.points as p (p.at)}<circle
+          cx={p.x}
+          cy={p.y}
+          r={p.at === focusedAt ? 3.5 : 1.5}
+        />{/each}
+      {#if focusedAt !== null}<line
+          class="cursor"
+          x1={plotX(focusedAt, start, end)}
+          x2={plotX(focusedAt, start, end)}
+          y1="0"
+          y2="160"
+        />{/if}
+      {#if focus}<circle class="focus" cx={focus.x} cy={focus.y} r="4" />{/if}
+    </svg>
+    {#if !geometry.points.length}<div class="plot-empty">
+        <strong>No measurements in this interval</strong><span
+          >Waiting for this metric’s source.</span
+        >
+      </div>{/if}
+    <div class="plot-times" aria-hidden="true">
+      <span>{ago(1)} ago</span><span>{ago(0.5)} ago</span><span>{held ? 'Held' : 'Now'}</span>
+    </div>
+  </div>
+</div>
+
+<style>
+  .plot {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 10px;
+    min-width: 0;
+  }
+  .axis-values {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: end;
+    padding-bottom: 26px;
+    color: var(--muted);
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+  }
+  .plot-area {
+    position: relative;
+    min-width: 0;
+  }
+  svg {
+    width: 100%;
+    height: clamp(140px, 24vh, 220px);
+    display: block;
+    overflow: visible;
+  }
+  line {
+    stroke: var(--border);
+    vector-effect: non-scaling-stroke;
+  }
+  path {
+    fill: none;
+    stroke: var(--green);
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vector-effect: non-scaling-stroke;
+  }
+  circle {
+    fill: var(--green);
+  }
+  .focus {
+    stroke: var(--panel);
+    stroke-width: 2;
+    vector-effect: non-scaling-stroke;
+  }
+  .cursor {
+    stroke: var(--muted);
+    stroke-dasharray: 3 4;
+  }
+  .plot-times {
+    display: flex;
+    justify-content: space-between;
+    gap: 4px;
+    margin-top: 10px;
+    height: 16px;
+    color: var(--muted);
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+  }
+  .plot-empty {
+    position: absolute;
+    inset: 15% 5% 30%;
+    display: grid;
+    align-content: center;
+    gap: 8px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .plot-empty strong {
+    color: var(--ink);
+    font-weight: 500;
+  }
+</style>

--- a/frontend/observatory/components/Timeline.svelte
+++ b/frontend/observatory/components/Timeline.svelte
@@ -1,20 +1,30 @@
 <script lang="ts">
   import { instances, type Telemetry, type RecordData } from '../runtime/host';
-  import { activityBins } from '../runtime/activity';
+  import { activityBins, activityTimeLabel } from '../runtime/activity';
   import { radarGroups } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   let {
     telemetry,
+    paused = false,
     inspect,
-  }: { telemetry: Telemetry; inspect: (title: string, row: RecordData) => void } = $props();
+  }: {
+    telemetry: Telemetry;
+    paused?: boolean;
+    inspect: (_title: string, _row: RecordData) => void;
+  } = $props();
   let range = $state(15),
     offset = $state(0);
-  let end = $derived(
-    Math.max(telemetry.lastScan ?? 0, ...telemetry.events.map((e) => e.timestamp)) +
-      1 -
-      offset * 1000,
-  );
+  let now = $state(Date.now());
+  $effect(() => {
+    if (paused || telemetry.stale) return;
+    now = Date.now();
+    const timer = setInterval(() => {
+      now = Date.now();
+    }, 1000);
+    return () => clearInterval(timer);
+  });
+  let end = $derived(now + 1 - offset * 1000);
   let groups = $derived(radarGroups(instances(telemetry)));
   function keys(e: KeyboardEvent) {
     if (!['ArrowLeft', 'ArrowRight'].includes(e.key)) return;
@@ -31,7 +41,13 @@
 <section class="panel timeline-panel">
   <div class="panel-head">
     <h2><Icon name="activity" />Timeline</h2>
-    <span class="filter-count">{telemetry.events.length} retained events</span>
+    <span class="filter-count"
+      >{telemetry.events.length} retained events{paused
+        ? ' · Paused'
+        : telemetry.stale
+          ? ' · Observation unavailable'
+          : ''}</span
+    >
   </div>
   <div class="lanes">
     {#each groups as g (g.key)}{@const ids = new Set(
@@ -67,7 +83,7 @@
   </div>
   <div class="time-labels">
     {#each [0, 0.25, 0.5, 0.75, 1] as n (n)}<span
-        >{new Date(end - range * 60000 * (1 - n)).toLocaleTimeString().slice(0, 5)}</span
+        >{activityTimeLabel(end - range * 60000 * (1 - n) - (n === 1 ? 1 : 0))}</span
       >{/each}
   </div>
   <div class="timeline-controls">

--- a/frontend/observatory/runtime/activity.ts
+++ b/frontend/observatory/runtime/activity.ts
@@ -6,8 +6,8 @@ export interface ActivityBin {
   events: FileEvent[];
 }
 /** Bin retained observations with half-open intervals and no fabricated counts.
- * @param events Retained observations @param end End of visible period @param periodMs Period @param count Bin count
- * @returns Exact members and bounds @since 0.14.1
+ * @param events Retained observations @param end Exclusive visible boundary @param periodMs Period @param count Bin count (1–1000)
+ * @returns Exact members and bounds; empty for invalid ranges @since 0.14.1
  */
 export function activityBins(
   events: FileEvent[],
@@ -15,18 +15,48 @@ export function activityBins(
   periodMs: number,
   count = 24,
 ): ActivityBin[] {
+  if (
+    !Number.isFinite(end) ||
+    !Number.isFinite(periodMs) ||
+    periodMs <= 0 ||
+    !Number.isInteger(count) ||
+    count < 1 ||
+    count > 1000
+  )
+    return [];
   const start = end - periodMs;
+  if (!Number.isFinite(start) || start >= end) return [];
   const step = periodMs / count;
   const bins = Array.from({ length: count }, (_, index) => ({
     start: start + index * step,
-    end: start + (index + 1) * step,
+    end: index === count - 1 ? end : start + (index + 1) * step,
     events: [] as FileEvent[],
   }));
   for (const event of events) {
-    if (!Number.isFinite(event.timestamp) || event.timestamp < start || event.timestamp >= end)
-      continue;
-    const index = Math.min(count - 1, Math.floor((event.timestamp - start) / step));
-    bins[index].events.push(event);
+    const at = event.timestamp;
+    if (!Number.isFinite(at) || at < start || at >= end) continue;
+    // Search the actual boundaries: division may round an exact edge into the preceding bin.
+    let low = 0,
+      high = count;
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (bins[middle].end <= at) low = middle + 1;
+      else high = middle;
+    }
+    if (low < count && at >= bins[low].start) bins[low].events.push(event);
   }
   return bins;
+}
+
+/** Format the complete local clock without slicing locale-specific output.
+ * @param at Timestamp @param seconds Include seconds for interval evidence
+ * @returns Localized clock label or unavailable marker @since 0.14.1
+ */
+export function activityTimeLabel(at: number, seconds = false): string {
+  if (!Number.isFinite(at) || !Number.isFinite(new Date(at).getTime())) return '—';
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    ...(seconds ? { second: '2-digit' as const } : {}),
+  }).format(at);
 }

--- a/frontend/observatory/runtime/host.ts
+++ b/frontend/observatory/runtime/host.ts
@@ -22,6 +22,11 @@ export interface Telemetry {
   resources: RecordData[];
   tokens: RecordData[];
   resourcesAt: number | null;
+  tokensAt: number | null;
+  ownAt: number | null;
+  networkAt: number | null;
+  statsAt: number | null;
+  scanCounters: { files: number; sensitive: number; evicted: number } | null;
   own: RecordData;
   anomalies: Record<string, number>;
   falsePositives: FalsePositiveEntry[];
@@ -77,6 +82,11 @@ export function emptyTelemetry(): Telemetry {
     resources: [],
     tokens: [],
     resourcesAt: null,
+    tokensAt: null,
+    ownAt: null,
+    networkAt: null,
+    statsAt: null,
+    scanCounters: null,
     own: {},
     anomalies: {},
     falsePositives: [],
@@ -163,6 +173,7 @@ export function connectHost(
     const stats = record(value);
     update({
       stats,
+      statsAt: Date.now(),
       stale:
         healthStale(stats) ||
         (state.lastScan !== null && Date.now() - state.lastScan > staleAfterMs),
@@ -197,10 +208,17 @@ export function connectHost(
       patch.ready = true;
       patch.stale = false;
       patch.lastScan = Date.now();
+      patch.scanCounters = {
+        files: state.events.length + state.evicted,
+        sensitive:
+          state.events.filter((event) => event.sensitive === true).length + state.retainedEvicted,
+        evicted: state.evicted,
+      };
       patch.error = '';
     }
     if (batch.resourceUsage) {
       patch.own = record(batch.resourceUsage);
+      patch.ownAt = Date.now();
       revisions.set('own', (revisions.get('own') ?? 0) + 1);
     }
     if (batch.anomalyScoresByInstance && reliable)
@@ -218,13 +236,16 @@ export function connectHost(
     });
   });
   subscribe('onNetworkUpdate', (value) =>
-    update({ network: Array.isArray(value) ? (value as NetworkConnection[]) : [] }),
+    update({
+      network: Array.isArray(value) ? (value as NetworkConnection[]) : [],
+      networkAt: Date.now(),
+    }),
   );
   subscribe('onScanStatus', (value) => update({ scanning: record(value).scanning === true }));
   subscribe('onAgentResourceUsage', (value) =>
     update({ resources: records(value), resourcesAt: Date.now() }),
   );
-  subscribe('onTokenCosts', (value) => update({ tokens: records(value) }));
+  subscribe('onTokenCosts', (value) => update({ tokens: records(value), tokensAt: Date.now() }));
   const seed = (method: string, revision: string, apply: (value: unknown) => void) => {
     const before = revisions.get(revision) ?? 0;
     invoke(host, method)
@@ -234,7 +255,7 @@ export function connectHost(
       .catch(fail);
   };
   seed('getStats', 'onStatsUpdate', applyStats);
-  seed('getResourceUsage', 'own', (value) => update({ own: record(value) }));
+  seed('getResourceUsage', 'own', (value) => update({ own: record(value), ownAt: Date.now() }));
   seed('getFalsePositives', 'fp', (value) =>
     update({ falsePositives: Array.isArray(value) ? (value as FalsePositiveEntry[]) : [] }),
   );
@@ -250,6 +271,7 @@ export function connectHost(
     if (state.lastScan !== null && !state.stale && Date.now() - state.lastScan > staleAfterMs) {
       update({
         stale: true,
+        statsAt: Date.now(),
         error: 'No fresh process snapshot has arrived. Last observations are retained.',
       });
     }

--- a/frontend/observatory/runtime/resources.ts
+++ b/frontend/observatory/runtime/resources.ts
@@ -1,4 +1,6 @@
-import { measured, type RecordData } from './host';
+import { measured, type RecordData, type Telemetry } from './host';
+import type { RadarGroup } from './radar';
+import { measuredStatisticsTotal, type StatisticsMeasurement } from './statistics-metrics';
 
 /** Convert two cumulative microsecond samples to a CPU percentage.
  * @param previous Previous sample @param next Latest sample @param elapsedMs Elapsed wall time
@@ -17,4 +19,27 @@ export function cpuPercent(
   const [u0, s0, u1, s1] = counters as number[];
   if (u1 < u0 || s1 < s0) return null;
   return ((u1 - u0 + s1 - s0) / (elapsedMs * 1000)) * 100;
+}
+
+/** Sum measured group members with explicit coverage and current stamped identities.
+ * @param group Product group @param state Current telemetry @param key Resource field
+ * @returns Measured subtotal and coverage; missing members never imply zero @since 0.14.1
+ */
+export function measuredGroupResource(
+  group: RadarGroup,
+  state: Telemetry,
+  key: 'cpu' | 'memMb',
+): StatisticsMeasurement {
+  const currentIds = new Set(state.agents.map((agent) => agent.instanceId).filter(Boolean));
+  return measuredStatisticsTotal(
+    {
+      ...state,
+      agents: group.members.map((member) => ({
+        ...member,
+        instanceId: member.instanceId ?? undefined,
+      })),
+    },
+    state.resources.filter((row) => !!row.instanceId && currentIds.has(String(row.instanceId))),
+    key,
+  );
 }

--- a/frontend/observatory/runtime/statistics-history.ts
+++ b/frontend/observatory/runtime/statistics-history.ts
@@ -1,139 +1,261 @@
-import { instances, measured, record, type Telemetry } from './host';
+import { instances, record, type Telemetry, type RecordData } from './host';
 import { radarGroups } from './radar';
 import { cpuPercent } from './resources';
-import { completeStatisticsTotal } from './statistics-metrics';
+import { measuredStatisticsTotal, type StatisticsCoverage } from './statistics-metrics';
 
 export interface StatisticsSample {
   at: number;
+  /** Missing key: no new measurement. Null: observed unavailability. */
   values: Record<string, number | null>;
+  coverage?: Record<string, StatisticsCoverage>;
+  boundary?: boolean;
+}
+interface ScanBaseline {
+  at: number;
+  files: number;
+  sensitive: number;
+  session: unknown;
+}
+interface TokenBaseline {
+  at: number;
+  counters: Record<string, number>;
+  session: unknown;
 }
 export interface StatisticsHistory {
   samples: StatisticsSample[];
-  previous: Telemetry | null;
-  ownAt: number | null;
-  ownCpu: number | null;
-  interrupted: boolean;
+  clocks: Record<string, number>;
+  scan: ScanBaseline | null;
+  tokens: TokenBaseline | null;
+  own: { at: number; value: RecordData } | null;
+  stale: boolean;
+  population: string;
 }
-export const STATISTICS_HISTORY_LIMIT = 120;
-/** Create an isolated bounded history; no background timer or subscription is required.
+export const STATISTICS_HISTORY_LIMIT = 1000;
+export const STATISTICS_HISTORY_MS = 300000;
+/** Create source-specific clock state with no timers.
  * @returns Empty history @since 0.14.1
  */
 export function createStatisticsHistory(): StatisticsHistory {
-  return { samples: [], previous: null, ownAt: null, ownCpu: null, interrupted: false };
+  return {
+    samples: [],
+    clocks: {},
+    scan: null,
+    tokens: null,
+    own: null,
+    stale: true,
+    population: '',
+  };
 }
-/** Derive a monotonic counter rate; missing/reset counters are not zero activity.
- * @param before Previous counter @param after New counter @param elapsed Elapsed milliseconds
+/** Derive a monotonic counter rate between observations from the same source.
+ * @param before Previous counter @param after New counter @param elapsed Milliseconds
  * @returns Per-minute rate or unavailable @since 0.14.1
  */
 export function statisticsRate(before: unknown, after: unknown, elapsed: number): number | null {
-  const a = measured(before),
-    b = measured(after);
-  const value =
-    a === null || b === null || a < 0 || b < a || elapsed <= 0 || !Number.isFinite(elapsed)
-      ? null
-      : ((b - a) * 60000) / elapsed;
-  return value !== null && Number.isFinite(value) ? value : null;
+  if (
+    typeof before !== 'number' ||
+    typeof after !== 'number' ||
+    !Number.isFinite(before) ||
+    !Number.isFinite(after) ||
+    before < 0 ||
+    after < before ||
+    elapsed <= 0 ||
+    !Number.isFinite(elapsed)
+  )
+    return null;
+  const value = ((after - before) * 60000) / elapsed;
+  return Number.isFinite(value) ? value : null;
 }
-/** Append one observed scan/resource revision and leave identical or paused snapshots unchanged.
- * @param history Previous local history @param state Displayed telemetry
- * @returns Next bounded history @since 0.14.1
+function tokenRate(before: TokenBaseline | null, after: TokenBaseline): number | null {
+  const ids = Object.keys(after.counters);
+  if (
+    !before ||
+    before.session !== after.session ||
+    !ids.length ||
+    ids.length !== Object.keys(before.counters).length
+  )
+    return null;
+  let rate = 0;
+  for (const id of ids) {
+    const delta = statisticsRate(before.counters[id], after.counters[id], after.at - before.at);
+    if (delta === null) return null;
+    rate += delta;
+  }
+  return Number.isFinite(rate) ? rate : null;
+}
+/** Observe each telemetry source only on its own receipt timestamp.
+ * @param history Prior source clocks @param state Displayed telemetry @param interruptionAt Actual user pause time
+ * @returns Sparse five-minute history; no interpolated points @since 0.14.1
  */
-export function observeStatistics(history: StatisticsHistory, state: Telemetry): StatisticsHistory {
-  if (state.stale || !state.ready)
-    return history.interrupted ? history : { ...history, interrupted: true };
-  const at = Math.max(state.lastScan ?? 0, state.resourcesAt ?? 0);
-  const last = history.samples.at(-1);
-  if (!at || (last && at <= last.at)) return history;
-  const previous = history.previous;
-  const elapsed = last ? at - last.at : 0;
-  const continuous =
-    !!previous &&
-    !history.interrupted &&
-    elapsed > 0 &&
-    elapsed <= 30000 &&
-    previous.stats.monitoringStarted === state.stats.monitoringStarted;
-  const resourceFresh = state.resourcesAt !== null && at - state.resourcesAt <= 30000;
-  const agents = instances(state);
-  const networkHealth = record(record(record(record(state.stats.appHealth).sensors).byId).network);
-  const ownChanged = !previous || state.own !== previous.own;
-  const ownAt = ownChanged ? state.lastScan : history.ownAt;
-  const ownCpu = ownChanged
-    ? continuous && history.ownAt && ownAt && previous
-      ? cpuPercent(previous.own, state.own, ownAt - history.ownAt)
-      : null
-    : history.ownCpu;
-  const samePopulation =
-    !!previous &&
-    previous.agents.length === state.agents.length &&
-    state.agents.every(
-      (a) => a.instanceId && previous.agents.some((p) => p.instanceId === a.instanceId),
-    );
-  const tokens = completeStatisticsTotal(state, state.tokens, 'totalTokens');
-  const tokenCountersContinuous =
-    samePopulation &&
-    previous &&
-    state.agents.every((agent) => {
-      const old = previous.tokens.find((t) => t.instanceId === agent.instanceId);
-      const current = state.tokens.find((t) => t.instanceId === agent.instanceId);
-      return statisticsRate(old?.totalTokens, current?.totalTokens, elapsed) !== null;
+export function observeStatistics(
+  history: StatisticsHistory,
+  state: Telemetry,
+  interruptionAt?: number,
+): StatisticsHistory {
+  const next: StatisticsHistory = { ...history, clocks: { ...history.clocks } };
+  const frames: StatisticsSample[] = [];
+  const session = state.stats.monitoringStarted;
+  const coverage = ({ measured, total }: StatisticsCoverage): StatisticsCoverage => ({
+    measured,
+    total,
+  });
+  const fresh = (source: string, at: number | null | undefined): at is number => {
+    if (!at || !Number.isFinite(at) || at <= (history.clocks[source] ?? 0)) return false;
+    next.clocks[source] = at;
+    return true;
+  };
+  const emit = (
+    at: number,
+    values: StatisticsSample['values'],
+    coverage?: StatisticsSample['coverage'],
+    boundary = false,
+  ): void => {
+    frames.push({
+      at,
+      values,
+      ...(coverage ? { coverage } : {}),
+      ...(boundary ? { boundary } : {}),
     });
-  const values: StatisticsSample['values'] = {
-    cpu: resourceFresh ? completeStatisticsTotal(state, state.resources, 'cpu') : null,
-    memory: resourceFresh ? completeStatisticsTotal(state, state.resources, 'memMb') : null,
-    processes: state.agents.length,
-    products: radarGroups(agents).length,
-    connections:
-      networkHealth.state && networkHealth.state !== 'HEALTHY'
-        ? null
-        : state.network.length || networkHealth.state === 'HEALTHY'
-          ? state.network.length
-          : null,
-    fileRate:
-      continuous && previous
-        ? statisticsRate(
-            previous.events.length + previous.evicted,
-            state.events.length + state.evicted,
-            elapsed,
-          )
-        : null,
-    sensitiveRate:
-      continuous && previous
-        ? statisticsRate(
-            previous.events.filter((event) => event.sensitive === true).length +
-              previous.retainedEvicted,
-            state.events.filter((event) => event.sensitive === true).length + state.retainedEvicted,
-            elapsed,
-          )
-        : null,
-    risk: agents.length ? Math.max(...agents.map((a) => a.riskScore)) : null,
-    tokens,
-    input: completeStatisticsTotal(state, state.tokens, 'inputTokens'),
-    output: completeStatisticsTotal(state, state.tokens, 'outputTokens'),
-    tokenRate:
-      continuous && tokenCountersContinuous && previous
-        ? statisticsRate(
-            completeStatisticsTotal(previous, previous.tokens, 'totalTokens'),
-            tokens,
-            elapsed,
-          )
-        : null,
-    cost: completeStatisticsTotal(state, state.tokens, 'costUsd'),
-    ownCpu,
-    ownMemory: measured(state.own.memMB),
-    ownHeap: measured(state.own.heapMB),
-    evictions: state.evicted,
   };
-  const gap: StatisticsSample[] =
-    last && (!continuous || elapsed > 30000) ? [{ at: at - 1, values: {} }] : [];
-  return {
-    samples: [...history.samples, ...gap, { at, values }].slice(-STATISTICS_HISTORY_LIMIT),
-    previous: state,
-    ownAt,
-    ownCpu,
-    interrupted: false,
-  };
+  if (state.stale && !history.stale) {
+    const at = interruptionAt ?? state.statsAt;
+    if (at)
+      emit(
+        at,
+        {
+          cpu: null,
+          memory: null,
+          processes: null,
+          products: null,
+          risk: null,
+          tokens: null,
+          input: null,
+          output: null,
+          cost: null,
+          tokenRate: null,
+          fileRate: null,
+          sensitiveRate: null,
+        },
+        undefined,
+        true,
+      );
+    if (interruptionAt) {
+      emit(
+        interruptionAt,
+        {
+          ownCpu: null,
+          ownMemory: null,
+          ownHeap: null,
+          connections: null,
+          evictions: null,
+        },
+        undefined,
+        true,
+      );
+      next.own = null;
+    }
+    next.scan = null;
+    next.tokens = null;
+  }
+  next.stale = state.stale;
+  if (fresh('scan', state.lastScan) && state.ready && !state.stale) {
+    const at = state.lastScan;
+    const agents = instances(state);
+    const scan: ScanBaseline = {
+      at,
+      files: state.scanCounters?.files ?? state.events.length + state.evicted,
+      sensitive:
+        state.scanCounters?.sensitive ??
+        state.events.filter((event) => event.sensitive === true).length + state.retainedEvicted,
+      session,
+    };
+    const previous = next.scan?.session === session ? next.scan : null;
+    emit(at, {
+      processes: state.agents.length,
+      products: radarGroups(agents).length,
+      risk: agents.length ? Math.max(...agents.map((agent) => agent.riskScore)) : null,
+      fileRate: previous ? statisticsRate(previous.files, scan.files, at - previous.at) : null,
+      sensitiveRate: previous
+        ? statisticsRate(previous.sensitive, scan.sensitive, at - previous.at)
+        : null,
+      evictions: state.scanCounters?.evicted ?? state.evicted,
+    });
+    next.scan = scan;
+    const population = state.agents
+      .map((agent) => agent.instanceId || 'unkeyed:' + agent.pid)
+      .sort()
+      .join('\n');
+    if (history.population && history.population !== population) next.tokens = null;
+    next.population = population;
+  }
+  if (fresh('resources', state.resourcesAt)) {
+    const cpu = measuredStatisticsTotal(state, state.resources, 'cpu');
+    const memory = measuredStatisticsTotal(state, state.resources, 'memMb');
+    emit(
+      state.resourcesAt,
+      { cpu: cpu.value, memory: memory.value },
+      { cpu: coverage(cpu), memory: coverage(memory) },
+    );
+  }
+  if (fresh('tokens', state.tokensAt)) {
+    const total = measuredStatisticsTotal(state, state.tokens, 'totalTokens');
+    const input = measuredStatisticsTotal(state, state.tokens, 'inputTokens');
+    const output = measuredStatisticsTotal(state, state.tokens, 'outputTokens');
+    const cost = measuredStatisticsTotal(state, state.tokens, 'costUsd');
+    const baseline: TokenBaseline = { at: state.tokensAt, counters: total.counters, session };
+    emit(
+      state.tokensAt,
+      {
+        tokens: total.value,
+        input: input.value,
+        output: output.value,
+        cost: cost.value,
+        tokenRate: state.stale ? null : tokenRate(next.tokens, baseline),
+      },
+      {
+        tokens: coverage(total),
+        input: coverage(input),
+        output: coverage(output),
+        cost: coverage(cost),
+        tokenRate: coverage(total),
+      },
+    );
+    next.tokens = state.stale ? null : baseline;
+  }
+  if (fresh('own', state.ownAt)) {
+    const at = state.ownAt;
+    const ownCpu = history.own
+      ? cpuPercent(history.own.value, state.own, at - history.own.at)
+      : null;
+    const measured = (value: unknown): number | null =>
+      typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+    emit(at, { ownCpu, ownMemory: measured(state.own.memMB), ownHeap: measured(state.own.heapMB) });
+    next.own = { at, value: state.own };
+  }
+  if (fresh('network', state.networkAt)) {
+    const network = record(record(record(record(state.stats.appHealth).sensors).byId).network);
+    const available = !network.state || network.state === 'HEALTHY';
+    emit(state.networkAt, { connections: available ? state.network.length : null });
+  }
+  if (!frames.length) return next.stale === history.stale ? history : next;
+  const merged: StatisticsSample[] = [];
+  for (const sample of [...history.samples, ...frames].sort((a, b) => a.at - b.at)) {
+    const prior = merged.at(-1);
+    if (prior?.at === sample.at && !!prior.boundary === !!sample.boundary) {
+      merged[merged.length - 1] = {
+        at: sample.at,
+        values: { ...prior.values, ...sample.values },
+        coverage: { ...prior.coverage, ...sample.coverage },
+        ...(sample.boundary ? { boundary: true } : {}),
+      };
+    } else merged.push(sample);
+  }
+  const latest = merged.at(-1)!.at;
+  next.samples = merged
+    .filter((sample) => sample.at >= latest - STATISTICS_HISTORY_MS)
+    .slice(-STATISTICS_HISTORY_LIMIT);
+  return next;
 }
-/** Split graph paths at unavailable samples and preserve actual elapsed spacing.
+/** Split graph paths at explicit unavailable values, ignoring unrelated source frames.
  * @param samples Timeline @param key Metric @param maximum Vertical scale
  * @returns SVG line paths @since 0.14.1
  */
@@ -142,14 +264,15 @@ export function statisticsPaths(
   key: string,
   maximum: number,
 ): string[] {
-  if (!samples.length || !Number.isFinite(maximum) || maximum <= 0) return [];
-  const start = samples[0].at,
-    span = Math.max(1, samples.at(-1)!.at - start);
+  const measured = samples.filter((sample) => Object.hasOwn(sample.values, key));
+  if (!measured.length || !Number.isFinite(maximum) || maximum <= 0) return [];
+  const start = measured[0].at,
+    span = Math.max(1, measured.at(-1)!.at - start);
   const paths: string[] = [];
   let path = '';
-  for (const sample of samples) {
-    const value = measured(sample.values[key]);
-    if (value === null || value < 0) {
+  for (const sample of measured) {
+    const value = sample.values[key];
+    if (value === null || !Number.isFinite(value) || value < 0) {
       if (path) paths.push(path);
       path = '';
       continue;

--- a/frontend/observatory/runtime/statistics-metrics.ts
+++ b/frontend/observatory/runtime/statistics-metrics.ts
@@ -19,19 +19,19 @@ export const statisticsTabs = [
 export const statisticsMetrics: StatsMetric[] = [
   {
     id: 'cpu',
-    label: 'Agent CPU',
+    label: 'Measured agent CPU',
     unit: '%',
     description:
-      'Share of total CPU capacity used by all observed agent processes. Every process must have a matching resource sample.',
+      'Measured current processes as a share of total machine CPU capacity. Coverage shows how many exact process identities contributed; missing processes are excluded, never assumed idle.',
     sections: ['overview', 'processes'],
     floor: 100,
   },
   {
     id: 'memory',
-    label: 'Agent memory',
+    label: 'Measured agent memory',
     unit: 'MB',
     description:
-      'Combined resident memory of all observed agent processes. Shared pages may be counted in more than one process.',
+      'Resident memory of measured current processes. Coverage identifies missing processes; shared pages may be counted in more than one process.',
     sections: ['overview', 'processes'],
   },
   {
@@ -62,7 +62,7 @@ export const statisticsMetrics: StatsMetric[] = [
     label: 'File observations',
     unit: '/min',
     description:
-      'Rate of observations delivered to this window between samples, including retained-history evictions. Initial history is excluded. Delivery may arrive in batches.',
+      'Delivered observations per minute between reliable process scans, including display-history evictions. Resource and token deliveries do not change the sampling interval.',
     sections: ['overview', 'activity'],
   },
   {
@@ -70,7 +70,7 @@ export const statisticsMetrics: StatsMetric[] = [
     label: 'Sensitive observations',
     unit: '/min',
     description:
-      'Rate of sensitive observations delivered to this window, including evicted sensitive records, normalized per minute. Initial history, counter resets and observation gaps have no rate.',
+      'Sensitive observations delivered between reliable process scans, including evicted sensitive records, per minute. Initial history, counter resets and observation gaps have no rate.',
     sections: ['activity'],
   },
   {
@@ -87,7 +87,7 @@ export const statisticsMetrics: StatsMetric[] = [
     label: 'Accumulated tokens',
     unit: '',
     description:
-      'Supported log measurements summed only when every current process has exact instance attribution. A changing process population changes this total.',
+      'Accumulated supported-log measurements for current exact process identities. Coverage shows measured processes; unsupported processes do not erase measured usage. A changing population changes this subtotal.',
     sections: ['tokens'],
   },
   {
@@ -95,7 +95,7 @@ export const statisticsMetrics: StatsMetric[] = [
     label: 'Input tokens',
     unit: '',
     description:
-      'Accumulated input tokens for the current process population, with complete identity coverage.',
+      'Accumulated input tokens from measured current process identities, with explicit coverage.',
     sections: ['tokens'],
   },
   {
@@ -103,7 +103,7 @@ export const statisticsMetrics: StatsMetric[] = [
     label: 'Output tokens',
     unit: '',
     description:
-      'Accumulated output tokens for the current process population, with complete identity coverage.',
+      'Accumulated output tokens from measured current process identities, with explicit coverage.',
     sections: ['tokens'],
   },
   {
@@ -111,7 +111,7 @@ export const statisticsMetrics: StatsMetric[] = [
     label: 'Token arrival rate',
     unit: '/min',
     description:
-      'Change in supported log counters per minute for an unchanged process population. Process changes, counter resets and observation gaps interrupt the rate.',
+      'Change in measured supported-log counters between token deliveries, per minute. A changed measured identity set, counter reset or observation gap interrupts the rate.',
     sections: ['tokens'],
   },
   {
@@ -184,4 +184,42 @@ export function completeStatisticsTotal(
     total += value;
   }
   return Number.isFinite(total) ? total : null;
+}
+
+export interface StatisticsCoverage {
+  measured: number;
+  total: number;
+}
+export interface StatisticsMeasurement extends StatisticsCoverage {
+  value: number | null;
+  counters: Record<string, number>;
+}
+/** Sum measured current identities, preserving missing coverage separately.
+ * @param state Population @param rows Source rows @param key Field
+ * @returns Measured subtotal and exact coverage @since 0.14.1
+ */
+export function measuredStatisticsTotal(
+  state: Telemetry,
+  rows: Record<string, unknown>[],
+  key: string,
+): StatisticsMeasurement {
+  const ids = new Set(
+    state.agents.map((agent) => agent.instanceId).filter((id): id is string => !!id),
+  );
+  const total = ids.size + state.agents.filter((agent) => !agent.instanceId).length;
+  const counters: Record<string, number> = {};
+  if (state.stale || !state.ready) return { value: null, measured: 0, total, counters };
+  for (const id of ids) {
+    const matches = rows.filter((row) => row.instanceId === id);
+    const value = matches.length === 1 ? measured(matches[0][key]) : null;
+    if (value !== null && value >= 0) counters[id] = value;
+  }
+  const values = Object.values(counters);
+  const sum = values.reduce((a, b) => a + b, 0);
+  return {
+    value: (values.length || total === 0) && Number.isFinite(sum) ? sum : null,
+    measured: values.length,
+    total,
+    counters,
+  };
 }

--- a/frontend/observatory/runtime/statistics-plot.ts
+++ b/frontend/observatory/runtime/statistics-plot.ts
@@ -1,0 +1,85 @@
+import type { StatisticsSample } from './statistics-history';
+
+export interface PlotPoint {
+  at: number;
+  value: number;
+  x: number;
+  y: number;
+}
+/** Read only measurements delivered by this metric's own source clock.
+ * @param samples Sparse history @param key Metric @param start Window start @param end Window end
+ * @returns Actual metric observations, including explicit gaps @since 0.14.1
+ */
+export function metricObservations(
+  samples: StatisticsSample[],
+  key: string,
+  start: number,
+  end: number,
+): StatisticsSample[] {
+  return samples.filter(
+    (s) => Number.isFinite(s.at) && s.at >= start && s.at <= end && Object.hasOwn(s.values, key),
+  );
+}
+/** Choose a readable, stable zero-based vertical scale.
+ * @param values Measurements @param floor Fixed minimum scale @returns Axis upper bound @since 0.14.1
+ */
+export function plotMaximum(values: (number | null | undefined)[], floor = 0): number {
+  const peak = Math.max(
+    0,
+    ...values.filter((n): n is number => typeof n === 'number' && Number.isFinite(n) && n >= 0),
+  );
+  if (floor >= peak && floor > 0) return floor;
+  if (!peak) return 1;
+  const power = 10 ** Math.floor(Math.log10(peak));
+  return ([1, 2, 2.5, 5, 10].find((n) => n * power >= peak) ?? 10) * power;
+}
+/** Map an observed timestamp to a fixed duration, never to the number of arrivals.
+ * @param at Timestamp @param start Window start @param end Window end @returns SVG x coordinate @since 0.14.1
+ */
+export function plotX(at: number, start: number, end: number): number {
+  return Math.max(0, Math.min(600, ((at - start) / Math.max(1, end - start)) * 600));
+}
+/** Plot sparse source observations, retaining isolated points and explicit breaks.
+ * @param samples Metric history @param key Metric @param start Window start @param end Window end
+ * @param maximum Vertical maximum @param stepped Discrete state series
+ * @returns Line segments and actual measured points @since 0.14.1
+ */
+export function plotGeometry(
+  samples: StatisticsSample[],
+  key: string,
+  start: number,
+  end: number,
+  maximum: number,
+  stepped = false,
+): { paths: string[]; points: PlotPoint[] } {
+  const paths: string[] = [],
+    points: PlotPoint[] = [];
+  let path = '';
+  for (const sample of metricObservations(samples, key, start, end)) {
+    const value = sample.values[key];
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+      if (path) paths.push(path);
+      path = '';
+      continue;
+    }
+    const x = plotX(sample.at, start, end),
+      y = 160 - Math.min(1, value / Math.max(1e-12, maximum)) * 160;
+    const xy = x.toFixed(2) + ' ' + y.toFixed(2);
+    path += path ? (stepped ? ' H ' + x.toFixed(2) + ' V ' + y.toFixed(2) : ' L ' + xy) : 'M ' + xy;
+    points.push({ at: sample.at, value, x, y });
+  }
+  if (path) paths.push(path);
+  return { paths, points };
+}
+/** Resolve a cursor to the nearest actual observation, without inventing interpolation.
+ * @param samples Metric observations @param at Cursor timestamp @returns Actual observation @since 0.14.1
+ */
+export function nearestObservation(
+  samples: StatisticsSample[],
+  at: number,
+): StatisticsSample | undefined {
+  return samples.reduce<StatisticsSample | undefined>(
+    (best, s) => (!best || Math.abs(s.at - at) < Math.abs(best.at - at) ? s : best),
+    undefined,
+  );
+}

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -5,6 +5,7 @@ import { resolve, sep, extname } from 'node:path';
 import { chromium } from 'playwright';
 import { createHash } from 'node:crypto';
 import { checkComfort } from './comfort-check.mjs';
+import { checkGraphs } from './graph-check.mjs';
 import { checkDetails } from './detail-check.mjs';
 import { checkMotion } from './motion-check.mjs';
 import { checkResourceLayers } from './resource-layer-check.mjs';
@@ -380,6 +381,7 @@ try {
   await checkResourceLayers(browser, base + '/desktop/', out);
   await checkDetails(browser, base + '/desktop/', out);
   await checkComfort(browser, base + '/preview/', out);
+  await checkGraphs(browser, base + '/preview/', out);
   const desktop = await browser.newPage();
   desktop.on('pageerror', (e) => errors.push(e.message));
   await desktop.goto(base + '/desktop/');

--- a/frontend/observatory/tests/graph-check.mjs
+++ b/frontend/observatory/tests/graph-check.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+export async function checkGraphs(browser, url, out) {
+  const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  const settle = async () => {
+    await page.waitForFunction(() => !document.documentElement.dataset.transitionSurface);
+    await page.mouse.move(0, 0);
+  };
+  try {
+    await page.goto(url);
+    await page.locator('.sidebar').getByRole('button', { name: 'Statistics', exact: true }).click();
+    await page.getByRole('heading', { name: 'Statistics', level: 1, exact: true }).waitFor();
+    await page.waitForFunction(
+      () => document.querySelectorAll('.plot circle').length >= 2,
+      undefined,
+      { timeout: 30000 },
+    );
+    let checks = 0;
+    for (const size of [
+      { width: 1200, height: 800 },
+      { width: 900, height: 600 },
+    ]) {
+      await page.setViewportSize(size);
+      for (const theme of ['dark', 'light', 'dark-hc', 'light-hc']) {
+        await page.evaluate(
+          ({ theme, scale }) => {
+            document.documentElement.dataset.theme = theme;
+            document.documentElement.style.setProperty('--ui-scale', String(scale));
+          },
+          { theme, scale: size.width === 900 ? 1.5 : 1 },
+        );
+        for (const name of ['Overview', 'Processes', 'Activity', 'Tokens', 'Sensors']) {
+          await page.locator('.stats-navigation').getByRole('tab', { name, exact: true }).click();
+          await settle();
+          for (const duration of ['60000', '180000', '300000']) {
+            await page
+              .getByRole('combobox', { name: 'Performance history length' })
+              .selectOption(duration);
+            const label = await page.locator('.plot').getAttribute('aria-label');
+            assert(label.includes(Number(duration) / 1000 + ' seconds'), label);
+          }
+          await page
+            .getByRole('combobox', { name: 'Performance history length' })
+            .selectOption('60000');
+          const geo = await page.evaluate(() => {
+            const m = document.querySelector('#main');
+            return (
+              document.documentElement.scrollWidth <= innerWidth + 2 &&
+              m.scrollWidth <= m.clientWidth + 2
+            );
+          });
+          assert(geo, name + ' overflow');
+          await page.locator('#main').evaluate((el) => (el.scrollTop = 0));
+          if (theme === 'dark' || theme === 'light')
+            await page.screenshot({
+              path: resolve(
+                out,
+                'graph-' + name.toLowerCase() + '-' + theme + '-' + size.width + '.png',
+              ),
+            });
+          checks++;
+        }
+      }
+    }
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await page
+      .locator('.stats-navigation')
+      .getByRole('tab', { name: 'Overview', exact: true })
+      .click();
+    await page.getByRole('button', { name: 'Pause view', exact: true }).click();
+    await settle();
+    const paths = await page
+      .locator('.plot path')
+      .evaluateAll((els) => els.map((el) => el.getAttribute('d')));
+    const value = await page.locator('.monitor-detail .current').innerText();
+    await page.waitForTimeout(2200);
+    assert.deepEqual(
+      await page.locator('.plot path').evaluateAll((els) => els.map((el) => el.getAttribute('d'))),
+      paths,
+      'paused graph moved',
+    );
+    assert.equal(
+      await page.locator('.monitor-detail .current').innerText(),
+      value,
+      'paused value changed',
+    );
+    await page.getByRole('button', { name: 'Resume view', exact: true }).click();
+    await page.waitForTimeout(2200);
+    assert.notDeepEqual(
+      await page.locator('.plot path').evaluateAll((els) => els.map((el) => el.getAttribute('d'))),
+      paths,
+      'resumed graph did not advance',
+    );
+    assert.deepEqual(errors, []);
+    console.log(
+      'Graphs: ' +
+        checks +
+        ' theme/viewport/section states; fixed time windows, real points and pause/resume passed.',
+    );
+  } finally {
+    await page.close();
+  }
+}

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -37,7 +37,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (frontend/observatory/) — Svelte 5 + Vite 7
-39 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
+40 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
 
 App.svelte owns workspace tabs, history and the host connection. Monitoring shows stamped instances; Events and ActivityChart show retained evidence; Details and EntityLinks connect observations; Rules, Catalog, Analysis, Reports, Statistics and Settings expose host actions. SensorStatus renders effective sensor IDs; Notifications tracks anomaly crossings.
 

--- a/tests/renderer/components/ObservatoryActivityCorrectness.test.js
+++ b/tests/renderer/components/ObservatoryActivityCorrectness.test.js
@@ -1,0 +1,136 @@
+import { afterEach, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import ActivityChart from '../../../frontend/observatory/components/ActivityChart.svelte';
+import Timeline from '../../../frontend/observatory/components/Timeline.svelte';
+import { emptyTelemetry } from '../../../frontend/observatory/runtime/host';
+import { activityBins } from '../../../frontend/observatory/runtime/activity';
+const now = Date.UTC(2026, 8, 10, 12, 0, 0);
+const event = (timestamp, extra = {}) => ({
+  timestamp,
+  agent: 'Codex',
+  instanceId: '1:live',
+  file: 'X:/project/file.ts',
+  ...extra,
+});
+const renderChart = (props) => render(ActivityChart, { props });
+function clock() {
+  vi.useFakeTimers({ toFake: ['Date', 'setInterval', 'clearInterval'] });
+  vi.setSystemTime(now);
+}
+const total = (container) => container.querySelector('.chart-reading strong').textContent;
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+it('advances an idle live histogram so expired retained events leave the chosen period', async () => {
+  clock();
+  const mounted = renderChart({
+    events: [event(now - 290000)],
+    observedAt: now,
+    inspect: vi.fn(),
+  });
+  await fireEvent.click(screen.getByRole('button', { name: '5 min', exact: true }));
+  expect(total(mounted.container)).toBe('1');
+  const last = () =>
+    within(screen.getByRole('group', { name: 'File activity histogram' }))
+      .getAllByRole('button')
+      .at(-1)
+      .getAttribute('aria-label');
+  const initial = last();
+  await vi.advanceTimersByTimeAsync(11000);
+  await tick();
+  expect(total(mounted.container)).toBe('0');
+  expect(last()).not.toBe(initial);
+  mounted.unmount();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it('freezes paused and stale windows, then resumes at the current clock', async () => {
+  clock();
+  const mounted = renderChart({
+    events: [event(now - 290000)],
+    observedAt: now,
+    paused: true,
+    inspect: vi.fn(),
+  });
+  await fireEvent.click(screen.getByRole('button', { name: '5 min', exact: true }));
+  await vi.advanceTimersByTimeAsync(20000);
+  await tick();
+  expect(total(mounted.container)).toBe('1');
+  expect(screen.getByText(/View paused/)).toBeInTheDocument();
+  await mounted.rerender({ paused: false, stale: true });
+  await vi.advanceTimersByTimeAsync(20000);
+  await tick();
+  expect(total(mounted.container)).toBe('1');
+  expect(screen.getByText(/Observation unavailable/)).toBeInTheDocument();
+  await mounted.rerender({ stale: false });
+  await tick();
+  expect(total(mounted.container)).toBe('0');
+});
+
+it('does not let a future or malformed event or scan timestamp move the time axis', () => {
+  clock();
+  const mounted = renderChart({
+    events: [event(now), event(now + 86400000), event(NaN)],
+    observedAt: now + 86400000,
+    inspect: vi.fn(),
+  });
+  expect(total(mounted.container)).toBe('1');
+  const buttons = within(
+    screen.getByRole('group', { name: 'File activity histogram' }),
+  ).getAllByRole('button');
+  expect(buttons.at(-1)).toHaveAccessibleName(/1 observations$/);
+  expect(mounted.container.textContent).not.toContain('Invalid Date');
+});
+
+it('keeps bucket membership and scale exact when inspecting boundaries and clears obsolete hover on period changes', async () => {
+  clock();
+  const bounds = activityBins([], now + 1, 15 * 60000);
+  const rows = [event(bounds[5].start), ...Array.from({ length: 7 }, () => event(bounds[5].end))];
+  const inspect = vi.fn();
+  const mounted = renderChart({ events: rows, observedAt: now, inspect });
+  const buttons = within(
+    screen.getByRole('group', { name: 'File activity histogram' }),
+  ).getAllByRole('button');
+  await fireEvent.click(buttons[5]);
+  expect(inspect.mock.calls[0][1].observations).toEqual([rows[0]]);
+  await fireEvent.click(buttons[6]);
+  expect(inspect.mock.calls[1][1].observations).toEqual(rows.slice(1));
+  expect(screen.getByText('Scale 0–10 / interval')).toBeInTheDocument();
+  await fireEvent.pointerEnter(buttons[6]);
+  expect(mounted.container.querySelector('.chart-readout')).toHaveTextContent('7 observations');
+  await fireEvent.pointerLeave(screen.getByRole('group', { name: 'File activity histogram' }));
+  expect(mounted.container.querySelector('.chart-readout')).toHaveTextContent('Select an interval');
+  await fireEvent.pointerEnter(buttons[6]);
+  await fireEvent.click(screen.getByRole('button', { name: '5 min', exact: true }));
+  expect(mounted.container.querySelector('.chart-readout')).toHaveTextContent('Select an interval');
+  buttons[0].focus();
+  await fireEvent.keyDown(buttons[0], { key: 'End' });
+  expect(buttons.at(-1)).toHaveFocus();
+});
+
+it('advances and freezes timeline lanes independently of pushes while keeping future observations out', async () => {
+  clock();
+  const telemetry = {
+    ...emptyTelemetry(),
+    stale: false,
+    ready: true,
+    lastScan: now,
+    agents: [{ agent: 'Codex', process: 'codex.exe', pid: 1, instanceId: '1:live' }],
+    events: [event(now - 290000), event(now + 86400000)],
+  };
+  const mounted = render(Timeline, { telemetry, paused: true, inspect: vi.fn() });
+  await fireEvent.change(screen.getByLabelText('Range'), { target: { value: '5' } });
+  expect(screen.getByRole('button', { name: 'Codex: 1 events' })).toBeInTheDocument();
+  await vi.advanceTimersByTimeAsync(20000);
+  await tick();
+  expect(screen.getByRole('button', { name: 'Codex: 1 events' })).toBeInTheDocument();
+  await mounted.rerender({ paused: false });
+  await tick();
+  expect(screen.queryByRole('button', { name: /Codex: .* events/ })).toBeNull();
+  mounted.unmount();
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/tests/renderer/components/ObservatoryGraphCorrectness.test.js
+++ b/tests/renderer/components/ObservatoryGraphCorrectness.test.js
@@ -1,0 +1,55 @@
+import { it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import StatsChart from '../../../frontend/observatory/components/StatsChart.svelte';
+import { statisticsMetrics } from '../../../frontend/observatory/runtime/statistics-metrics';
+
+const metrics = statisticsMetrics.filter((m) => ['cpu', 'memory'].includes(m.id));
+const samples = [
+  { at: 1000, values: { cpu: 10 }, coverage: { cpu: { measured: 1, total: 2 } } },
+  { at: 1010, values: { tokens: 1000 } },
+  { at: 2000, values: { cpu: 20 } },
+];
+it('renders partial measured values and only its own source points in a real duration', async () => {
+  const mounted = render(StatsChart, { samples, metrics, now: 3000 });
+  expect(screen.getByRole('img')).toHaveAttribute(
+    'aria-label',
+    expect.stringContaining('2 measured samples; 60 seconds'),
+  );
+  expect(mounted.container.querySelector('.current')).toHaveTextContent('20 %');
+  await fireEvent.input(screen.getByRole('slider'), { target: { value: '0' } });
+  expect(mounted.container.querySelector('.current')).toHaveTextContent('10 %');
+  expect(screen.getByText(/Measured subtotal/)).toHaveTextContent('1 / 2 processes');
+  await fireEvent.change(screen.getByRole('combobox', { name: 'Performance history length' }), {
+    target: { value: '300000' },
+  });
+  expect(screen.getByRole('img')).toHaveAttribute(
+    'aria-label',
+    expect.stringContaining('300 seconds'),
+  );
+});
+it('holds an inspected observation on updates, then returns to Latest when it expires', async () => {
+  const mounted = render(StatsChart, { samples, metrics, now: 3000 });
+  await fireEvent.input(screen.getByRole('slider'), { target: { value: '0' } });
+  const updated = [...samples, { at: 4000, values: { cpu: 30 } }];
+  await mounted.rerender({ samples: updated, now: 5000 });
+  expect(mounted.container.querySelector('.current')).toHaveTextContent('10 %');
+  expect(screen.getByRole('button', { name: 'Latest' })).toHaveAttribute('aria-pressed', 'false');
+  await mounted.rerender({ now: 63000 });
+  expect(screen.getByRole('button', { name: 'Latest' })).toHaveAttribute('aria-pressed', 'true');
+  expect(mounted.container.querySelector('.current')).toHaveTextContent('30 %');
+});
+it('preserves the displayed measured value at a pause boundary without joining its gap', async () => {
+  const paused = [...samples, { at: 2500, values: { cpu: null }, boundary: true }];
+  const mounted = render(StatsChart, {
+    samples: paused,
+    metrics,
+    now: 3000,
+    paused: true,
+    stale: true,
+  });
+  expect(mounted.container.querySelector('.current')).toHaveTextContent('20 %');
+  expect(screen.getByText(/^View held/)).toBeVisible();
+  expect(mounted.container.querySelectorAll('.plot path')).toHaveLength(1);
+  await mounted.rerender({ paused: false });
+  expect(mounted.container.querySelector('.current')).toHaveTextContent('—');
+});

--- a/tests/renderer/components/ObservatoryGroups.test.js
+++ b/tests/renderer/components/ObservatoryGroups.test.js
@@ -103,7 +103,12 @@ it('opens the group without process controls and resolves a chosen member to its
 });
 
 it('offers one activity filter for the same product across multiple processes', async () => {
-  render(ActivityChart, { props: { events: state().events, observedAt: 1000, inspect: vi.fn() } });
+  const observedAt = Date.now();
+  const events = state().events.map((row) => ({
+    ...row,
+    timestamp: observedAt - 1000 + row.timestamp,
+  }));
+  render(ActivityChart, { props: { events, observedAt, inspect: vi.fn() } });
   const select = screen.getByLabelText('Chart agent');
   expect(within(select).getAllByRole('option')).toHaveLength(2);
   await fireEvent.change(select, { target: { value: 'Claude Code' } });

--- a/tests/renderer/components/ObservatoryResourceCoverage.test.js
+++ b/tests/renderer/components/ObservatoryResourceCoverage.test.js
@@ -1,0 +1,124 @@
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/svelte';
+import ResourceUsage from '../../../frontend/observatory/components/ResourceUsage.svelte';
+import { emptyTelemetry, instances } from '../../../frontend/observatory/runtime/host';
+import { radarGroups } from '../../../frontend/observatory/runtime/radar';
+import { measuredGroupResource } from '../../../frontend/observatory/runtime/resources';
+
+const agent = (pid, name = 'Codex', identity = pid + ':current') => ({
+  agent: name,
+  pid,
+  process: 'agent.exe',
+  instanceId: identity,
+  instanceIdSource: 'os',
+});
+const state = () => ({
+  ...emptyTelemetry(),
+  ready: true,
+  stale: false,
+  resourcesAt: 10000,
+  agents: [agent(1), agent(2), agent(3), agent(4, 'Codex', null), agent(10, 'Cursor')],
+  resources: [
+    { instanceId: '1:current', cpu: 5, memMb: 100 },
+    { instanceId: '2:current', memMb: 200 },
+    { instanceId: '10:current', cpu: 0, memMb: 600 },
+    { instanceId: '3:retired', pid: 3, cpu: 99, memMb: 999 },
+    { instanceId: null, pid: 4, cpu: 99, memMb: 999 },
+  ],
+});
+const codex = (s) => radarGroups(instances(s)).find((group) => group.name === 'Codex');
+
+it('keeps measured group subtotals with per-field coverage and excludes reused PIDs and unkeyed rows', () => {
+  const s = state();
+  expect(measuredGroupResource(codex(s), s, 'cpu')).toMatchObject({
+    value: 5,
+    measured: 1,
+    total: 4,
+  });
+  expect(measuredGroupResource(codex(s), s, 'memMb')).toMatchObject({
+    value: 300,
+    measured: 2,
+    total: 4,
+  });
+});
+
+it('rejects ambiguous, negative and non-finite rows without erasing another measured process', () => {
+  const s = state();
+  s.resources.push({ instanceId: '1:current', cpu: 20, memMb: 20 });
+  expect(measuredGroupResource(codex(s), s, 'memMb')).toMatchObject({
+    value: 200,
+    measured: 1,
+    total: 4,
+  });
+  expect(measuredGroupResource(codex(s), s, 'cpu').value).toBeNull();
+  s.resources.push({ instanceId: '3:current', cpu: -4, memMb: Infinity });
+  expect(measuredGroupResource(codex(s), s, 'cpu').value).toBeNull();
+  expect(measuredGroupResource(codex(s), s, 'memMb').value).toBe(200);
+});
+
+it('counts a duplicated stamped member once and rejects measurements for a retired group identity', () => {
+  const s = state();
+  s.agents.push(agent(1));
+  expect(measuredGroupResource(codex(s), s, 'cpu')).toMatchObject({
+    value: 5,
+    measured: 1,
+    total: 4,
+  });
+  const oldGroup = codex(s);
+  s.agents = [agent(1, 'Codex', '1:replacement')];
+  expect(measuredGroupResource(oldGroup, s, 'cpu').value).toBeNull();
+});
+
+it('shows partial CPU and memory bars at their actual scales and keeps measured zero distinct from unavailable', async () => {
+  const inspect = vi.fn();
+  render(ResourceUsage, { telemetry: state(), inspect });
+  const row = screen.getByRole('button', { name: /Codex/ });
+  expect(within(row).getByText('5.0%')).toBeInTheDocument();
+  expect(row).toHaveTextContent('1/4 processes measured · partial');
+  expect(row.querySelector('.usage-track')).toHaveClass('partial');
+  expect(row.querySelector('.usage-track > span').style.transform).toBe('scaleX(0.05)');
+  const cursor = screen.getByRole('button', { name: /Cursor/ });
+  expect(within(cursor).getByText('0.0%')).toBeInTheDocument();
+  expect(cursor.querySelector('.usage-track')).not.toHaveClass('unavailable');
+  await fireEvent.click(screen.getByRole('button', { name: 'RAM', exact: true }));
+  expect(within(row).getByText('300.0 MB')).toBeInTheDocument();
+  expect(row).toHaveTextContent('2/4 processes measured · partial');
+  expect(row.querySelector('.usage-track > span').style.transform).toBe('scaleX(0.5)');
+  expect(cursor.querySelector('.usage-track > span').style.transform).toBe('scaleX(1)');
+  await fireEvent.click(row);
+  expect(inspect).toHaveBeenCalledWith('Codex', { agentGroupKey: 'Codex', name: 'Codex' });
+});
+
+it('does not render a current numeric reading during an outage or before a reliable population', async () => {
+  const s = state();
+  const { rerender } = render(ResourceUsage, { telemetry: s, inspect: vi.fn() });
+  await rerender({ telemetry: { ...s, stale: true } });
+  expect(screen.queryByText('5.0%')).toBeNull();
+  const row = screen.getByRole('button', { name: /Codex/ });
+  expect(row).toHaveTextContent('Readings paused');
+  expect(row.querySelector('.usage-track')).toHaveClass('unavailable');
+  expect(within(row).getByText('—')).toBeInTheDocument();
+  await rerender({ telemetry: { ...s, ready: false } });
+  expect(within(row).getByText('—')).toBeInTheDocument();
+});
+
+it('normalizes fractional MB totals against the actual largest subtotal and keeps all-zero scales finite', async () => {
+  const s = {
+    ...state(),
+    resources: [
+      { instanceId: '1:current', memMb: 0.25 },
+      { instanceId: '10:current', memMb: 0.5 },
+    ],
+  };
+  const { rerender } = render(ResourceUsage, { telemetry: s, inspect: vi.fn() });
+  await fireEvent.click(screen.getByRole('button', { name: 'RAM', exact: true }));
+  const codexRow = screen.getByRole('button', { name: /Codex/ });
+  const cursorRow = screen.getByRole('button', { name: /Cursor/ });
+  expect(codexRow.querySelector('.usage-track > span').style.transform).toBe('scaleX(0.5)');
+  expect(cursorRow.querySelector('.usage-track > span').style.transform).toBe('scaleX(1)');
+  await rerender({
+    telemetry: { ...s, resources: s.resources.map((row) => ({ ...row, memMb: 0 })) },
+  });
+  expect(codexRow.querySelector('.usage-track > span').style.transform).toBe('scaleX(0)');
+  expect(cursorRow.querySelector('.usage-track > span').style.transform).toBe('scaleX(0)');
+});

--- a/tests/renderer/observatory-activity.test.js
+++ b/tests/renderer/observatory-activity.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { activityBins } from '../../frontend/observatory/runtime/activity';
+import { activityBins, activityTimeLabel } from '../../frontend/observatory/runtime/activity';
 import { cpuPercent } from '../../frontend/observatory/runtime/resources';
 
 describe('Observatory measurement contracts', () => {
@@ -26,4 +26,45 @@ describe('Observatory measurement contracts', () => {
     ).toBeNull();
     expect(cpuPercent({ cpuUser: 0, cpuSystem: 0 }, { cpuUser: 0, cpuSystem: 0 }, 0)).toBeNull();
   });
+});
+
+it('assigns fractional epoch boundaries to the following bucket without floating-point drift', () => {
+  const end = 1788961234567.25;
+  const bounds = activityBins([], end, 12345.67, 24);
+  const events = bounds.map((bin) => ({ timestamp: bin.start }));
+  const bins = activityBins([...events, { timestamp: end }], end, 12345.67, 24);
+  expect(bins.map((bin) => bin.events)).toEqual(events.map((event) => [event]));
+  expect(bins.at(-1).end).toBe(end);
+});
+
+it('rejects invalid histogram ranges and counts without throwing or allocating unbounded arrays', () => {
+  for (const [end, period, count] of [
+    [NaN, 100, 4],
+    [100, 0, 4],
+    [100, -100, 4],
+    [100, Infinity, 4],
+    [100, 100, 0],
+    [100, 100, -1],
+    [100, 100, 2.5],
+    [100, 100, Infinity],
+    [100, 100, 1001],
+  ]) {
+    expect(activityBins([{ timestamp: 50 }], end, period, count)).toEqual([]);
+  }
+});
+
+it('formats a complete local axis clock and leaves malformed dates unavailable', () => {
+  const at = Date.UTC(2026, 8, 10, 13, 5, 30);
+  expect(activityTimeLabel(at)).toBe(
+    new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' }).format(at),
+  );
+  expect(activityTimeLabel(at, true)).toBe(
+    new Intl.DateTimeFormat(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    }).format(at),
+  );
+  expect(activityTimeLabel(NaN)).toBe('—');
+  expect(activityTimeLabel(1e30)).toBe('—');
 });

--- a/tests/renderer/observatory-host.test.js
+++ b/tests/renderer/observatory-host.test.js
@@ -30,12 +30,12 @@ const deferred = () => {
   });
   return { promise, resolve };
 };
-function setup(seed = Promise.resolve({})) {
+function setup(seed = Promise.resolve({}), ownSeed = Promise.resolve({})) {
   const listeners = {};
   const unsubs = [];
   const host = {
     getStats: () => seed,
-    getResourceUsage: async () => ({}),
+    getResourceUsage: () => ownSeed,
     getFalsePositives: async () => [],
   };
   for (const name of [
@@ -212,4 +212,79 @@ describe('Observatory host boundary', () => {
       'HTTP',
     );
   });
+});
+
+it('keeps source receipt clocks independent through async scan, token, resource and network ordering', async () => {
+  let now = 1000;
+  const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+  const run = setup();
+  try {
+    await Promise.resolve();
+    await Promise.resolve();
+    run.listeners.onScanBatch({
+      stats: healthy,
+      agents: [agent('123:1')],
+      resourceUsage: { cpuUser: 100, cpuSystem: 0 },
+    });
+    expect(run.current.lastScan).toBe(1000);
+    expect(run.current.ownAt).toBe(1000);
+    now = 1020;
+    run.listeners.onTokenCosts([{ instanceId: '123:1', totalTokens: 20 }]);
+    expect(run.current.tokensAt).toBe(1020);
+    expect(run.current.lastScan).toBe(1000);
+    expect(run.current.resourcesAt).toBeNull();
+    now = 1800;
+    run.listeners.onAgentResourceUsage([{ instanceId: '123:1', cpu: 3 }]);
+    expect(run.current.resourcesAt).toBe(1800);
+    expect(run.current.tokensAt).toBe(1020);
+    expect(run.current.ownAt).toBe(1000);
+    now = 2000;
+    run.listeners.onNetworkUpdate([]);
+    expect(run.current.networkAt).toBe(2000);
+    expect(run.current.statsAt).toBe(1000);
+  } finally {
+    run.dispose();
+    clock.mockRestore();
+  }
+});
+it('a delayed own-resource seed cannot replace a newer scan value or timestamp', async () => {
+  let now = 1000;
+  const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+  const own = deferred();
+  const run = setup(Promise.resolve(healthy), own.promise);
+  try {
+    await Promise.resolve();
+    await Promise.resolve();
+    now = 2000;
+    run.listeners.onScanBatch({
+      stats: healthy,
+      agents: [agent('123:1')],
+      resourceUsage: { memMB: 20 },
+    });
+    now = 5000;
+    own.resolve({ memMB: 10 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(run.current.own.memMB).toBe(20);
+    expect(run.current.ownAt).toBe(2000);
+  } finally {
+    run.dispose();
+    clock.mockRestore();
+  }
+});
+
+it('captures delivery totals at scan receipt rather than borrowing later file pushes', async () => {
+  const run = setup();
+  try {
+    await Promise.resolve();
+    await Promise.resolve();
+    run.listeners.onFileAccess([{ sensitive: true }]);
+    run.listeners.onScanBatch({ stats: healthy, agents: [agent('123:1')] });
+    expect(run.current.scanCounters).toEqual({ files: 1, sensitive: 1, evicted: 0 });
+    run.listeners.onFileAccess([{ sensitive: true }, { sensitive: false }]);
+    expect(run.current.events).toHaveLength(3);
+    expect(run.current.scanCounters).toEqual({ files: 1, sensitive: 1, evicted: 0 });
+  } finally {
+    run.dispose();
+  }
 });

--- a/tests/renderer/observatory-statistics-plot.test.js
+++ b/tests/renderer/observatory-statistics-plot.test.js
@@ -1,0 +1,71 @@
+import { it, expect } from 'vitest';
+import {
+  metricObservations,
+  plotGeometry,
+  plotMaximum,
+  plotX,
+  nearestObservation,
+} from '../../frontend/observatory/runtime/statistics-plot';
+
+it('places measurements in a fixed real-time window despite unrelated arrivals', () => {
+  const samples = [
+    { at: 1000, values: { cpu: 10 } },
+    { at: 1001, values: { tokens: 100 } },
+    { at: 31000, values: { cpu: 20 } },
+    { at: 61000, values: { cpu: 30 } },
+  ];
+  expect(metricObservations(samples, 'cpu', 1000, 61000)).toHaveLength(3);
+  expect(plotGeometry(samples, 'cpu', 1000, 61000, 100).points.map((p) => p.x)).toEqual([
+    0, 300, 600,
+  ]);
+  expect(plotX(31000, 1000, 61000)).toBe(300);
+  expect(plotX(31000, 11000, 71000)).toBe(200);
+});
+it('draws isolated measurements and breaks only at explicit missing observations', () => {
+  const samples = [
+    { at: 0, values: { cpu: 10 } },
+    { at: 10, values: { tokens: 20 } },
+    { at: 20, values: { cpu: 20 } },
+    { at: 30, values: { cpu: null } },
+    { at: 40, values: { cpu: 30 } },
+  ];
+  const graph = plotGeometry(samples, 'cpu', 0, 60, 100);
+  expect(graph.paths).toHaveLength(2);
+  expect(graph.points).toHaveLength(3);
+  expect(graph.paths[0]).toContain(' L ');
+  expect(graph.paths[1]).toBe('M 400.00 112.00');
+  expect(plotGeometry([{ at: 40, values: { cpu: 10 } }], 'cpu', 0, 60, 100).points).toHaveLength(1);
+});
+it('uses discrete steps for population counters and stable readable scales', () => {
+  const graph = plotGeometry(
+    [
+      { at: 0, values: { processes: 2 } },
+      { at: 10, values: { processes: 4 } },
+    ],
+    'processes',
+    0,
+    20,
+    5,
+    true,
+  );
+  expect(graph.paths).toEqual(['M 0.00 96.00 H 300.00 V 32.00']);
+  expect(plotMaximum([null, NaN, Infinity])).toBe(1);
+  expect(plotMaximum([21, 22, 24])).toBe(25);
+  expect(plotMaximum([4, 7], 100)).toBe(100);
+});
+it('inspects an actual measured timestamp and excludes expired or future points', () => {
+  const visible = metricObservations(
+    [
+      { at: 0, values: { cpu: 1 } },
+      { at: 500, values: { cpu: 2 } },
+      { at: 1000, values: { cpu: 3 } },
+      { at: 2000, values: { cpu: 4 } },
+    ],
+    'cpu',
+    100,
+    1000,
+  );
+  expect(visible.map((s) => s.at)).toEqual([500, 1000]);
+  expect(nearestObservation(visible, 890)?.at).toBe(1000);
+  expect(nearestObservation([], 890)).toBeUndefined();
+});

--- a/tests/renderer/observatory-statistics.test.js
+++ b/tests/renderer/observatory-statistics.test.js
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest';
 import { emptyTelemetry } from '../../frontend/observatory/runtime/host';
 import {
-  completeStatisticsTotal,
+  measuredStatisticsTotal,
   statisticsValue,
 } from '../../frontend/observatory/runtime/statistics-metrics';
 import {
@@ -10,8 +10,8 @@ import {
   statisticsRate,
   statisticsPaths,
   STATISTICS_HISTORY_LIMIT,
+  STATISTICS_HISTORY_MS,
 } from '../../frontend/observatory/runtime/statistics-history';
-
 const agent = (pid) => ({
   pid,
   agent: 'Codex',
@@ -25,6 +25,10 @@ const state = (at = 1000, extra = {}) => ({
   stale: false,
   lastScan: at,
   resourcesAt: at,
+  tokensAt: at,
+  ownAt: at,
+  networkAt: at,
+  statsAt: at,
   agents: [agent(1), agent(2)],
   resources: [
     { instanceId: '1:live', cpu: 0, memMb: 10 },
@@ -36,168 +40,228 @@ const state = (at = 1000, extra = {}) => ({
   ],
   stats: {
     monitoringStarted: 1,
-    totalSensitive: 2,
     appHealth: { sensors: { byId: { network: { state: 'HEALTHY' } } } },
   },
   own: { memMB: 60, heapMB: 20, cpuUser: 1000, cpuSystem: 1000 },
   ...extra,
 });
-const last = (h) => h.samples.at(-1).values;
+const latest = (history, id) =>
+  history.samples.findLast((sample) => Object.hasOwn(sample.values, id));
 
-it('requires complete exact identity coverage and ignores unrelated resource rows', () => {
+it('shows measured partial subtotals without matching by PID or counting departed identities', () => {
   const s = state();
+  const rows = [s.resources[1], { instanceId: 'departed', cpu: 999 }];
+  expect(measuredStatisticsTotal(s, rows, 'cpu')).toMatchObject({
+    value: 20,
+    measured: 1,
+    total: 2,
+  });
   expect(
-    completeStatisticsTotal(s, [...s.resources, { instanceId: 'gone', cpu: 999 }], 'cpu'),
-  ).toBe(20);
-  expect(completeStatisticsTotal(s, s.resources.slice(0, 1), 'cpu')).toBeNull();
-  expect(completeStatisticsTotal(s, [...s.resources, s.resources[0]], 'cpu')).toBeNull();
-  expect(
-    completeStatisticsTotal(
-      { ...s, agents: [agent(1), { ...agent(2), instanceId: null }] },
-      s.resources,
-      'cpu',
-    ),
-  ).toBeNull();
-  expect(completeStatisticsTotal({ ...s, stale: true }, s.resources, 'cpu')).toBeNull();
+    measuredStatisticsTotal(s, [{ ...s.resources[1], instanceId: 'other:birth', pid: 2 }], 'cpu'),
+  ).toMatchObject({ value: null, measured: 0, total: 2 });
+  expect(measuredStatisticsTotal(s, [s.resources[1], s.resources[1]], 'cpu').value).toBeNull();
 });
-it('rejects missing, negative and nonfinite totals while preserving real zero', () => {
-  const s = state();
-  for (const value of [null, undefined, NaN, Infinity, -1, '20']) {
-    expect(
-      completeStatisticsTotal(s, [{ ...s.resources[0], cpu: value }, s.resources[1]], 'cpu'),
-    ).toBeNull();
-  }
-  expect(
-    completeStatisticsTotal(
-      s,
-      s.resources.map((r) => ({ ...r, cpu: 0 })),
-      'cpu',
-    ),
-  ).toBe(0);
-  expect(statisticsValue(null, '%')).toBe('—');
+it('deduplicates current stamped identities while preserving unmeasurable synthetic coverage', () => {
+  const s = state(1000, { agents: [agent(1), agent(1), { ...agent(0), instanceId: null }] });
+  expect(measuredStatisticsTotal(s, s.resources, 'memMb')).toMatchObject({
+    value: 10,
+    measured: 1,
+    total: 2,
+  });
+});
+it('distinguishes reliable zero population from unknown population or unmeasured load', () => {
+  const s = state(1000, { agents: [] });
+  expect(measuredStatisticsTotal(s, [], 'cpu')).toMatchObject({ value: 0, total: 0, measured: 0 });
+  expect(measuredStatisticsTotal({ ...s, stale: true }, [], 'cpu').value).toBeNull();
+  expect(measuredStatisticsTotal({ ...s, ready: false }, [], 'cpu').value).toBeNull();
+  expect(measuredStatisticsTotal(state(), [], 'cpu').value).toBeNull();
   expect(statisticsValue(0, '%')).toBe('0 %');
+  expect(statisticsValue(null, '%')).toBe('—');
 });
-it('keeps bounded histories and does not append for a frozen or repeated display snapshot', () => {
-  let h = createStatisticsHistory();
+it('excludes invalid measurements rather than discarding other measured processes', () => {
   const s = state();
-  h = observeStatistics(h, s);
-  expect(observeStatistics(h, s)).toBe(h);
-  expect(observeStatistics(h, { ...s, events: [{ timestamp: 500 }] })).toBe(h);
-  for (let i = 2; i < 300; i++) h = observeStatistics(h, state(i * 1000));
-  expect(h.samples).toHaveLength(STATISTICS_HISTORY_LIMIT);
-  expect(h.samples[0].at).toBe(180000);
-  expect(last(h).memory).toBe(40);
+  for (const cpu of [null, undefined, NaN, Infinity, -1, '20']) {
+    expect(
+      measuredStatisticsTotal(s, [{ ...s.resources[0], cpu }, s.resources[1]], 'cpu'),
+    ).toMatchObject({ value: 20, measured: 1, total: 2 });
+  }
 });
-it('freezes outages and inserts a visual gap without fabricating recovery rates', () => {
-  let h = observeStatistics(createStatisticsHistory(), state());
-  h = observeStatistics(h, state(2000, { stale: true }));
-  expect(h.samples).toHaveLength(1);
-  h = observeStatistics(h, state(3000));
-  expect(h.samples).toHaveLength(3);
-  expect(h.samples[1].values).toEqual({});
-  expect(last(h).fileRate).toBeNull();
-  expect(last(h).tokenRate).toBeNull();
-  expect(last(h).ownCpu).toBeNull();
-});
-it('counts delivered events across retention eviction and normalizes sensitive rates', () => {
-  let h = observeStatistics(
-    createStatisticsHistory(),
-    state(1000, { events: [{ sensitive: true }, {}], evicted: 5 }),
-  );
-  h = observeStatistics(
-    h,
-    state(3000, {
-      events: [{ sensitive: true }, { sensitive: true }],
-      evicted: 7,
-      stats: { ...state().stats, totalSensitive: 3 },
-    }),
-  );
-  expect(last(h).fileRate).toBe(60);
-  expect(last(h).sensitiveRate).toBe(30);
-});
-it('breaks rates on monitoring restart and reset instead of drawing negative activity', () => {
-  let h = observeStatistics(
-    createStatisticsHistory(),
-    state(1000, { evicted: 5, retainedEvicted: 1 }),
-  );
-  h = observeStatistics(h, state(3000, { stats: { ...state().stats, totalSensitive: 1 } }));
-  expect(last(h).fileRate).toBeNull();
-  expect(last(h).sensitiveRate).toBeNull();
-  h = observeStatistics(h, state(4000, { stats: { ...state().stats, monitoringStarted: 4000 } }));
-  expect(last(h).tokenRate).toBeNull();
-  expect(h.samples.at(-2).values).toEqual({});
-});
-it('invalidates token rates for a changed population or an individual counter reset hidden by other growth', () => {
+it('isolates scan, token and resource ordering so a 20ms resource reply cannot spike rates', () => {
   const first = state();
-  let next = state(2000, {
+  let h = observeStatistics(createStatisticsHistory(), first);
+  const scan = { ...first, lastScan: 11000, ownAt: 11000, statsAt: 11000, events: [{}, {}, {}] };
+  h = observeStatistics(h, scan);
+  expect(h.samples.at(-1).values).not.toHaveProperty('cpu');
+  expect(h.samples.at(-1).values).not.toHaveProperty('tokenRate');
+  expect(latest(h, 'fileRate').values.fileRate).toBe(18);
+  const tokens = {
+    ...scan,
+    tokensAt: 11020,
+    tokens: first.tokens.map((t) => ({ ...t, totalTokens: t.totalTokens + 150 })),
+  };
+  h = observeStatistics(h, tokens);
+  expect(latest(h, 'tokenRate').values.tokenRate).toBeCloseTo((300 * 60000) / 10020);
+  expect(h.samples.at(-1).values).not.toHaveProperty('fileRate');
+  const resources = { ...tokens, resourcesAt: 11040 };
+  h = observeStatistics(h, resources);
+  expect(h.samples.at(-1).values).toEqual({ cpu: 20, memory: 40 });
+  expect(latest(h, 'tokenRate').at).toBe(11020);
+  expect(latest(h, 'fileRate').at).toBe(11000);
+  expect(observeStatistics(h, resources)).toBe(h);
+});
+it('samples delivered sensitive counters between scans even when both ring occupancies stay constant', () => {
+  const first = state(1000, {
+    events: [{ sensitive: true }],
+    retainedEvicted: 8,
+    stats: { ...state().stats, totalSensitive: 100 },
+  });
+  let h = observeStatistics(createStatisticsHistory(), first);
+  const delivery = { ...first, retainedEvicted: 10, evicted: 2 };
+  expect(observeStatistics(h, delivery)).toBe(h);
+  h = observeStatistics(h, { ...delivery, lastScan: 3000, statsAt: 3000 });
+  expect(latest(h, 'sensitiveRate').values.sensitiveRate).toBe(60);
+  expect(latest(h, 'fileRate').values.fileRate).toBe(60);
+});
+it('uses the token source clock even if resources arrive before the token reply', () => {
+  const first = state();
+  let h = observeStatistics(createStatisticsHistory(), first);
+  const resources = { ...first, lastScan: 11000, resourcesAt: 11005 };
+  h = observeStatistics(h, resources);
+  const tokens = {
+    ...resources,
+    tokensAt: 15000,
+    tokens: first.tokens.map((t) => ({ ...t, totalTokens: t.totalTokens + 70 })),
+  };
+  h = observeStatistics(h, tokens);
+  expect(latest(h, 'tokenRate').values.tokenRate).toBe(600);
+  expect(latest(h, 'cpu').at).toBe(11005);
+});
+it('keeps partial token measurements visible when other agents have unsupported logs', () => {
+  const s = state(1000, { tokens: [state().tokens[0]] });
+  const h = observeStatistics(createStatisticsHistory(), s);
+  expect(latest(h, 'tokens').values.tokens).toBe(100);
+  expect(latest(h, 'tokens').coverage.tokens).toMatchObject({ measured: 1, total: 2 });
+});
+it('interrupts token rates when measured identities change or one counter resets behind another increase', () => {
+  const first = state();
+  let h = observeStatistics(createStatisticsHistory(), first);
+  h = observeStatistics(h, {
+    ...first,
+    tokensAt: 2000,
     tokens: first.tokens.map((t, i) => ({ ...t, totalTokens: i ? 400 : 50 })),
   });
-  let h = observeStatistics(observeStatistics(createStatisticsHistory(), first), next);
-  expect(last(h).tokens).toBe(450);
-  expect(last(h).tokenRate).toBeNull();
-  next = state(3000, { agents: [agent(1)] });
-  h = observeStatistics(h, next);
-  expect(last(h).tokens).toBe(100);
-  expect(last(h).tokenRate).toBeNull();
+  expect(latest(h, 'tokens').values.tokens).toBe(450);
+  expect(latest(h, 'tokenRate').values.tokenRate).toBeNull();
+  h = observeStatistics(h, { ...first, tokensAt: 3000, tokens: [first.tokens[0]] });
+  expect(latest(h, 'tokens').values.tokens).toBe(100);
+  expect(latest(h, 'tokenRate').values.tokenRate).toBeNull();
 });
-it('computes log counter growth and AEGIS CPU using real elapsed timestamps', () => {
+it('uses AEGIS own receipt clock, without manufacturing CPU points on resource replies', () => {
   const first = state();
-  const next = state(3000, {
-    tokens: first.tokens.map((t) => ({ ...t, totalTokens: t.totalTokens + 10 })),
-    own: { memMB: 70, heapMB: 25, cpuUser: 201000, cpuSystem: 1000 },
+  let h = observeStatistics(createStatisticsHistory(), first);
+  h = observeStatistics(h, { ...first, resourcesAt: 2000 });
+  expect(h.samples.at(-1).values).not.toHaveProperty('ownCpu');
+  h = observeStatistics(h, {
+    ...first,
+    resourcesAt: 2000,
+    ownAt: 3000,
+    own: { ...first.own, cpuUser: 201000 },
   });
-  const h = observeStatistics(observeStatistics(createStatisticsHistory(), first), next);
-  expect(last(h).tokenRate).toBe(600);
-  expect(last(h).ownCpu).toBe(10);
-  expect(last(h).ownMemory).toBe(70);
+  expect(latest(h, 'ownCpu').values.ownCpu).toBe(10);
 });
-it('leaves stale resources unavailable and distinguishes missing or failed network coverage from healthy empty', () => {
-  expect(
-    last(observeStatistics(createStatisticsHistory(), state(40000, { resourcesAt: 1000 }))).cpu,
-  ).toBeNull();
-  expect(last(observeStatistics(createStatisticsHistory(), state())).connections).toBe(0);
-  expect(
-    last(observeStatistics(createStatisticsHistory(), state(1000, { stats: {} }))).connections,
-  ).toBeNull();
-  const s = state();
-  s.stats.appHealth.sensors.byId.network.state = 'FAILED';
-  s.network = [{ remoteIp: '192.0.2.1' }];
-  expect(last(observeStatistics(createStatisticsHistory(), s)).connections).toBeNull();
+it('permits configured long scan intervals rather than inserting a fabricated 30-second gap', () => {
+  let h = observeStatistics(createStatisticsHistory(), state());
+  h = observeStatistics(h, state(61000, { events: [{}] }));
+  expect(latest(h, 'fileRate').values.fileRate).toBe(1);
+  expect(h.samples.map((s) => s.at)).toEqual([1000, 61000]);
 });
-it('rate calculations reject invalid intervals and overflowing arithmetic', () => {
+it('records outage at its received time and resets scan/token rates on recovery', () => {
+  let h = observeStatistics(createStatisticsHistory(), state());
+  h = observeStatistics(h, { ...state(), stale: true, statsAt: 2000 });
+  expect(h.samples.map((s) => s.at)).toEqual([1000, 2000]);
+  expect(latest(h, 'cpu').values.cpu).toBeNull();
+  h = observeStatistics(h, state(3000));
+  expect(latest(h, 'fileRate').values.fileRate).toBeNull();
+  expect(latest(h, 'tokenRate').values.tokenRate).toBeNull();
+});
+it('bounds by elapsed five minutes and a hard frame limit, merging simultaneous source frames', () => {
+  let h = observeStatistics(createStatisticsHistory(), state());
+  expect(h.samples).toHaveLength(1);
+  for (let i = 1; i <= 1100; i++) h = observeStatistics(h, state(1000 + i * 200));
+  expect(h.samples).toHaveLength(STATISTICS_HISTORY_LIMIT);
+  h = observeStatistics(h, state(700000));
+  expect(h.samples.every((s) => s.at >= 700000 - STATISTICS_HISTORY_MS)).toBe(true);
+  expect(h.samples).toHaveLength(1);
+});
+it('treats network delivery as a distinct source and never infers a missing snapshot from healthy stats', () => {
+  const first = state(1000, { networkAt: null });
+  let h = observeStatistics(createStatisticsHistory(), first);
+  expect(latest(h, 'connections')).toBeUndefined();
+  h = observeStatistics(h, { ...first, networkAt: 2000 });
+  expect(latest(h, 'connections').values.connections).toBe(0);
+  h = observeStatistics(h, {
+    ...first,
+    networkAt: 3000,
+    stats: { appHealth: { sensors: { byId: { network: { state: 'FAILED' } } } } },
+    network: [{}],
+  });
+  expect(latest(h, 'connections').values.connections).toBeNull();
+});
+it('rate arithmetic rejects resets, invalid intervals and overflow', () => {
   expect(statisticsRate(1, 3, 2000)).toBe(60);
   for (const interval of [0, -1, Infinity, NaN]) expect(statisticsRate(1, 3, interval)).toBeNull();
   expect(statisticsRate(3, 1, 1000)).toBeNull();
   expect(statisticsRate(0, Number.MAX_VALUE, 1)).toBeNull();
 });
-it('keeps graph gaps and actual time spacing, without linking unavailable points', () => {
+it('ignores unrelated sparse frames while preserving explicit graph gaps', () => {
   const paths = statisticsPaths(
     [
       { at: 0, values: { cpu: 0 } },
-      { at: 1000, values: { cpu: 20 } },
-      { at: 2000, values: {} },
+      { at: 1000, values: { memory: 20 } },
+      { at: 2000, values: { cpu: null } },
       { at: 4000, values: { cpu: 40 } },
     ],
     'cpu',
     100,
   );
-  expect(paths).toHaveLength(2);
-  expect(paths[0]).toContain('151.00');
-  expect(paths[1]).toBe('M 598.00 96.40');
-  expect(statisticsPaths([{ at: 1, values: { cpu: Infinity } }], 'cpu', 100)).toEqual([]);
+  expect(paths).toEqual(['M 2.00 158.00', 'M 598.00 96.40']);
 });
 
-it('counts new sensitive delivery when both backend and renderer ring occupancy stay constant', () => {
-  const initial = state(1000, {
-    events: [{ sensitive: true }],
-    retainedEvicted: 8,
-    stats: { ...state().stats, totalSensitive: 100 },
-  });
-  const next = state(3000, {
-    events: [{ sensitive: true }],
-    retainedEvicted: 10,
-    stats: { ...state().stats, totalSensitive: 100 },
-  });
-  const h = observeStatistics(observeStatistics(createStatisticsHistory(), initial), next);
-  expect(last(h).sensitiveRate).toBe(60);
+it('manual pause records its real action time without erasing a prior valid sample', () => {
+  const first = state();
+  let h = observeStatistics(createStatisticsHistory(), first);
+  h = observeStatistics(h, { ...first, stale: true }, 2500);
+  expect(h.samples[0].values.cpu).toBe(20);
+  expect(h.samples.map((sample) => sample.at)).toEqual([1000, 2500]);
+  expect(latest(h, 'ownCpu').values.ownCpu).toBeNull();
+  h = observeStatistics(h, state(5000));
+  expect(latest(h, 'fileRate').values.fileRate).toBeNull();
+  expect(latest(h, 'tokenRate').values.tokenRate).toBeNull();
+  expect(latest(h, 'ownCpu').values.ownCpu).toBeNull();
+});
+
+it('does not overwrite a measured frame when a health boundary has the same millisecond timestamp', () => {
+  const first = state();
+  let h = observeStatistics(createStatisticsHistory(), first);
+  h = observeStatistics(h, { ...first, stale: true, statsAt: 1000 });
+  expect(h.samples).toHaveLength(2);
+  expect(h.samples[0].values.cpu).toBe(20);
+  expect(h.samples[1].values.cpu).toBeNull();
+  expect(h.samples.map((s) => s.at)).toEqual([1000, 1000]);
+});
+
+it('uses the scan-captured delivery counter when later file pushes are coalesced before rendering', () => {
+  let h = observeStatistics(
+    createStatisticsHistory(),
+    state(1000, { scanCounters: { files: 0, sensitive: 0, evicted: 0 } }),
+  );
+  h = observeStatistics(
+    h,
+    state(11000, {
+      events: [{ sensitive: true }, { sensitive: true }, {}],
+      scanCounters: { files: 1, sensitive: 1, evicted: 0 },
+    }),
+  );
+  expect(latest(h, 'fileRate').values.fileRate).toBe(6);
+  expect(latest(h, 'sensitiveRate').values.sensitiveRate).toBe(6);
 });


### PR DESCRIPTION
Statistics mixed scan, token, resource and own-process timestamps. A token delta spanning ten seconds could be divided by a resource reply arriving milliseconds later, producing a false spike; missing one process measurement also erased the entire CPU/RAM graph. Each source now has its own receipt clock and sparse history. File counters are captured at scan receipt, including when Svelte coalesces subsequent messages. Measured subtotals expose exact coverage, and pause/outage boundaries preserve earlier observations.

Graphs use fixed one/three/five-minute windows, explicit source gaps, visible isolated points, readable axes, discrete steps for count series, and inspection of actual observations. Activity histograms and timelines advance without new events, reject invalid/future timestamps, freeze with the view, and use correct fractional bucket boundaries. Per-agent resource bars retain partial measurements and correctly scale sub-MB values.

Validation: 2947 tests passed with 4 skipped; six affected resource tests rerun after the final formatting/scale fixes; renderer and preview builds; format, lint with zero errors, TypeScript and both Svelte checks; witness/sequence gates, counts and production audit. Browser verification passed 464 workspace/resource/detail/section/graph states. Packaged Windows smoke passed real sensors, all eleven workspaces, six exports, configuration round trip and settings persistence.

Receipt timestamps remain delivery times: the backend does not provide the original OS measurement timestamp for every resource result. Missing source data stays explicit.
