### PR TITLE
feat(etw): measure collector and main service intervals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The desktop and preview share `frontend/observatory/`. Read its `AGENTS.md` and 
 
 ## Project facts
 
-`src/main/` contains 74 main modules: 56 top-level + platform/ 16 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
+`src/main/` contains 75 main modules: 56 top-level + platform/ 17 + token-adapters/ 2. Platform-specific operations live in `src/main/platform/`. `src/main/preload.js` exposes 44 invoke + 10 push = 54 IPC channels through contextBridge. `src/shared/types/` contains 9 TS files. These counts are derived by `npm run counts:check`.
 
 A birth time is observed on the pass that stamps it or is `null`; no cache stores one. A snapshot outage freezes sessions and never splits them. For changes touching identity stamping, the audit chain, or the Windows git worktree flow, `memory-bank/ai-mistakes.md` holds the relevant failure history.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,7 +118,12 @@ The dependency is those observations, not the absence of a Windows host.
    adds protocol v3 cause counters and single-pass encoding. Managed batch
    allocation fell about 54% in a controlled test; the new live run recorded
    51,648 output overflow drops and zero invalidation/ingress/native loss.
-   Next separate encoding service time from transport/main waits and idle polling.
+   The [service measurements](docs/roadmap/etw-service-timings.md) now add v4 bounded
+   collector/main timing and stage queue depths. The same workload retained 52,066
+   output overflow drops; non-write pump work took 49.225 ms, writes 124.442 ms,
+   and empty-pump waits averaged 15.587 ms. Next test an output-available wakeup
+   with existing cancellation/drain bounds; these aggregates alone do not prove
+   that polling caused the overflow.
 
 ## C — existing rules coverage
 

--- a/docs/current-state/CORRECTNESS-AUDIT.md
+++ b/docs/current-state/CORRECTNESS-AUDIT.md
@@ -68,7 +68,7 @@ has to remember to redo. The evidence-code row is not covered and still is one.
 | Agents | `node -p` over `src/shared/agent-database.json` | **110** |
 | Name signatures | sum of `names[]` in the same file | **262** |
 | Rules / YAML files | `- id:` matches in `rules/*.yaml`; `git ls-files 'rules/'` | **73** / **8** |
-| main CJS modules | `git ls-files 'src/main/'` split by depth | **74** = 56 top-level + 16 `platform/` + 2 `token-adapters/` |
+| main CJS modules | `git ls-files 'src/main/'` split by depth | **75** = 56 top-level + 17 `platform/` + 2 `token-adapters/` |
 | Svelte components | `git ls-files 'src/renderer/lib/components/*.svelte'` | **50** (plus `src/renderer/App.svelte` → **51** tracked `.svelte` in total) |
 | Renderer stores | `git ls-files 'src/renderer/lib/stores/'` | **16** files (4 of them demo-only) |
 | Renderer utils | `git ls-files 'src/renderer/lib/utils/'` | **21** files |

