### PR TITLE
perf(ui): share snapshot assessments and reuse clock formatters

### DIFF
--- a/docs/current-state/RENDERER-WORKLOAD.md
+++ b/docs/current-state/RENDERER-WORKLOAD.md
@@ -1,0 +1,37 @@
+# Renderer workload — 10 September 2026
+
+Profiling identified repeated instance-risk enrichment across components, deep Svelte proxy enumeration of delivered snapshots, and repeated Intl.DateTimeFormat construction for chart labels. The change shares assessments within a snapshot, uses raw reactive references for immutable telemetry/history, and reuses the two clock formats. Settings and other editable drafts retain deep reactivity.
+
+A new host delivery still updates consumers. Assessment source-reference replacement invalidates the cache even when a wrapper is reused. PID reuse and captured-vs-current risk remain distinct. A held snapshot retains its assessment; a new delivery recomputes age decay. The weak-key cache does not keep old snapshots alive. Clock formatters refresh every minute and after backwards clock changes.
+
+## Identical-input comparison
+
+Baseline renderer: packaged PR #421, commit `51ac7fb382526b49e18b3a137defd976780755bd`. Candidate: this change. Both run in the same installed Playwright Chromium, headless, 1440×1000, en-US/UTC, dark theme, full motion. The harness injects a synthetic desktop bridge with 49 process instances, four agent products, 500 file observations and 49 sockets. Five warmup deliveries precede 120 measured ordered deliveries. Timestamps, input values and navigation are identical. This is a renderer workload, not live sensor accuracy or whole-application CPU.
+
+| Measurement | Before | After |
+| --- | ---: | ---: |
+| Renderer task time, 120 deliveries | 10,328 ms | 1,062 ms |
+| JavaScript execution time | 9,291 ms | 768 ms |
+| Live JS heap after first workspace round and GC | 7.86 MiB | 4.89 MiB |
+| Live JS heap after fourth round and GC | 7.91 MiB | 4.94 MiB |
+| Attached DOM elements after navigation | 1,746 | 1,746 |
+| Page errors | 0 | 0 |
+
+Task time fell about 90%; retained JS heap in this fixture fell about 38%. TaskDuration and ScriptDuration are CDP cumulative execution counters, not user click latency. Heap numbers follow explicit GC in the disposable browser, not forced collection in production. These figures do not claim the installed application's total RAM fell by the same amount, prove absence of a long-session leak, or identify the earlier GPU allocation growth.
+
+Visible summary values match exactly, including four products / 49 processes, risk 12, 500 retained observations / 50 sensitive, 49 unverified endpoints, and unavailable tokens with 0/49 coverage. The radar and layout screenshots were inspected; motion remains enabled. Four repeated tours cover Agents, Events, Network, Statistics and Monitoring.
+
+Earlier live Electron profiles with 20 temporary loopback processes also identified enrichment, proxy traps and date formatting as hot paths. Their view states diverged, so their large timing difference is not used for the numeric before/after claim above.
+
+## Reproduction
+
+Build the desktop renderer with `npm run build:renderer`. To compare two versions, preserve their respective `dist/renderer` directories and run these sequentially from the current checkout:
+
+```sh
+node frontend/observatory/tests/renderer-workload.mjs <baseline-renderer-directory> before
+node frontend/observatory/tests/renderer-workload.mjs dist/renderer after
+```
+
+The harness serves only the selected directory on an ephemeral loopback port, injects its fixture in a disposable browser and writes numeric JSON plus screenshots under ignored `dist/renderer-workload/`. It does not alter settings, start monitored processes, read user transcripts, or call a model provider. The fixture is confined to test tooling and is not imported by the desktop renderer.
+
+Regression coverage includes held/new assessments, evidence replacement within a reused wrapper, PID reuse, bounded formatter creation and default-zone refresh. Existing App, scope, graph and departed-history regressions cover delivery updates and retention. Required repository and isolated Electron checks accompany the change.

