### PR TITLE
fix(ui): keep evidence pagination and focus stationary

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -74,3 +74,12 @@ never scrolls the workspace or focuses its contents; arrow keys move between tab
 Inactive panels stay mounted and hidden, preserving resource history and metric
 selection. Exact-process attributes and controls belong to Processes. Requested
 risk/process sections select their panel; the default overview opens Risk.
+
+
+### Observation pagination (2026-09-10)
+
+Events and Network keep page controls above the evidence table. Changing pages
+updates rows without scrolling to a record or moving focus away from the control.
+Unavailable directions use aria-disabled and a guarded handler so reaching the
+first or last page does not remove keyboard focus. Filter changes still reset to
+the first page; grouping and exact process attribution remain unchanged.

--- a/frontend/observatory/components/ObservationTable.svelte
+++ b/frontend/observatory/components/ObservationTable.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { tick } from 'svelte';
   import {
     describeObservation,
     groupObservations,
@@ -22,7 +21,6 @@
     resetKey?: string;
   } = $props();
   let page = $state(0);
-  let surface: HTMLElement;
   let agents = $derived(instances(telemetry) as unknown as RecordData[]);
   let groups = $derived(groupObservations(rows, grouping, agents));
   let currentPage = $derived(Math.min(page, Math.max(0, Math.ceil(groups.length / 30) - 1)));
@@ -32,12 +30,9 @@
     grouping;
     page = 0;
   });