--- a/docs/recon/evidence/etw-file-home-26200-service-timings.json
+++ b/docs/recon/evidence/etw-file-home-26200-service-timings.json
@@ -1,0 +1,2144 @@
+{
+  "schema": 1,
+  "recordedAt": "2026-09-10T23:28:29.711Z",
+  "scope": "Protocol v4 collector/main elapsed-time aggregates and stage queue depths. Measurement only; E3 remains open.",
+  "sourceBaseCommit": "40062686d7c53f1a2d9418c5e246894cfadf7ce2",
+  "sourceHashNormalization": "UTF-8 bytes with CRLF normalized to LF; source hashes match the checked working tree and staged implementation",
+  "sourceHashes": {
+    "scripts/etw-file-load.mjs": "60e7591651b065d46adbff3581b24729068bd5b699e6061c78f82c925fc0e585",
+    "scripts/etw-file-workload.mjs": "d889fab260036c8326fe5751bca6e4908855bd3c9c001366e11529fcf910579c",
+    "scripts/verify-etw-file.mjs": "0425ee226e679030ac35664f9114501581016f61cabce6c492ac93d05b4a8ebf",
+    "sidecar/etw-file/EtwFile.csproj": "9e34c6ad37d5751758d618095cf6b32ae54d90382855ece0b622fa2588589205",
+    "sidecar/etw-file/FileBroker.cs": "1997937dc7d337ac3c2ad8db031dbc0ba8d2b67263a385c037962aec18ee6d3a",
+    "sidecar/etw-file/FileBurstTests.cs": "427b039cbc288791ee5671087a11bed210913193c38d67c5079fe8e2d458be01",
+    "sidecar/etw-file/FileCapture.cs": "318d80a666392cbf1ab3b03666b1fec28f1d57e958229f0e050a639bb1726dc3",
+    "sidecar/etw-file/FileCollector.cs": "60dbeb5625eaa5a177dff26fe13571d30f162a5066d87890fe320dbc31f17360",
+    "sidecar/etw-file/FileGeneration.cs": "8520aa3bda23ee51bf6efe556f7aa72a2b31fa75f2cd7d8dd2077047369ff768",
+    "sidecar/etw-file/FileLossFixture.cs": "ab4210f402d278ea51ae23e978104ec6e91fb6f2be7cb225579424c193a1cda0",
+    "sidecar/etw-file/FileMapping.cs": "c0c2975837899e9e820328a8cd638e24c183ab0c3d36d9c0cb58cc936855922c",
+    "sidecar/etw-file/FileOutputTests.cs": "aadc58212ee9272dabcad4cf1932a3b6683941c50e138f701b4de6a468016ae9",
+    "sidecar/etw-file/FilePerformance.cs": "72cc842004a0b71f89c606de30f68694458fea25abb681b126b2ce9b834d60a8",
+    "sidecar/etw-file/FilePerformanceTests.cs": "dae11e9b91e575759e10061593a057830dcfa61a37a83cf871d87b2de3cc7b89",
+    "sidecar/etw-file/FilePipeline.cs": "bdc7804b84e04a15c0ae92d9caf27eb43df23edf71ae1a55222d3e310681815f",
+    "sidecar/etw-file/FileScope.cs": "05976472d37b07c60be71aedb6fb89da795ba0a41d527a3b41d244bd5aee5ca0",
+    "sidecar/etw-file/FileTests.cs": "8f6ff69c68433cffe25033731caeec0bbb60743e41c27112dc63d9a1a6aa4819",
+    "sidecar/etw-file/FileTrace.cs": "25fd9d2f46a0d66c01610a1c4a5b03bc6042af654e6bcd2cdf85ec69e94c4dc6",
+    "sidecar/etw-file/FileWire.cs": "179c133478a45ef80e5d3e59b4882433cca88334ae5c46ae21120587553170fa",
+    "sidecar/etw-file/Program.cs": "578502da3372353dc8316d3c53eb56ecdf6bb4b1162436891903deb572e54092",
+    "sidecar/etw-lifecycle/Security.cs": "19fde5ace53914b1e8804b9716a2d041d794e09b273bd8acc385405ba6fadc96",
+    "src/main/platform/etw-file-diagnostics.js": "3b9d801d899ee6c04b14d000df9bb344bb1026b97d9fc51385de0bd4aa90fc87",
+    "src/main/platform/etw-file-health.js": "d164d2c1cf2b4e262813c8c89a93e547412432a8909b3f46245159c9c8757e7c",
+    "src/main/platform/etw-file-protocol.js": "e44f18e5827a8dcce3fbcb2f5074b7f97fb7eeaed1c981a15b8c5d12f01b94e8",
+    "src/main/platform/etw-file-schema.js": "6452d6042a3fff92954f5f90c3a4c838158658726b625c2cac615565e5a713b9",
+    "src/main/platform/etw-file-supervisor.js": "83415935a9e7d662f859afb61cacf609b2b45bb5b49d52aa1f3434ae3816bfb9"
+  },
+  "host": {
+    "edition": "Windows 11 Home",
+    "version": "25H2",
+    "build": "26200.8655",
+    "node": "v24.11.1"
+  },
+  "preflight": {
+    "normalTokenParent": true,
+    "matchingNormalLossAndLiveBinaries": true,
+    "matchingBaselineWorkloadModulesAndProfile": true,
+    "priorHelpers": 0
+  },
+  "selfTests": {
+    "passed": 39,
+    "logSha256": "052e0e7f837fc42535dc8a9e6d9e57d84496d28fbdef0be0a98360948fc85ad1"
+  },
+  "normal": {
+    "file": "aegis-etw-timings-normal-20260911.json",
+    "sha256": "02fe3fc3019d1e15c5250ef2a0e9786a7c6031cc70f27172de1c8f259d5cd3fd",
+    "report": {
+      "schema": 1,
+      "live": false,
+      "synthetic": true,
+      "protocol": "etw-file/4",
+      "lossCheck": false,
+      "loadCheck": false,
+      "startedAt": "2026-09-10T23:26:49.428Z",
+      "binarySha256": "f1c4db38a3019d4ef47b77d913cbf3d9bf4dddfd0af31297b3efcea763f988e1",
+      "assemblySha256": "82308218d20c6ee287acf7f5cb677233df48fbc07179d8c34c81ce57f602a3a1",
+      "cases": [
+        {
+          "kind": "normal-stop",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 1617,
+          "ringDropped": 0,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "4efd0568-aea0-40fe-9985-a13106acf7ca",
+            "sessionId": "4d869ad7-14fe-4853-81de-26b43de17221",
+            "endedAt": 1789082809896,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "283563549952",
+                "unixMs": "1789082809754",
+                "uncertaintyQpc": "10510"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "283562573717"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "283564730456",
+              "pump": {
+                "calls": "8",
+                "totalTicks": "88742",
+                "maxTicks": "87814",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "1",
+                "totalTicks": "4089",
+                "maxTicks": "4089",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "6",
+                "totalTicks": "913143",
+                "maxTicks": "155016",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 2,
+                "highWaterBytes": 713
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "28356497105700",
+              "decodeChunk": {
+                "calls": "5",
+                "totalTicks": "4066400",
+                "maxTicks": "1328000",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "4",
+                "totalTicks": "2598200",
+                "maxTicks": "845600",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "1",
+                "totalTicks": "169000",
+                "maxTicks": "169000",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "19",
+                "totalTicks": "1637500",
+                "maxTicks": "204400",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "explicit-new-session",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 1617,
+          "ringDropped": 0,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "ca897325-dccd-4bbc-a97d-6a39ddfe6778",
+            "sessionId": "9ae200c2-355e-441c-a2dc-e4aa83f0ef8b",
+            "endedAt": 1789082810364,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "283568230164",
+                "unixMs": "1789082810223",
+                "uncertaintyQpc": "10492"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "283567320964"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "283569428053",
+              "pump": {
+                "calls": "8",
+                "totalTicks": "74678",
+                "maxTicks": "74191",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "1",
+                "totalTicks": "1835",
+                "maxTicks": "1835",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "6",
+                "totalTicks": "956988",
+                "maxTicks": "185521",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 2,
+                "highWaterBytes": 713
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "28356964772500",
+              "decodeChunk": {
+                "calls": "6",
+                "totalTicks": "1407800",
+                "maxTicks": "505600",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "4",
+                "totalTicks": "827500",
+                "maxTicks": "320400",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "1",
+                "totalTicks": "78100",
+                "maxTicks": "78100",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "18",
+                "totalTicks": "1744600",
+                "maxTicks": "206800",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "parent-eof-unverified",
+          "summary": {
+            "launchId": "495f3f6c-6d81-4794-bd37-aff280249b39",
+            "sessionId": "46cdb19d-368f-407f-afe1-135bb8c6978a",
+            "endedAt": 1789082810754,
+            "phase": "failed",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain",
+              "stream-ended"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "283572873217",
+                "unixMs": "1789082810687",
+                "uncertaintyQpc": "10756"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "283571745777"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "283572960964",
+              "pump": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 2,
+                "highWaterBytes": 713
+              },
+              "output": {
+                "records": 1,
+                "bytes": 2182,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "28357354722500",
+              "decodeChunk": {
+                "calls": "3",
+                "totalTicks": "826300",
+                "maxTicks": "401800",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "2",
+                "totalTicks": "424900",
+                "maxTicks": "259600",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "14",
+                "totalTicks": "2140700",
+                "maxTicks": "368700",
+                "failed": "0"
+              }
+            },
+            "stopReason": null,
+            "exitCode": 2,
+            "stopVerified": false
+          }
+        }
+      ],
+      "passed": true,
+      "observationCheck": {
+        "observed": true,
+        "named": true,
+        "fixtureRead": false,
+        "leaked": false
+      },
+      "endedSessions": [
+        {
+          "launchId": "4efd0568-aea0-40fe-9985-a13106acf7ca",
+          "sessionId": "4d869ad7-14fe-4853-81de-26b43de17221",
+          "endedAt": 1789082809896,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "283563549952",
+              "unixMs": "1789082809754",
+              "uncertaintyQpc": "10510"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "283562573717"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "283564730456",
+            "pump": {
+              "calls": "8",
+              "totalTicks": "88742",
+              "maxTicks": "87814",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "1",
+              "totalTicks": "4089",
+              "maxTicks": "4089",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "6",
+              "totalTicks": "913143",
+              "maxTicks": "155016",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "28356497105700",
+            "decodeChunk": {
+              "calls": "5",
+              "totalTicks": "4066400",
+              "maxTicks": "1328000",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "2598200",
+              "maxTicks": "845600",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "169000",
+              "maxTicks": "169000",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "19",
+              "totalTicks": "1637500",
+              "maxTicks": "204400",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "ca897325-dccd-4bbc-a97d-6a39ddfe6778",
+          "sessionId": "9ae200c2-355e-441c-a2dc-e4aa83f0ef8b",
+          "endedAt": 1789082810364,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "283568230164",
+              "unixMs": "1789082810223",
+              "uncertaintyQpc": "10492"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "283567320964"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "283569428053",
+            "pump": {
+              "calls": "8",
+              "totalTicks": "74678",
+              "maxTicks": "74191",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "1",
+              "totalTicks": "1835",
+              "maxTicks": "1835",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "6",
+              "totalTicks": "956988",
+              "maxTicks": "185521",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "28356964772500",
+            "decodeChunk": {
+              "calls": "6",
+              "totalTicks": "1407800",
+              "maxTicks": "505600",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "827500",
+              "maxTicks": "320400",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "78100",
+              "maxTicks": "78100",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "18",
+              "totalTicks": "1744600",
+              "maxTicks": "206800",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "495f3f6c-6d81-4794-bd37-aff280249b39",
+          "sessionId": "46cdb19d-368f-407f-afe1-135bb8c6978a",
+          "endedAt": 1789082810754,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "283572873217",
+              "unixMs": "1789082810687",
+              "uncertaintyQpc": "10756"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "283571745777"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "283572960964",
+            "pump": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 1,
+              "bytes": 2182,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "28357354722500",
+            "decodeChunk": {
+              "calls": "3",
+              "totalTicks": "826300",
+              "maxTicks": "401800",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "2",
+              "totalTicks": "424900",
+              "maxTicks": "259600",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "14",
+              "totalTicks": "2140700",
+              "maxTicks": "368700",
+              "failed": "0"
+            }
+          },
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      ],
+      "endedAt": "2026-09-10T23:26:50.777Z"
+    }
+  },
+  "lossCheck": {
+    "file": "aegis-etw-timings-loss-20260911.json",
+    "sha256": "1f418f35c6735f6ff72bb169bc932e6774128a880158a26cc445cc344039e816",
+    "report": {
+      "schema": 1,
+      "live": false,
+      "synthetic": true,
+      "protocol": "etw-file/4",
+      "lossCheck": true,
+      "loadCheck": false,
+      "startedAt": "2026-09-10T23:26:50.862Z",
+      "binarySha256": "f1c4db38a3019d4ef47b77d913cbf3d9bf4dddfd0af31297b3efcea763f988e1",
+      "assemblySha256": "82308218d20c6ee287acf7f5cb677233df48fbc07179d8c34c81ce57f602a3a1",
+      "cases": [
+        {
+          "kind": "normal-stop",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 412928,
+          "ringDropped": 32,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "88b30985-87dc-4610-9fb4-9a6da6241b27",
+            "sessionId": "fb908384-ff65-4964-bb11-71da8ec68f85",
+            "endedAt": 1789082811611,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "dropped",
+              "ingressDropped",
+              "outputDropped",
+              "outputOverflowDropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "283580660717",
+                "unixMs": "1789082811466",
+                "uncertaintyQpc": "10786"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "283576988581"
+            },
+            "finalTotals": {
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 32,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "283581829618",
+              "pump": {
+                "calls": "28",
+                "totalTicks": "993424",
+                "maxTicks": "100708",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "27",
+                "totalTicks": "818417",
+                "maxTicks": "40361",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 4096,
+                "highWaterBytes": 1048576
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "28358212271300",
+              "decodeChunk": {
+                "calls": "31",
+                "totalTicks": "22356700",
+                "maxTicks": "2113200",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "30",
+                "totalTicks": "9605000",
+                "maxTicks": "1098900",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "4",
+                "totalTicks": "1690900",
+                "maxTicks": "479200",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "28",
+                "totalTicks": "5611400",
+                "maxTicks": "976900",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "explicit-new-session",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 412928,
+          "ringDropped": 32,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "eb060ec5-69ed-493f-a043-f54bed1b45c5",
+            "sessionId": "56662aa4-22b7-467f-85d7-b71ae16c6948",
+            "endedAt": 1789082812329,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "dropped",
+              "ingressDropped",
+              "outputDropped",
+              "outputOverflowDropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "283587992532",
+                "unixMs": "1789082812199",
+                "uncertaintyQpc": "10895"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "283584482344"
+            },
+            "finalTotals": {
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 32,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "283589058601",
+              "pump": {
+                "calls": "28",
+                "totalTicks": "859438",
+                "maxTicks": "97599",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "27",
+                "totalTicks": "686245",
+                "maxTicks": "36282",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 4096,
+                "highWaterBytes": 1048576
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "28358930468600",
+              "decodeChunk": {
+                "calls": "32",
+                "totalTicks": "14725900",
+                "maxTicks": "872900",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "30",
+                "totalTicks": "5960500",
+                "maxTicks": "535100",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "4",
+                "totalTicks": "1399200",
+                "maxTicks": "375000",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "28",
+                "totalTicks": "5931800",
+                "maxTicks": "1076000",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "parent-eof-unverified",
+          "summary": {
+            "launchId": "ff4cf63e-d6d2-47c1-a90b-f0de15e3db3d",
+            "sessionId": "54336ba0-8f21-47ae-b182-8ce89c22a0f3",
+            "endedAt": 1789082812995,
+            "phase": "failed",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "dropped",
+              "ingressDropped",
+              "outputDropped",
+              "outputOverflowDropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain",
+              "stream-ended"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "283595241160",
+                "unixMs": "1789082812924",
+                "uncertaintyQpc": "10919"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "283591574443"
+            },
+            "finalTotals": {
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "283595265382",
+              "pump": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 4096,
+                "highWaterBytes": 1048576
+              },
+              "output": {
+                "records": 1922,
+                "bytes": 4193804,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "28359596648500",
+              "decodeChunk": {
+                "calls": "6",
+                "totalTicks": "3575400",
+                "maxTicks": "1353100",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "5",
+                "totalTicks": "2244600",
+                "maxTicks": "872700",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "3",
+                "totalTicks": "1388700",
+                "maxTicks": "626200",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "22",
+                "totalTicks": "4379400",
+                "maxTicks": "560200",
+                "failed": "0"
+              }
+            },
+            "stopReason": null,
+            "exitCode": 2,
+            "stopVerified": false
+          }
+        }
+      ],
+      "passed": true,
+      "observationCheck": {
+        "observed": true,
+        "named": true,
+        "fixtureRead": false,
+        "leaked": false
+      },
+      "endedSessions": [
+        {
+          "launchId": "88b30985-87dc-4610-9fb4-9a6da6241b27",
+          "sessionId": "fb908384-ff65-4964-bb11-71da8ec68f85",
+          "endedAt": 1789082811611,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "283580660717",
+              "unixMs": "1789082811466",
+              "uncertaintyQpc": "10786"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "283576988581"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 32,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "283581829618",
+            "pump": {
+              "calls": "28",
+              "totalTicks": "993424",
+              "maxTicks": "100708",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "27",
+              "totalTicks": "818417",
+              "maxTicks": "40361",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "28358212271300",
+            "decodeChunk": {
+              "calls": "31",
+              "totalTicks": "22356700",
+              "maxTicks": "2113200",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "30",
+              "totalTicks": "9605000",
+              "maxTicks": "1098900",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "4",
+              "totalTicks": "1690900",
+              "maxTicks": "479200",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "28",
+              "totalTicks": "5611400",
+              "maxTicks": "976900",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "eb060ec5-69ed-493f-a043-f54bed1b45c5",
+          "sessionId": "56662aa4-22b7-467f-85d7-b71ae16c6948",
+          "endedAt": 1789082812329,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "283587992532",
+              "unixMs": "1789082812199",
+              "uncertaintyQpc": "10895"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "283584482344"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 32,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "283589058601",
+            "pump": {
+              "calls": "28",
+              "totalTicks": "859438",
+              "maxTicks": "97599",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "27",
+              "totalTicks": "686245",
+              "maxTicks": "36282",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "28358930468600",
+            "decodeChunk": {
+              "calls": "32",
+              "totalTicks": "14725900",
+              "maxTicks": "872900",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "30",
+              "totalTicks": "5960500",
+              "maxTicks": "535100",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "4",
+              "totalTicks": "1399200",
+              "maxTicks": "375000",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "28",
+              "totalTicks": "5931800",
+              "maxTicks": "1076000",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "ff4cf63e-d6d2-47c1-a90b-f0de15e3db3d",
+          "sessionId": "54336ba0-8f21-47ae-b182-8ce89c22a0f3",
+          "endedAt": 1789082812995,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "283595241160",
+              "unixMs": "1789082812924",
+              "uncertaintyQpc": "10919"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "283591574443"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "283595265382",
+            "pump": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 1922,
+              "bytes": 4193804,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "28359596648500",
+            "decodeChunk": {
+              "calls": "6",
+              "totalTicks": "3575400",
+              "maxTicks": "1353100",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "5",
+              "totalTicks": "2244600",
+              "maxTicks": "872700",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "3",
+              "totalTicks": "1388700",
+              "maxTicks": "626200",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "22",
+              "totalTicks": "4379400",
+              "maxTicks": "560200",
+              "failed": "0"
+            }
+          },
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      ],
+      "endedAt": "2026-09-10T23:26:53.018Z"
+    }
+  },
+  "live": {
+    "file": "aegis-etw-timings-live-20260911.json",
+    "sha256": "182ce5a715125fccf67194dd7b9a97e662be318966c82b87ca33adefbf8c3efa",
+    "report": {
+      "schema": 1,
+      "live": true,
+      "synthetic": false,
+      "protocol": "etw-file/4",
+      "lossCheck": false,
+      "loadCheck": true,
+      "startedAt": "2026-09-10T23:27:10.101Z",
+      "binarySha256": "f1c4db38a3019d4ef47b77d913cbf3d9bf4dddfd0af31297b3efcea763f988e1",
+      "assemblySha256": "82308218d20c6ee287acf7f5cb677233df48fbc07179d8c34c81ce57f602a3a1",
+      "cases": [
+        {
+          "kind": "normal-stop",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": true,
+          "ringBytes": 416602,
+          "ringDropped": 11775,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "4c806334-fbae-4f84-a90c-5d9ad59fe35a",
+            "sessionId": "d2a93c60-148b-46fb-9374-e5e017bd4582",
+            "endedAt": 1789082909696,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "mapResets",
+              "dropped",
+              "outputDropped",
+              "outputOverflowDropped",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "117946",
+              "filtered": "51927",
+              "dropped": "52066",
+              "ingressDropped": "0",
+              "outputDropped": "52066",
+              "outputOverflowDropped": "52066",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "6",
+              "mapResets": "6",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "284363348116",
+                "unixMs": "1789082889737",
+                "uncertaintyQpc": "10187"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "queryStatus": 0,
+              "asOfQpc": "284561415141"
+            },
+            "finalTotals": {
+              "delivered": "117946",
+              "filtered": "51927",
+              "dropped": "52066",
+              "ingressDropped": "0",
+              "outputDropped": "52066",
+              "outputOverflowDropped": "52066",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "6",
+              "mapResets": "6",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 11775,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "284562611479",
+              "pump": {
+                "calls": "1476",
+                "totalTicks": "1736668",
+                "maxTicks": "161484",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "211",
+                "totalTicks": "1244423",
+                "maxTicks": "28067",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "1264",
+                "totalTicks": "197024616",
+                "maxTicks": "243653",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 831,
+                "highWaterBytes": 262755
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "28456294673800",
+              "decodeChunk": {
+                "calls": "167",
+                "totalTicks": "161115600",
+                "maxTicks": "2964000",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "223",
+                "totalTicks": "98001900",
+                "maxTicks": "1352900",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "183",
+                "totalTicks": "60598900",
+                "maxTicks": "773300",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "2559",
+                "totalTicks": "687098700",
+                "maxTicks": "2835100",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        }
+      ],
+      "passed": true,
+      "load": {
+        "profile": {
+          "id": "repeated-read-4k-v1",
+          "handlePolicy": "one-open-per-phase",
+          "bytesPerRead": 4096,
+          "settleMs": 2000,
+          "timeoutMs": 90000,
+          "phases": [
+            {
+              "repeat": 1,
+              "kind": "paced",
+              "operations": 2000,
+              "rate": 1000,
+              "batch": 25
+            },
+            {
+              "repeat": 1,
+              "kind": "burst",
+              "operations": 20000,
+              "rate": null,
+              "batch": 250
+            },
+            {
+              "repeat": 2,
+              "kind": "paced",
+              "operations": 2000,
+              "rate": 1000,
+              "batch": 25
+            },
+            {
+              "repeat": 2,
+              "kind": "burst",
+              "operations": 20000,
+              "rate": null,
+              "batch": 250
+            },
+            {
+              "repeat": 3,
+              "kind": "paced",
+              "operations": 2000,
+              "rate": 1000,
+              "batch": 25
+            },
+            {
+              "repeat": 3,
+              "kind": "burst",
+              "operations": 20000,
+              "rate": null,
+              "batch": 250
+            }
+          ]
+        },
+        "monitorIntervalMs": 25,
+        "phases": [
+          {
+            "repeat": 1,
+            "kind": "paced",
+            "operations": 2000,
+            "rate": 1000,
+            "batch": 25,
+            "completed": 2000,
+            "bytesRead": 8192000,
+            "durationMs": 2500.1574000000037,
+            "achievedOperationsPerSecond": 799.9496351709685,
+            "maxBatchLatenessMs": 7.357100000001083
+          },
+          {
+            "repeat": 1,
+            "kind": "burst",
+            "operations": 20000,
+            "rate": null,
+            "batch": 250,
+            "completed": 20000,
+            "bytesRead": 81920000,
+            "durationMs": 59.7528999999995,
+            "achievedOperationsPerSecond": 334711.78804711014,
+            "maxBatchLatenessMs": null
+          },
+          {
+            "repeat": 2,
+            "kind": "paced",
+            "operations": 2000,
+            "rate": 1000,
+            "batch": 25,
+            "completed": 2000,
+            "bytesRead": 8192000,
+            "durationMs": 2499.452799999999,
+            "achievedOperationsPerSecond": 800.1751423351546,
+            "maxBatchLatenessMs": 7.3607000000047265
+          },
+          {
+            "repeat": 2,
+            "kind": "burst",
+            "operations": 20000,
+            "rate": null,
+            "batch": 250,
+            "completed": 20000,
+            "bytesRead": 81920000,
+            "durationMs": 61.72609999999986,
+            "achievedOperationsPerSecond": 324012.0467678996,
+            "maxBatchLatenessMs": null
+          },
+          {
+            "repeat": 3,
+            "kind": "paced",
+            "operations": 2000,
+            "rate": 1000,
+            "batch": 25,
+            "completed": 2000,
+            "bytesRead": 8192000,
+            "durationMs": 2489.787000000011,
+            "achievedOperationsPerSecond": 803.2815658528183,
+            "maxBatchLatenessMs": 7.4821999999985565
+          },
+          {
+            "repeat": 3,
+            "kind": "burst",
+            "operations": 20000,
+            "rate": null,
+            "batch": 250,
+            "completed": 20000,
+            "bytesRead": 81920000,
+            "durationMs": 57.27529999999388,
+            "achievedOperationsPerSecond": 349190.66334008094,
+            "maxBatchLatenessMs": null
+          }
+        ],
+        "completed": true,
+        "durationMs": 19738.335600000006
+      },
+      "observationCheck": {
+        "observed": true,
+        "named": true,
+        "fixtureRead": true,
+        "leaked": false
+      },
+      "endedSessions": [
+        {
+          "launchId": "4c806334-fbae-4f84-a90c-5d9ad59fe35a",
+          "sessionId": "d2a93c60-148b-46fb-9374-e5e017bd4582",
+          "endedAt": 1789082909696,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "mapResets",
+            "dropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "117946",
+            "filtered": "51927",
+            "dropped": "52066",
+            "ingressDropped": "0",
+            "outputDropped": "52066",
+            "outputOverflowDropped": "52066",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "6",
+            "mapResets": "6",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "284363348116",
+              "unixMs": "1789082889737",
+              "uncertaintyQpc": "10187"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "queryStatus": 0,
+            "asOfQpc": "284561415141"
+          },
+          "finalTotals": {
+            "delivered": "117946",
+            "filtered": "51927",
+            "dropped": "52066",
+            "ingressDropped": "0",
+            "outputDropped": "52066",
+            "outputOverflowDropped": "52066",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "6",
+            "mapResets": "6",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 11775,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "284562611479",
+            "pump": {
+              "calls": "1476",
+              "totalTicks": "1736668",
+              "maxTicks": "161484",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "211",
+              "totalTicks": "1244423",
+              "maxTicks": "28067",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "1264",
+              "totalTicks": "197024616",
+              "maxTicks": "243653",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 831,
+              "highWaterBytes": 262755
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "28456294673800",
+            "decodeChunk": {
+              "calls": "167",
+              "totalTicks": "161115600",
+              "maxTicks": "2964000",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "223",
+              "totalTicks": "98001900",
+              "maxTicks": "1352900",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "183",
+              "totalTicks": "60598900",
+              "maxTicks": "773300",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "2559",
+              "totalTicks": "687098700",
+              "maxTicks": "2835100",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      ],
+      "endedAt": "2026-09-10T23:28:29.711Z"
+    }
+  },
+  "baselineReference": {
+    "aggregate": "etw-file-home-26200-output-drain.json",
+    "liveReportSha256": "03d351ff3a12ccf726e1e1b55428f15d1eeacf9da5d927753eb8def5e78f86b0",
+    "protocol": "etw-file/3",
+    "outputOverflowDropped": "51648",
+    "serviceMeasurements": null,
+    "controlledThroughputComparison": false
+  },
+  "postRun": {
+    "remainingEtwFileProcesses": 0,
+    "independentSessionAbsenceWitness": false
+  },
+  "limits": [
+    "Elapsed wall time, not CPU time. OutputWrite is nested in Pump; AcceptFrame and RetainBatch are nested in DecodeChunk. Never sum nested or cross-process durations.",
+    "Collector Pump minus OutputWrite includes dequeue, generation observation, encoding and empty polls. Broker CPU, end-to-end latency and phase-local queue occupancy are not measured.",
+    "IdleWait includes deliberate workload settling and OS scheduling; a large sum alone does not prove polling caused overflow. Queue high water does not measure time at capacity.",
+    "Main Snapshot includes harness polling from launch through close, including UAC wait; each snapshot excludes its own unfinished measurement. Final summaries cover completed calls at broker close.",
+    "Whole-session losses and timing aggregates include ambient activity. Changed ambient delivery and burst rates prevent a causal throughput comparison.",
+    "No event-time identity proof, protected crash recovery, independent absence witness, sleep/wake test or installed-app replacement."
+  ],
+  "postMeasurementSourceChanges": [
+    {
+      "file": "src/main/platform/etw-file-diagnostics.js",
+      "finalSha256": "e4c944f6ba3c1ea7c28974f56ec62e8ff9471dcb82b68f62c3ec9b1ccf1c1cdd",
+      "change": "Two comment lines document and locally permit the intentional rejection of an invalid injected clock in finally. Removing exactly those comments reproduces the measured source hash; no executable change."
+    }
+  ]
+}

--- a/docs/roadmap/etw-output-drain.md
+++ b/docs/roadmap/etw-output-drain.md
@@ -1,11 +1,14 @@
 # B5 follow-up — output drop causes and frame encoding
 
+This records the v3 step. The [service-timing follow-up](etw-service-timings.md)
+extends the current protocol to v4; the evidence below remains a v3 measurement.
+
 Implemented on `codex/etw-output-drain` from `93aae23`, following the fixed
 66,000-read baseline that recorded 49,406 output-stage drops. E3 remains open.
 
 ## Counter contract
 
-The diagnostic protocol is now `etw-file/3`. Main and helper require canonical
+This step introduced `etw-file/3`. Main and helper require canonical
 uint64 `outputOverflowDropped` and `outputInvalidatedDropped` in every telemetry
 sample. Older versions are rejected; missing measurements never become zero.
 

--- a/docs/roadmap/etw-sensor-design.md
+++ b/docs/roadmap/etw-sensor-design.md
@@ -126,7 +126,7 @@ UAC storms. Each attempt has a new session ID and rejects old frames.
 
 ## 4. Proposed diagnostic wire and bounds
 
-Independent protocol `etw-file/3`: four-byte little-endian length, UTF-8 JSON,
+Independent protocol `etw-file/4`: four-byte little-endian length, UTF-8 JSON,
 maximum 256 KiB payload, maximum JSON depth 16. Reject length before allocating.
 Decode fragmentation/coalescing with a capped accumulator. No stdout text logs.
 All uint64 values (QPC, frequency, FILETIME, sequence/counters) are decimal strings
@@ -299,7 +299,7 @@ approves no runtime integration and closes none of the remaining B1 questions.
 ## 8. Diagnostic contract details (B3, updated by B5)
 
 Every envelope has exactly `{t, proto, launchId, sessionId, seq, data}`; `proto`
-is `etw-file/3`, IDs are 1–64 ASCII letters/digits/underscore/hyphen, and `seq` is
+is `etw-file/4`, IDs are 1–64 ASCII letters/digits/underscore/hyphen, and `seq` is
 a positive canonical uint64 decimal string. IDs bind one launch and session;
 they provide no authentication by themselves. Sequences are independent in each
 direction. Each nested object has closed fields; unknown keys and omitted nullable
@@ -320,7 +320,7 @@ not approve live schema decoding or other Windows builds.
 | `error` | Nullable `requestId`, static `code` from the exported `ERROR_CODES`. |
 
 Telemetry has exactly `operational`, `reasons`, `counters`, `totals`, `queues`,
-`coverage`. Reasons are unique members of `mapping-uncertain`, `identity-uncertain`,
+`performance`, `coverage`. Reasons are unique members of `mapping-uncertain`, `identity-uncertain`,
 `population-unavailable`, `schema-gap`. The reducer derives its own state; there
 is no sender-provided `HEALTHY` assertion. `counters` contains nullable uint64
 `eventsLost`, `realTimeBuffersLost`, `logBuffersLost`, uint32 `queryStatus` and
@@ -330,11 +330,20 @@ accounting; the received values remain available in the copied diagnostic sample
 `outputDropped`, `outputOverflowDropped`, `outputInvalidatedDropped`,
 `decoderErrors`, `mapEpoch`, `mapResets`, `mapConflicts`.
 Ingress and output losses sum exactly to `dropped`; the two output causes sum
-exactly to `outputDropped`. Absent measurements and version 1/2 peers are rejected.
+exactly to `outputDropped`. Absent measurements and version 1–3 peers are rejected.
 See [output-drop accounting](etw-output-drain.md) for discard semantics, bounded
 frame encoding and normal/live evidence. `queues` contains uint32 `records`, `bytes`,
 `highWaterRecords`, `highWaterBytes`, with the section 4 caps and high-water checks.
 These reported counters do not implement a collector queue or prove a live bound.
+
+`performance` has exactly `frequency`, `asOfQpc`, `pump`, `outputWrite`, `idleWait`,
+`ingress`, `output`. Frequency is positive uint64; the timestamp is uint64. Each
+duration has canonical uint64 `calls`, `totalTicks`, `maxTicks`, `failed` with
+`failed <= calls`, `maxTicks <= totalTicks <= calls * maxTicks`. Zero calls require
+zero durations. Output-write calls/time cannot exceed enclosing pump calls/time.
+Each stage queue has the same four uint32 fields/caps as `queues`. Main keeps its
+own fixed timing groups in local diagnostics and ended summaries; none enter IPC
+or the health loss count. See [measurement boundaries](etw-service-timings.md).
 
 Observation uint64s are strings; PID/TID fields are uint32 with the payload/issuing
 fields nullable. `generationInterval` is null or `{fromQpc, toQpc}` with ordered

--- a/docs/roadmap/etw-service-timings.md
+++ b/docs/roadmap/etw-service-timings.md
@@ -1,0 +1,113 @@
+# B5 follow-up — collector and main service measurements
+
+Implemented on `codex/etw-service-timings` from `4006268` (merged #432). The
+diagnostic protocol is v4. This step measures existing behavior; output overflow
+and E3 remain open. Main/helper v1–3 are rejected rather than given invented zeros.
+
+## Measurement boundaries
+
+Collector counters have one serial writer. Every completed call records `calls`,
+`totalTicks`, `maxTicks`, `failed` as canonical uint64 strings. `frequency` converts
+ticks to seconds; `asOfQpc` dates the snapshot. Failed/cancelled calls count, but a
+failed transport may prevent the last snapshot from reaching main. An ended
+summary then retains the last received sample, not an inferred final measurement.
+
+| Collector group | Elapsed interval |
+| --- | --- |
+| `pump` | Entire observation pump: dequeue, fresh process observation, encoding, pipe write; includes empty polls. |
+| `outputWrite` | Nested header/body writes and flush for observation frames only. |
+| `idleWait` | Actual elapsed `Task.Delay(10)` after an empty pump; includes scheduler delay. |
+
+Pump minus output-write time includes all non-write pump work, not just encoding.
+Control/heartbeat writes, mapper CPU and broker parsing/forwarding are outside
+these intervals. Pipe write completion does not acknowledge main processing.
+Telemetry is sampled between completed pump calls; the stopped frame itself is
+outside its embedded sample. Both stage queue snapshots retain current/high-water
+record counts and bytes, each capped at 4,096 records / 4 MiB. High water is not
+the time spent at capacity. The existing combined fields remain per-field maxima.
+
+Main uses an independent monotonic nanosecond clock and constant-space counters:
+
+| Main group | Elapsed interval |
+| --- | --- |
+| `decodeChunk` | Synchronous framed parsing, validation and callbacks for one stdout chunk. |
+| `acceptFrame` | Nested session reducer and accepted-frame handling. |
+| `retainBatch` | Nested copying, accounting and eviction in the diagnostic ring. |
+| `snapshot` | Separate `getDiagnostics()` copies, including the harness's polling overhead. |
+
+These are wall durations, not CPU usage. Nested groups and different processes
+must not be added. Main does not measure event-loop queue delay before the callback.
+Snapshot counters cover launch through broker close, including polls during UAC;
+the snapshot being constructed appears only in subsequent completed measurements.
+Final summaries freeze completed main calls at broker close. Session restart resets
+current metrics; prior summaries remain detached. Missing collector telemetry is
+null. Raw observations and exceptions are absent from the metrics/report.
+
+The ring extraction preserves 256 records / 1 MiB, copied snapshots, eviction
+counts and clearing on stop/failure. The existing 32-summary bound remains. No
+timing IPC, agent attribution, FileEvent admission or automatic restart is added.
+
+## Live evidence
+
+The [aggregate](../recon/evidence/etw-file-home-26200-service-timings.json) retains
+three original normal/saturation/live reports with their hashes and 26 measured
+source hashes. Two subsequent lint-comment lines have a separate final hash;
+removing those comments reproduces the measured source. Normal and saturation
+checks used the same binaries as the live run.
+The workload modules and `repeated-read-4k-v1` profile match #432. One authorized
+UAC session on Windows 11 Home 25H2 / 26200.8655 completed all 66,000 reads in
+19.738 seconds (270,336,000 logical bytes).
+
+| Whole live session | Result |
+| --- | ---: |
+| Delivered / filtered | 117,946 / 51,927 |
+| Output overflow / invalidation | 52,066 / 0 |
+| Ingress / native event / realtime-buffer / log-buffer loss | 0 / 0 / 0 / 0 |
+| Decoder errors / map conflicts / map resets | 0 / 0 / 6 |
+| Main ring evictions | 11,775 |
+| Ingress high water | 831 records / 262,755 bytes |
+| Output high water | 1,922 records / 4,193,804 bytes |
+| Fixture Read/header-PID candidate | Observed |
+| Out-of-root path or non-null agent/instanceId in checked records | None observed |
+| Owned stop / child exit / remaining EtwFile processes | Verified / 0 / 0 |
+
+| Completed elapsed measurements | Calls | Total ms | Maximum ms |
+| --- | ---: | ---: | ---: |
+| Collector pump, including writes | 1,476 | 173.667 | 16.148 |
+| Collector output writes, nested | 211 | 124.442 | 2.807 |
+| Collector empty-pump delay | 1,264 | 19,702.462 | 24.365 |
+| Main chunk handling, including callbacks | 167 | 161.116 | 2.964 |
+| Main accepted frames, nested | 223 | 98.002 | 1.353 |
+| Main retained batches, nested | 183 | 60.599 | 0.773 |
+| Main diagnostic snapshots, separate | 2,559 | 687.099 | 2.835 |
+
+All timing failure counters are zero. Non-write collector pump work totals
+49.225 ms. Mean empty-pump delay is 15.587 ms. Paced rates were 799.95, 800.18 and
+803.28 reads/s; bursts ran at 334,711.79, 324,012.05 and 349,190.66 reads/s in
+57–62 ms. Whole-session counters include ambient activity and settling; neither
+losses nor timings can be attributed to individual phases or divided by logical
+reads to claim coverage. The earlier run had different background traffic and
+burst rates, so these results do not establish a throughput improvement/regression.
+
+The output queue reached its byte cap while measured write and main callback
+intervals were short. The next bounded experiment is an output-available signal
+that wakes the empty pump, with cancellation and drain semantics preserved, then
+the same live profile. The large idle total includes the workload's deliberate
+pauses and is not proof that polling caused overflow. Phase-local occupancy,
+wake latency and broker-specific timing remain unmeasured; compare evidence
+before adopting a throughput claim or increasing buffers.
+
+Event-time agent identity and safe path admission (E4/E5), independent session
+absence evidence, protected crash recovery and deployment remain open. Sleep/wake
+is still deferred. The installed app was not replaced.
+
+## Verification
+
+39 C# self-tests and 161 focused JS tests passed, including nested durations,
+failed writes, detached counters, stage high-water retention, protocol rejection,
+uint64 precision and final-summary/reset behavior. Normal and deliberate-saturation
+process checks passed three scenarios each; missing EOF acknowledgement remained
+unverified. C# Release build and formatter passed. Full JS coverage passed 200
+files / 3,354 tests with four skips. Renderer build, format/lint, TypeScript/Svelte,
+witness/sequence gates, derived counts and the production dependency audit passed.
+The PR retains the CI result; live reports preserve the measured source revision.

--- a/docs/roadmap/etw-stage-loss.md
+++ b/docs/roadmap/etw-stage-loss.md
@@ -1,7 +1,8 @@
 # B5 follow-up — separate collector stage losses
 
 This records the v2 step. The [output-drain follow-up](etw-output-drain.md) extends
-the current protocol to v3 with mandatory output-cause measurements.
+that protocol to v3 with mandatory output-cause measurements. The current v4 adds
+[service measurements](etw-service-timings.md); this page preserves the v2 evidence.
 
 Implemented on `codex/etw-stage-loss-counters` from `4a23c9c`, after the previous
 live measurement could only report a combined application drop count.

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # AEGIS Architecture
 
-## Main Process (src/main/) — 74 CommonJS modules (56 top-level + 16 platform/ + 2 token-adapters/)
+## Main Process (src/main/) — 75 CommonJS modules (56 top-level + 17 platform/ + 2 token-adapters/)
 
 Optional development ETW: main → platform/etw-file-runtime → etw-file-supervisor
 → normal `sidecar/etw-file` broker → authenticated elevated file collector.

--- a/memory-bank/next-session.md
+++ b/memory-bank/next-session.md
@@ -1,6 +1,33 @@
 # AEGIS — старт следующего чата
 
-## Актуальное продолжение — причины output loss и сериализация, 2026-09-11
+## Актуальное продолжение — замеры ETW, 2026-09-11
+
+В `X:/tmp/aegis-etw-burst-20260911`, ветка `codex/etw-service-timings` от `4006268`
+(слитый #432), реализован протокол v4: collector pump/outputWrite/idleWait и
+раздельные глубины ingress/output; main decodeChunk/acceptFrame/retainBatch/snapshot.
+Это накопленное elapsed time, не CPU. Вложенные интервалы не складывать. Метрики
+ограничены по памяти, итоговые отчёты сохраняются после stop; старые v1–3 отвергаются.
+
+39 C# и 161 точечный JS-тест прошли. Normal/loss-check прошли по три сценария.
+Один live UAC на тех же бинарниках: все 66000 чтений за 19,738 с, delivered 117946,
+filtered 51927, overflow 52066, invalidation/ingress/native loss 0, resets 6,
+ring eviction 11775. Fixture Read/PID найден, stopVerified true, exit 0, helpers 0.
+Pump 173,667 мс, из них write 124,442; остальная работа pump 49,225. Empty wait
+19702,462 мс суммарно / 15,587 мс в среднем / 24,365 мс максимум. Main decode
+161,116 мс; snapshot 687,099 мс включает опросы во время ожидания UAC. Output high
+water 1922 записи / 4193804 байта. Вложения и разные процессы не складывать.
+
+Следующий эксперимент E3: пробуждать пустой output pump по появлению данных,
+сохранив cancellation, stop/drain и лимиты, затем повторить fixed profile.
+Большой idle total включает паузы теста, поэтому он не доказывает причину потерь.
+Нагрузка и фон изменились; throughput улучшенным не объявлять. E4/E5 identity,
+crash recovery, independent absence witness и deployment остаются открыты.
+Сон отложен, установленная программа не заменялась. Отчёт:
+`docs/roadmap/etw-service-timings.md`; три raw JSON и 26 хешей:
+`docs/recon/evidence/etw-file-home-26200-service-timings.json`.
+Проверить финальный PR/CI/merge этой ветки; исходную грязную UI-копию сохранить.
+
+## Предыдущий шаг — причины output loss и сериализация, 2026-09-11
 
 В `X:/tmp/aegis-etw-burst-20260911`, ветка `codex/etw-output-drain` от `93aae23`,
 реализованы `outputOverflowDropped` и `outputInvalidatedDropped`. Их сумма равна

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2252,3 +2252,35 @@ Next E3 step: separate encoder service time, pipe/broker/main waits, retained qu
 depths and idle polling effects before choosing another throughput change.
 Sleep/wake remains deferred, the installed app was not replaced, and the original
 dirty UI checkout was preserved. Check the output-drain branch's final PR/CI/merge.
+
+## 2026-09-11 — ETW collector/main service measurements
+
+Implemented on `codex/etw-service-timings` from merged #432 / `4006268`. Protocol v4
+adds fixed collector pump/output-write/empty-delay aggregates, separate queue stage
+current/high-water values, and main decode/accept/retain/snapshot measurements.
+All durations are wall time; nested intervals and clocks are kept separate.
+Ended summaries retain the last collector sample and completed main counters;
+restart resets current counters. The bounded main ring was extracted intact.
+No IPC, attribution, queue-size, workload, retry or ownership changes were made.
+
+39 C# self-tests and 161 focused JS tests passed. Normal/loss process checks passed
+three scenarios each on matching binaries. The authorized live run completed
+66,000 reads in 19.738 s: delivered 117946, filtered 51927, output overflow 52066,
+invalidation/ingress/native loss 0, map resets 6, ring evictions 11775. Fixture
+Read/header-PID candidate observed; owned stop verified, exit 0, helpers 0.
+Collector pump total 173.667 ms contains output writes 124.442 ms, leaving 49.225 ms
+for other pump work. Empty-pump waits average 15.587 ms, maximum 24.365 ms; output
+high water 1922 records / 4193804 bytes. Main decode total 161.116 ms; snapshots
+687.099 ms include launch/UAC polling. Aggregate idle time includes settling and
+cannot prove polling caused overflow. Ambient load and burst rates changed.
+
+Next: test an output-available signal with existing cancellation/drain bounds
+and repeat the fixed workload. Broker timing, phase-local queue occupancy and
+wake latency are not yet measured. E3 and E4/E5 remain open, as do independent
+absence witnessing, protected crash recovery and deployment. Sleep/wake remains
+deferred and the installed app was not replaced. Evidence: three original reports
+and 26 measured source hashes in `etw-file-home-26200-service-timings.json`.
+The subsequent source change only documents the intentional fail-closed clock
+check for lint; evidence records its separate final hash. Full JS coverage passed
+200 files / 3354 tests with four skips. Check this branch's final PR/CI/merge before
+the next block; preserve the original dirty UI checkout.

--- a/scripts/verify-etw-file.mjs
+++ b/scripts/verify-etw-file.mjs
@@ -103,6 +103,14 @@ try {
     await until(() => sensor.getDiagnostics().summaries.length > index, 20000);
     const result = sensor.getDiagnostics().summaries.at(-1);
     if (!result.stopVerified) throw new Error('stop-unverified');
+    if (
+      !result.collectorPerformance ||
+      !result.mainPerformance ||
+      BigInt(result.collectorPerformance.pump.calls) === 0n ||
+      BigInt(result.collectorPerformance.outputWrite.calls) === 0n ||
+      BigInt(result.mainPerformance.decodeChunk.calls) === 0n
+    )
+      throw new Error('service-measurements-missing');
     const totals = result.finalTotals;
     if (
       !totals ||

--- a/sidecar/etw-file/FileCollector.cs
+++ b/sidecar/etw-file/FileCollector.cs
@@ -16,7 +16,8 @@ internal static class FileCollector
         bool checkLoss = args[0] == "check-loss-collector";
         if (checkLoss) FileLossFixture.OverflowIngress(ingress);
         using var pipeline = new FilePipeline(ingress, scope, live);
-        var send = new FileWire(args[1], args[2]);
+        var performance = new FilePerformance();
+        var send = new FileWire(args[1], args[2], performance);
         var read = new FileWire(args[1], args[2]);
         using var lifetime = new CancellationTokenSource();
         using var trace = live ? new FileTrace() : null;
@@ -36,7 +37,7 @@ internal static class FileCollector
         {
             await send.Write(pipe, "hello", new
             {
-                build = live ? "etw-file-diagnostic-dev-3" : "etw-file-synthetic-check-3",
+                build = live ? "etw-file-diagnostic-dev-4" : "etw-file-synthetic-check-4",
                 profile = FileWire.Profile,
                 schemas = FileWire.Schemas
             }, lifetime.Token);
@@ -98,7 +99,7 @@ internal static class FileCollector
                     Sample();
                     await send.Write(pipe, "heartbeat", Telemetry(), lifetime.Token);
                 }
-                if (!await Pump(lifetime.Token)) await Task.Delay(10, lifetime.Token);
+                if (!await Pump(lifetime.Token)) await Idle(lifetime.Token);
             }
             stopRequest = await stopSignal.Task;
             if (trace != null) { stats = trace.Stop(); stopped = stats.Status == 0; owns = !stopped; CheckStats(); }
@@ -108,7 +109,7 @@ internal static class FileCollector
             pipeline.Complete();
             while (!pipeline.Worker.IsCompleted)
             {
-                if (!await Pump(drain.Token)) await Task.Delay(10, drain.Token);
+                if (!await Pump(drain.Token)) await Idle(drain.Token);
             }
             await pipeline.Worker;
             while (await Pump(drain.Token)) { }
@@ -151,6 +152,7 @@ internal static class FileCollector
         }
         object Telemetry()
         {
+            var queues = pipeline.QueueSnapshot();
             return new
             {
                 operational = true,
@@ -164,10 +166,22 @@ internal static class FileCollector
                     asOfQpc = statsAsOf.ToString()
                 },
                 totals = pipeline.Totals(),
-                queues = pipeline.Queues(),
+                queues = queues.combined,
+                performance = performance.Snapshot(queues),
                 coverage = FileWire.Profile
             };
         }
-        Task<bool> Pump(CancellationToken token) => send.WriteObservations(pipe, pipeline.Take, token);
+        async Task<bool> Pump(CancellationToken token)
+        {
+            long start = performance.Now(); bool success = false;
+            try { bool result = await send.WriteObservations(pipe, pipeline.Take, token); success = true; return result; }
+            finally { performance.Pump.Record(performance.Now() - start, !success); }
+        }
+        async Task Idle(CancellationToken token)
+        {
+            long start = performance.Now(); bool success = false;
+            try { await Task.Delay(10, token); success = true; }
+            finally { performance.IdleWait.Record(performance.Now() - start, !success); }
+        }
     }
 }

--- a/sidecar/etw-file/FilePerformance.cs
+++ b/sidecar/etw-file/FilePerformance.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+
+namespace Aegis.EtwLifecycle;
+
+// One serial collector writer owns these counters. Durations are elapsed wall
+// ticks, not CPU time; completed calls include failed/cancelled calls.
+internal sealed class FileDuration
+{
+    private ulong calls, total, maximum, failed;
+    internal void Record(long ticks, bool failure = false)
+    {
+        if (ticks < 0) throw new InvalidOperationException();
+        calls++; total += (ulong)ticks; maximum = Math.Max(maximum, (ulong)ticks);
+        if (failure) failed++;
+    }
+    internal object Snapshot() => new
+    {
+        calls = calls.ToString(),
+        totalTicks = total.ToString(),
+        maxTicks = maximum.ToString(),
+        failed = failed.ToString()
+    };
+}
+
+internal sealed class FilePerformance(Func<long>? timestamp = null, long? frequency = null)
+{
+    internal readonly FileDuration Pump = new(), OutputWrite = new(), IdleWait = new();
+    internal long Now() => (timestamp ?? Stopwatch.GetTimestamp)();
+    internal object Snapshot(FileQueueSnapshot queues) => new
+    {
+        frequency = (frequency ?? Stopwatch.Frequency).ToString(),
+        asOfQpc = Now().ToString(),
+        pump = Pump.Snapshot(),
+        outputWrite = OutputWrite.Snapshot(),
+        idleWait = IdleWait.Snapshot(),
+        ingress = queues.ingress,
+        output = queues.output
+    };
+}
+
+internal sealed record FileQueueDepth(int records, int bytes, int highWaterRecords, int highWaterBytes);
+internal sealed record FileQueueSnapshot(FileQueueDepth combined, FileQueueDepth ingress, FileQueueDepth output);

--- a/sidecar/etw-file/FilePerformanceTests.cs
+++ b/sidecar/etw-file/FilePerformanceTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+
+namespace Aegis.EtwLifecycle;
+
+internal static class FilePerformanceTests
+{
+    internal static void Run(Action<string, Action> test)
+    {
+        test("duration totals include failures and preserve a detached snapshot", () =>
+        {
+            var duration = new FileDuration();
+            duration.Record(20); duration.Record(7, true); duration.Record(0);
+            var before = JsonSerializer.SerializeToElement(duration.Snapshot());
+            duration.Record(100);
+            Check(before.GetProperty("calls").GetString() == "3");
+            Check(before.GetProperty("totalTicks").GetString() == "27");
+            Check(before.GetProperty("maxTicks").GetString() == "20");
+            Check(before.GetProperty("failed").GetString() == "1");
+            bool rejected = false;
+            try { duration.Record(-1); } catch (InvalidOperationException) { rejected = true; }
+            Check(rejected);
+        });
+        test("output timing covers header body flush but excludes record preparation and control", () =>
+        {
+            long clock = 0;
+            var performance = new FilePerformance(() => clock, 1000);
+            using var stream = new TimedStream(() => clock += 3);
+            var wire = new FileWire("launch", "session", performance);
+            var map = new FileMapping(new FileScope(@"C:\fixture", false), 1000);
+            map.Accept(new(1, 12, 1, 1, 71, 72, 72, null, 1, 0, @"C:\fixture\a"));
+            var record = map.Accept(new(2, 15, 1, 2, 71, 72, 72, null, 1, 0, null));
+            int taken = 0;
+            long start = clock;
+            Check(wire.WriteObservations(stream, () => { clock += 20; return taken++ == 0 ? record : null; }, default).GetAwaiter().GetResult());
+            performance.Pump.Record(clock - start);
+            Check(!wire.WriteObservations(stream, () => null, default).GetAwaiter().GetResult());
+            wire.Write(stream, "heartbeat", new { }, default).GetAwaiter().GetResult();
+            var sample = JsonSerializer.SerializeToElement(performance.Snapshot(EmptyQueues()));
+            Check(sample.GetProperty("frequency").GetString() == "1000");
+            Check(sample.GetProperty("asOfQpc").GetString() == "58");
+            Check(sample.GetProperty("pump").GetProperty("totalTicks").GetString() == "49");
+            var write = sample.GetProperty("outputWrite");
+            Check(write.GetProperty("calls").GetString() == "1");
+            Check(write.GetProperty("totalTicks").GetString() == "9");
+            Check(write.GetProperty("failed").GetString() == "0");
+        });
+        test("failed output writes are measured without retaining exception details", () =>
+        {
+            long clock = 0;
+            var performance = new FilePerformance(() => clock, 1000);
+            using var stream = new TimedStream(() => { clock += 5; throw new IOException("private-details"); });
+            bool failed = false;
+            try { new FileWire("launch", "session", performance).Write(stream, "observations", new { records = Array.Empty<object>() }, default).GetAwaiter().GetResult(); }
+            catch (IOException) { failed = true; }
+            string json = JsonSerializer.Serialize(performance.OutputWrite.Snapshot());
+            var write = JsonSerializer.Deserialize<JsonElement>(json);
+            Check(failed && write.GetProperty("calls").GetString() == "1");
+            Check(write.GetProperty("totalTicks").GetString() == "5");
+            Check(write.GetProperty("failed").GetString() == "1" && !json.Contains("private-details"));
+        });
+        test("queue stage high water remains after drain", () =>
+        {
+            var ingress = new FileIngress();
+            ingress.Enqueue(new(1, 12, 1, 1, 71, 72, 72, null, 1, 0, @"C:\fixture\a"));
+            ingress.Enqueue(new(2, 15, 1, 2, 71, 72, 72, null, 1, 0, null));
+            using var pipeline = new FilePipeline(ingress, new FileScope(@"C:\fixture", false), false);
+            pipeline.Complete(); pipeline.Worker.WaitAsync(TimeSpan.FromSeconds(3)).GetAwaiter().GetResult();
+            var before = pipeline.QueueSnapshot();
+            Check(before.ingress.records == 0 && before.ingress.highWaterRecords == 2);
+            Check(before.output.records == 1 && before.output.highWaterRecords == 1);
+            Check(pipeline.Take() != null && pipeline.Take() == null);
+            var after = pipeline.QueueSnapshot();
+            Check(after.output.records == 0 && after.output.bytes == 0);
+            Check(after.output.highWaterBytes == before.output.highWaterBytes);
+            Check(after.combined.highWaterRecords == 2);
+        });
+    }
+    private static FileQueueSnapshot EmptyQueues()
+    {
+        var empty = new FileQueueDepth(0, 0, 0, 0);
+        return new(empty, empty, empty);
+    }
+    private static void Check(bool value) { if (!value) throw new InvalidOperationException("performance-check-failed"); }
+    private sealed class TimedStream(Action advance) : MemoryStream
+    {
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token = default)
+        {
+            advance(); return base.WriteAsync(buffer, token);
+        }
+        public override Task FlushAsync(CancellationToken token)
+        {
+            advance(); return base.FlushAsync(token);
+        }
+    }
+}

--- a/sidecar/etw-file/FilePipeline.cs
+++ b/sidecar/etw-file/FilePipeline.cs
@@ -130,19 +130,18 @@ internal sealed class FilePipeline : IDisposable
             };
         }
     }
-    internal object Queues()
+    internal object Queues() => QueueSnapshot().combined;
+    internal FileQueueSnapshot QueueSnapshot()
     {
         lock (gate)
         {
             var input = ingress.Snapshot();
             // v1 queue fields describe maxima across two independently capped stages.
-            return new
-            {
-                records = Math.Max(input.Records, outbound.Count),
-                bytes = Math.Max(input.Bytes, bytes),
-                highWaterRecords = Math.Max(input.HighRecords, highRecords),
-                highWaterBytes = Math.Max(input.HighBytes, highBytes)
-            };
+            return new(
+                new(Math.Max(input.Records, outbound.Count), Math.Max(input.Bytes, bytes),
+                    Math.Max(input.HighRecords, highRecords), Math.Max(input.HighBytes, highBytes)),
+                new(input.Records, input.Bytes, input.HighRecords, input.HighBytes),
+                new(outbound.Count, bytes, highRecords, highBytes));
         }
     }
     public void Dispose() { cancel.Cancel(); if (Worker.IsCompleted) cancel.Dispose(); }

--- a/sidecar/etw-file/FileTests.cs
+++ b/sidecar/etw-file/FileTests.cs
@@ -139,6 +139,7 @@ internal static class FileTests
         });
         FileBurstTests.Run(Test);
         FileOutputTests.Run(Test);
+        FilePerformanceTests.Run(Test);
         Console.WriteLine($"{passed} self-tests passed; no ETW session or UAC requested.");
         return 0;
     }

--- a/sidecar/etw-file/FileWire.cs
+++ b/sidecar/etw-file/FileWire.cs
@@ -6,9 +6,9 @@ using System.Text.Json;
 namespace Aegis.EtwLifecycle;
 
 internal sealed record Envelope(string t, string proto, string launchId, string sessionId, string seq, JsonElement data);
-internal sealed class FileWire(string launch, string session)
+internal sealed class FileWire(string launch, string session, FilePerformance? performance = null)
 {
-    internal const string Protocol = "etw-file/3", Profile = "home-26200-diagnostic-v1";
+    internal const string Protocol = "etw-file/4", Profile = "home-26200-diagnostic-v1";
     internal const int Limit = 256 * 1024;
     internal static readonly string[] Schemas = ["10:0", "12:1", "13:1", "14:1", "15:1"];
     private static readonly UTF8Encoding Utf8 = new(false, true);
@@ -95,7 +95,13 @@ internal sealed class FileWire(string launch, string session)
             writer.WriteEndObject(); writer.Flush();
         }
         sent++;
-        await WriteBody(stream, buffer.Written, token);
+        if (kind != "observations" || performance == null) await WriteBody(stream, buffer.Written, token);
+        else
+        {
+            long start = performance.Now(); bool success = false;
+            try { await WriteBody(stream, buffer.Written, token); success = true; }
+            finally { performance.OutputWrite.Record(performance.Now() - start, !success); }
+        }
         return true;
     }
     internal static async Task Forward(Stream stream, Envelope message, CancellationToken token)

--- a/sidecar/etw-file/README.md
+++ b/sidecar/etw-file/README.md
@@ -25,10 +25,14 @@ Choose a new report path on every run. Temporary fixture folders are retained.
 normal-token fixtures, requiring nonzero split losses in the final report. It
 cannot be combined with `--live` and never requests UAC or ETW.
 
-The matching main/helper now require `etw-file/3`. Each telemetry sample includes
+The matching main/helper now require `etw-file/4`. Each telemetry sample includes
 `ingressDropped` and `outputDropped` uint64 strings whose sum is exactly `dropped`.
 `outputOverflowDropped + outputInvalidatedDropped` must equal `outputDropped`.
-Versions 1 and 2 are rejected; rebuild the helper together with the main reader.
+Versions 1–3 are rejected; rebuild the helper together with the main reader.
+Collector telemetry also requires bounded elapsed-time aggregates and separate
+ingress/output queue depths. Ended reports retain collector and main measurements;
+see [service measurements](../../docs/roadmap/etw-service-timings.md) for clock regions,
+nested durations and interpretation limits. No per-event timing history is retained.
 
 For a separately agreed live check, run the following from normal PowerShell and
 approve **one** UAC prompt. The ordinary Node process reads its own temporary test

--- a/src/main/platform/etw-file-diagnostics.js
+++ b/src/main/platform/etw-file-diagnostics.js
@@ -1,0 +1,94 @@
+/** @file Bounded ETW observation retention and synchronous wall-time measurements. */
+'use strict';
+const KEYS = ['decodeChunk', 'acceptFrame', 'retainBatch', 'snapshot'];
+
+/** Own one session's diagnostic ring and nested timing counters.
+ * @param {Function} clock - Monotonic nanosecond clock, separate from lifecycle deadlines.
+ * @returns {Object} Retention, copied snapshots and synchronous measurement methods.
+ * @since v0.14.2
+ */
+function createDiagnostics(clock = process.hrtime.bigint) {
+  let ring = [],
+    bytes = 0,
+    dropped = 0;
+  const times = Object.fromEntries(
+    KEYS.map((key) => [
+      key,
+      {
+        calls: 0n,
+        totalTicks: 0n,
+        maxTicks: 0n,
+        failed: 0n,
+      },
+    ]),
+  );
+  function measure(key, callback) {
+    if (!Object.hasOwn(times, key)) throw new Error('etw-file:invalid-timing-key');
+    const start = clock();
+    let success = false;
+    try {
+      const value = callback();
+      success = true;
+      return value;
+    } finally {
+      const elapsed = clock() - start;
+      // A regressing injected monotonic clock invalidates even a failed measurement.
+      // eslint-disable-next-line no-unsafe-finally
+      if (elapsed < 0n) throw new Error('etw-file:timing-clock-regressed');
+      const metric = times[key];
+      metric.calls++;
+      metric.totalTicks += elapsed;
+      if (elapsed > metric.maxTicks) metric.maxTicks = elapsed;
+      if (!success) metric.failed++;
+    }
+  }
+  function performance() {
+    return {
+      frequency: '1000000000',
+      asOfQpc: clock().toString(),
+      ...Object.fromEntries(
+        KEYS.map((key) => [
+          key,
+          Object.fromEntries(
+            Object.entries(times[key]).map(([field, value]) => [field, value.toString()]),
+          ),
+        ]),
+      ),
+    };
+  }
+  return {
+    measure,
+    performance,
+    clear() {
+      ring = [];
+      bytes = 0;
+    },
+    retain(records) {
+      measure('retainBatch', () => {
+        for (const record of records) {
+          const copy = structuredClone(record);
+          const cost =
+            1024 + Buffer.byteLength(JSON.stringify(copy)) + (copy.path?.length || 0) * 2;
+          while (ring.length && (ring.length >= 256 || bytes + cost > 1024 * 1024)) {
+            bytes -= ring.shift().bytes;
+            dropped++;
+          }
+          ring.push({ record: copy, bytes: cost });
+          bytes += cost;
+        }
+      });
+    },
+    get dropped() {
+      return dropped;
+    },
+    snapshot() {
+      return {
+        records: ring.map((v) => structuredClone(v.record)),
+        ringBytes: bytes,
+        ringDropped: dropped,
+        mainPerformance: performance(),
+      };
+    },
+  };
+}
+module.exports = { createDiagnostics };

--- a/src/main/platform/etw-file-schema.js
+++ b/src/main/platform/etw-file-schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Closed ETW diagnostic schemas, separate from framing and session validation.
-const PROTOCOL = 'etw-file/3';
+const PROTOCOL = 'etw-file/4';
 const PROFILE = 'home-26200-diagnostic-v1';
 const MAX_FRAME_BYTES = 256 * 1024;
 const MAX_DEPTH = 16;
@@ -79,12 +79,44 @@ const queues = shape({
   highWaterRecords: uint32,
   highWaterBytes: uint32,
 });
+const boundedQueue = (v) =>
+  queues(v) &&
+  v.records <= v.highWaterRecords &&
+  v.bytes <= v.highWaterBytes &&
+  v.highWaterRecords <= 4096 &&
+  v.highWaterBytes <= 4 * 1024 * 1024;
+const durationShape = shape({
+  calls: uint64,
+  totalTicks: uint64,
+  maxTicks: uint64,
+  failed: uint64,
+});
+const duration = (v) =>
+  durationShape(v) &&
+  BigInt(v.failed) <= BigInt(v.calls) &&
+  BigInt(v.maxTicks) <= BigInt(v.totalTicks) &&
+  BigInt(v.totalTicks) <= BigInt(v.calls) * BigInt(v.maxTicks) &&
+  (v.calls !== '0' || (v.totalTicks === '0' && v.maxTicks === '0'));
+const performanceShape = shape({
+  frequency: positive64,
+  asOfQpc: uint64,
+  pump: duration,
+  outputWrite: duration,
+  idleWait: duration,
+  ingress: boundedQueue,
+  output: boundedQueue,
+});
+const performance = (v) =>
+  performanceShape(v) &&
+  BigInt(v.outputWrite.totalTicks) <= BigInt(v.pump.totalTicks) &&
+  BigInt(v.outputWrite.calls) <= BigInt(v.pump.calls);
 const telemetryShape = shape({
   operational: oneOf(true, false),
   reasons: unique(oneOf(...REASONS), REASONS.length),
   counters: counts,
   totals,
   queues,
+  performance,
   coverage: oneOf(PROFILE),
 });
 const telemetry = (v) =>

--- a/src/main/platform/etw-file-supervisor.js
+++ b/src/main/platform/etw-file-supervisor.js
@@ -5,6 +5,7 @@ const { performance } = require('node:perf_hooks');
 const wire = require('./etw-file-protocol');
 const model = require('./etw-file-health');
 const health = require('../sensor-health');
+const { createDiagnostics } = require('./etw-file-diagnostics');
 
 /** Own one broker at a time, with explicit retry and no elevated kill or replay.
  * @param {Object} deps - spawnBroker, optional clocks/ID factory for deterministic tests.
@@ -16,6 +17,7 @@ function createSupervisor({
   now = Date.now,
   mono = () => performance.now(),
   id = randomUUID,
+  profileClock = process.hrtime.bigint,
 }) {
   let current = null,
     child = null,
@@ -38,16 +40,13 @@ function createSupervisor({
     failedAt = null;
   let stopReason = null;
   let capture = null;
-  let ring = [],
-    ringBytes = 0,
-    ringDropped = 0,
-    summaries = [],
+  let diagnostics = createDiagnostics(profileClock);
+  let summaries = [],
     omittedSummaries = 0;
   let idle = { ...health.createSensorHealth('etw-file'), state: 'DISABLED' };
 
   function clearRing() {
-    ring = [];
-    ringBytes = 0;
+    diagnostics.clear();
   }
   function fail(code) {
     if (!current || current.phase === 'failed') return;
@@ -121,17 +120,7 @@ function createSupervisor({
       clearRing();
     }
     if (message.t === 'observations' && stopAt === null) {
-      for (const record of message.data.records) {
-        // Account retained UTF-16 strings as well as JSON bytes and entry overhead.
-        const copy = structuredClone(record);
-        const bytes = 1024 + Buffer.byteLength(JSON.stringify(copy)) + (copy.path?.length || 0) * 2;
-        while (ring.length && (ring.length >= 256 || ringBytes + bytes > 1024 * 1024)) {
-          ringBytes -= ring.shift().bytes;
-          ringDropped++;
-        }
-        ring.push({ record: copy, bytes });
-        ringBytes += bytes;
-      }
+      diagnostics.retain(message.data.records);
     }
     if (message.t === 'stopped') {
       clearRing();
@@ -174,7 +163,9 @@ function createSupervisor({
       capture,
       finalCounters: structuredClone(current.latest?.counters || null),
       finalTotals: structuredClone(current.latest?.totals || null),
-      ringDropped,
+      ringDropped: diagnostics.dropped,
+      collectorPerformance: structuredClone(current.latest?.performance || null),
+      mainPerformance: diagnostics.performance(),
       stopReason,
       exitCode: code,
       stopVerified: current.phase === 'stopped' && code === 0,
@@ -201,7 +192,7 @@ function createSupervisor({
     sent = 0n;
     pendingWrite = false;
     receivedReady = false;
-    ringDropped = 0;
+    diagnostics = createDiagnostics(profileClock);
     stopSent = false;
     failedAt = null;
     clearRing();
@@ -215,12 +206,15 @@ function createSupervisor({
       return false;
     }
     const target = child;
-    decoder = wire.createFrameDecoder({ ...current, onMessage: accept });
+    decoder = wire.createFrameDecoder({
+      ...current,
+      onMessage: (message) => diagnostics.measure('acceptFrame', () => accept(message)),
+    });
     const reader = decoder;
     target.stdout.on('data', (bytes) => {
       if (target !== child || closed) return;
       try {
-        reader.push(bytes);
+        diagnostics.measure('decodeChunk', () => reader.push(bytes));
       } catch {
         fail('protocol-failed');
       }
@@ -281,16 +275,15 @@ function createSupervisor({
       idle = { ...idle, state, detail };
     },
     getHealth: () => structuredClone(current?.record || idle),
-    getDiagnostics: () => ({
-      records: ring.map((v) => structuredClone(v.record)),
-      ringBytes,
-      ringDropped,
-      summaries: structuredClone(summaries),
-      omittedSummaries,
-      restartBlocked: unsafe,
-      phase: current?.phase || 'disabled',
-      pendingBytes: decoder?.allocatedBytes() || 0,
-    }),
+    getDiagnostics: () =>
+      diagnostics.measure('snapshot', () => ({
+        ...diagnostics.snapshot(),
+        summaries: structuredClone(summaries),
+        omittedSummaries,
+        restartBlocked: unsafe,
+        phase: current?.phase || 'disabled',
+        pendingBytes: decoder?.allocatedBytes() || 0,
+      })),
   };
 }
 module.exports = { createSupervisor };

--- a/tests/main/platform/etw-file-fixtures.js
+++ b/tests/main/platform/etw-file-fixtures.js
@@ -24,8 +24,23 @@ export function telemetry(overrides = {}) {
       mapConflicts: '0',
     },
     queues: { records: 0, bytes: 0, highWaterRecords: 2, highWaterBytes: 1024 },
+    performance: collectorPerformance(),
     coverage: 'home-26200-diagnostic-v1',
     ...overrides,
+  };
+}
+
+export function collectorPerformance() {
+  const duration = () => ({ calls: '0', totalTicks: '0', maxTicks: '0', failed: '0' });
+  const queue = () => ({ records: 0, bytes: 0, highWaterRecords: 0, highWaterBytes: 0 });
+  return {
+    frequency: '10000000',
+    asOfQpc: '100',
+    pump: duration(),
+    outputWrite: duration(),
+    idleWait: duration(),
+    ingress: queue(),
+    output: queue(),
   };
 }
 
@@ -83,7 +98,7 @@ export function message(t = 'hello', seq = '1', data) {
   };
   return {
     t,
-    proto: 'etw-file/3',
+    proto: 'etw-file/4',
     launchId: 'launch-1',
     sessionId: 'session-1',
     seq,

--- a/tests/main/platform/etw-file-performance.test.js
+++ b/tests/main/platform/etw-file-performance.test.js
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import protocol from '../../../src/main/platform/etw-file-protocol.js';
+import { createDiagnostics } from '../../../src/main/platform/etw-file-diagnostics.js';
+import { createSupervisor } from '../../../src/main/platform/etw-file-supervisor.js';
+import { message, observation, rawFrame, telemetry } from './etw-file-fixtures.js';
+
+describe('ETW service measurements', () => {
+  it('keeps nested wall-time groups separate and records thrown calls', () => {
+    let clock = 0n;
+    const diagnostics = createDiagnostics(() => clock);
+    diagnostics.measure('decodeChunk', () => {
+      clock = 5n;
+      diagnostics.measure('acceptFrame', () => {
+        clock = 15n;
+      });
+      clock = 20n;
+    });
+    const failure = new Error('private-error');
+    expect(() =>
+      diagnostics.measure('decodeChunk', () => {
+        clock = 27n;
+        throw failure;
+      }),
+    ).toThrow(failure);
+    expect(diagnostics.performance()).toMatchObject({
+      frequency: '1000000000',
+      decodeChunk: { calls: '2', totalTicks: '27', maxTicks: '20', failed: '1' },
+      acceptFrame: { calls: '1', totalTicks: '10', maxTicks: '10', failed: '0' },
+    });
+    expect(JSON.stringify(diagnostics.performance())).not.toContain('private-error');
+  });
+
+  it('retains the ring cap, copy isolation and loss count when clearing records', () => {
+    const diagnostics = createDiagnostics(() => 0n);
+    const records = Array.from({ length: 300 }, (_, index) =>
+      observation({ eventSeq: String(index + 1) }),
+    );
+    diagnostics.retain(records);
+    records.at(-1).headerPid = 900;
+    const snapshot = diagnostics.snapshot();
+    expect(snapshot.records).toHaveLength(256);
+    expect(snapshot.records[0].eventSeq).toBe('45');
+    expect(snapshot.records.at(-1).headerPid).toBe(71);
+    expect(snapshot.ringDropped).toBe(44);
+    snapshot.records[0].headerPid = 800;
+    snapshot.mainPerformance.retainBatch.calls = '999';
+    expect(diagnostics.snapshot().records[0].headerPid).toBe(71);
+    expect(diagnostics.performance().retainBatch.calls).toBe('1');
+    diagnostics.clear();
+    expect(diagnostics.snapshot()).toMatchObject({ records: [], ringBytes: 0, ringDropped: 44 });
+  });
+
+  it('bounds retained large paths by bytes', () => {
+    const diagnostics = createDiagnostics(() => 0n);
+    diagnostics.retain(
+      Array.from({ length: 100 }, (_, index) =>
+        observation({
+          eventSeq: String(index + 1),
+          path: 'x'.repeat(32000),
+          pathEvidence: 'candidate-object',
+        }),
+      ),
+    );
+    const snapshot = diagnostics.snapshot();
+    expect(snapshot.ringBytes).toBeLessThanOrEqual(1024 * 1024);
+    expect(snapshot.records.length).toBeLessThan(100);
+    expect(snapshot.records.length + snapshot.ringDropped).toBe(100);
+  });
+
+  it.each([
+    (p) => {
+      p.frequency = '0';
+    },
+    (p) => {
+      p.pump.calls = 1;
+    },
+    (p) => {
+      p.pump.totalTicks = '-1';
+    },
+    (p) => {
+      p.pump.totalTicks = '1';
+    },
+    (p) => {
+      p.pump.failed = '1';
+    },
+    (p) => {
+      p.pump.maxTicks = '1';
+    },
+    (p) => {
+      p.pump = { calls: '2', totalTicks: '9', maxTicks: '4', failed: '0' };
+    },
+    (p) => {
+      p.outputWrite.calls = '1';
+    },
+    (p) => {
+      p.outputWrite = { calls: '1', totalTicks: '2', maxTicks: '2', failed: '0' };
+    },
+    (p) => {
+      p.output.highWaterRecords = 4097;
+    },
+    (p) => {
+      p.ingress.highWaterBytes = 4 * 1024 * 1024 + 1;
+    },
+    (p) => {
+      p.output.records = 1;
+    },
+    (p) => {
+      p.pump.path = 'must-not-leak';
+    },
+  ])('rejects malformed timing/queue telemetry %#', (change) => {
+    const sample = telemetry();
+    change(sample.performance);
+    expect(() => protocol.validateMessage(message('health', '3', sample))).toThrow();
+  });
+
+  it('rejects absent profiling instead of inventing measurements', () => {
+    const sample = telemetry();
+    delete sample.performance;
+    expect(() => protocol.validateMessage(message('health', '3', sample))).toThrow();
+  });
+
+  it('preserves uint64 measurements beyond Number precision in frames', () => {
+    const sample = telemetry();
+    sample.performance.pump = {
+      calls: '2',
+      totalTicks: '18014398509481988',
+      maxTicks: '9007199254740995',
+      failed: '1',
+    };
+    sample.performance.outputWrite = {
+      calls: '1',
+      totalTicks: '9007199254740993',
+      maxTicks: '9007199254740993',
+      failed: '0',
+    };
+    const frames = [];
+    protocol
+      .createFrameDecoder({
+        launchId: 'launch-1',
+        sessionId: 'session-1',
+        onMessage: (v) => {
+          frames.push(v);
+        },
+      })
+      .push(protocol.encodeFrame(message('health', '3', sample)));
+    expect(frames[0].data.performance).toEqual(sample.performance);
+  });
+
+  it('freezes final measurements in ended summaries and resets for the next session', () => {
+    let peer,
+      time = 0n;
+    const sensor = createSupervisor({
+      profileClock: () => ++time,
+      spawnBroker: (launchId, sessionId) => {
+        peer = new EventEmitter();
+        peer.stdout = new EventEmitter();
+        peer.stdin = new EventEmitter();
+        peer.sent = [];
+        peer.stdin.write = (bytes, callback) => {
+          peer.sent.push(JSON.parse(bytes.subarray(4)));
+          callback?.();
+          return true;
+        };
+        peer.stdin.end = () => {};
+        peer.kill = () => {};
+        peer.send = (t, seq, data) =>
+          peer.stdout.emit('data', rawFrame({ ...message(t, seq, data), launchId, sessionId }));
+        return peer;
+      },
+    });
+    try {
+      sensor.start();
+      peer.send('hello', '1');
+      const ready = message('ready', '2').data;
+      ready.requestId = peer.sent[0].data.requestId;
+      peer.send('ready', '2', ready);
+      peer.send('observations', '3', { records: [observation()] });
+      sensor.getDiagnostics();
+      sensor.stop();
+      const done = message('stopped', '4').data;
+      done.requestId = peer.sent.at(-1).data.requestId;
+      done.telemetry.performance.pump = {
+        calls: '1',
+        totalTicks: '40',
+        maxTicks: '40',
+        failed: '0',
+      };
+      peer.send('stopped', '4', done);
+      peer.emit('close', 0);
+      const final = sensor.getDiagnostics().summaries[0];
+      expect(final.collectorPerformance.pump.totalTicks).toBe('40');
+      expect(final.mainPerformance.decodeChunk.calls).toBe('4');
+      expect(final.mainPerformance.retainBatch.calls).toBe('1');
+      expect(final.mainPerformance.snapshot.calls).toBe('1');
+      done.telemetry.performance.pump.totalTicks = '999';
+      sensor.start();
+      expect(sensor.getDiagnostics().mainPerformance.decodeChunk.calls).toBe('0');
+      expect(sensor.getDiagnostics().summaries[0]).toEqual(final);
+      peer.emit('close', 1);
+      const failed = sensor.getDiagnostics().summaries.at(-1);
+      expect(failed.collectorPerformance).toBeNull();
+      expect(failed.stopVerified).toBe(false);
+    } finally {
+      sensor.dispose();
+    }
+  });
+});

--- a/tests/main/platform/etw-file-protocol.test.js
+++ b/tests/main/platform/etw-file-protocol.test.js
@@ -48,7 +48,7 @@ describe('offline ETW envelope', () => {
 
   it.each([
     { proto: 'etw-file/1' },
-    { proto: 'etw-file/4' },
+    { proto: 'etw-file/5' },
     { sessionId: '' },
     { launchId: 'x'.repeat(65) },
     { t: '__proto__' },

--- a/tests/main/platform/etw-file-stage-loss.test.js
+++ b/tests/main/platform/etw-file-stage-loss.test.js
@@ -69,17 +69,20 @@ describe('ETW stage loss contract', () => {
     );
   });
 
-  it.each(['etw-file/1', 'etw-file/2'])(
+  it.each(['etw-file/1', 'etw-file/2', 'etw-file/3'])(
     'rejects legacy %s without inventing measurements',
     (version) => {
       const old = message('health', '3', stageSample());
       old.proto = version;
+      delete old.data.performance;
       if (version === 'etw-file/1') {
         delete old.data.totals.ingressDropped;
         delete old.data.totals.outputDropped;
       }
-      delete old.data.totals.outputOverflowDropped;
-      delete old.data.totals.outputInvalidatedDropped;
+      if (version !== 'etw-file/3') {
+        delete old.data.totals.outputOverflowDropped;
+        delete old.data.totals.outputInvalidatedDropped;
+      }
       const sink = vi.fn();
       const reader = protocol.createFrameDecoder({
         launchId: 'launch-1',

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -63,6 +63,8 @@ export default defineConfig({
         'src/main/platform/etw-file-protocol.js',
         'src/main/platform/etw-file-schema.js',
         'src/main/platform/etw-file-health.js',
+        'src/main/platform/etw-file-diagnostics.js',
+        'src/main/platform/etw-file-supervisor.js',
         'src/main/platform/proc-snapshot-client.js',
         'src/main/platform/process-snapshot.js',
         'src/main/platform/linux.js',


### PR DESCRIPTION
Burst capture already identified output-queue overflow, but its reports could not distinguish pump work, pipe writes and main processing. Protocol v4 adds bounded elapsed-time aggregates, separate ingress/output queue depths and preserved measurements in ended summaries. Main keeps its existing ring limits and copies through an extracted diagnostic owner. Older peers fail validation; rebuild main and helper together.

The same 66,000-read live workload completed with verified stop and zero remaining helpers. It recorded 52,066 output overflow drops, zero ingress/invalidation/native loss, 173.667 ms total collector pump time including 124.442 ms of writes, and 161.116 ms of main chunk handling. Empty-pump waits averaged 15.587 ms. These are nested wall-time aggregates, not CPU usage or phase-local causality; overflow remains open. The next experiment is an output-available wakeup with the existing cancellation/drain bounds.

Evidence retains three original process/live reports, matching binary hashes and 26 measured source hashes, plus a separate hash for the subsequent comment-only lint annotation. No workload, buffer budget, IPC, agent attribution or installed-app changes.

Validation: 39 C# self-tests; 161 focused JS tests; full coverage 200 files / 3,354 passed / 4 skipped; C# Release build/format; renderer build; format/lint; TypeScript/Svelte; witness and sequence mutation gates; derived counts; production dependency audit. Normal and deliberate-saturation process checks passed three scenarios each; missing EOF acknowledgement stayed unverified. Real sleep/wake remains deferred.