--- a/frontend/observatory/App.svelte
+++ b/frontend/observatory/App.svelte
@@ -92,9 +92,10 @@
     await navigate(entry.target);
     commands = false;
   }
-  let telemetry = $state(emptyTelemetry());
+  // Host deliveries replace immutable snapshots; deep proxies multiply work per record.
+  let telemetry = $state.raw(emptyTelemetry());
   let paused = $state(false);
-  let held = $state(emptyTelemetry());
+  let held = $state.raw(emptyTelemetry());
   let displayTelemetry = $derived(paused ? held : telemetry);
   const agentCount = $derived(new Set(displayTelemetry.agents.map((agent) => agent.agent)).size);
   const healthCaption = $derived(

--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -57,3 +57,10 @@ The shared sizing contract lives in styles/coherence.css: 4/8/12/16/24 px spacin
 The user's feedback supersedes the earlier sliding workspace/detail snapshots, control press scaling, hover lifts and animated disclosure height. Workspace navigation now commits directly, with scroll restoration in the same Svelte update; Back/Forward still restores each workspace. Ordinary selection, tabs and process filters never translate or scale controls or reading surfaces. Changing the shared scope retains the current scroll position; explicitly opening an agent starts its overview at the top. Section keyboard navigation scrolls only its horizontal tab strip. Editor sections capture scroll before the DOM changes.
 
 Feedback uses 140 ms colour/border changes and a 120 ms opacity-only dialog/entity reveal. Native disclosures resize once without height interpolation. Busy indicators do not change button width. Radar sweep, coordinate echoes and pending indicators remain subject to pause/stale and both reduced-motion settings. Verify full-motion interactions as well as reduced motion; disabling animation in tests must not conceal geometry or scroll regressions.
+
+
+## Renderer workload
+
+Host deliveries are immutable snapshots held with `$state.raw`; charts also receive immutable history arrays without deep proxying. Draft forms retain their ordinary reactive state. Consumers share an exposure assessment for one snapshot and invalidate it when source references change. Weak snapshot keys do not keep departed observations alive. A held snapshot preserves its captured assessment; new deliveries recalculate event age and evidence. Clock labels share two Intl formatters, refreshed at least once a minute or after a backwards clock change to pick up default locale/time-zone changes. Composition, motion preferences, history retention, selection and measurement provenance remain governed by the sections above.
+
+The identical-input comparison and its limits are recorded in [RENDERER-WORKLOAD.md](../../docs/current-state/RENDERER-WORKLOAD.md).

--- a/frontend/observatory/components/AgentPerformance.svelte
+++ b/frontend/observatory/components/AgentPerformance.svelte
@@ -16,7 +16,7 @@
     paused = false,
   }: { telemetry: Telemetry; scope: AgentScope; paused?: boolean } = $props();
   let history = createStatisticsHistory();
-  let samples = $state<StatisticsSample[]>([]);
+  let samples = $state.raw<StatisticsSample[]>([]);
   let key = '';
   let selected = $state('cpu');
   let now = $state(Date.now());

--- a/frontend/observatory/components/Statistics.svelte
+++ b/frontend/observatory/components/Statistics.svelte
@@ -59,8 +59,8 @@
   ];
   let allHistory = createStatisticsHistory();
   let scopedHistory = createStatisticsHistory();
-  let allSamples = $state<StatisticsSample[]>([]);
-  let scopedSamples = $state<StatisticsSample[]>([]);
+  let allSamples = $state.raw<StatisticsSample[]>([]);
+  let scopedSamples = $state.raw<StatisticsSample[]>([]);
   let historyKey = '';
   let lastRequest = -1;
   let lastScopeRequest = -1;

--- a/frontend/observatory/runtime/activity.ts
+++ b/frontend/observatory/runtime/activity.ts
@@ -48,15 +48,30 @@ export function activityBins(
   return bins;
 }
 
