### PR TITLE
perf(main): avoid redundant resource and token collection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The desktop and preview share `frontend/observatory/`. Read its `AGENTS.md` and 
 
 ## Project facts
 
-`src/main/` contains 72 main modules: 55 top-level + platform/ 15 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
+`src/main/` contains 73 main modules: 56 top-level + platform/ 15 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
 
 A birth time is observed on the pass that stamps it or is `null`; no cache stores one. A snapshot outage freezes sessions and never splits them. For changes touching identity stamping, the audit chain, or the Windows git worktree flow, `memory-bank/ai-mistakes.md` holds the relevant failure history.
 

--- a/bench/collection-efficiency.js
+++ b/bench/collection-efficiency.js
@@ -1,0 +1,77 @@
+/**
+ * Deterministic operation counts for collection backpressure and token routing.
+ * Uses synthetic processes and injected providers; never reads a user's transcripts.
+ * Run: node bench/collection-efficiency.js
+ */
+'use strict';
+
+const assert = require('node:assert/strict');
+const { createResourceSampler } = require('../src/main/resource-sampler');
+const adapter = require('../src/main/token-adapters/claude-code');
+const feed = require('../src/main/token-feed');
+
+async function main() {
+  const procs = Array.from({ length: 100 }, (_, i) => ({
+    pid: i + 1,
+    startTime: 1700000000000,
+    agent: i < 2 ? 'Claude Code' : 'Cursor',
+  }));
+  let registryReads = 0;
+  adapter._setHomedirForTest(() => '/synthetic-home');
+  adapter._setFsForTest({
+    readFileSync: () => {
+      registryReads++;
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+    },
+  });
+  // The previous feed forwarded the entire batch to each adapter.
+  await adapter.readUsage(procs);
+  const beforeReads = registryReads;
+  registryReads = 0;
+  await feed.readUsageByPid(procs);
+  assert.equal(beforeReads, 100);
+  assert.equal(registryReads, 2);
+
+  async function burst(serialized) {
+    let calls = 0;
+    let active = 0;
+    let peak = 0;
+    const releases = [];
+    const collect = async () => {
+      calls++;
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => releases.push(resolve));
+      active--;
+      return [];
+    };
+    const sampler = createResourceSampler(collect);
+    const promises = Array.from({ length: 20 }, () =>
+      serialized ? sampler.sample([{ pid: 1, instanceId: '1:1000' }]) : collect(),
+    );
+    for (const release of releases) release();
+    await Promise.all(promises);
+    return { calls, peak };
+  }
+  const before = await burst(false);
+  const after = await burst(true);
+  assert.deepEqual(before, { calls: 20, peak: 20 });
+  assert.deepEqual(after, { calls: 1, peak: 1 });
+  console.log(
+    JSON.stringify(
+      {
+        fixture: '100 agents, 2 Claude Code; 20 ticks while resource provider is blocked',
+        registryReads: { before: beforeReads, after: registryReads },
+        resourceQueries: { before, after },
+        limitation:
+          'Operation counts on synthetic providers, not an application-wide latency benchmark',
+      },
+      null,
+      2,
+    ),
+  );
+}
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -225,7 +225,7 @@ Key token namespaces:
 
 ## Conventions
 
