### PR TITLE
feat(ui): refine settings layout and precise controls

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -93,3 +93,15 @@ inspection ends, so its boundaries and opened observations agree. The readout
 reserves two lines to prevent adjacent content from moving. Idle live windows
 still advance; paused/stale windows remain frozen. An agent whose retained events
 expire stays explicitly selected until the user changes that filter.
+
+
+### Settings workspace refinement (2026-09-11)
+
+Settings retain four persistent sections and their draft while presenting each
+purpose as a labelled group with a description and consistent setting rows.
+Appearance previews are explicit; scale and scan interval offer precise numeric
+entry and presets without automatically saving. Invalid numbers block Save.
+Startup explains restart-sensitive options, update states use readable labels,
+and failed initial settings reads can be retried. The shared save/discard bar
+stays reachable with a distinct primary action and saving/reloading status.
+Provider credentials remain outside the generic settings form and exports.

--- a/frontend/observatory/components/Settings.svelte
+++ b/frontend/observatory/components/Settings.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import { onMount, tick } from 'svelte';
+  import { onMount, tick, untrack } from 'svelte';
   import { confirmed, invoke, record, type Host, type RecordData } from '../runtime/host';
   import Action from './Action.svelte';
   import Icon from './Icon.svelte';
-  import AgentLogo from './AgentLogo.svelte';
+  import SettingsGroup from './SettingsGroup.svelte';
+  import SettingsAppearance from './SettingsAppearance.svelte';
+  import SettingsMonitoring from './SettingsMonitoring.svelte';
   import SectionTabs from './SectionTabs.svelte';
   const id = $props.id();
   const tabs = [
@@ -50,13 +52,44 @@
   let ignored = $state('');
   let patternInput = $state<HTMLTextAreaElement>();
   let dirty = $derived(loaded && baseline !== snapshot());
+  let validation = $derived(
+    !loaded
+      ? ''
+      : !Number.isFinite(Number(form.scanIntervalSec ?? 10)) ||
+          Number(form.scanIntervalSec ?? 10) <= 0
+        ? 'Scan interval must be a positive number of seconds.'
+        : !Number.isFinite(Number(form.uiScale ?? 1)) ||
+            Number(form.uiScale ?? 1) < 0.5 ||
+            Number(form.uiScale ?? 1) > 3
+          ? 'Interface scale must be between 50% and 300%.'
+          : '',
+  );
+  const updateLabels: Record<string, string> = {
+    idle: 'Ready to check for updates',
+    checking: 'Checking for updates...',
+    available: 'An update is available',
+    'up-to-date': 'You are up to date',
+    downloading: 'Downloading update...',
+    ready: 'Update ready to install',
+    installing: 'Installing update...',
+    unsupported: 'Automatic updates are unavailable in this build',
+    error: 'Update could not be completed',
+  };
+  const startupHelp: Record<string, string> = {
+    startMinimized: 'Open in the system tray instead of showing the window.',
+    autoStartWithWindows: 'Launch AEGIS when you sign in to Windows.',
+    hardwareAcceleration:
+      'Use the GPU to draw the interface. Restart AEGIS after changing this setting.',
+  };
   let alive = true;
   let previousTheme: string | null = null;
   $effect(() => {
     if (loaded && currentTheme && currentTheme !== previousTheme) {
+      const clean = untrack(() => baseline === snapshot());
       previousTheme = currentTheme;
       form.darkMode = currentTheme.startsWith('dark');
       contrast = currentTheme.endsWith('-hc');
+      if (clean) baseline = untrack(snapshot);
     }
   });
   async function load() {
@@ -90,6 +123,7 @@
   }
   async function save() {
     if (mutation) throw new Error('A settings operation is already in progress');
+    if (validation) throw new Error(validation);
     mutation = 'save';
     refreshWarning = '';
     const submitted = { form: { ...form }, patterns, ignored, contrast, motion };
@@ -158,7 +192,7 @@
       if (alive && cause instanceof Error && /pattern|regex/i.test(cause.message)) {
         section = 'monitoring';
         await tick();
-        patternInput?.focus();
+        patternInput?.focus({ preventScroll: true });
       }
       throw cause;
     } finally {
@@ -197,8 +231,9 @@
       .then((value) => {
         if (alive && revision === 0) updates = record(value);
       })
-      .catch((e) => {
-        if (alive) error = String(e);
+      .catch(() => {
+        if (alive)
+          updates = { status: 'error', error: 'Could not read update status. Try checking again.' };
       });
     return () => {
       alive = false;
@@ -220,9 +255,24 @@
   ] as const;
 </script>
 
-{#if error}<p role="alert" class="notice">{error}</p>{/if}
+{#if error}<div class="notice">
+    <p role="alert">{error}</p>
+    <Action
+      action={async () => {
+        await load();
+        if (alive) error = '';
+      }}>Retry loading</Action
+    >
+  </div>{/if}
 {#if refreshWarning}<p role="status" class="notice">{refreshWarning}</p>{/if}
 <div class="settings-workspace panel">
+  <div class="settings-intro">
+    <div>
+      <h2>Application preferences</h2>
+      <p>Configure this workstation. Your draft stays here when you switch sections.</p>
+    </div>
+    <span class="badge">Local settings</span>
+  </div>
   <SectionTabs
     {tabs}
     selected={section}
@@ -241,51 +291,7 @@
       aria-labelledby={id + '-tab-appearance'}
       hidden={section !== 'appearance'}
     >
-      <div class="settings-section">
-        <label class="setting"
-          ><span>Theme</span><select
-            aria-label="Theme"
-            value={(form.darkMode ? 'dark' : 'light') + (contrast ? '-hc' : '')}
-            onchange={(e) => {
-              const theme = e.currentTarget.value;
-              form.darkMode = theme.startsWith('dark');
-              contrast = theme.endsWith('-hc');
-              document.documentElement.dataset.theme = theme;
-            }}
-            ><option value="dark">Dark</option><option value="light">Light</option><option
-              value="dark-hc">Dark, high contrast</option
-            ><option value="light-hc">Light, high contrast</option></select
-          ></label
-        >
-        <label class="setting range"
-          ><span>Scale <output>{Math.round(Number(form.uiScale ?? 1) * 100)}%</output></span><input
-            aria-label="Interface scale"
-            type="range"
-            min="0.8"
-            max="1.5"
-            step="0.05"
-            value={Number(form.uiScale ?? 1)}
-            oninput={(e) => {
-              form.uiScale = Number(e.currentTarget.value);
-              document.documentElement.style.setProperty('--ui-scale', String(form.uiScale));
-            }}
-          /></label
-        >
-        <label class="setting"
-          ><span>Animations<small>Radar sweep, markers and transitions</small></span><input
-            type="checkbox"
-            bind:checked={motion}
-            onchange={(event) => {
-              document.documentElement.dataset.motion = event.currentTarget.checked
-                ? 'full'
-                : 'reduce';
-            }}
-          /></label
-        >
-        <div class="setting">
-          <span>Language<small>English interface</small></span><span class="badge">English</span>
-        </div>
-      </div>
+      <SettingsAppearance bind:form bind:contrast bind:motion />
     </div>
     <div
       class="settings-page"
@@ -295,54 +301,7 @@
       aria-labelledby={id + '-tab-monitoring'}
       hidden={section !== 'monitoring'}
     >
-      <div class="settings-section">
-        <label class="setting range"
-          ><span>Scan interval <output>{String(form.scanIntervalSec ?? 10)} s</output></span><input
-            aria-label="Scan interval (seconds)"
-            type="range"
-            min="1"
-            max={Math.max(60, Number(form.scanIntervalSec ?? 10))}
-            step="1"
-            value={Number(form.scanIntervalSec ?? 10)}
-            oninput={(e) => (form.scanIntervalSec = Number(e.currentTarget.value))}
-          /></label
-        >
-        <div class="setting">
-          <label class="switch"
-            ><input
-              type="checkbox"
-              checked={form.notificationsEnabled === true}
-              onchange={(e) => (form.notificationsEnabled = e.currentTarget.checked)}
-            />Notifications</label
-          ><Action action={async () => confirmed(await invoke(host, 'testNotification'))}
-            ><Icon name="bell" />Test</Action
-          >
-        </div>
-        <label class="setting"
-          ><span>Exclude build folders</span><input
-            type="checkbox"
-            checked={form.ignoreCommonBuildDirs === true}
-            onchange={(e) => (form.ignoreCommonBuildDirs = e.currentTarget.checked)}
-          /></label
-        >
-        <label class="setting-stack"
-          >Additional exclusions<textarea
-            aria-label="Additional exclusions"
-            rows="3"
-            maxlength="10000"
-            bind:value={ignored}
-          ></textarea><small>One directory per line</small></label
-        >
-        <label class="setting-stack"
-          >Sensitive paths<textarea
-            bind:this={patternInput}
-            aria-label="Sensitive paths"
-            rows="3"
-            maxlength="10000"
-            bind:value={patterns}
-          ></textarea><small>One regular expression per line</small></label
-        >
-      </div>
+      <SettingsMonitoring bind:form bind:patterns bind:ignored bind:patternInput {host} />
     </div>
     <div
       class="settings-page"
@@ -352,27 +311,34 @@
       aria-labelledby={id + '-tab-desktop'}
       hidden={section !== 'desktop'}
     >
-      <div class="settings-section">
-        <h2><Icon name="monitor" /><span>Desktop startup</span></h2>
+      <SettingsGroup
+        title="Desktop startup"
+        description="Choose how AEGIS starts and renders its interface."
+      >
         {#each toggles.slice(2, 5) as [key, label] (key)}<label class="setting"
-            ><span>{label}</span><input
+            ><span>{label}<small>{startupHelp[key]}</small></span><input
               type="checkbox"
+              aria-label={label}
               checked={form[key] === true}
               onchange={(e) => (form[key] = e.currentTarget.checked)}
             /></label
           >{/each}
-      </div>
-      <div class="settings-section">
-        <h2><Icon name="refresh" /><span>Updates</span></h2>
+      </SettingsGroup>
+      <SettingsGroup
+        title="Updates"
+        description="Check for releases and choose when to install them."
+      >
         <label class="setting"
-          ><span>Check automatically</span><input
+          ><span
+            >Check automatically<small>Look for available releases in the background.</small></span
+          ><input
             type="checkbox"
             checked={form.automaticUpdatesEnabled === true}
             onchange={(e) => (form.automaticUpdatesEnabled = e.currentTarget.checked)}
           /></label
         >
         <p class="muted" role="status">
-          {String(updates.status ?? 'Loading')}
+          {updateLabels[String(updates.status)] ?? 'Update status unavailable'}
           {String(updates.version ?? '')}
         </p>
         {#if updates.notes}<p class="muted">{String(updates.notes)}</p>{/if}{#if updates.error}<p
@@ -385,7 +351,9 @@
           ></progress>{/if}
         <div class="toolbar">
           <Action
-            disabled={['checking', 'downloading'].includes(String(updates.status))}
+            disabled={['checking', 'downloading', 'installing', 'unsupported'].includes(
+              String(updates.status),
+            )}
             action={() => update('checkForUpdates')}
             ><Icon name="refresh" />Check for updates</Action
           >{#if updates.status === 'available'}<Action action={() => update('downloadUpdate')}
@@ -394,7 +362,7 @@
               >Install and restart</Action
             >{/if}
         </div>
-      </div>
+      </SettingsGroup>
     </div>
     <div
       class="settings-page"
@@ -404,8 +372,10 @@
       aria-labelledby={id + '-tab-data'}
       hidden={section !== 'data'}
     >
-      <div class="settings-section">
-        <h2><AgentLogo name="Claude Code" /><span>Anthropic analysis</span></h2>
+      <SettingsGroup
+        title="Anthropic analysis"
+        description="Manage the provider connection and analysis options in their dedicated workspace."
+      >
         <p class="muted">
           Connect Anthropic, review evidence and customize reports in the AI analysis workspace.
         </p>
@@ -414,11 +384,14 @@
             ><Icon name="shield" />Open AI analysis</button
           >
         </div>
-      </div>
-      <div class="settings-section">
-        <h2><Icon name="settings" /><span>Configuration</span></h2>
+      </SettingsGroup>
+      <SettingsGroup
+        title="Configuration"
+        description="Back up saved preferences or restore them from a configuration file."
+      >
         <p class="muted">
-          Export settings without the API key. Imports are checked for valid format and values.
+          Export contains saved settings without the API key. Import replaces saved preferences and
+          the current draft; imported values are validated.
         </p>
         <div class="toolbar">
           <Action action={async () => confirmed(await invoke(host, 'exportConfig'))}
@@ -427,9 +400,11 @@
             ><Icon name="upload" />Import</Action
           >
         </div>
-      </div>
-      <div class="settings-section">
-        <h2><Icon name="keyboard" /><span>Keyboard shortcuts</span></h2>
+      </SettingsGroup>
+      <SettingsGroup
+        title="Keyboard shortcuts"
+        description="Navigate AEGIS without leaving the keyboard."
+      >
         <dl class="details-grid">
           <dt>Commands</dt>
           <dd><kbd>Ctrl K</kbd></dd>
@@ -442,16 +417,25 @@
           <dt>Close dialog</dt>
           <dd><kbd>Esc</kbd></dd>
         </dl>
-      </div>
+      </SettingsGroup>
     </div>
   </fieldset>
+  {#if validation}<p class="notice" role="alert">{validation}</p>{/if}
   <div class="settings-save">
     <span class="settings-draft" role="status"
-      >{!loaded ? 'Loading settings…' : dirty ? 'Unsaved changes' : 'Settings saved'}</span
+      >{!loaded
+        ? 'Loading settings…'
+        : mutation === 'save'
+          ? 'Saving changes…'
+          : mutation === 'replace'
+            ? 'Reloading settings…'
+            : dirty
+              ? 'Unsaved changes'
+              : 'Settings saved'}</span
     >
     <Action disabled={!loaded || !dirty || mutation !== null} action={() => replaceSettings()}
       ><Icon name="close" />Discard changes</Action
-    ><Action disabled={!loaded || !dirty || mutation !== null} action={save}
+    ><Action disabled={!loaded || !dirty || mutation !== null || !!validation} action={save}
       ><Icon name="check" />Save settings</Action
     >
   </div>
@@ -464,7 +448,7 @@
   }
   .settings-workspace :global(.section-tabs) {
     position: sticky;
-    top: 0;
+    top: var(--workspace-sticky-offset, 70px);
     z-index: 3;
     background: var(--panel);
   }
@@ -477,22 +461,36 @@
   }
   .settings-page {
     min-width: 0;
+    display: grid;
+    gap: var(--space-4);
+    padding: var(--panel-inset);
+    min-height: 420px;
+    align-content: start;
+  }
+  .settings-intro {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--panel-inset);
+  }
+  .settings-intro h2 {
+    margin: 0;
+    font-size: var(--text-section);
+  }
+  .settings-intro p {
+    margin: var(--space-1) 0 0;
+    color: var(--muted);
+    font-size: var(--text-body);
+    line-height: 1.5;
+  }
+  .settings-intro .badge {
+    flex-shrink: 0;
   }
   .settings-page[hidden] {
     display: none;
   }
-  .setting {
-    margin: 16px 0;
-  }
-  .settings-section {
-    max-width: 860px;
-  }
-  .settings-section h2 {
-    font-size: calc(14px * var(--ui-scale));
-  }
-  .settings-section + .settings-section {
-    border-top: 1px solid var(--border);
-  }
+
   .settings-save {
     position: sticky;
     bottom: 0;
@@ -513,15 +511,16 @@
     margin-top: 12px;
   }
   @media (max-width: 700px) {
-    .settings-section {
-      padding: 16px;
-    }
-    .setting {
-      gap: 12px;
+    .settings-intro {
       flex-wrap: wrap;
     }
     .settings-save {
-      padding: 12px 16px;
+      padding: var(--space-3) var(--panel-inset);
     }
+  }
+  .settings-save :global(.action-control:last-child .button:not(:disabled)) {
+    background: var(--ink);
+    color: var(--bg);
+    border-color: var(--ink);
   }
 </style>

--- a/frontend/observatory/components/SettingsAppearance.svelte
+++ b/frontend/observatory/components/SettingsAppearance.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import type { RecordData } from '../runtime/host';
+  import SettingsGroup from './SettingsGroup.svelte';
+  let {
+    form = $bindable(),
+    contrast = $bindable(),
+    motion = $bindable(),
+  }: { form: RecordData; contrast: boolean; motion: boolean } = $props();
+</script>
+
+<SettingsGroup
+  title="Display & accessibility"
+  description="Theme, scale and motion preview immediately. Save to keep them; discard to restore your saved preferences."
+>
+  <label class="setting"
+    ><span>Theme<small>Choose a light, dark or high-contrast interface.</small></span><select
+      aria-label="Theme"
+      value={(form.darkMode ? 'dark' : 'light') + (contrast ? '-hc' : '')}
+      onchange={(e) => {
+        const theme = e.currentTarget.value;
+        form.darkMode = theme.startsWith('dark');
+        contrast = theme.endsWith('-hc');
+        document.documentElement.dataset.theme = theme;
+      }}
+      ><option value="dark">Dark</option><option value="light">Light</option><option value="dark-hc"
+        >Dark, high contrast</option
+      ><option value="light-hc">Light, high contrast</option></select
+    ></label
+  >
+  <label class="setting range"
+    ><span
+      >Scale <output
+        >{Number.isFinite(Number(form.uiScale ?? 1))
+          ? Math.round(Number(form.uiScale ?? 1) * 100) + '%'
+          : '\u2014'}</output
+      ></span
+    ><input
+      aria-label="Interface scale"
+      type="range"
+      min="0.8"
+      max="1.5"
+      step="0.05"
+      value={Number(form.uiScale ?? 1)}
+      oninput={(e) => {
+        form.uiScale = Number(e.currentTarget.value);
+        document.documentElement.style.setProperty('--ui-scale', String(form.uiScale));
+      }}
+    /></label
+  >
+  <div class="setting">
+    <span
+      >Exact scale<small
+        >Percentage of the default size. 80-150% is recommended for this layout.</small
+      ></span
+    >
+    <input
+      class="scale-number"
+      aria-label="Interface scale percent"
+      aria-invalid={!Number.isFinite(Number(form.uiScale ?? 1)) ||
+        Number(form.uiScale ?? 1) < 0.5 ||
+        Number(form.uiScale ?? 1) > 3}
+      type="number"
+      min="50"
+      max="300"
+      step="1"
+      value={Number(form.uiScale ?? 1) * 100}
+      oninput={(event) => {
+        const value = event.currentTarget.valueAsNumber / 100;
+        form.uiScale = value;
+        if (Number.isFinite(value) && value >= 0.5 && value <= 3)
+          document.documentElement.style.setProperty('--ui-scale', String(value));
+      }}
+    />
+  </div>
+  <div class="presets" role="group" aria-label="Scale presets">
+    {#each [1, 1.25, 1.5] as value (value)}<button
+        class="button"
+        aria-pressed={Number(form.uiScale ?? 1) === value}
+        onclick={() => {
+          form.uiScale = value;
+          document.documentElement.style.setProperty('--ui-scale', String(value));
+        }}>{Math.round(value * 100)}%</button
+      >{/each}
+  </div>
+  <label class="setting"
+    ><span
+      >Animations<small
+        >Radar motion and visual feedback. Reduced motion keeps the data available.</small
+      ></span
+    ><input
+      aria-label="Animations"
+      type="checkbox"
+      bind:checked={motion}
+      onchange={(event) => {
+        document.documentElement.dataset.motion = event.currentTarget.checked ? 'full' : 'reduce';
+      }}
+    /></label
+  >
+  <div class="setting">
+    <span>Language<small>English interface</small></span><span class="badge">English</span>
+  </div>
+</SettingsGroup>
+
+<style>
+  .scale-number {
+    width: 110px;
+    min-width: 0;
+  }
+</style>

--- a/frontend/observatory/components/SettingsGroup.svelte
+++ b/frontend/observatory/components/SettingsGroup.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  let { title, description, children }: { title: string; description: string; children: Snippet } =
+    $props();
+</script>
+
+<section class="settings-group" aria-label={title}>
+  <header>
+    <h2>{title}</h2>
+    <p>{description}</p>
+  </header>
+  <div class="group-fields">{@render children()}</div>
+</section>
+
+<style>
+  .settings-group {
+    min-width: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--surface-radius);
+    background: var(--panel);
+  }
+  header {
+    padding: var(--panel-inset);
+    border-bottom: 1px solid var(--border);
+  }
+  h2 {
+    margin: 0;
+    font-size: var(--text-section);
+  }
+  p {
+    margin: var(--space-1) 0 0;
+    color: var(--muted);
+    font-size: var(--text-caption);
+    line-height: 1.5;
+  }
+  .group-fields {
+    padding: 0 var(--panel-inset);
+  }
+  .group-fields :global(.setting) {
+    margin: 0;
+    padding: var(--space-4) 0;
+    gap: var(--space-4);
+    align-items: center;
+  }
+  .group-fields :global(.setting + .setting) {
+    border-top: 1px solid var(--border);
+  }
+  .group-fields :global(.setting > span:first-child) {
+    flex: 1;
+    min-width: 0;
+    font-size: var(--text-body);
+  }
+  .group-fields :global(.setting small),
+  .group-fields :global(.setting-stack small) {
+    color: var(--muted);
+    line-height: 1.5;
+    font-size: var(--text-caption);
+  }
+  .group-fields :global(.setting > select) {
+    width: 220px;
+    max-width: 45%;
+  }
+  .group-fields :global(.setting-stack) {
+    margin: var(--space-4) 0;
+  }
+  .group-fields :global(textarea) {
+    resize: vertical;
+    min-height: 90px;
+    font-family: var(--mono);
+  }
+  .group-fields :global(.setting input[type='checkbox']) {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    accent-color: var(--accent);
+  }
+  .group-fields :global(.setting.range) {
+    flex-wrap: wrap;
+  }
+  .group-fields :global(.setting.range input[type='range']) {
+    flex: 1;
+    min-width: 140px;
+  }
+  .group-fields :global(.setting.range input[type='number']) {
+    flex: 0 0 100px;
+    min-width: 0;
+    width: 100px;
+  }
+  .group-fields :global(.setting output) {
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+  }
+  .group-fields :global(.presets) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    padding: 0 0 var(--space-4);
+  }
+  .group-fields :global(.presets button[aria-pressed='true']) {
+    background: var(--hover);
+    border-color: var(--strong-border);
+  }
+  .group-fields :global(.toolbar) {
+    margin: var(--space-3) 0 var(--space-4);
+  }
+  .group-fields :global(.muted) {
+    font-size: var(--text-body);
+    line-height: 1.5;
+  }
+</style>

--- a/frontend/observatory/components/SettingsMonitoring.svelte
+++ b/frontend/observatory/components/SettingsMonitoring.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { confirmed, invoke, type Host, type RecordData } from '../runtime/host';
+  import SettingsGroup from './SettingsGroup.svelte';
+  import Action from './Action.svelte';
+  import Icon from './Icon.svelte';
+  let {
+    form = $bindable(),
+    patterns = $bindable(),
+    ignored = $bindable(),
+    patternInput = $bindable(),
+    host,
+  }: {
+    form: RecordData;
+    patterns: string;
+    ignored: string;
+    patternInput: HTMLTextAreaElement | undefined;
+    host: Host | null;
+  } = $props();
+</script>
+
+<SettingsGroup
+  title="Collection & notifications"
+  description="Control process scanning and desktop notifications. Changes apply after saving."
+>
+  <label class="setting range"
+    ><span
+      >Scan interval <output
+        >{Number.isFinite(Number(form.scanIntervalSec ?? 10))
+          ? String(form.scanIntervalSec ?? 10) + ' s'
+          : '\u2014'}</output
+      ><small
+        >Shorter intervals update processes more often and use more resources. File and network
+        sources have their own collection timing.</small
+      ></span
+    ><input
+      aria-label="Scan interval (seconds)"
+      type="range"
+      min="1"
+      max={Math.max(60, Number(form.scanIntervalSec ?? 10))}
+      step="1"
+      value={Number(form.scanIntervalSec ?? 10)}
+      oninput={(e) => (form.scanIntervalSec = Number(e.currentTarget.value))}
+    /></label
+  >
+  <div class="setting">
+    <span>Exact interval<small>Enter a positive number of seconds.</small></span>
+    <input
+      class="interval-number"
+      aria-label="Exact scan interval (seconds)"
+      aria-invalid={!Number.isFinite(Number(form.scanIntervalSec ?? 10)) ||
+        Number(form.scanIntervalSec ?? 10) <= 0}
+      type="number"
+      min="1"
+      step="1"
+      value={Number(form.scanIntervalSec ?? 10)}
+      oninput={(event) => (form.scanIntervalSec = event.currentTarget.valueAsNumber)}
+    />
+  </div>
+  <div class="presets" role="group" aria-label="Scan interval presets">
+    {#each [1, 5, 10, 30] as seconds (seconds)}<button
+        class="button"
+        aria-pressed={Number(form.scanIntervalSec ?? 10) === seconds}
+        onclick={() => (form.scanIntervalSec = seconds)}
+        >{seconds} s{seconds === 10 ? ' (default)' : ''}</button
+      >{/each}
+  </div>
+  <div class="setting">
+    <label class="switch"
+      ><input
+        type="checkbox"
+        checked={form.notificationsEnabled === true}
+        onchange={(e) => (form.notificationsEnabled = e.currentTarget.checked)}
+      />Notifications</label
+    ><Action action={async () => confirmed(await invoke(host, 'testNotification'))}
+      ><Icon name="bell" />Test</Action
+    >
+  </div>
+</SettingsGroup>
+<SettingsGroup
+  title="File coverage"
+  description="Choose which directories the file watcher skips and which additional paths count as sensitive."
+>
+  <label class="setting"
+    ><span
+      >Exclude build folders<small>Skip common generated folders to reduce file-event noise.</small
+      ></span
+    ><input
+      type="checkbox"
+      aria-label="Exclude build folders"
+      checked={form.ignoreCommonBuildDirs === true}
+      onchange={(e) => (form.ignoreCommonBuildDirs = e.currentTarget.checked)}
+    /></label
+  >
+  <label class="setting-stack"
+    >Additional exclusions<textarea
+      aria-label="Additional exclusions"
+      rows="3"
+      maxlength="10000"
+      bind:value={ignored}
+    ></textarea><small>One directory path per line. Empty means no additional exclusions.</small
+    ></label
+  >
+  <label class="setting-stack"
+    >Sensitive paths<textarea
+      bind:this={patternInput}
+      aria-label="Sensitive paths"
+      rows="3"
+      maxlength="10000"
+      bind:value={patterns}
+    ></textarea><small
+      >One regular expression per line. Adds sensitive-path matches; built-in rules remain active.</small
+    ></label
+  >
+</SettingsGroup>
+
+<style>
+  .interval-number {
+    width: 110px;
+    min-width: 0;
+  }
+</style>

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -4,6 +4,7 @@ import { readFile, readdir, mkdir, writeFile } from 'node:fs/promises';
 import { resolve, sep, extname } from 'node:path';
 import { chromium } from 'playwright';
 import { createHash } from 'node:crypto';
+import { checkSettings } from './settings-check.mjs';
 import { checkActivity } from './activity-check.mjs';
 import { checkPagination } from './pagination-check.mjs';
 import { checkComfort } from './comfort-check.mjs';
@@ -392,6 +393,7 @@ try {
   await checkClarity(browser, base + '/desktop/', out);
   await checkResourceLayers(browser, base + '/desktop/', out);
   await checkDetails(browser, base + '/desktop/', out);
+  await checkSettings(browser, base + '/desktop/', out);
   await checkActivity(browser, base + '/desktop/', out);
   await checkPagination(browser, base + '/desktop/', out);
   await checkComfort(browser, base + '/preview/', out);

--- a/frontend/observatory/tests/comfort-check.mjs
+++ b/frontend/observatory/tests/comfort-check.mjs
@@ -114,10 +114,13 @@ export async function checkComfort(browser, url, out) {
       'true',
     );
     await page.getByRole('tab', { name: 'Monitoring', exact: true }).click();
-    await page.getByLabel('Scan interval (seconds)').fill('17');
+    await page.getByLabel('Scan interval (seconds)', { exact: true }).fill('17');
     await navigate('Events');
     await navigate('Settings');
-    assert.equal(await page.getByLabel('Scan interval (seconds)').inputValue(), '17');
+    assert.equal(
+      await page.getByLabel('Scan interval (seconds)', { exact: true }).inputValue(),
+      '17',
+    );
     await page.getByRole('button', { name: 'Discard changes', exact: true }).click();
     await navigate('Monitoring');
     await page.keyboard.press('Control+k');

--- a/frontend/observatory/tests/electron-smoke.mjs
+++ b/frontend/observatory/tests/electron-smoke.mjs
@@ -156,7 +156,7 @@ try {
   }
   await window.getByLabel('Theme', { exact: true }).selectOption('light-hc');
   await window.getByRole('tab', { name: 'Monitoring', exact: true }).click();
-  await window.getByLabel('Scan interval (seconds)').evaluate((input) => {
+  await window.getByLabel('Scan interval (seconds)', { exact: true }).evaluate((input) => {
     input.value = '20';
     input.dispatchEvent(new Event('input', { bubbles: true }));
   });

--- a/frontend/observatory/tests/settings-check.mjs
+++ b/frontend/observatory/tests/settings-check.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+/** Verify settings layout, precise draft edits and persistence controls.
+ * @param {import('playwright').Browser} browser Browser @param {string} url Desktop build
+ * @param {string} out Screenshot directory @returns {Promise<void>} Verified settings @since 0.14.1
+ */
+export async function checkSettings(browser, url, out) {
+  const page = await browser.newPage();
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  try {
+    await page.addInitScript(() => {
+      let saved = {
+        darkMode: true,
+        uiScale: 1,
+        scanIntervalSec: 10,
+        notificationsEnabled: true,
+        ignoreCommonBuildDirs: true,
+        hardwareAcceleration: true,
+        automaticUpdatesEnabled: true,
+        ignoredDirectories: [],
+        customSensitivePatterns: [],
+        anthropicApiKey: 'DO-NOT-DISPLAY',
+      };
+      window.settingsWrites = [];
+      window.aegis = new Proxy(
+        {},
+        {
+          get: (_, name) => {
+            if (name.startsWith('on')) return () => () => {};
+            return async (patch) => {
+              if (name === 'getSettings') return { ...saved };
+              if (name === 'getUpdateStatus') return { status: 'idle' };
+              if (name === 'getFalsePositives') return [];
+              if (name === 'saveSettings') {
+                window.settingsWrites.push(patch);
+                saved = { ...saved, ...patch };
+                return { success: true };
+              }
+              return {};
+            };
+          },
+        },
+      );
+    });
+    await page.goto(url + '?view=settings');
+    await page.getByText('Settings saved', { exact: true }).waitFor();
+    const workspace = page.locator('.settings-workspace');
+    let states = 0;
+    for (const width of [900, 1200]) {
+      await page.setViewportSize({ width, height: width === 900 ? 600 : 800 });
+      for (const scale of [1, 1.5]) {
+        for (const theme of ['light', 'dark', 'light-hc', 'dark-hc']) {
+          await page.evaluate(
+            ({ scale, theme }) => {
+              document.documentElement.style.setProperty('--ui-scale', String(scale));
+              document.documentElement.dataset.theme = theme;
+            },
+            { scale, theme },
+          );
+          for (const name of ['Appearance', 'Monitoring', 'Desktop & updates', 'Data & help']) {
+            await page.locator('#main').evaluate((node) => {
+              node.scrollTop = 0;
+            });
+            const tab = workspace.getByRole('tab', { name, exact: true });
+            await tab.click();
+            assert(await tab.evaluate((node) => document.activeElement === node));
+            assert.equal(await workspace.getByRole('tabpanel').count(), 1);
+            assert(
+              await workspace.evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
+              name + ' overflows',
+            );
+            assert(
+              await page
+                .locator('#main')
+                .evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
+              name + ' overflows main',
+            );
+            const footer = workspace.locator('.settings-save');
+            assert(
+              await footer.evaluate((node) => {
+                const box = node.getBoundingClientRect();
+                const main = document.querySelector('#main').getBoundingClientRect();
+                return box.bottom <= main.bottom + 1 && box.top >= main.top;
+              }),
+              name + ' save bar is unreachable',
+            );
+            assert(!/DO-NOT-DISPLAY/.test(await workspace.innerText()));
+            if (
+              !theme.endsWith('-hc') &&
+              ((width === 900 && scale === 1.5) || (width === 1200 && scale === 1))
+            ) {
+              await page.screenshot({
+                path: resolve(
+                  out,
+                  'settings-' +
+                    name.split(' ')[0].toLowerCase() +
+                    '-' +
+                    width +
+                    '-' +
+                    theme +
+                    '.png',
+                ),
+              });
+            }
+            states++;
+          }
+        }
+      }
+    }
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await workspace.getByRole('tab', { name: 'Appearance', exact: true }).click();
+    await page.getByLabel('Interface scale percent', { exact: true }).fill('125');
+    await workspace.getByRole('tab', { name: 'Monitoring', exact: true }).click();
+    await page.getByLabel('Exact scan interval (seconds)', { exact: true }).fill('0');
+    assert(await page.getByRole('button', { name: 'Save settings', exact: true }).isDisabled());
+    await page.getByLabel('Exact scan interval (seconds)', { exact: true }).fill('17');
+    assert.deepEqual(await page.evaluate(() => window.settingsWrites), []);
+    await page.getByRole('button', { name: 'Save settings', exact: true }).click();
+    await page.getByText('Settings saved', { exact: true }).waitFor();
+    assert.deepEqual(await page.evaluate(() => window.settingsWrites), [
+      { uiScale: 1.25, scanIntervalSec: 17 },
+    ]);
+    assert.deepEqual(errors, []);
+    console.log(
+      'Settings: ' +
+        states +
+        ' layouts; persistent save bar, numeric validation, previews and exact patch saving passed.',
+    );
+  } finally {
+    await page.close();
+  }
+}

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -37,7 +37,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (frontend/observatory/) — Svelte 5 + Vite 7
-46 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
+49 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
 
 App.svelte owns workspace tabs, history and the host connection. Monitoring groups products and exposes stamped instances for process actions; Events and ActivityChart show retained evidence; Details and EntityLinks connect observations; Rules, Catalog, Analysis, Reports, Statistics and Settings expose host actions. SensorStatus renders effective sensor IDs; Notifications tracks anomaly crossings.
 

--- a/tests/renderer/components/ObservatorySettingsPatch.test.js
+++ b/tests/renderer/components/ObservatorySettingsPatch.test.js
@@ -223,3 +223,73 @@ it('does not replay saved appearance over a newer global theme or scale preview'
   expect(appearance).not.toHaveBeenCalled();
   expect(second.getByText('Unsaved changes')).toBeInTheDocument();
 });
+
+it('blocks invalid exact values and saves valid interval and scale changes as a patch', async () => {
+  const host = sharedHost();
+  mountSettings(host);
+  await screen.findByText('Settings saved');
+  await fireEvent.input(screen.getByLabelText('Interface scale percent'), {
+    target: { value: '125' },
+  });
+  expect(document.documentElement.style.getPropertyValue('--ui-scale')).toBe('1.25');
+  await fireEvent.click(screen.getByRole('tab', { name: 'Monitoring' }));
+  const exact = screen.getByLabelText('Exact scan interval (seconds)');
+  await fireEvent.input(exact, { target: { value: '' } });
+  expect(exact).toHaveAttribute('aria-invalid', 'true');
+  expect(screen.getByRole('button', { name: 'Save settings' })).toBeDisabled();
+  expect(screen.getByRole('alert')).toHaveTextContent('positive number');
+  expect(host.saveSettings).not.toHaveBeenCalled();
+  await fireEvent.input(exact, { target: { value: '17' } });
+  expect(exact).toHaveAttribute('aria-invalid', 'false');
+  await fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
+  await screen.findByText('Completed');
+  expect(host.saveSettings).toHaveBeenCalledExactlyOnceWith(
+    { uiScale: 1.25, scanIntervalSec: 17 },
+    { patch: true },
+  );
+});
+
+it('keeps presets as a draft and restores their preview when discarded', async () => {
+  const host = sharedHost();
+  const appearance = vi.fn();
+  mountSettings(host, { appearance });
+  await screen.findByText('Settings saved');
+  const savedTheme = screen.getByLabelText('Theme').value;
+  await fireEvent.click(screen.getByRole('button', { name: '125%', exact: true }));
+  expect(screen.getByLabelText('Interface scale percent')).toHaveValue(125);
+  await fireEvent.click(screen.getByRole('tab', { name: 'Monitoring' }));
+  await fireEvent.click(screen.getByRole('button', { name: '5 s', exact: true }));
+  expect(screen.getByLabelText('Exact scan interval (seconds)')).toHaveValue(5);
+  expect(host.saveSettings).not.toHaveBeenCalled();
+  await fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+  await waitFor(() =>
+    expect(screen.getByLabelText('Exact scan interval (seconds)')).toHaveValue(10),
+  );
+  expect(appearance).toHaveBeenLastCalledWith(
+    savedTheme.startsWith('dark'),
+    1,
+    savedTheme.endsWith('-hc'),
+  );
+});
+
+it('recovers a failed settings load without reloading the workspace', async () => {
+  const host = sharedHost();
+  host.getSettings.mockRejectedValueOnce(new Error('Settings temporarily unavailable'));
+  mountSettings(host);
+  await screen.findByRole('alert');
+  await fireEvent.click(screen.getByRole('button', { name: 'Retry loading' }));
+  await screen.findByText('Settings saved');
+  await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  expect(screen.getByLabelText('Theme')).toBeEnabled();
+});
+
+it('does not create a dirty draft when the initial shell theme settles after loading', async () => {
+  localStorage.setItem('aegis-theme', 'light');
+  const host = sharedHost();
+  mountSettings(host, { currentTheme: 'dark' });
+  await waitFor(() => expect(screen.getByLabelText('Theme')).toHaveValue('dark'));
+  expect(screen.getByText('Settings saved')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Save settings' })).toBeDisabled();
+  expect(host.saveSettings).not.toHaveBeenCalled();
+  localStorage.removeItem('aegis-theme');
+});


### PR DESCRIPTION
Settings now group related preferences with consistent rows and descriptions. Users can enter exact interface scale and scan intervals or choose presets, preview appearance, and save or discard a draft that persists across sections. Invalid numeric values prevent saving, initial-load failures can be retried, and initial theme synchronization no longer creates a false unsaved draft.

Validation: 3290 tests passed (4 skipped); renderer and preview builds; format, lint, TypeScript and Svelte checks; both verification gates and derived counts; production dependency audit. Browser checks include 64 settings layouts plus existing UI regressions. Electron smoke verified persistence after restart and key-free configuration export/import.