+// Intl formatters allocate native state; reuse the two formats across chart ticks.
+const clockFormats = new Map<boolean, Intl.DateTimeFormat>();
+let clockFormatsAt: number | null = null;
+
 /** Format the complete local clock without slicing locale-specific output.
  * @param at Timestamp @param seconds Include seconds for interval evidence
  * @returns Localized clock label or unavailable marker @since 0.14.1
  */
 export function activityTimeLabel(at: number, seconds = false): string {
   if (!Number.isFinite(at) || !Number.isFinite(new Date(at).getTime())) return '—';
-  return new Intl.DateTimeFormat(undefined, {
-    hour: '2-digit',
-    minute: '2-digit',
-    ...(seconds ? { second: '2-digit' as const } : {}),
-  }).format(at);
+  // Periodically pick up default locale/time-zone changes, including after clock rollback.
+  const now = Date.now();
+  if (clockFormatsAt === null || now < clockFormatsAt || now - clockFormatsAt >= 60000) {
+    clockFormats.clear();
+    clockFormatsAt = now;
+  }
+  let formatter = clockFormats.get(seconds);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      ...(seconds ? { second: '2-digit' as const } : {}),
+    });
+    clockFormats.set(seconds, formatter);
+  }
+  return formatter.format(at);
 }

--- a/frontend/observatory/runtime/host.ts
+++ b/frontend/observatory/runtime/host.ts
@@ -103,15 +103,40 @@ export function emptyTelemetry(): Telemetry {
     error: '',
   };
 }
