### PR TITLE
fix(ui): switch agent sections without scrolling

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -64,3 +64,13 @@ Feedback uses 140 ms colour/border changes and a 120 ms opacity-only dialog/enti
 Host deliveries are immutable snapshots held with `$state.raw`; charts also receive immutable history arrays without deep proxying. Draft forms retain their ordinary reactive state. Consumers share an exposure assessment for one snapshot and invalidate it when source references change. Weak snapshot keys do not keep departed observations alive. A held snapshot preserves its captured assessment; new deliveries recalculate event age and evidence. Clock labels share two Intl formatters, refreshed at least once a minute or after a backwards clock change to pick up default locale/time-zone changes. Composition, motion preferences, history retention, selection and measurement provenance remain governed by the sections above.
 
 The identical-input comparison and its limits are recorded in [RENDERER-WORKLOAD.md](../../docs/current-state/RENDERER-WORKLOAD.md).
+
+
+### Agent section tabs (2026-09-10)
+
+Risk, Resources, Activity and Processes switch one local panel beneath the shared
+agent context. This supersedes the earlier in-page section links. Clicking a tab
+never scrolls the workspace or focuses its contents; arrow keys move between tabs.
+Inactive panels stay mounted and hidden, preserving resource history and metric
+selection. Exact-process attributes and controls belong to Processes. Requested
+risk/process sections select their panel; the default overview opens Risk.

--- a/frontend/observatory/components/AgentWorkspace.svelte
+++ b/frontend/observatory/components/AgentWorkspace.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { tick } from 'svelte';
+  import SectionTabs from './SectionTabs.svelte';
   import { instances, type Host, type Telemetry, type RecordData } from '../runtime/host';
   import { scopeEvidence, type AgentScope } from '../runtime/agent-scope';
   import { radarGroups, groupRecord, riskBand } from '../runtime/radar';
@@ -62,25 +62,29 @@
     scopeEvidence(telemetry.network as unknown as RecordData[], telemetry, scope),
   );
   let absent = $derived(scope.instanceId ? !process : !group);
-  let riskOpen = $state(false);
+  const prefix = $props.id();
+  let section = $state('risk');
+  let riskOpen = $state(true);
+  let tabs = $derived([
+    { id: 'risk', label: 'Risk' },
+    { id: 'resources', label: 'Resources' },
+    { id: 'activity', label: 'Activity', count: files.length + connections.length },
+    { id: 'processes', label: 'Processes' },
+  ]);
   let lastRequest = -1;