-- **300-line soft limit** per file — a target for NEW files, not an invariant; 28 existing `src/` files already exceed it. Not enforced by the linter
+- **300-line soft limit** per file — a target for NEW files, not an invariant; 29 existing `src/` files already exceed it. Not enforced by the linter
 - **JSDoc on all exported functions**: `@param`, `@returns`, `@since`
 - **Commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`; see [BRANCHING.md](../BRANCHING.md)
 - **IPC channel names**: `kebab-case`

--- a/docs/current-state/BACKEND-COLLECTION-2026-09-10.md
+++ b/docs/current-state/BACKEND-COLLECTION-2026-09-10.md
@@ -1,0 +1,38 @@
+# Backend collection efficiency — 2026-09-10
+
+Resource sampling now permits one in-flight CPU/RAM/GPU collection per scan loop.
+Process batches continue while the collector is busy. Busy ticks skip the resource
+sample; the next idle tick supplies fresh PID/instance pairs. No backlog of aging
+process snapshots is retained. Stopping intervals or reinjecting dependencies
+invalidates late results; an already-running process scan cannot start a resource
+query after the stop. The OS query itself finishes under the existing provider
+timeouts. Under sustained slow collection, resource updates can therefore be less
+frequent than process updates.
+
+Token collection retains each process's agent family. Adapters can declare exact
+scanner display names in `agentNames`; Claude Code opts in. Known other families
+no longer trigger Claude session-registry reads. Unlabelled legacy callers and
+adapters without a family restriction retain the previous behavior. Birth-time
+validation, transcript offsets, message deduplication and instance accounting are
+unchanged.
+
+## Reproduce the operation counts
+
+Run `node bench/collection-efficiency.js`. The fixture uses injected providers,
+100 synthetic processes (two Claude Code), missing session-registry files and
+20 requests issued while resource collection is blocked. It reads no user logs.
+
+| Operation | Previous behavior | Current behavior |
+| --- | ---: | ---: |
+| Claude registry read attempts for the mixed batch | 100 | 2 |
+| Resource provider calls during the blocked burst | 20 | 1 |
+| Peak concurrent resource provider calls | 20 | 1 |
+
+These are operation counts for controlled fixtures, not a measurement of total
+application CPU, memory or latency. Normal scan cadence may already avoid overlap.
+The work does not change process enumeration, network/DNS collection, file sensing,
+or make transcript parsing asynchronous.
+
+Regression coverage exercises busy ticks, fresh identities after PID reuse,
+unstamped PIDs, synchronous/asynchronous provider errors, pause/resume, late process
+scans, continued process delivery and mixed-family token accounting.

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **72** = 55 top-level + 15 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **73** = 56 top-level + 15 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **50** (plus `src/renderer/App.svelte` → **51** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **16** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 72 CommonJS modules (55 top-level + 15 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 73 CommonJS modules (56 top-level + 15 platform/ + 2 token-adapters/)
 
 Optional development ETW: main → platform/etw-file-runtime → etw-file-supervisor
 → normal `sidecar/etw-file` broker → authenticated elevated file collector.

--- a/src/main/resource-sampler.js
+++ b/src/main/resource-sampler.js
@@ -1,0 +1,38 @@
+/**
+ * @file resource-sampler.js
+ * @description Keep slow resource collection from overlapping between scan ticks.
+ */
+'use strict';
+
+/**
+ * Create a single-flight sampler. Busy ticks are skipped: the next idle tick must
+ * supply its fresh PID/instance pairing, rather than queuing an aging snapshot.
+ * Invalidation suppresses a late result without pretending to cancel its OS query.
+ * @param {(targets: Array<{pid: number, instanceId: string|null}>) => Promise<Array>} collect
+ * @returns {{sample: Function, invalidate: Function}}
+ * @since v0.14.1-alpha
+ */
+function createResourceSampler(collect) {
+  let running = false;
+  let generation = 0;
+
+  async function sample(targets) {
+    if (running) return null;
+    running = true;
+    const startedGeneration = generation;
+    try {
+      const records = await collect(targets.map(({ pid, instanceId }) => ({ pid, instanceId })));
+      return generation === startedGeneration ? records : null;
+    } finally {
+      running = false;
+    }
+  }
+
+  function invalidate() {
+    generation++;
+  }
+
+  return { sample, invalidate };
+}
+
+module.exports = { createResourceSampler };

--- a/src/main/scan-loop.js
+++ b/src/main/scan-loop.js
@@ -10,6 +10,11 @@ const sessionTracker = require('./session-tracker');
 const ideExtensionDetector = require('./ide-extension-detector');
 const wslDetector = require('./wsl-detector');
 const resourceMonitor = require('./resource-monitor');
+const { createResourceSampler } = require('./resource-sampler');
+const resourceSampler = createResourceSampler((targets) =>
+  resourceMonitor.getResourcesForPids(targets),
+);
+let resourceScanGeneration = 0;
 const tokenTracker = require('./token-tracker');
 const { collectTokenCosts } = require('./token-cost-collector');
 const blocklist = require('./blocklist');
@@ -168,6 +173,8 @@ function sequenceScoreFor(instanceId) {
 }
 
 function stopScanIntervals() {
+  resourceScanGeneration++;
+  resourceSampler.invalidate();
   for (const t of startupTimers) clearTimeout(t);
   startupTimers = [];
   if (warmupTimer) {
@@ -419,6 +426,7 @@ async function doProcessScan() {
   // bump activeScanCount, whose only decrement lives in the finally below.
   if (processScanRunning) return;
   processScanRunning = true;
+  const resourceGeneration = resourceScanGeneration;
   updateScanStatus(true);
   const t0 = performance.now();
   try {
@@ -671,10 +679,18 @@ async function doProcessScan() {
         pid: a.pid,
         instanceId: typeof a.instanceId === 'string' && a.instanceId !== '' ? a.instanceId : null,
       }));
-    resourceMonitor
-      .getResourcesForPids(resourceTargets)
-      .then((records) => sendToRenderer('agent-resource-usage', records))
-      .catch((err) => logger.error('main', 'Resource usage scan failed', { error: err.message }));
+    // One OS query at a time; busy ticks leave freshness to the next scan.
+    // A scan already awaiting the provider when paused must not start new sampling.
+    if (resourceGeneration === resourceScanGeneration) {
+      resourceSampler
+        .sample(resourceTargets)
+        .then((records) => {
+          if (records !== null && resourceGeneration === resourceScanGeneration) {
+            sendToRenderer('agent-resource-usage', records);
+          }
+        })
+        .catch((err) => logger.error('main', 'Resource usage scan failed', { error: err.message }));
+    }
 
     if (result.changed && Date.now() - _lastTriggeredNetScan > 15000) {
       _lastTriggeredNetScan = Date.now();
@@ -929,6 +945,8 @@ function staggeredStartup(intervalMs, paused) {
 
 /** @param {Object} injected @since v0.3.0 */
 function init(injected) {
+  resourceScanGeneration++;
+  resourceSampler.invalidate();
   deps = injected;
   deps.baselines?.init?.({
     isInstanceActive: (instanceId) =>

--- a/src/main/token-adapters/claude-code.js
+++ b/src/main/token-adapters/claude-code.js
@@ -33,6 +33,7 @@ const { readSubagentUsage } = require('./claude-code-subagents');
 /**
  * @typedef {Object} Proc
  * @property {number} pid - live process id (C-01 attribution key).
+ * @property {string} [agent] - scanner display name, used by the feed for routing.
  * @property {number} startTime - live OS process-creation time (epoch ms), from the
  *   scan layer; compared against the registry to reject PID reuse.
  */
@@ -288,6 +289,7 @@ function _resetForTest() {
 
 module.exports = {
   id,
+  agentNames: Object.freeze(['Claude Code']),
   GUARD_TOLERANCE_MS,
   readUsage,
   _encodeCwd,

--- a/src/main/token-cost-collector.js
+++ b/src/main/token-cost-collector.js
@@ -73,7 +73,7 @@ async function collectTokenCosts(agents) {
   let droppedClaude = false;
   for (const a of list) {
     if (a && typeof a.startTime === 'number') {
-      procs.push({ pid: a.pid, startTime: a.startTime });
+      procs.push({ pid: a.pid, startTime: a.startTime, agent: a.agent });
       identityByPid.set(a.pid, a);
     } else if (a && a.agent === CLAUDE_CODE_AGENT) {
       droppedClaude = true;

--- a/src/main/token-feed.js
+++ b/src/main/token-feed.js
@@ -10,6 +10,7 @@
  *
  *   Each adapter implements the contract:
  *     { id: string,
+ *       agentNames?: readonly string[], // exact scanner display names; absent = all
  *       readUsage(procs: Proc[]) => Promise<UsageDelta[]>,
  *       _resetForTest(): void }
  *
@@ -35,7 +36,7 @@ const claudeCode = require('./token-adapters/claude-code');
 /** Default adapter registry. Append a module here to support a new agent. */
 const DEFAULT_ADAPTERS = [claudeCode];
 
-/** @type {Array<{ id: string, readUsage: Function, _resetForTest?: Function }>} */
+/** @type {Array<{ id: string, agentNames?: readonly string[], readUsage: Function, _resetForTest?: Function }>} */
 let adapters = DEFAULT_ADAPTERS.slice();
 
 /**
@@ -50,7 +51,13 @@ async function readUsageByPid(procs) {
   for (const adapter of adapters) {
     let deltas;
     try {
-      deltas = await adapter.readUsage(procs);
+      // Legacy callers may omit the family. Keep those eligible, while avoiding
+      // another agent's registry paths for processes the scanner has identified.
+      const eligible = adapter.agentNames
+        ? procs.filter((proc) => !proc?.agent || adapter.agentNames.includes(proc.agent))
+        : procs;
+      if (eligible.length === 0) continue;
+      deltas = await adapter.readUsage(eligible);
     } catch (err) {
       // One adapter failing never crashes the feed or starves the others.
       logger.debug('token-feed', 'adapter failed', {

--- a/tests/main/resource-sampler.test.js
+++ b/tests/main/resource-sampler.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createResourceSampler } = require('../../src/main/resource-sampler');
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('resource sampling under load', () => {
+  it('keeps one active query, skips busy ticks, and samples a fresh identity on the next tick', async () => {
+    const pending = deferred();
+    const collect = vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValueOnce([]);
+    const sampler = createResourceSampler(collect);
+    const targets = [{ pid: 100, instanceId: '100:1000' }];
+    const first = sampler.sample(targets);
+    targets[0].instanceId = '100:2000';
+    for (let tick = 0; tick < 20; tick++) expect(await sampler.sample(targets)).toBeNull();
+    expect(collect).toHaveBeenCalledTimes(1);
+    expect(collect).toHaveBeenNthCalledWith(1, [{ pid: 100, instanceId: '100:1000' }]);
+    pending.resolve([{ pid: 100, instanceId: '100:1000' }]);
+    expect(await first).toEqual([{ pid: 100, instanceId: '100:1000' }]);
+    // Completing an old query must not start a queued, aging PID snapshot.
+    expect(collect).toHaveBeenCalledTimes(1);
+    await sampler.sample(targets);
+    expect(collect).toHaveBeenNthCalledWith(2, [{ pid: 100, instanceId: '100:2000' }]);
+  });
+
+  it('suppresses results after invalidation and preserves the in-flight limit across resume', async () => {
+    const pending = deferred();
+    const collect = vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValueOnce([]);
+    const sampler = createResourceSampler(collect);
+    const first = sampler.sample([{ pid: 1, instanceId: '1:1000' }]);
+    sampler.invalidate();
+    expect(await sampler.sample([{ pid: 2, instanceId: '2:2000' }])).toBeNull();
+    pending.resolve([{ pid: 1, instanceId: '1:1000' }]);
+    expect(await first).toBeNull();
+    expect(await sampler.sample([])).toEqual([]);
+    expect(collect).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([false, true])(
+    'recovers after a provider failure (synchronous=%s)',
+    async (synchronous) => {
+      const error = new Error('provider failed');
+      const collect = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          if (synchronous) throw error;
+          return Promise.reject(error);
+        })
+        .mockResolvedValueOnce([]);
+      const sampler = createResourceSampler(collect);
+      await expect(sampler.sample([])).rejects.toBe(error);
+      await expect(sampler.sample([])).resolves.toEqual([]);
+    },
+  );
+
+  it('keeps distinct unstamped PIDs and valid empty results', async () => {
+    const targets = [
+      { pid: 1, instanceId: null },
+      { pid: 2, instanceId: null },
+    ];
+    const collect = vi.fn().mockResolvedValue([]);
+    expect(await createResourceSampler(collect).sample(targets)).toEqual([]);
+    expect(collect).toHaveBeenCalledWith(targets);
+  });
+});

--- a/tests/main/scan-loop.test.js
+++ b/tests/main/scan-loop.test.js
@@ -1509,6 +1509,96 @@ describe('scan-loop', () => {
   // ── per-agent resource push (`agent-resource-usage`) ──
 
   describe('agent-resource-usage push', () => {
+    it('slow sampling never blocks process batches or spawns a second resource query', async () => {
+      const rm = require_('../../src/main/resource-monitor.js');
+      let finish;
+      const collect = vi
+        .spyOn(rm, 'getResourcesForPids')
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              finish = resolve;
+            }),
+        )
+        .mockResolvedValue([]);
+      const deps = makeStampingDeps(vi.fn(), () => [
+        { agent: 'Cursor', pid: 100, startTime: 1717000000000 },
+      ]);
+      try {
+        scanLoop.init(deps);
+        scanLoop.startScanIntervals(1000);
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(
+          deps.sendToRenderer.mock.calls.filter(([channel]) => channel === 'scan-batch'),
+        ).toHaveLength(5);
+        expect(collect).toHaveBeenCalledTimes(1);
+        expect(pushes(deps.sendToRenderer)).toHaveLength(0);
+        finish([]);
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(collect).toHaveBeenCalledTimes(2);
+      } finally {
+        finish?.([]);
+        await vi.advanceTimersByTimeAsync(0);
+        collect.mockRestore();
+      }
+    });
+
+    it('pause suppresses an unfinished resource result', async () => {
+      const rm = require_('../../src/main/resource-monitor.js');
+      let finish;
+      const collect = vi.spyOn(rm, 'getResourcesForPids').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          }),
+      );
+      const deps = makeDeps();
+      try {
+        scanLoop.init(deps);
+        scanLoop.startScanIntervals(1000);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(collect).toHaveBeenCalledTimes(1);
+        scanLoop.stopScanIntervals();
+        finish([]);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(pushes(deps.sendToRenderer)).toHaveLength(0);
+      } finally {
+        finish?.([]);
+        await vi.advanceTimersByTimeAsync(0);
+        collect.mockRestore();
+      }
+    });
+
+    it('a process scan finishing after pause cannot launch resource sampling', async () => {
+      const rm = require_('../../src/main/resource-monitor.js');
+      const collect = vi.spyOn(rm, 'getResourcesForPids').mockResolvedValue([]);
+      let finish;
+      const deps = makeDeps({
+        scanner: {
+          scanProcesses: vi.fn(
+            () =>
+              new Promise((resolve) => {
+                finish = resolve;
+              }),
+          ),
+        },
+      });
+      try {
+        scanLoop.init(deps);
+        scanLoop.startScanIntervals(1000);
+        await vi.advanceTimersByTimeAsync(1000);
+        scanLoop.stopScanIntervals();
+        finish({ agents: [], changed: false });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(collect).not.toHaveBeenCalled();
+      } finally {
+        finish?.({ agents: [], changed: false });
+        await vi.advanceTimersByTimeAsync(0);
+        collect.mockRestore();
+      }
+    });
+
     const MB = 1048576;
 
     /**

--- a/tests/main/token-cost-collector.test.js
+++ b/tests/main/token-cost-collector.test.js
@@ -77,8 +77,8 @@ describe('token-cost-collector — folds measured deltas into the tracker', () =
     expect(readUsage).toHaveBeenCalledTimes(1);
     const procs = readUsage.mock.calls[0][0];
     expect(procs).toEqual([
-      { pid: 1, startTime: 1000 },
-      { pid: 2, startTime: 2000 },
+      { pid: 1, startTime: 1000, agent: 'OtherAgent' },
+      { pid: 2, startTime: 2000, agent: 'OtherAgent' },
     ]);
   });
 
@@ -131,4 +131,14 @@ it('keeps its never-throws contract if the feed rejects with null', async () => 
   } finally {
     feed.mockRestore();
   }
+});
+
+it('routes a mixed scan to the matching adapter without losing instance attribution', async () => {
+  const readUsage = vi.fn(async (procs) => procs.map((proc) => delta(proc.pid, 100)));
+  tokenFeed._setAdaptersForTest([{ id: 'claude', agentNames: ['Claude Code'], readUsage }]);
+  await collectTokenCosts([agent(1, 1000, 'Cursor'), agent(2, 2000, 'Claude Code')]);
+  expect(readUsage).toHaveBeenCalledWith([{ pid: 2, startTime: 2000, agent: 'Claude Code' }]);
+  expect(tokenTracker.getAllCosts()).toEqual([
+    expect.objectContaining({ pid: 2, instanceId: '2:2000' }),
+  ]);
 });

--- a/tests/main/token-feed.test.js
+++ b/tests/main/token-feed.test.js
@@ -102,3 +102,31 @@ it.each([null, undefined, 'adapter-failure'])(
     await expect(readUsageByPid([{ pid: 3, startTime: 1000 }])).resolves.toEqual([delta(3, 30)]);
   },
 );
+
+describe('token-feed family routing', () => {
+  it('routes known families exactly and preserves unlabelled legacy callers', async () => {
+    const claude = {
+      ...fakeAdapter('claude', async () => [delta(1, 10)]),
+      agentNames: ['Claude Code'],
+    };
+    const other = { ...fakeAdapter('other', async () => [delta(2, 20)]), agentNames: ['Codex'] };
+    _setAdaptersForTest([claude, other]);
+    const procs = [
+      { pid: 1, startTime: 1000, agent: 'Claude Code' },
+      { pid: 2, startTime: 2000, agent: 'Codex' },
+      { pid: 3, startTime: 3000 },
+      { pid: 4, startTime: 4000, agent: 'Claude Desktop' },
+    ];
+    expect(await readUsageByPid(procs)).toEqual([delta(1, 10), delta(2, 20)]);
+    expect(claude.readUsage).toHaveBeenCalledWith([procs[0], procs[2]]);
+    expect(other.readUsage).toHaveBeenCalledWith([procs[1], procs[2]]);
+    expect(procs).toHaveLength(4);
+  });
+
+  it('does not invoke a family adapter when all processes belong to other agents', async () => {
+    const adapter = { ...fakeAdapter('claude', async () => []), agentNames: ['Claude Code'] };
+    _setAdaptersForTest([adapter]);
+    expect(await readUsageByPid([{ pid: 1, startTime: 1000, agent: 'Cursor' }])).toEqual([]);
+    expect(adapter.readUsage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Slow resource queries could overlap across process scan ticks, and every monitored process triggered a Claude Code session-registry lookup. Resource collection now allows one in-flight query, skips busy ticks without queuing stale PID snapshots, and suppresses late results after pause. Token adapters can declare supported agent families; Claude Code receives its own processes plus unlabelled legacy callers.

Added regression coverage for delayed queries, failures, pause/resume, PID reuse, continued process delivery and mixed-family accounting. Existing birth-time checks and token deduplication remain in place. `node bench/collection-efficiency.js` reproduces synthetic operation counts: 100 mixed-agent registry read attempts become 2; 20 requests while the resource provider is blocked become one active query. These figures do not measure whole-app speed. Resource updates may be less frequent while the provider is busy.

Validation: 3,228 tests passed, 4 skipped across 187 files; format, lint (0 errors), TypeScript, Svelte checks, renderer build, both mutation gates and derived counts passed. Production dependency audit: 0 vulnerabilities.