-/** Share the existing exposure computation. @param state Telemetry @returns Enriched instances @since 0.14.1 */
+// Snapshot keys are weak: a closed view does not retain earlier observations or assessments.
+type Assessment = Pick<
+  Telemetry,
+  'agents' | 'events' | 'anomalies' | 'network' | 'falsePositives'
+> & {
+  rows: ReturnType<typeof enrichAgents>;
+};
+const assessments = new WeakMap<Telemetry, Assessment>();
+/** Share one assessment across consumers of an immutable telemetry snapshot.
+ * A new delivery recomputes time decay; a held snapshot keeps its captured assessment.
+ * @param state Telemetry snapshot @returns Shared enriched instances @since 0.14.1
+ */
 export function instances(state: Telemetry) {
-  return enrichAgents(
-    state.agents,
-    state.events,
-    state.anomalies,
-    state.network,
-    state.falsePositives,
-  );
+  const { agents, events, anomalies, network, falsePositives } = state;
+  let cached = assessments.get(state);
+  if (
+    !cached ||
+    cached.agents !== agents ||
+    cached.events !== events ||
+    cached.anomalies !== anomalies ||
+    cached.network !== network ||
+    cached.falsePositives !== falsePositives
+  ) {
+    cached = {
+      agents,
+      events,
+      anomalies,
+      network,
+      falsePositives,
+      rows: enrichAgents(agents, events, anomalies, network, falsePositives),
+    };
+    assessments.set(state, cached);
+  }
+  return cached.rows;
 }
 /** Re-resolve a process immediately before dispatch, including after confirmation. @param state Latest telemetry @param id Stamped identity @returns Live process @since 0.14.1 */
 export function actionTarget(state: Telemetry, id: string) {

--- a/frontend/observatory/tests/renderer-workload.mjs
+++ b/frontend/observatory/tests/renderer-workload.mjs
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { resolve, sep, extname } from 'node:path';
+import { chromium } from 'playwright';
+
+// Compare built desktop renderers under identical, explicitly synthetic deliveries.
+// Usage: node frontend/observatory/tests/renderer-workload.mjs <renderer-dir> <label>
+const root = resolve(process.argv[2] || 'dist/renderer');
+const label = process.argv[3] || 'current';
+assert(/^[a-z0-9-]+$/i.test(label));
+const output = resolve('dist/renderer-workload');
+const types = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+};
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url, 'http://127.0.0.1');
+    const file = resolve(
+      root,
+      '.' + decodeURIComponent(url.pathname === '/' ? '/index.html' : url.pathname),
+    );
+    if (!file.startsWith(root + sep)) {
+      response.writeHead(403).end();
+      return;
+    }
+    const bytes = await readFile(file);
+    response.writeHead(200, { 'Content-Type': types[extname(file)] || 'application/octet-stream' });
+    response.end(bytes);
+  } catch {
+    response.writeHead(404).end();
+  }
+});
+await new Promise((done) => server.listen(0, '127.0.0.1', done));
+let browser;
+try {
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 1000 },
+    locale: 'en-US',
+    timezoneId: 'UTC',
+    reducedMotion: 'no-preference',
+  });
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  await page.addInitScript(() => {
+    const listeners = {};
+    const epoch = Date.UTC(2026, 8, 10, 12);
+    let clock = epoch;
+    Date.now = () => clock;
+    localStorage.setItem('aegis-motion', 'full');
+    localStorage.setItem('aegis-theme', 'dark');
+    const agents = Array.from({ length: 49 }, (_, i) => ({
+      agent: ['Codex', 'Claude Code', 'Cursor', 'Gemini CLI'][i % 4],
+      process: 'fixture.exe',
+      pid: i + 100,
+      instanceId: `${i + 100}:fixture`,
+      instanceIdSource: 'os',
+      category: 'cli-tool',
+      cwd: 'X:/synthetic-project',
+    }));
+    const stats = {
+      currentAgents: 49,
+      monitoringStarted: epoch - 100000,
+      appHealth: { state: 'HEALTHY', populationReliable: true, identityDegraded: false },
+    };
+    const settings = { scanIntervalSec: 1, uiScale: 1, darkMode: true };
+    window.aegis = new Proxy(
+      {},
+      {
+        get(_target, name) {
+          if (String(name).startsWith('on'))
+            return (callback) => {
+              listeners[name] = callback;
+              return () => {
+                delete listeners[name];
+              };
+            };
+          return async () =>
+            name === 'getStats'
+              ? stats
+              : name === 'getSettings'
+                ? settings
+                : name === 'getAppVersion'
+                  ? 'workload-fixture'
+                  : name === 'getResourceUsage'
+                    ? { memMB: 80, heapMB: 20 }
+                    : [];
+        },
+      },
+    );
+    window.workload = {
+      seed() {
+        listeners.onScanBatch({ stats, agents: structuredClone(agents) });
+        listeners.onFileAccess(
+          Array.from({ length: 500 }, (_, i) => {
+            const a = agents[i % agents.length];
+            return {
+              agent: a.agent,
+              pid: a.pid,
+              instanceId: a.instanceId,
+              timestamp: epoch - i * 100,
+              file: `X:/synthetic-project/file-${i}.txt`,
+              action: 'read',
+              sensitive: i % 10 === 0,
+              reason: '',
+              attribution: { status: 'confirmed' },
+            };
+          }),
+        );
+        listeners.onNetworkUpdate(
+          agents.map((a) => ({
+            agent: a.agent,
+            pid: a.pid,
+            instanceId: a.instanceId,
+            remoteIp: '192.0.2.1',
+            remotePort: 443,
+            verdict: 'unknown',
+            verdictReason: 'ptr-missing',
+          })),
+        );
+      },
+      async deliver(sequence) {
+        clock = epoch + sequence * 1000;
+        listeners.onScanStatus({ scanning: true });
+        await Promise.resolve();
+        listeners.onScanBatch({
+          agents: structuredClone(agents),
+          stats: { ...stats },
+          resourceUsage: { memMB: 80, heapMB: 20, cpuUser: sequence * 10000, cpuSystem: 0 },
+        });
+        await Promise.resolve();
+        listeners.onAgentResourceUsage(
+          agents.map((a) => ({
+            instanceId: a.instanceId,
+            cpu: sequence % 30,
+            memMb: 100,
+            collectionSequence: sequence,
+            collectedAt: clock,
+          })),
+        );
+        await Promise.resolve();
+        listeners.onScanStatus({ scanning: false });
+        await new Promise(requestAnimationFrame);
+      },
+    };
+  });
+  await page.goto(`http://127.0.0.1:${server.address().port}/`);
+  await page.getByRole('heading', { name: 'Monitoring', exact: true, level: 1 }).waitFor();
+  await page.evaluate(() => window.workload.seed());
+  const session = await page.context().newCDPSession(page);
+  await session.send('Performance.enable');
+  const metric = async () =>
+    Object.fromEntries(
+      (await session.send('Performance.getMetrics')).metrics.map((m) => [m.name, m.value]),
+    );
+  for (let i = 1; i <= 5; i++) await page.evaluate((i) => window.workload.deliver(i), i);
+  await session.send('HeapProfiler.collectGarbage');
+  const before = await metric();
+  const start = performance.now();
+  for (let i = 6; i <= 125; i++) await page.evaluate((i) => window.workload.deliver(i), i);
+  const elapsedMs = performance.now() - start;
+  const after = await metric();
+  const navigation = [],
+    retained = [];
+  for (let round = 0; round < 4; round++) {
+    for (const name of ['Agents', 'Events', 'Network', 'Statistics', 'Monitoring']) {
+      const ms = await page.evaluate((name) => {
+        const start = performance.now();
+        [...document.querySelectorAll('.sidebar button')]
+          .find((button) => button.getAttribute('aria-label') === name)
+          .click();
+        return new Promise((done) => {
+          const observe = () =>
+            document.querySelector('h1')?.textContent.trim() === name
+              ? done(performance.now() - start)
+              : setTimeout(observe, 0);
+          observe();
+        });
+      }, name);
+      navigation.push({ round, name, ms });
+    }
+    await session.send('HeapProfiler.collectGarbage');
+    retained.push(await metric());
+  }
+  const visible = await page.evaluate(() => ({
+    heading: document.querySelector('h1')?.textContent,
+    summary: [...document.querySelectorAll('.summary-stat')].map((n) => n.textContent.trim()),
+    nodes: document.querySelectorAll('*').length,
+    animations: document.getAnimations().length,
+  }));
+  assert.equal(visible.heading, 'Monitoring');
+  assert.equal(visible.summary[0].replace(/\s/g, ''), 'Agents4online49processesinsnapshot');
+  assert.deepEqual(errors, []);
+  await mkdir(output, { recursive: true });
+  await page.screenshot({ path: resolve(output, `${label}.png`) });
+  const result = {
+    label,
+    fixture:
+      '49 processes, 500 file observations, 49 sockets, 120 ordered deliveries; synthetic desktop bridge; UTC/en-US; 1440x1000',
+    elapsedMs,
+    taskMs: (after.TaskDuration - before.TaskDuration) * 1000,
+    scriptMs: (after.ScriptDuration - before.ScriptDuration) * 1000,
+    layoutMs: (after.LayoutDuration - before.LayoutDuration) * 1000,
+    before,
+    after,
+    retained,
+    navigation,
+    visible,
+    errors,
+  };
+  await writeFile(resolve(output, `${label}.json`), JSON.stringify(result, null, 2));
+  console.log(
+    JSON.stringify({
+      label,
+      taskMs: result.taskMs,
+      scriptMs: result.scriptMs,
+      heapMiB: retained.map((m) => m.JSHeapUsedSize / 1048576),
+      visible,
+    }),
+  );
+} finally {
+  await browser?.close();
+  await new Promise((done) => server.close(done));
+}