-  let shell: HTMLElement;
-  async function jump(id: string, scroll = true) {
-    if (id === 'risk') riskOpen = true;
-    await tick();
-    const node = shell?.querySelector<HTMLElement>('#agent-' + id);
-    if (scroll) node?.scrollIntoView({ block: 'start' });
-    node?.focus({ preventScroll: true });
+  function selectSection(id: string) {
+    section = tabs.some((tab) => tab.id === id) ? id : 'risk';
+    if (section === 'risk') riskOpen = true;
   }
   $effect(() => {
     if (visible && sectionRequest && sectionRequest.revision !== lastRequest) {
       lastRequest = sectionRequest.revision;
-      void jump(sectionRequest.id, sectionRequest.id !== 'overview');
+      selectSection(sectionRequest.id);
     }
   });
 </script>
 
-<div class="agent-workspace" bind:this={shell}>
+<div class="agent-workspace">
   <section id="agent-overview" tabindex="-1" class="agent-intro" aria-label="Agent overview">
     <AgentLogo name={scope.agent} size={34} />
     <div class="agent-description">
@@ -99,19 +103,19 @@
     </div>
     <button class="button" onclick={() => navigate('stats')}>Detailed statistics</button>
   </section>
-  <nav class="agent-jumps" aria-label="Agent sections">
-    <button onclick={() => jump('risk')}>Risk</button>
-    <button onclick={() => jump('resources')}>Resources</button>
-    <button onclick={() => jump('activity')}
-      >Activity <span>{files.length + connections.length}</span></button
-    >
-    <button onclick={() => jump('processes')}>Processes</button>
-  </nav>
+  <SectionTabs {tabs} selected={section} change={selectSection} {prefix} label="Agent sections" />
   {#if absent}<p class="notice" role="status">
       This selection is no longer observed. Its retained activity stays visible; AEGIS will not
       switch to another process with the same PID.
     </p>{/if}
-  <section id="agent-risk" tabindex="-1" class="agent-risk panel" aria-label="Selected agent risk">
+  <div
+    id={prefix + '-panel-risk'}
+    role="tabpanel"
+    aria-labelledby={prefix + '-tab-risk'}
+    tabindex="0"
+    hidden={section !== 'risk'}
+    class="agent-risk panel"
+  >
     <details bind:open={riskOpen}>
       <summary
         ><span class="risk-heading"
@@ -125,7 +129,9 @@
             : !risk.subject.instanceId
               ? 'Process identity not recorded'
               : (risk.contributions[0]?.label ?? 'No scored activity')}<small
-            >{scope.instanceId ? 'This process' : 'Highest process score'} · Expand explanation</small
+            >{scope.instanceId ? 'This process' : 'Highest process score'} · {riskOpen
+              ? 'Collapse explanation'
+              : 'Expand explanation'}</small
           ></span
         >
       </summary>
@@ -133,48 +139,61 @@
         <RiskExplanation row={riskSubject} {telemetry} navigate={inspect} />
       </div>
     </details>
-  </section>
-  <div class="agent-live-grid">
-    <section id="agent-resources" tabindex="-1" aria-label="Selected agent resources">
-      <AgentPerformance {telemetry} {scope} {paused} />
-    </section>
-    <section
-      id="agent-activity"
-      tabindex="-1"
-      class="agent-activity"
-      aria-label="Selected agent activity"
-    >
-      <AgentEvidence
-        agents={all as unknown as RecordData[]}
-        rows={files}
-        {inspect}
-        more={() => navigate('events')}
-      />
-      <AgentEvidence
-        agents={all as unknown as RecordData[]}
-        rows={connections}
-        network
-        {inspect}
-        more={() => navigate('network')}
-      />
-    </section>
   </div>
-  <section id="agent-processes" tabindex="-1">
+  <div
+    id={prefix + '-panel-resources'}
+    role="tabpanel"
+    aria-labelledby={prefix + '-tab-resources'}
+    tabindex="0"
+    hidden={section !== 'resources'}
+  >
+    <AgentPerformance {telemetry} {scope} {paused} />
+  </div>
+  <div
+    id={prefix + '-panel-activity'}
+    role="tabpanel"
+    aria-labelledby={prefix + '-tab-activity'}
+    tabindex="0"
+    hidden={section !== 'activity'}
+    class="agent-activity"
+  >
+    <AgentEvidence
+      agents={all as unknown as RecordData[]}
+      rows={files}
+      {inspect}
+      more={() => navigate('events')}
+    />
+    <AgentEvidence
+      agents={all as unknown as RecordData[]}
+      rows={connections}
+      network
+      {inspect}
+      more={() => navigate('network')}
+    />
+  </div>
+  <div
+    id={prefix + '-panel-processes'}
+    role="tabpanel"
+    aria-labelledby={prefix + '-tab-processes'}
+    tabindex="0"
+    hidden={section !== 'processes'}
+    class="agent-process-panel"
+  >
     <AgentProcesses {telemetry} {scope} {change} />
-  </section>
-  {#if process}
-    <details class="process-information panel">
-      <summary>Process attributes and controls</summary>
-      <div class="process-information-body">
-        <DetailSummary row={subject} {telemetry} section="attributes" />
-        {#key scope.instanceId}<DetailControls
-            row={subject}
-            telemetry={liveTelemetry}
-            {host}
-          />{/key}
-      </div>
-    </details>
-  {/if}
+    {#if process}
+      <details class="process-information panel">
+        <summary>Process attributes and controls</summary>
+        <div class="process-information-body">
+          <DetailSummary row={subject} {telemetry} section="attributes" />
+          {#key scope.instanceId}<DetailControls
+              row={subject}
+              telemetry={liveTelemetry}
+              {host}
+            />{/key}
+        </div>
+      </details>
+    {/if}
+  </div>
 </div>
 
 <style>
@@ -201,35 +220,16 @@
     margin: 5px 0 0;
     font-size: var(--text-body);
   }
-  .agent-jumps {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 6px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid var(--border);
+  [role='tabpanel'][hidden] {
+    display: none;
   }
-  .agent-jumps button {
-    background: transparent;
-    border: 1px solid transparent;
-    color: var(--ink);
-    min-height: var(--control-height);
-    padding: var(--space-1) var(--space-3);
-    border-radius: var(--control-radius);
-    font-size: var(--text-body);
-  }
-  .agent-jumps button:hover {
-    background: var(--hover);
-  }
-  .agent-jumps span {
-    color: var(--muted);
-    margin-left: 5px;
-  }
-  section[id] {
-    scroll-margin-top: calc(var(--workspace-sticky-offset, 70px) + 12px);
+  [role='tabpanel'] {
+    min-width: 0;
     outline-offset: 4px;
+  }
+  .agent-process-panel {
+    display: grid;
+    gap: var(--space-4);
   }
   summary {
     cursor: pointer;
@@ -269,12 +269,6 @@
     border-top: 1px solid var(--border);
     padding: var(--panel-inset);
   }
-  .agent-live-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
-    gap: var(--space-4);
-    align-items: start;
-  }
   .agent-activity {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
@@ -292,9 +286,6 @@
     border-top: 1px solid var(--border);
   }
   @media (max-width: 1150px) {
-    .agent-live-grid {
-      grid-template-columns: minmax(0, 1fr);
-    }
     .agent-activity {
       grid-template-columns: minmax(0, 1fr);
     }

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -371,6 +371,10 @@ try {
     .getByLabel('Selected process', { exact: true })
     .selectOption({ index: 1 });
   await page.getByRole('heading', { name: 'Process overview', exact: true }).waitFor();
+  await page
+    .getByRole('tablist', { name: 'Agent sections' })
+    .getByRole('tab', { name: 'Processes', exact: true })
+    .click();
   await page.getByText('Process attributes and controls', { exact: true }).click();
   await page.getByRole('button', { name: 'Suspend', exact: true }).waitFor();
   await page.screenshot({ path: resolve(out, 'instance.png') });

--- a/frontend/observatory/tests/clarity-check.mjs
+++ b/frontend/observatory/tests/clarity-check.mjs
@@ -75,7 +75,7 @@ export async function checkClarity(browser, url, out) {
     const context = page.locator('.agent-context');
     await workspace.waitFor();
     assert.equal(await page.getByRole('dialog').count(), 0);
-    assert(await workspace.locator('#agent-risk details').evaluate((node) => node.open));
+    assert(await workspace.locator('.agent-risk details').evaluate((node) => node.open));
     assert.match(await workspace.innerText(), /Plain HTTP connections/);
     assert.match(await workspace.innerText(), /SSH \/ cloud credentials/);
     let states = 0;
@@ -91,8 +91,8 @@ export async function checkClarity(browser, url, out) {
             { scale, theme },
           );
           await workspace
-            .getByRole('navigation', { name: 'Agent sections' })
-            .getByRole('button', { name: 'Risk', exact: true })
+            .getByRole('tablist', { name: 'Agent sections' })
+            .getByRole('tab', { name: 'Risk', exact: true })
             .click();
           assert(
             await page.evaluate(
@@ -133,8 +133,8 @@ export async function checkClarity(browser, url, out) {
     );
     assert.equal(await page.getByRole('dialog').count(), 0);
     await workspace
-      .getByRole('navigation', { name: 'Agent sections' })
-      .getByRole('button', { name: 'Risk', exact: true })
+      .getByRole('tablist', { name: 'Agent sections' })
+      .getByRole('tab', { name: 'Risk', exact: true })
       .click();
     assert.match(
       await workspace.locator('.risk-explanation').innerText(),

--- a/frontend/observatory/tests/detail-check.mjs
+++ b/frontend/observatory/tests/detail-check.mjs
@@ -148,6 +148,30 @@ export async function checkDetails(browser, url, out) {
             await workspace.evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
             'agent workspace overflows',
           );
+          const sections = workspace.getByRole('tablist', { name: 'Agent sections' });
+          const readPosition = () =>
+            page.evaluate(() => {
+              const strip = document.querySelector('.agent-workspace [role="tablist"]');
+              return {
+                top: strip.getBoundingClientRect().top,
+                scroll: document.querySelector('#main').scrollTop,
+              };
+            });
+          await page.locator('#main').evaluate((node) => {
+            node.scrollTop = 0;
+          });
+          const position = await readPosition();
+          for (const name of ['Resources', 'Activity', 'Processes', 'Risk']) {
+            const control = sections.getByRole('tab', { name: new RegExp('^' + name) });
+            await control.click();
+            assert.deepEqual(await readPosition(), position, name + ' moved the page or tab strip');
+            assert(
+              await control.evaluate((node) => node === document.activeElement),
+              name + ' stole focus',
+            );
+            assert.equal(await workspace.getByRole('tabpanel').count(), 1);
+            assert.equal(await control.getAttribute('aria-selected'), 'true');
+          }
           assert.equal(await page.getByRole('dialog').count(), 0);
           assert(!/DO-NOT-DISPLAY/.test(await workspace.innerText()));
           if (
@@ -167,8 +191,8 @@ export async function checkDetails(browser, url, out) {
       document.documentElement.dataset.theme = 'dark';
     });
     await workspace
-      .getByRole('navigation', { name: 'Agent sections' })
-      .getByRole('button', { name: 'Processes', exact: true })
+      .getByRole('tablist', { name: 'Agent sections' })
+      .getByRole('tab', { name: 'Processes', exact: true })
       .click();
     await page.getByRole('button', { name: 'Show all 26 processes' }).click();
     await page.getByRole('button', { name: 'PID 220', exact: true }).click();
@@ -185,6 +209,7 @@ export async function checkDetails(browser, url, out) {
       name: 'Inspect file observation 1',
       exact: true,
     });
+    await workspace.getByRole('tab', { name: /^Activity/ }).click();
     await observation.click();
     await page.getByRole('dialog').waitFor();
     await tab('Attributes').click();
@@ -197,6 +222,7 @@ export async function checkDetails(browser, url, out) {
       await context.getByLabel('Selected process', { exact: true }).inputValue(),
       'detail:0',
     );
+    await workspace.getByRole('tab', { name: /^Activity/ }).click();
     await workspace
       .getByRole('region', { name: 'Selected agent file activity' })
       .getByRole('button', { name: 'View all', exact: true })

--- a/frontend/observatory/tests/electron-smoke.mjs
+++ b/frontend/observatory/tests/electron-smoke.mjs
@@ -144,8 +144,8 @@ try {
       assert.equal(await window.getByRole('dialog').count(), 0);
       assert.equal(await window.getByRole('button', { name: 'Suspend', exact: true }).count(), 0);
       await window
-        .getByRole('navigation', { name: 'Agent sections' })
-        .getByRole('button', { name: 'Processes', exact: true })
+        .getByRole('tablist', { name: 'Agent sections' })
+        .getByRole('tab', { name: 'Processes', exact: true })
         .click();
       assert(
         (await window.locator('.agent-processes tbody tr').count()) > 0,

--- a/frontend/observatory/tests/usability-check.mjs
+++ b/frontend/observatory/tests/usability-check.mjs
@@ -76,13 +76,13 @@ export async function checkUsability(browser, url, out) {
         assert(selectedProcess, 'fixture lacks a stamped process');
         await page.getByRole('heading', { name: 'Process overview', exact: true }).waitFor();
         await page
-          .getByRole('navigation', { name: 'Agent sections' })
-          .getByRole('button', { name: 'Risk', exact: true })
+          .getByRole('tablist', { name: 'Agent sections' })
+          .getByRole('tab', { name: 'Risk', exact: true })
           .click();
-        assert(await page.locator('#agent-risk details').evaluate((node) => node.open));
+        assert(await page.locator('.agent-risk details').evaluate((node) => node.open));
         await page
-          .getByRole('navigation', { name: 'Agent sections' })
-          .getByRole('button', { name: 'Processes', exact: true })
+          .getByRole('tablist', { name: 'Agent sections' })
+          .getByRole('tab', { name: 'Processes', exact: true })
           .click();
         assert(await page.getByRole('region', { name: 'Agent worker processes' }).isVisible());
         assert.equal(await page.getByRole('dialog').count(), 0);

--- a/tests/renderer/components/ObservatoryAgentWorkspace.test.js
+++ b/tests/renderer/components/ObservatoryAgentWorkspace.test.js
@@ -250,3 +250,39 @@ it('opens Monitoring as a global overview while preserving the separate agent wo
   expect(within(screen.getByRole('table')).getByText('192.0.2.10:443')).toBeVisible();
   expect(within(screen.getByRole('table')).getByText('192.0.2.20:443')).toBeVisible();
 }, 15000);
+
+it('switches local panels without scrolling or moving focus into content and preserves the resource view', async () => {
+  const { container, push, agents } = await start();
+  await chooseAgent();
+  const tabs = within(screen.getByRole('tablist', { name: 'Agent sections' }));
+  const resources = tabs.getByRole('tab', { name: 'Resources', exact: true });
+  const risk = tabs.getByRole('tab', { name: 'Risk', exact: true });
+  expect(screen.getAllByRole('tabpanel')).toHaveLength(1);
+  expect(screen.getByRole('tabpanel', { name: 'Risk' })).toBeVisible();
+  HTMLElement.prototype.scrollIntoView.mockClear();
+  resources.focus();
+  await fireEvent.click(resources);
+  expect(resources).toHaveFocus();
+  const panel = screen.getByRole('tabpanel', { name: 'Resources' });
+  const memory = within(panel).getByRole('button', { name: /memory/i });
+  await fireEvent.click(memory);
+  expect(memory).toHaveAttribute('aria-pressed', 'true');
+  resources.focus();
+  await fireEvent.keyDown(resources, { key: 'ArrowRight' });
+  await waitFor(() => expect(tabs.getByRole('tab', { name: /^Activity/ })).toHaveFocus());
+  expect(screen.getAllByRole('tabpanel')).toHaveLength(1);
+  expect(within(screen.getByRole('tabpanel')).getByText('codex-only.txt')).toBeVisible();
+  await push('onAgentResourceUsage', [{ instanceId: agents[0].instanceId, cpu: 25, memMb: 250 }]);
+  risk.focus();
+  await fireEvent.click(risk);
+  expect(risk).toHaveFocus();
+  await fireEvent.click(resources);
+  expect(screen.getByRole('tabpanel', { name: 'Resources' })).toBe(panel);
+  expect(memory).toHaveAttribute('aria-pressed', 'true');
+  await waitFor(() =>
+    expect(container.querySelector('.agent-workspace .monitor-detail .current')).toHaveTextContent(
+      '250',
+    ),
+  );
+  expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
+}, 15000);


### PR DESCRIPTION
Agent section buttons scrolled down a long page and moved focus into its content. Risk, Resources, Activity and Processes now switch one local tab panel beneath the shared agent context. Inactive panels remain mounted, preserving resource history and metric selection; process attributes and controls live in Processes.

The shared tab component retains keyboard focus on the selected tab. Browser regression checks verify an unchanged tab-strip position and page scroll through all four panels in 16 theme/scale/viewport combinations. Existing evidence and process workflows now select their panel explicitly.

Validation: 3282 tests passed, 4 skipped; format/lint/types/Svelte, build, coverage, witness/sequence gates, counts and production audit passed. Browser matrix and Electron smoke passed. Packaged source and renderer matched all 203 workspace files checked.
