### PR TITLE
fix(ui): separate activity panels and hold inspected intervals

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -83,3 +83,13 @@ updates rows without scrolling to a record or moving focus away from the control
 Unavailable directions use aria-disabled and a guarded handler so reaching the
 first or last page does not remove keyboard focus. Filter changes still reset to
 the first page; grouping and exact process attribution remain unchanged.
+
+
+### Monitoring activity correction (2026-09-11)
+
+Activity and Recent events are separate panels with the shared 16 px gap.
+Hovering or keyboard-focusing a histogram interval holds its time window until
+inspection ends, so its boundaries and opened observations agree. The readout
+reserves two lines to prevent adjacent content from moving. Idle live windows
+still advance; paused/stale windows remain frozen. An agent whose retained events
+expire stays explicitly selected until the user changes that filter.

--- a/frontend/observatory/components/ActivityChart.svelte
+++ b/frontend/observatory/components/ActivityChart.svelte
@@ -24,7 +24,7 @@
   let focused = $state(false);
   let now = $state(Date.now());
   $effect(() => {
-    if (paused || stale) return;
+    if (paused || stale || hover !== null || focused) return;
     now = Date.now();
     const timer = setInterval(() => {
       now = Date.now();
@@ -56,6 +56,7 @@
     return `${activityTimeLabel(b.start, true)}–${activityTimeLabel(b.end, true)} · ${b.events.length} observations`;
   }
   function keys(e: KeyboardEvent, i: number) {
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
     if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) return;
     e.preventDefault();
     focus =
@@ -67,7 +68,7 @@
     (e.currentTarget as HTMLElement).parentElement
       ?.querySelectorAll<HTMLButtonElement>('button')
       .item(focus)
-      ?.focus();
+      ?.focus({ preventScroll: true });
   }
 </script>
 
@@ -89,7 +90,9 @@
     ><select aria-label="Chart agent" bind:value={agent}
       ><option value="">All agents</option>{#each names as name (name)}<option value={name}
           >{name}</option
-        >{/each}</select
+        >{/each}{#if agent && !names.includes(agent)}<option value={agent}
+          >{agent} · no retained events</option
+        >{/if}</select
     >
   </div>
   <div class="chart-reading">
@@ -138,6 +141,13 @@
           : stale
             ? 'Observation unavailable · retained window frozen.'
             : 'Select an interval to inspect its events.'
-      : caption(selection)}
+      : caption(selection) + ' · Interval held while inspecting'}
   </div>
 </section>
+
+<style>
+  .chart-readout {
+    line-height: 1.5;
+    min-height: calc(3em + var(--space-2) + var(--space-3));
+  }
+</style>

--- a/frontend/observatory/components/Monitoring.svelte
+++ b/frontend/observatory/components/Monitoring.svelte
@@ -146,3 +146,9 @@
   </div>
 </div>
 <div hidden={mode !== 'agents'}><Agents {telemetry} {inspect} {openStatistics} /></div>
+
+<style>
+  .recent-evidence {
+    margin-top: var(--space-4);
+  }
+</style>

--- a/frontend/observatory/tests/activity-check.mjs
+++ b/frontend/observatory/tests/activity-check.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+/** Verify Monitoring activity spacing and interval inspection with deterministic events.
+ * @param {import('playwright').Browser} browser Browser
+ * @param {string} url Desktop build @param {string} out Screenshot directory
+ * @returns {Promise<void>} Verified states @since 0.14.1
+ */
+export async function checkActivity(browser, url, out) {
+  const page = await browser.newPage();
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  try {
+    await page.addInitScript(() => {
+      const listeners = {};
+      window.activityFixture = listeners;
+      window.aegis = new Proxy(
+        {},
+        {
+          get: (_, name) =>
+            name.startsWith('on')
+              ? (callback) => {
+                  listeners[name] = callback;
+                  return () => {};
+                }
+              : async () =>
+                  name === 'getSettings'
+                    ? { darkMode: true, uiScale: 1 }
+                    : name === 'getFalsePositives'
+                      ? []
+                      : {},
+        },
+      );
+    });
+    await page.goto(url);
+    await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
+    await page.evaluate(() => {
+      window.activityFixture.onScanBatch({
+        agents: [
+          {
+            agent: 'Codex',
+            pid: 123,
+            instanceId: 'activity:123',
+            instanceIdSource: 'os',
+            process: 'codex.exe',
+          },
+        ],
+        stats: { appHealth: { populationReliable: true, state: 'HEALTHY' } },
+      });
+      window.activityFixture.onFileAccess(
+        Array.from({ length: 48 }, (_, i) => ({
+          agent: 'Codex',
+          pid: 123,
+          instanceId: 'activity:123',
+          file: 'X:/Fixture/file-' + i + '.txt',
+          timestamp: Date.now() - (i + 1) * 10000,
+          action: 'read',
+          attribution: { status: 'confirmed' },
+        })),
+      );
+    });
+    const chart = page.locator('.activity-chart');
+    const recent = page.locator('.recent-evidence');
+    const geometry = () =>
+      page.evaluate(() => {
+        const chart = document.querySelector('.activity-chart').getBoundingClientRect();
+        const recent = document.querySelector('.recent-evidence').getBoundingClientRect();
+        return {
+          gap: recent.top - chart.bottom,
+          chartHeight: chart.height,
+          recentTop: recent.top + document.querySelector('#main').scrollTop,
+        };
+      });
+    let states = 0;
+    for (const width of [900, 1200]) {
+      await page.setViewportSize({ width, height: width === 900 ? 600 : 800 });
+      for (const scale of [1, 1.5]) {
+        for (const theme of ['light', 'dark', 'light-hc', 'dark-hc']) {
+          await page.mouse.move(0, 0);
+          await page.evaluate(
+            ({ scale, theme }) => {
+              document.documentElement.dataset.theme = theme;
+              document.documentElement.style.setProperty('--ui-scale', String(scale));
+              const main = document.querySelector('#main');
+              main.scrollTop +=
+                document.querySelector('.activity-chart').getBoundingClientRect().top - 100;
+            },
+            { scale, theme },
+          );
+          const before = await geometry();
+          assert.equal(before.gap, 16, 'activity and recent events touch');
+          const bucket = chart.getByRole('button').filter({ hasText: /^$/ }).nth(16);
+          await bucket.hover();
+          assert.deepEqual(await geometry(), before, 'inspection moved adjacent content');
+          assert(
+            await chart.evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
+            'chart overflow',
+          );
+          await page.mouse.move(0, 0);
+          if (width === 900 && scale === 1.5)
+            await page.screenshot({ path: resolve(out, 'monitoring-activity-' + theme + '.png') });
+          if (width === 1200 && scale === 1)
+            await page.screenshot({ path: resolve(out, 'activity-overview-' + theme + '.png') });
+          states++;
+        }
+      }
+    }
+    const bucket = chart.locator('.chart-bucket').nth(16);
+    await bucket.hover();
+    const caption = await bucket.getAttribute('aria-label');
+    await page.waitForTimeout(2100);
+    assert.equal(await bucket.getAttribute('aria-label'), caption, 'hovered interval drifted');
+    const count = Number(caption.match(/(\d+) observations$/)[1]);
+    await bucket.click();
+    const dialog = page.getByRole('dialog');
+    await dialog.waitFor();
+    assert.equal(await dialog.locator('.observation-history [data-detail-focus]').count(), count);
+    await dialog.getByRole('button', { name: 'Close details', exact: true }).click();
+    await page.mouse.move(0, 0);
+    await chart.getByRole('button', { name: '5 min', exact: true }).click();
+    assert(await recent.isVisible());
+    assert.deepEqual(errors, []);
+    console.log(
+      'Monitoring activity: ' +
+        states +
+        ' layout states; separated panels, stable readout and exact held interval drill-down passed.',
+    );
+  } finally {
+    await page.close();
+  }
+}

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -4,6 +4,7 @@ import { readFile, readdir, mkdir, writeFile } from 'node:fs/promises';
 import { resolve, sep, extname } from 'node:path';
 import { chromium } from 'playwright';
 import { createHash } from 'node:crypto';
+import { checkActivity } from './activity-check.mjs';
 import { checkPagination } from './pagination-check.mjs';
 import { checkComfort } from './comfort-check.mjs';
 import { checkClarity } from './clarity-check.mjs';
@@ -391,6 +392,7 @@ try {
   await checkClarity(browser, base + '/desktop/', out);
   await checkResourceLayers(browser, base + '/desktop/', out);
   await checkDetails(browser, base + '/desktop/', out);
+  await checkActivity(browser, base + '/desktop/', out);
   await checkPagination(browser, base + '/desktop/', out);
   await checkComfort(browser, base + '/preview/', out);
   await checkGraphs(browser, base + '/preview/', out);

--- a/tests/renderer/components/ObservatoryActivityCorrectness.test.js
+++ b/tests/renderer/components/ObservatoryActivityCorrectness.test.js
@@ -134,3 +134,54 @@ it('advances and freezes timeline lanes independently of pushes while keeping fu
   mounted.unmount();
   expect(vi.getTimerCount()).toBe(0);
 });
+
+it('holds hovered and keyboard-selected interval boundaries until inspection ends', async () => {
+  clock();
+  const bounds = activityBins([], now + 1, 15 * 60000);
+  const rows = [event(bounds[5].start + 500)];
+  const inspect = vi.fn();
+  const mounted = renderChart({ events: rows, observedAt: now, inspect });
+  const plot = screen.getByRole('group', { name: 'File activity histogram' });
+  const buttons = within(plot).getAllByRole('button');
+  await fireEvent.pointerEnter(buttons[5]);
+  const initial = buttons[5].getAttribute('aria-label');
+  await vi.advanceTimersByTimeAsync(2000);
+  await tick();
+  expect(buttons[5]).toHaveAccessibleName(initial);
+  await fireEvent.click(buttons[5]);
+  expect(inspect).toHaveBeenLastCalledWith(
+    'Activity interval',
+    expect.objectContaining({
+      from: new Date(bounds[5].start).toISOString(),
+      to: new Date(bounds[5].end).toISOString(),
+      count: 1,
+      observations: rows,
+    }),
+  );
+  await fireEvent.pointerLeave(plot);
+  await tick();
+  expect(buttons[5].getAttribute('aria-label')).not.toBe(initial);
+  buttons[6].focus();
+  await tick();
+  const keyboard = buttons[6].getAttribute('aria-label');
+  await vi.advanceTimersByTimeAsync(2000);
+  await tick();
+  expect(buttons[6]).toHaveAccessibleName(keyboard);
+  buttons[6].blur();
+  await tick();
+  expect(buttons[6].getAttribute('aria-label')).not.toBe(keyboard);
+  mounted.unmount();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it('keeps an explicit agent filter when its retained events disappear', async () => {
+  clock();
+  const mounted = renderChart({ events: [event(now)], observedAt: now, inspect: vi.fn() });
+  await fireEvent.change(screen.getByLabelText('Chart agent'), { target: { value: 'Codex' } });
+  await mounted.rerender({ events: [event(now, { agent: 'Claude Code' })] });
+  expect(screen.getByLabelText('Chart agent')).toHaveValue('Codex');
+  expect(screen.getByRole('option', { name: /Codex.*no retained events/ })).toBeInTheDocument();
+  expect(total(mounted.container)).toBe('0');
+  await fireEvent.change(screen.getByLabelText('Chart agent'), { target: { value: '' } });
+  expect(total(mounted.container)).toBe('1');
+});


### PR DESCRIPTION
Monitoring Activity touched Recent events, and its histogram boundaries drifted while users inspected a bar. The panels now have a shared 16 px gap. Hover and keyboard focus hold the interval window until inspection ends, so a click opens the displayed interval. The readout reserves two lines without shifting adjacent content.

An agent filter remains explicit when its retained events disappear. Keyboard chart navigation avoids scrolling ancestors and leaves modifier shortcuts alone. Idle, paused and stale clock behavior remains covered by regression tests.

Validation: 3286 tests passed, 4 skipped; required build, format/lint, types/Svelte, coverage, witness/sequence gates, counts and production audit passed. Browser matrix and isolated Electron smoke passed. New activity checks cover 16 layouts, stable readout geometry and matching opened record counts.