--- a/tests/renderer/observatory-activity.test.js
+++ b/tests/renderer/observatory-activity.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { activityBins, activityTimeLabel } from '../../frontend/observatory/runtime/activity';
 import { cpuPercent } from '../../frontend/observatory/runtime/resources';
 
@@ -67,4 +67,46 @@ it('formats a complete local axis clock and leaves malformed dates unavailable',
   );
   expect(activityTimeLabel(NaN)).toBe('—');
   expect(activityTimeLabel(1e30)).toBe('—');
+});
+
+it('bounds formatter allocation across ticks and refreshes the default zone after time changes', () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(10000);
+  const Original = Intl.DateTimeFormat;
+  let timeZone = 'UTC';
+  const constructor = vi
+    .spyOn(Intl, 'DateTimeFormat')
+    .mockImplementation(function (locale, options) {
+      return new Original(locale, { ...options, timeZone });
+    });
+  try {
+    const at = Date.UTC(2026, 8, 10, 12, 0);
+    for (let i = 0; i < 100; i++) {
+      activityTimeLabel(at + i * 1000);
+      activityTimeLabel(at + i * 1000, true);
+    }
+    expect(constructor).toHaveBeenCalledTimes(2);
+    timeZone = 'Asia/Tokyo';
+    vi.setSystemTime(70000);
+    expect(activityTimeLabel(at)).toBe(
+      new Original(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone,
+      }).format(at),
+    );
+    expect(constructor).toHaveBeenCalledTimes(3);
+    timeZone = 'UTC';
+    vi.setSystemTime(5000);
+    expect(activityTimeLabel(at)).toBe(
+      new Original(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone,
+      }).format(at),
+    );
+  } finally {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  }
 });