-  async function changePage(next: number) {
+  function changePage(next: number) {
+    if (next < 0 || next >= Math.ceil(groups.length / 30)) return;
     page = next;
-    await tick();
-    const target = surface.querySelector<HTMLButtonElement>('.observation-open');
-    target?.focus({ preventScroll: true });
-    target?.scrollIntoView?.({ block: 'nearest', behavior: 'instant' });
   }
   function open(group: (typeof groups)[number]) {
     inspect(
@@ -49,7 +44,25 @@
   }
 </script>
 
-<section class="panel observation-table" bind:this={surface}>
+<section class="panel observation-table">
+  <nav class="pagination" aria-label="Observation pages">
+    <span
+      >{groups.length ? currentPage * 30 + 1 : 0}–{Math.min((currentPage + 1) * 30, groups.length)} of
+      {groups.length}
+      {grouping === 'none' ? 'records' : 'groups'} · {rows.length} observations</span
+    >
+    <div class="toolbar">
+      <button
+        class="button"
+        aria-disabled={currentPage === 0}
+        onclick={() => changePage(currentPage - 1)}>Previous</button
+      ><button
+        class="button"
+        aria-disabled={(currentPage + 1) * 30 >= groups.length}
+        onclick={() => changePage(currentPage + 1)}>Next</button
+      >
+    </div>
+  </nav>
   <div class="table-wrap">
     <table>
       <thead
@@ -141,27 +154,24 @@
       </tbody>
     </table>
   </div>
-  <div class="pagination">
-    <span
-      >{groups.length ? currentPage * 30 + 1 : 0}–{Math.min((currentPage + 1) * 30, groups.length)} of
-      {groups.length}
-      {grouping === 'none' ? 'records' : 'groups'} · {rows.length} observations</span
-    >
-    <div class="toolbar">
-      <button
-        class="button"
-        disabled={currentPage === 0}
-        onclick={() => changePage(currentPage - 1)}>Previous</button
-      ><button
-        class="button"
-        disabled={(currentPage + 1) * 30 >= groups.length}
-        onclick={() => changePage(currentPage + 1)}>Next</button
-      >
-    </div>
-  </div>
 </section>
 
 <style>
+  .observation-table .pagination {
+    flex-direction: row;
+    border-top: 0;
+    border-bottom: 1px solid var(--border);
+    border-radius: var(--surface-radius) var(--surface-radius) 0 0;
+  }
+  .pagination .button[aria-disabled='true'] {
+    opacity: 0.45;
+    cursor: default;
+  }
+  .pagination .button[aria-disabled='true']:hover {
+    background: var(--panel);
+    border-color: var(--border);
+  }
+
   table {
     min-width: 640px;
     table-layout: fixed;

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -4,6 +4,7 @@ import { readFile, readdir, mkdir, writeFile } from 'node:fs/promises';
 import { resolve, sep, extname } from 'node:path';
 import { chromium } from 'playwright';
 import { createHash } from 'node:crypto';
+import { checkPagination } from './pagination-check.mjs';
 import { checkComfort } from './comfort-check.mjs';
 import { checkClarity } from './clarity-check.mjs';
 import { checkUsability } from './usability-check.mjs';
@@ -390,6 +391,7 @@ try {
   await checkClarity(browser, base + '/desktop/', out);
   await checkResourceLayers(browser, base + '/desktop/', out);
   await checkDetails(browser, base + '/desktop/', out);
+  await checkPagination(browser, base + '/desktop/', out);
   await checkComfort(browser, base + '/preview/', out);
   await checkGraphs(browser, base + '/preview/', out);
   await checkUsability(browser, base + '/preview/', out);

--- a/frontend/observatory/tests/pagination-check.mjs
+++ b/frontend/observatory/tests/pagination-check.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+/** Verify stationary pagination of live evidence, including short last pages.
+ * @param {import('playwright').Browser} browser Browser
+ * @param {string} url Desktop fixture URL @param {string} out Screenshot directory
+ * @returns {Promise<void>} Checked workflows @since 0.14.1
+ */
+export async function checkPagination(browser, url, out) {
+  const page = await browser.newPage();
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  try {
+    await page.addInitScript(() => {
+      const listeners = {};
+      window.paginationFixture = listeners;
+      window.aegis = new Proxy(
+        {},
+        {
+          get: (_, name) =>
+            name.startsWith('on')
+              ? (callback) => {
+                  listeners[name] = callback;
+                  return () => {};
+                }
+              : async () =>
+                  name === 'getSettings'
+                    ? { darkMode: true, uiScale: 1 }
+                    : name === 'getFalsePositives'
+                      ? []
+                      : {},
+        },
+      );
+    });
+    await page.goto(url);
+    await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
+    await page.evaluate(() => {
+      window.paginationFixture.onScanBatch({
+        agents: [
+          {
+            agent: 'Codex',
+            pid: 123,
+            instanceId: 'pagination:123',
+            instanceIdSource: 'os',
+            process: 'codex.exe',
+          },
+        ],
+        stats: { appHealth: { populationReliable: true, state: 'HEALTHY' } },
+      });
+      const common = { agent: 'Codex', pid: 123, instanceId: 'pagination:123' };
+      window.paginationFixture.onFileAccess(
+        Array.from({ length: 65 }, (_, i) => ({
+          ...common,
+          file: 'X:/Fixture/file-' + i + '.txt',
+          timestamp: Date.now() - i * 1000,
+          action: 'read',
+          attribution: { status: 'confirmed' },
+        })),
+      );
+      window.paginationFixture.onNetworkUpdate(
+        Array.from({ length: 65 }, (_, i) => ({
+          ...common,
+          remoteIp: '192.0.2.' + (i + 1),
+          remotePort: 443,
+          state: 'ESTABLISHED',
+          verdict: 'unknown',
+        })),
+      );
+    });
+    let states = 0;
+    for (const view of ['Events', 'Network']) {
+      await page.locator('.sidebar').getByRole('button', { name: view, exact: true }).click();
+      for (const width of [900, 1200]) {
+        await page.setViewportSize({ width, height: width === 900 ? 600 : 800 });
+        for (const scale of [1, 1.5]) {
+          for (const theme of ['light', 'dark', 'light-hc', 'dark-hc']) {
+            await page.evaluate(
+              ({ scale, theme }) => {
+                document.documentElement.dataset.theme = theme;
+                document.documentElement.style.setProperty('--ui-scale', String(scale));
+                document.querySelector('#main').scrollTop = 0;
+              },
+              { scale, theme },
+            );
+            const pager = page.getByRole('navigation', { name: 'Observation pages' });
+            const next = pager.getByRole('button', { name: 'Next', exact: true });
+            const previous = pager.getByRole('button', { name: 'Previous', exact: true });
+            const geometry = () =>
+              pager.evaluate((node) => ({
+                top: node.getBoundingClientRect().top,
+                height: node.getBoundingClientRect().height,
+                scroll: document.querySelector('#main').scrollTop,
+              }));
+            const before = await geometry();
+            for (const [control, count] of [
+              [next, 30],
+              [next, 5],
+              [previous, 30],
+              [previous, 30],
+            ]) {
+              await control.click();
+              assert.deepEqual(await geometry(), before, view + ' pagination moved');
+              assert(
+                await control.evaluate((node) => node === document.activeElement),
+                'pagination stole focus',
+              );
+              assert.equal(
+                await page.locator('.observation-table:visible tbody tr').count(),
+                count,
+              );
+            }
+            await previous.press('Enter');
+            assert.match(await pager.innerText(), /1.*30 of 65/);
+            await next.press('Enter');
+            assert.match(await pager.innerText(), /31.*60 of 65/);
+            assert(await next.evaluate((node) => node === document.activeElement));
+            await previous.click();
+            assert(
+              await pager.evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
+              'pager overflow',
+            );
+            if (width === 900 && scale === 1.5 && !theme.endsWith('-hc')) {
+              await page.screenshot({
+                path: resolve(out, 'pagination-' + view.toLowerCase() + '-' + theme + '.png'),
+              });
+            }
+            states++;
+          }
+        }
+      }
+    }
+    assert.deepEqual(errors, []);
+    console.log(
+      'Observation pagination: ' +
+        states +
+        ' viewport/theme/scale states; mouse/keyboard focus, first/last pages and stationary controls passed.',
+    );
+  } finally {
+    await page.close();
+  }
+}

--- a/tests/renderer/components/ObservatoryComfortEvidence.test.js
+++ b/tests/renderer/components/ObservatoryComfortEvidence.test.js
@@ -116,15 +116,18 @@ it('searches grouped process activity without attributing unrelated records to t
   expect(screen.getByText('No resources match this search.')).toBeInTheDocument();
 });
 
-it('returns keyboard focus to the first record when changing a long evidence page', async () => {
+it('opens the correct observation after paging forward and back', async () => {
   const rows = Array.from({ length: 31 }, (_, i) => observation(i));
-  const { container } = render(ObservationTable, { rows, telemetry: telemetry(), inspect: noop });
+  const inspect = vi.fn();
+  const { container } = render(ObservationTable, { rows, telemetry: telemetry(), inspect });
   await fireEvent.click(screen.getByRole('button', { name: 'Next', exact: true }));
-  await waitFor(() => expect(container.querySelector('.observation-open')).toHaveFocus());
   expect(container.querySelectorAll('.observation-group')).toHaveLength(1);
+  await fireEvent.click(container.querySelector('.observation-open'));
+  expect(inspect).toHaveBeenLastCalledWith('Observation', rows[0]);
   await fireEvent.click(screen.getByRole('button', { name: 'Previous', exact: true }));
-  await waitFor(() => expect(container.querySelector('.observation-open')).toHaveFocus());
   expect(container.querySelectorAll('.observation-group')).toHaveLength(30);
+  await fireEvent.click(container.querySelector('.observation-open'));
+  expect(inspect).toHaveBeenLastCalledWith('Observation', rows[30]);
 });
 
 it('retains loaded audit records and reports a failed refresh without success feedback', async () => {

--- a/tests/renderer/components/ObservatoryObservationPagination.test.ts
+++ b/tests/renderer/components/ObservatoryObservationPagination.test.ts
@@ -1,0 +1,61 @@
+import { expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
+import ObservationTable from '../../../frontend/observatory/components/ObservationTable.svelte';
+import { emptyTelemetry } from '../../../frontend/observatory/runtime/host';
+
+const rows = Array.from({ length: 65 }, (_, index) => ({
+  file: '/fixture/file-' + index + '.txt',
+  timestamp: 1000 + index,
+  action: 'read',
+}));
+
+it('keeps pagination focus through full, final and first pages, and ignores unavailable directions', async () => {
+  render(ObservationTable, {
+    rows,
+    telemetry: { ...emptyTelemetry(), ready: true },
+    inspect: vi.fn(),
+  });
+  const pages = within(screen.getByRole('navigation', { name: 'Observation pages' }));
+  const next = pages.getByRole('button', { name: 'Next' });
+  const previous = pages.getByRole('button', { name: 'Previous' });
+  const table = screen.getByRole('table');
+  expect(within(table).getAllByRole('row')).toHaveLength(31);
+  next.focus();
+  await fireEvent.click(next);
+  expect(next).toHaveFocus();
+  expect(screen.getByRole('navigation')).toHaveTextContent('31\u201360 of 65');
+  await fireEvent.click(next);
+  expect(next).toHaveFocus();
+  expect(next).toHaveAttribute('aria-disabled', 'true');
+  expect(within(table).getAllByRole('row')).toHaveLength(6);
+  await fireEvent.click(next);
+  expect(screen.getByRole('navigation')).toHaveTextContent('61\u201365 of 65');
+  previous.focus();
+  await fireEvent.click(previous);
+  await fireEvent.click(previous);
+  expect(previous).toHaveFocus();
+  expect(previous).toHaveAttribute('aria-disabled', 'true');
+  await fireEvent.click(previous);
+  expect(screen.getByRole('navigation')).toHaveTextContent('1\u201330 of 65');
+});
+
+it('resets to the first page when filters change and handles an empty result', async () => {
+  const props = {
+    rows,
+    telemetry: { ...emptyTelemetry(), ready: true },
+    inspect: vi.fn(),
+    resetKey: 'all',
+  };
+  const { rerender } = render(ObservationTable, props);
+  await fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  await rerender({ ...props, rows: [], resetKey: 'empty' });
+  expect(screen.getByRole('navigation')).toHaveTextContent('0\u20130 of 0');
+  expect(screen.getByText('No records match these filters.')).toBeVisible();
+  for (const name of ['Previous', 'Next']) {
+    const button = screen.getByRole('button', { name });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    await fireEvent.click(button);
+  }
+  await rerender({ ...props, resetKey: 'restored' });
+  expect(screen.getByRole('navigation')).toHaveTextContent('1\u201330 of 65');
+});


### PR DESCRIPTION
Changing pages in Events and Network previously scrolled to the first record and moved keyboard focus there. Page controls now sit above the table, with rows changing underneath them. Reaching the first or last page retains focus on the control; guarded aria-disabled actions prevent invalid page changes. Pagination stays compact at enlarged UI scale.

Added browser checks for stationary pagination, focus and short last pages across 32 viewport/theme/scale states. Component tests cover boundaries, empty results, filter resets and opening the correct observation after paging.

Validation: 3284 tests passed, 4 skipped; required builds, coverage, lint/format, types/Svelte, witness/sequence gates, counts and production audit passed. Browser matrix and isolated Electron smoke passed. Packaged source and renderer matched 203 workspace files.