--- a/tests/renderer/observatory-host.test.js
+++ b/tests/renderer/observatory-host.test.js
@@ -402,3 +402,33 @@ it('ignores a delayed settings read failure after a confirmed settings update', 
     run.dispose();
   }
 });
+
+it('shares a held assessment while new deliveries refresh evidence and time decay', () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1000000);
+  try {
+    const frame = {
+      ...emptyTelemetry(),
+      agents: [agent('123:old')],
+      events: [
+        { instanceId: '123:old', file: '/fixture/item', timestamp: Date.now(), sensitive: true },
+      ],
+    };
+    const held = instances(frame);
+    expect(held[0].fileCount).toBe(1);
+    // Concurrent views share the captured assessment without re-reading the records.
+    const reads = vi.spyOn(frame.events, 'flat');
+    for (let i = 0; i < 50; i++) expect(instances(frame)).toBe(held);
+    expect(reads).not.toHaveBeenCalled();
+    vi.setSystemTime(Date.now() + 3600001);
+    expect(instances(frame)[0].fileCount).toBe(1);
+    expect(instances({ ...frame })[0].fileCount).toBe(0.5);
+    expect(instances({ ...frame, agents: [agent('123:new')] })[0].fileCount).toBe(0);
+    const updated = instances({ ...frame, anomalies: { '123:old': 80 } });
+    expect(updated[0].anomalyScore).toBe(80);
+    expect(held[0].anomalyScore).toBe(0);
+  } finally {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  }
+});


### PR DESCRIPTION
Telemetry updates repeatedly enriched the same agents in several mounted views, traversed deep reactive proxies for immutable snapshots, and constructed Intl formatters for individual chart labels. Share assessments per snapshot with source-reference invalidation, retain telemetry/history as raw reactive references, and reuse clock formatters with periodic locale/time-zone refresh.

The captured-versus-current risk boundary, PID reuse, paused views and graph history remain covered. A reproducible desktop-renderer workload is included: 49 instances, 500 file observations, 49 sockets and 120 identical deliveries. In the recorded local comparison, task time decreased from 10,328 ms to 1,062 ms; retained JS heap after four workspace tours decreased from 7.91 to 4.94 MiB. Visible summary values and attached DOM counts matched. These are synthetic renderer measurements, not whole-app CPU/RAM or proof against long-session leaks.

Validation: 3281 tests passed, 4 skipped; required build, formatting, lint, type/Svelte checks, witness/sequence gates, counts and production audit passed. The browser matrix (264 viewport/theme/scale checks plus scope, graph, motion and draft scenarios) and isolated Electron smoke passed; settings survived restart and all six exports passed.

