### PR TITLE
perf(etw): wake output pump on queued records

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,9 +121,11 @@ The dependency is those observations, not the absence of a Windows host.
    The [service measurements](docs/roadmap/etw-service-timings.md) now add v4 bounded
    collector/main timing and stage queue depths. The same workload retained 52,066
    output overflow drops; non-write pump work took 49.225 ms, writes 124.442 ms,
-   and empty-pump waits averaged 15.587 ms. Next test an output-available wakeup
-   with existing cancellation/drain bounds; these aggregates alone do not prove
-   that polling caused the overflow.
+   and empty-pump waits averaged 15.587 ms. The [output-wakeup change](docs/roadmap/etw-output-wakeup.md)
+   now replaces polling with queue/lifecycle/deadline signals while preserving drain
+   bounds. Its live run recorded 40 empty waits and 50,246 output overflow drops.
+   Overflow remains; differing burst rates prevent a causal throughput claim.
+   Next measure burst-interval arrival/drain rates, wake latency and broker forwarding.
 
 ## C — existing rules coverage
 

--- a/docs/recon/evidence/etw-file-home-26200-output-wakeup.json
+++ b/docs/recon/evidence/etw-file-home-26200-output-wakeup.json
@@ -1,0 +1,2138 @@
+{
+  "schema": 1,
+  "recordedAt": "2026-09-11T00:16:31.130Z",
+  "scope": "Replace empty-output polling with queue/lifecycle/deadline signals; preserve v4 telemetry and bounded drain. One fixed-profile live experiment.",
+  "sourceBaseCommit": "3d88df444f5fa8f1c4b74c5036920e43e292fbf2",
+  "sourceHashNormalization": "UTF-8 bytes with CRLF normalized to LF; source hashes match the checked working tree and staged implementation",
+  "sourceHashes": {
+    "scripts/etw-file-load.mjs": "60e7591651b065d46adbff3581b24729068bd5b699e6061c78f82c925fc0e585",
+    "scripts/etw-file-workload.mjs": "d889fab260036c8326fe5751bca6e4908855bd3c9c001366e11529fcf910579c",
+    "scripts/verify-etw-file.mjs": "0425ee226e679030ac35664f9114501581016f61cabce6c492ac93d05b4a8ebf",
+    "sidecar/etw-file/EtwFile.csproj": "9e34c6ad37d5751758d618095cf6b32ae54d90382855ece0b622fa2588589205",
+    "sidecar/etw-file/FileBroker.cs": "1997937dc7d337ac3c2ad8db031dbc0ba8d2b67263a385c037962aec18ee6d3a",
+    "sidecar/etw-file/FileBurstTests.cs": "427b039cbc288791ee5671087a11bed210913193c38d67c5079fe8e2d458be01",
+    "sidecar/etw-file/FileCapture.cs": "318d80a666392cbf1ab3b03666b1fec28f1d57e958229f0e050a639bb1726dc3",
+    "sidecar/etw-file/FileCollector.cs": "12331525c9e889ad70f22ce8a3dd5ee300e465e3ec58cad839fa949444a0ab35",
+    "sidecar/etw-file/FileGeneration.cs": "8520aa3bda23ee51bf6efe556f7aa72a2b31fa75f2cd7d8dd2077047369ff768",
+    "sidecar/etw-file/FileLossFixture.cs": "ab4210f402d278ea51ae23e978104ec6e91fb6f2be7cb225579424c193a1cda0",
+    "sidecar/etw-file/FileMapping.cs": "c0c2975837899e9e820328a8cd638e24c183ab0c3d36d9c0cb58cc936855922c",
+    "sidecar/etw-file/FileOutputTests.cs": "aadc58212ee9272dabcad4cf1932a3b6683941c50e138f701b4de6a468016ae9",
+    "sidecar/etw-file/FilePerformance.cs": "72cc842004a0b71f89c606de30f68694458fea25abb681b126b2ce9b834d60a8",
+    "sidecar/etw-file/FilePerformanceTests.cs": "dae11e9b91e575759e10061593a057830dcfa61a37a83cf871d87b2de3cc7b89",
+    "sidecar/etw-file/FilePipeline.cs": "69e2f09de7ca870455591990460fb49472a7fa491b79ca516f568fff7650f03c",
+    "sidecar/etw-file/FilePumpWait.cs": "ded3306b5170172a22b0c8b0a5a5276e3d4a7b4473c10c57673288ce52cc613a",
+    "sidecar/etw-file/FileScope.cs": "05976472d37b07c60be71aedb6fb89da795ba0a41d527a3b41d244bd5aee5ca0",
+    "sidecar/etw-file/FileTests.cs": "616422d53e3fce52d336ee03dda4631fced43f4d995da8076dd5260fd147e949",
+    "sidecar/etw-file/FileTrace.cs": "25fd9d2f46a0d66c01610a1c4a5b03bc6042af654e6bcd2cdf85ec69e94c4dc6",
+    "sidecar/etw-file/FileWakeTests.cs": "77c5d9d590df040959f23fe96e3e6a8be4f7eea0f946ba479748e341501f6b6f",
+    "sidecar/etw-file/FileWire.cs": "179c133478a45ef80e5d3e59b4882433cca88334ae5c46ae21120587553170fa",
+    "sidecar/etw-file/Program.cs": "578502da3372353dc8316d3c53eb56ecdf6bb4b1162436891903deb572e54092",
+    "sidecar/etw-lifecycle/Security.cs": "19fde5ace53914b1e8804b9716a2d041d794e09b273bd8acc385405ba6fadc96",
+    "src/main/platform/etw-file-diagnostics.js": "e4c944f6ba3c1ea7c28974f56ec62e8ff9471dcb82b68f62c3ec9b1ccf1c1cdd",
+    "src/main/platform/etw-file-health.js": "d164d2c1cf2b4e262813c8c89a93e547412432a8909b3f46245159c9c8757e7c",
+    "src/main/platform/etw-file-protocol.js": "e44f18e5827a8dcce3fbcb2f5074b7f97fb7eeaed1c981a15b8c5d12f01b94e8",
+    "src/main/platform/etw-file-schema.js": "6452d6042a3fff92954f5f90c3a4c838158658726b625c2cac615565e5a713b9",
+    "src/main/platform/etw-file-supervisor.js": "83415935a9e7d662f859afb61cacf609b2b45bb5b49d52aa1f3434ae3816bfb9"
+  },
+  "host": {
+    "edition": "Windows 11 Home",
+    "version": "25H2",
+    "build": "26200.8655",
+    "node": "v24.11.1"
+  },
+  "preflight": {
+    "normalTokenParent": true,
+    "matchingNormalLossAndLiveBinaries": true,
+    "matchingBaselineWorkloadModulesAndProfile": true,
+    "priorHelpers": 0
+  },
+  "selfTests": {
+    "passed": 49,
+    "logSha256": "d72f26c9148b6c7da93c59ec4a0928ec8d9bb217d1796d867c2a1311f6c1ba73"
+  },
+  "normal": {
+    "file": "aegis-etw-wakeup-normal-20260911.json",
+    "sha256": "cdc9e820ab46bcc0b405928a77e448dadeb5e38d34217415d84c9c898f743594",
+    "report": {
+      "schema": 1,
+      "live": false,
+      "synthetic": true,
+      "protocol": "etw-file/4",
+      "lossCheck": false,
+      "loadCheck": false,
+      "startedAt": "2026-09-11T00:12:44.728Z",
+      "binarySha256": "72412301e205de36434999b0d4b9397b433be74ba691efb6c658de847696fa99",
+      "assemblySha256": "fef54eb7fb21673aa457ee8f768351f7464160bae86941290243ce1bf67f5bb4",
+      "cases": [
+        {
+          "kind": "normal-stop",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 1617,
+          "ringDropped": 0,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "9904e6d1-b3fe-4df0-8f82-9139b3d16523",
+            "sessionId": "bd5e3fa5-6e5b-4c7b-abc8-45f447a68852",
+            "endedAt": 1789085565254,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "311116419707",
+                "unixMs": "1789085565099",
+                "uncertaintyQpc": "10832"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "311115069372"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "311117609116",
+              "pump": {
+                "calls": "4",
+                "totalTicks": "166655",
+                "maxTicks": "165756",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "1",
+                "totalTicks": "2090",
+                "maxTicks": "2090",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "2",
+                "totalTicks": "670244",
+                "maxTicks": "641338",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 2,
+                "highWaterBytes": 713
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "31111797060900",
+              "decodeChunk": {
+                "calls": "5",
+                "totalTicks": "6013700",
+                "maxTicks": "2061900",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "4",
+                "totalTicks": "3729700",
+                "maxTicks": "1350800",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "1",
+                "totalTicks": "183400",
+                "maxTicks": "183400",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "21",
+                "totalTicks": "1893000",
+                "maxTicks": "182500",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "explicit-new-session",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 1617,
+          "ringDropped": 0,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "0bf3e0a6-db62-4f6c-8a3a-bf36e495f59f",
+            "sessionId": "f188fe01-d896-4f38-86ed-8e4198a54480",
+            "endedAt": 1789085565947,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "311123289969",
+                "unixMs": "1789085565786",
+                "uncertaintyQpc": "10769"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "311121385238"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "311124403320",
+              "pump": {
+                "calls": "4",
+                "totalTicks": "192360",
+                "maxTicks": "191816",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "1",
+                "totalTicks": "2550",
+                "maxTicks": "2550",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "2",
+                "totalTicks": "514508",
+                "maxTicks": "438970",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 2,
+                "highWaterBytes": 713
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "31112489938000",
+              "decodeChunk": {
+                "calls": "5",
+                "totalTicks": "2073100",
+                "maxTicks": "566600",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "4",
+                "totalTicks": "1141800",
+                "maxTicks": "333600",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "1",
+                "totalTicks": "69000",
+                "maxTicks": "69000",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "26",
+                "totalTicks": "3911400",
+                "maxTicks": "330500",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "parent-eof-unverified",
+          "summary": {
+            "launchId": "416cf9c4-b400-4f46-84fd-52ee51e649af",
+            "sessionId": "4b300a68-5f81-47e3-bd4c-7aea99dc8537",
+            "endedAt": 1789085566780,
+            "phase": "failed",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "mapping-uncertain",
+              "identity-uncertain",
+              "stream-ended"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "311132154402",
+                "unixMs": "1789085566673",
+                "uncertaintyQpc": "11052"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "311129638847"
+            },
+            "finalTotals": {
+              "delivered": "2",
+              "filtered": "1",
+              "dropped": "0",
+              "ingressDropped": "0",
+              "outputDropped": "0",
+              "outputOverflowDropped": "0",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "0",
+              "mapResets": "0",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "311132272586",
+              "pump": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 2,
+                "highWaterBytes": 713
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "31113323113600",
+              "decodeChunk": {
+                "calls": "4",
+                "totalTicks": "1436000",
+                "maxTicks": "512500",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "3",
+                "totalTicks": "750200",
+                "maxTicks": "297700",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "1",
+                "totalTicks": "81400",
+                "maxTicks": "81400",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "27",
+                "totalTicks": "7116800",
+                "maxTicks": "697200",
+                "failed": "0"
+              }
+            },
+            "stopReason": null,
+            "exitCode": 2,
+            "stopVerified": false
+          }
+        }
+      ],
+      "passed": true,
+      "observationCheck": {
+        "observed": true,
+        "named": true,
+        "fixtureRead": false,
+        "leaked": false
+      },
+      "endedSessions": [
+        {
+          "launchId": "9904e6d1-b3fe-4df0-8f82-9139b3d16523",
+          "sessionId": "bd5e3fa5-6e5b-4c7b-abc8-45f447a68852",
+          "endedAt": 1789085565254,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "311116419707",
+              "unixMs": "1789085565099",
+              "uncertaintyQpc": "10832"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "311115069372"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "311117609116",
+            "pump": {
+              "calls": "4",
+              "totalTicks": "166655",
+              "maxTicks": "165756",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "1",
+              "totalTicks": "2090",
+              "maxTicks": "2090",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "2",
+              "totalTicks": "670244",
+              "maxTicks": "641338",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "31111797060900",
+            "decodeChunk": {
+              "calls": "5",
+              "totalTicks": "6013700",
+              "maxTicks": "2061900",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "3729700",
+              "maxTicks": "1350800",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "183400",
+              "maxTicks": "183400",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "21",
+              "totalTicks": "1893000",
+              "maxTicks": "182500",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "0bf3e0a6-db62-4f6c-8a3a-bf36e495f59f",
+          "sessionId": "f188fe01-d896-4f38-86ed-8e4198a54480",
+          "endedAt": 1789085565947,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "311123289969",
+              "unixMs": "1789085565786",
+              "uncertaintyQpc": "10769"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "311121385238"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "311124403320",
+            "pump": {
+              "calls": "4",
+              "totalTicks": "192360",
+              "maxTicks": "191816",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "1",
+              "totalTicks": "2550",
+              "maxTicks": "2550",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "2",
+              "totalTicks": "514508",
+              "maxTicks": "438970",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "31112489938000",
+            "decodeChunk": {
+              "calls": "5",
+              "totalTicks": "2073100",
+              "maxTicks": "566600",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "1141800",
+              "maxTicks": "333600",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "69000",
+              "maxTicks": "69000",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "26",
+              "totalTicks": "3911400",
+              "maxTicks": "330500",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "416cf9c4-b400-4f46-84fd-52ee51e649af",
+          "sessionId": "4b300a68-5f81-47e3-bd4c-7aea99dc8537",
+          "endedAt": 1789085566780,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "311132154402",
+              "unixMs": "1789085566673",
+              "uncertaintyQpc": "11052"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "311129638847"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "311132272586",
+            "pump": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 0,
+              "highWaterBytes": 0
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "31113323113600",
+            "decodeChunk": {
+              "calls": "4",
+              "totalTicks": "1436000",
+              "maxTicks": "512500",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "3",
+              "totalTicks": "750200",
+              "maxTicks": "297700",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "81400",
+              "maxTicks": "81400",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "27",
+              "totalTicks": "7116800",
+              "maxTicks": "697200",
+              "failed": "0"
+            }
+          },
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      ],
+      "endedAt": "2026-09-11T00:12:46.797Z"
+    }
+  },
+  "lossCheck": {
+    "file": "aegis-etw-wakeup-loss-20260911.json",
+    "sha256": "0c166cca1b39fabbf13741c2322ed25ecf68ec1b1acabb530aec16cd8e03623a",
+    "report": {
+      "schema": 1,
+      "live": false,
+      "synthetic": true,
+      "protocol": "etw-file/4",
+      "lossCheck": true,
+      "loadCheck": false,
+      "startedAt": "2026-09-11T00:12:46.965Z",
+      "binarySha256": "72412301e205de36434999b0d4b9397b433be74ba691efb6c658de847696fa99",
+      "assemblySha256": "fef54eb7fb21673aa457ee8f768351f7464160bae86941290243ce1bf67f5bb4",
+      "cases": [
+        {
+          "kind": "normal-stop",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 412928,
+          "ringDropped": 248,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "fa9c6a52-9e26-4350-8697-8618bb4b74b0",
+            "sessionId": "6b8b2c5a-48ad-4b20-aa72-43351c7dbc64",
+            "endedAt": 1789085567948,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "dropped",
+              "ingressDropped",
+              "outputDropped",
+              "outputOverflowDropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "311143185281",
+                "unixMs": "1789085567776",
+                "uncertaintyQpc": "10999"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "311138789473"
+            },
+            "finalTotals": {
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 248,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "311144513847",
+              "pump": {
+                "calls": "28",
+                "totalTicks": "1057924",
+                "maxTicks": "215284",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "27",
+                "totalTicks": "704634",
+                "maxTicks": "45532",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 4096,
+                "highWaterBytes": 1048576
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "31114491066100",
+              "decodeChunk": {
+                "calls": "34",
+                "totalTicks": "37235600",
+                "maxTicks": "3713700",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "30",
+                "totalTicks": "18431400",
+                "maxTicks": "2120400",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "7",
+                "totalTicks": "6059300",
+                "maxTicks": "1386900",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "36",
+                "totalTicks": "4483000",
+                "maxTicks": "838000",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "explicit-new-session",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": false,
+          "ringBytes": 348408,
+          "ringDropped": 0,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "76466288-8e36-4d1c-a6a8-eb3a1c97a779",
+            "sessionId": "1d96b222-38b2-48a4-9f5c-d35b771e99ac",
+            "endedAt": 1789085568895,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "dropped",
+              "ingressDropped",
+              "outputDropped",
+              "outputOverflowDropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "311152659773",
+                "unixMs": "1789085568723",
+                "uncertaintyQpc": "11487"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "311148603479"
+            },
+            "finalTotals": {
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 0,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "311154021836",
+              "pump": {
+                "calls": "28",
+                "totalTicks": "1084503",
+                "maxTicks": "178800",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "27",
+                "totalTicks": "796956",
+                "maxTicks": "52756",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 4096,
+                "highWaterBytes": 1048576
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "31115438051400",
+              "decodeChunk": {
+                "calls": "31",
+                "totalTicks": "21741400",
+                "maxTicks": "2112900",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "30",
+                "totalTicks": "9226700",
+                "maxTicks": "1555900",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "3",
+                "totalTicks": "2313800",
+                "maxTicks": "1256000",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "35",
+                "totalTicks": "5597300",
+                "maxTicks": "1005800",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        },
+        {
+          "kind": "parent-eof-unverified",
+          "summary": {
+            "launchId": "81cd5591-a07e-4f56-bca4-4c3ade5a1e22",
+            "sessionId": "ae0c18fe-6c12-4b0d-93b5-67efab927f75",
+            "endedAt": 1789085569797,
+            "phase": "failed",
+            "reasons": [
+              "experimental-correlation",
+              "unmeasured-interval",
+              "dropped",
+              "ingressDropped",
+              "outputDropped",
+              "outputOverflowDropped",
+              "mapResets",
+              "mapping-uncertain",
+              "identity-uncertain",
+              "stream-ended"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "311162319218",
+                "unixMs": "1789085569689",
+                "uncertaintyQpc": "11012"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": null,
+              "realTimeBuffersLost": null,
+              "logBuffersLost": null,
+              "queryStatus": 50,
+              "asOfQpc": "311158127724"
+            },
+            "finalTotals": {
+              "delivered": "12290",
+              "filtered": "1",
+              "dropped": "10367",
+              "ingressDropped": "4097",
+              "outputDropped": "6270",
+              "outputOverflowDropped": "6270",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "1",
+              "mapResets": "1",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 176,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "311162346961",
+              "pump": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 4096,
+                "highWaterBytes": 1048576
+              },
+              "output": {
+                "records": 1922,
+                "bytes": 4193804,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "31116340022800",
+              "decodeChunk": {
+                "calls": "11",
+                "totalTicks": "7113500",
+                "maxTicks": "1591500",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "8",
+                "totalTicks": "4833700",
+                "maxTicks": "1261900",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "6",
+                "totalTicks": "3367600",
+                "maxTicks": "1073600",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "29",
+                "totalTicks": "7271500",
+                "maxTicks": "1152800",
+                "failed": "0"
+              }
+            },
+            "stopReason": null,
+            "exitCode": 2,
+            "stopVerified": false
+          }
+        }
+      ],
+      "passed": true,
+      "observationCheck": {
+        "observed": true,
+        "named": true,
+        "fixtureRead": false,
+        "leaked": false
+      },
+      "endedSessions": [
+        {
+          "launchId": "fa9c6a52-9e26-4350-8697-8618bb4b74b0",
+          "sessionId": "6b8b2c5a-48ad-4b20-aa72-43351c7dbc64",
+          "endedAt": 1789085567948,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "311143185281",
+              "unixMs": "1789085567776",
+              "uncertaintyQpc": "10999"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "311138789473"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 248,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "311144513847",
+            "pump": {
+              "calls": "28",
+              "totalTicks": "1057924",
+              "maxTicks": "215284",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "27",
+              "totalTicks": "704634",
+              "maxTicks": "45532",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "31114491066100",
+            "decodeChunk": {
+              "calls": "34",
+              "totalTicks": "37235600",
+              "maxTicks": "3713700",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "30",
+              "totalTicks": "18431400",
+              "maxTicks": "2120400",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "7",
+              "totalTicks": "6059300",
+              "maxTicks": "1386900",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "36",
+              "totalTicks": "4483000",
+              "maxTicks": "838000",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "76466288-8e36-4d1c-a6a8-eb3a1c97a779",
+          "sessionId": "1d96b222-38b2-48a4-9f5c-d35b771e99ac",
+          "endedAt": 1789085568895,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "311152659773",
+              "unixMs": "1789085568723",
+              "uncertaintyQpc": "11487"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "311148603479"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "311154021836",
+            "pump": {
+              "calls": "28",
+              "totalTicks": "1084503",
+              "maxTicks": "178800",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "27",
+              "totalTicks": "796956",
+              "maxTicks": "52756",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "31115438051400",
+            "decodeChunk": {
+              "calls": "31",
+              "totalTicks": "21741400",
+              "maxTicks": "2112900",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "30",
+              "totalTicks": "9226700",
+              "maxTicks": "1555900",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "3",
+              "totalTicks": "2313800",
+              "maxTicks": "1256000",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "35",
+              "totalTicks": "5597300",
+              "maxTicks": "1005800",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        },
+        {
+          "launchId": "81cd5591-a07e-4f56-bca4-4c3ade5a1e22",
+          "sessionId": "ae0c18fe-6c12-4b0d-93b5-67efab927f75",
+          "endedAt": 1789085569797,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "311162319218",
+              "unixMs": "1789085569689",
+              "uncertaintyQpc": "11012"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "311158127724"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 176,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "311162346961",
+            "pump": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 1922,
+              "bytes": 4193804,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "31116340022800",
+            "decodeChunk": {
+              "calls": "11",
+              "totalTicks": "7113500",
+              "maxTicks": "1591500",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "8",
+              "totalTicks": "4833700",
+              "maxTicks": "1261900",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "6",
+              "totalTicks": "3367600",
+              "maxTicks": "1073600",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "29",
+              "totalTicks": "7271500",
+              "maxTicks": "1152800",
+              "failed": "0"
+            }
+          },
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      ],
+      "endedAt": "2026-09-11T00:12:49.813Z"
+    }
+  },
+  "live": {
+    "file": "aegis-etw-wakeup-live-20260911.json",
+    "sha256": "00ccac1c065234ad99873342b42ece09aeb03c98a8b4c282366f52e02a015dbd",
+    "report": {
+      "schema": 1,
+      "live": true,
+      "synthetic": false,
+      "protocol": "etw-file/4",
+      "lossCheck": false,
+      "loadCheck": true,
+      "startedAt": "2026-09-11T00:16:08.806Z",
+      "binarySha256": "72412301e205de36434999b0d4b9397b433be74ba691efb6c658de847696fa99",
+      "assemblySha256": "fef54eb7fb21673aa457ee8f768351f7464160bae86941290243ce1bf67f5bb4",
+      "cases": [
+        {
+          "kind": "normal-stop",
+          "observedRead": true,
+          "observedScopedCandidate": true,
+          "observedFixturePidCandidate": true,
+          "ringBytes": 417353,
+          "ringDropped": 15516,
+          "sensorState": "DEGRADED",
+          "summary": {
+            "launchId": "5b82e98d-4ddc-4f67-9971-fa84c95791ff",
+            "sessionId": "5791d1a7-dd29-4048-ae2c-e78ed2472495",
+            "endedAt": 1789085791129,
+            "phase": "stopped",
+            "reasons": [
+              "experimental-correlation",
+              "mapResets",
+              "dropped",
+              "outputDropped",
+              "outputOverflowDropped",
+              "mapping-uncertain",
+              "identity-uncertain"
+            ],
+            "maxima": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "delivered": "111722",
+              "filtered": "45703",
+              "dropped": "50246",
+              "ingressDropped": "0",
+              "outputDropped": "50246",
+              "outputOverflowDropped": "50246",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "6",
+              "mapResets": "6",
+              "mapConflicts": "0"
+            },
+            "capture": {
+              "buffers": {
+                "count": 256,
+                "sizeKiB": 64
+              },
+              "frequency": "10000000",
+              "clock": {
+                "qpc": "313176555363",
+                "unixMs": "1789085771115",
+                "uncertaintyQpc": "10186"
+              }
+            },
+            "finalCounters": {
+              "eventsLost": "0",
+              "realTimeBuffersLost": "0",
+              "logBuffersLost": "0",
+              "queryStatus": 0,
+              "asOfQpc": "313375099521"
+            },
+            "finalTotals": {
+              "delivered": "111722",
+              "filtered": "45703",
+              "dropped": "50246",
+              "ingressDropped": "0",
+              "outputDropped": "50246",
+              "outputOverflowDropped": "50246",
+              "outputInvalidatedDropped": "0",
+              "decoderErrors": "0",
+              "mapEpoch": "6",
+              "mapResets": "6",
+              "mapConflicts": "0"
+            },
+            "ringDropped": 15516,
+            "collectorPerformance": {
+              "frequency": "10000000",
+              "asOfQpc": "313376230698",
+              "pump": {
+                "calls": "298",
+                "totalTicks": "3408210",
+                "maxTicks": "183742",
+                "failed": "0"
+              },
+              "outputWrite": {
+                "calls": "257",
+                "totalTicks": "2636843",
+                "maxTicks": "66560",
+                "failed": "0"
+              },
+              "idleWait": {
+                "calls": "40",
+                "totalTicks": "195893520",
+                "maxTicks": "19839180",
+                "failed": "0"
+              },
+              "ingress": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1095,
+                "highWaterBytes": 351624
+              },
+              "output": {
+                "records": 0,
+                "bytes": 0,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804
+              }
+            },
+            "mainPerformance": {
+              "frequency": "1000000000",
+              "asOfQpc": "31337669830000",
+              "decodeChunk": {
+                "calls": "188",
+                "totalTicks": "307434000",
+                "maxTicks": "7143700",
+                "failed": "0"
+              },
+              "acceptFrame": {
+                "calls": "269",
+                "totalTicks": "203724200",
+                "maxTicks": "2748900",
+                "failed": "0"
+              },
+              "retainBatch": {
+                "calls": "256",
+                "totalTicks": "141157800",
+                "maxTicks": "2534800",
+                "failed": "0"
+              },
+              "snapshot": {
+                "calls": "717",
+                "totalTicks": "781801600",
+                "maxTicks": "3059400",
+                "failed": "0"
+              }
+            },
+            "stopReason": "operator-stop",
+            "exitCode": 0,
+            "stopVerified": true
+          }
+        }
+      ],
+      "passed": true,
+      "load": {
+        "profile": {
+          "id": "repeated-read-4k-v1",
+          "handlePolicy": "one-open-per-phase",
+          "bytesPerRead": 4096,
+          "settleMs": 2000,
+          "timeoutMs": 90000,
+          "phases": [
+            {
+              "repeat": 1,
+              "kind": "paced",
+              "operations": 2000,
+              "rate": 1000,
+              "batch": 25
+            },
+            {
+              "repeat": 1,
+              "kind": "burst",
+              "operations": 20000,
+              "rate": null,
+              "batch": 250
+            },
+            {
+              "repeat": 2,
+              "kind": "paced",
+              "operations": 2000,
+              "rate": 1000,
+              "batch": 25
+            },
+            {
+              "repeat": 2,
+              "kind": "burst",
+              "operations": 20000,
+              "rate": null,
+              "batch": 250
+            },
+            {
+              "repeat": 3,
+              "kind": "paced",
+              "operations": 2000,
+              "rate": 1000,
+              "batch": 25
+            },
+            {
+              "repeat": 3,
+              "kind": "burst",
+              "operations": 20000,
+              "rate": null,
+              "batch": 250
+            }
+          ]
+        },
+        "monitorIntervalMs": 25,
+        "phases": [
+          {
+            "repeat": 1,
+            "kind": "paced",
+            "operations": 2000,
+            "rate": 1000,
+            "batch": 25,
+            "completed": 2000,
+            "bytesRead": 8192000,
+            "durationMs": 2503.7212,
+            "achievedOperationsPerSecond": 798.8109858238209,
+            "maxBatchLatenessMs": 12.356499999999869
+          },
+          {
+            "repeat": 1,
+            "kind": "burst",
+            "operations": 20000,
+            "rate": null,
+            "batch": 250,
+            "completed": 20000,
+            "bytesRead": 81920000,
+            "durationMs": 104.14750000000004,
+            "achievedOperationsPerSecond": 192035.3345015482,
+            "maxBatchLatenessMs": null
+          },
+          {
+            "repeat": 2,
+            "kind": "paced",
+            "operations": 2000,
+            "rate": 1000,
+            "batch": 25,
+            "completed": 2000,
+            "bytesRead": 8192000,
+            "durationMs": 2485.169,
+            "achievedOperationsPerSecond": 804.7742427174974,
+            "maxBatchLatenessMs": 7.3083000000005995
+          },
+          {
+            "repeat": 2,
+            "kind": "burst",
+            "operations": 20000,
+            "rate": null,
+            "batch": 250,
+            "completed": 20000,
+            "bytesRead": 81920000,
+            "durationMs": 56.45880000000034,
+            "achievedOperationsPerSecond": 354240.6143949195,
+            "maxBatchLatenessMs": null
+          },
+          {
+            "repeat": 3,
+            "kind": "paced",
+            "operations": 2000,
+            "rate": 1000,
+            "batch": 25,
+            "completed": 2000,
+            "bytesRead": 8192000,
+            "durationMs": 2491.824699999999,
+            "achievedOperationsPerSecond": 802.6246790153419,
+            "maxBatchLatenessMs": 7.421200000000681
+          },
+          {
+            "repeat": 3,
+            "kind": "burst",
+            "operations": 20000,
+            "rate": null,
+            "batch": 250,
+            "completed": 20000,
+            "bytesRead": 81920000,
+            "durationMs": 66.47880000000077,
+            "achievedOperationsPerSecond": 300847.78906959464,
+            "maxBatchLatenessMs": null
+          }
+        ],
+        "completed": true,
+        "durationMs": 19800.269099999998
+      },
+      "observationCheck": {
+        "observed": true,
+        "named": true,
+        "fixtureRead": true,
+        "leaked": false
+      },
+      "endedSessions": [
+        {
+          "launchId": "5b82e98d-4ddc-4f67-9971-fa84c95791ff",
+          "sessionId": "5791d1a7-dd29-4048-ae2c-e78ed2472495",
+          "endedAt": 1789085791129,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "mapResets",
+            "dropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "111722",
+            "filtered": "45703",
+            "dropped": "50246",
+            "ingressDropped": "0",
+            "outputDropped": "50246",
+            "outputOverflowDropped": "50246",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "6",
+            "mapResets": "6",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "313176555363",
+              "unixMs": "1789085771115",
+              "uncertaintyQpc": "10186"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "queryStatus": 0,
+            "asOfQpc": "313375099521"
+          },
+          "finalTotals": {
+            "delivered": "111722",
+            "filtered": "45703",
+            "dropped": "50246",
+            "ingressDropped": "0",
+            "outputDropped": "50246",
+            "outputOverflowDropped": "50246",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "6",
+            "mapResets": "6",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 15516,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "313376230698",
+            "pump": {
+              "calls": "298",
+              "totalTicks": "3408210",
+              "maxTicks": "183742",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "257",
+              "totalTicks": "2636843",
+              "maxTicks": "66560",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "40",
+              "totalTicks": "195893520",
+              "maxTicks": "19839180",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1095,
+              "highWaterBytes": 351624
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "31337669830000",
+            "decodeChunk": {
+              "calls": "188",
+              "totalTicks": "307434000",
+              "maxTicks": "7143700",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "269",
+              "totalTicks": "203724200",
+              "maxTicks": "2748900",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "256",
+              "totalTicks": "141157800",
+              "maxTicks": "2534800",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "717",
+              "totalTicks": "781801600",
+              "maxTicks": "3059400",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      ],
+      "endedAt": "2026-09-11T00:16:31.130Z"
+    }
+  },
+  "baselineReference": {
+    "aggregate": "etw-file-home-26200-service-timings.json",
+    "liveReportSha256": "182ce5a715125fccf67194dd7b9a97e662be318966c82b87ca33adefbf8c3efa",
+    "protocol": "etw-file/4",
+    "outputOverflowDropped": "52066",
+    "idleWaitBehavior": "Task.Delay(10) after empty pump",
+    "controlledThroughputComparison": false
+  },
+  "postRun": {
+    "remainingEtwFileProcesses": 0,
+    "independentSessionAbsenceWitness": false
+  },
+  "limits": [
+    "IdleWait now measures queue/lifecycle/heartbeat waiting; totals include quiet settling. Mean/max no longer represent a fixed polling interval.",
+    "Elapsed wall time, not CPU time. OutputWrite is nested in Pump; AcceptFrame and RetainBatch are nested in DecodeChunk. Never sum nested or cross-process durations.",
+    "Whole-session counters include ambient activity. Actual burst rates and ambient traffic vary; a single run does not establish general loss-free capture or causal throughput gains.",
+    "Main ring eviction is a separate retention limit. Broker CPU, end-to-end latency and phase-local queue occupancy remain unmeasured.",
+    "No event-time identity proof, protected crash recovery, independent absence witness, sleep/wake test or installed-app replacement."
+  ]
+}

--- a/docs/roadmap/etw-output-wakeup.md
+++ b/docs/roadmap/etw-output-wakeup.md
@@ -1,0 +1,107 @@
+# B5 follow-up — wake the output pump when records arrive
+
+Implemented on `codex/etw-output-wakeup` from `3d88df4` (merged #433). The previous
+timing run retained 52,066 output overflow drops while non-write pump work totaled
+49.225 ms. Empty-pump waits averaged 15.587 ms. Those aggregates motivated this
+experiment but did not establish polling as the cause of overflow.
+
+## Behavior
+
+`FilePipeline.OutputAvailable` exposes one notification task protected by the same
+lock as the output queue. The first enqueue into an empty queue completes it with
+asynchronous continuations. Taking the last record rearms it. Invalidation rearms
+a completed notification after discarding output; invalidation of an already empty
+queue preserves its pending task so existing waiters cannot be abandoned.
+
+Enqueue before wait registration is visible as an already completed task; enqueue
+after registration completes the task held by the waiter. A stale completed task
+may cause a harmless recheck after invalidation. There is no counting semaphore
+or per-record notification backlog. Copying, process queries and writer work stay
+outside the mapper's queue lock. Existing record/byte caps, invalidation accounting,
+fresh process-witness budget and frame limits are unchanged.
+
+`FilePumpWait` waits for output, mapper completion, capture completion, operator
+stop, cancellation or the next two-second heartbeat deadline. When another signal
+wins, the losing deadline is cancelled. Mapper/capture failures reach the owner's
+existing cleanup path. The running collector rechecks lifecycle state between
+pumps and continues sending heartbeats even when no records arrive.
+
+Draining waits only for output, mapper completion or its existing five-second
+cancellation deadline. Already completed stop/capture tasks are excluded, avoiding
+an empty-queue spin. The final output drain and owned native stop precede the
+stopped acknowledgement as before. Parent EOF, lease expiry and failure do not
+gain a clean-stop assertion. No elevated kill or automatic UAC retry is added.
+
+The protocol remains `etw-file/4`; the build marker ends in `-wakeup`. `idleWait`
+continues to measure elapsed empty-pump waiting, now a signal/deadline wait rather
+than `Task.Delay(10)`. Its total includes deliberately quiet workload periods;
+its mean and maximum no longer describe a fixed polling interval. Other timing
+regions and counters retain their v4 meanings. Main, IPC, workload and buffer
+budgets are unchanged. This remains an opt-in diagnostic collector.
+
+## Verification and live evidence
+
+49 C# self-tests passed, including ten new wakeup tests: notification before and
+after registration, 1,000 drain/rearm cycles, invalidation, stop versus drain,
+mapper cancellation, mapper/capture failures, cancelled waits, heartbeat timeout
+and final buffered drain. Release build and formatter passed. Normal and deliberate
+saturation process checks passed three scenarios each on matching binaries.
+
+The [aggregate](../recon/evidence/etw-file-home-26200-output-wakeup.json) preserves
+three original reports, matching binary hashes and 28 source hashes. One authorized
+live UAC session on Windows 11 Home 25H2 / 26200.8655 completed the unchanged
+`repeated-read-4k-v1` workload: all 66,000 reads / 270,336,000 logical bytes in
+19.800 seconds. No builds/tests were running concurrently with the live capture.
+
+| Whole live session | Result |
+| --- | ---: |
+| Delivered / filtered | 111,722 / 45,703 |
+| Output overflow / invalidation | 50,246 / 0 |
+| Ingress / native event / realtime-buffer / log-buffer loss | 0 / 0 / 0 / 0 |
+| Decoder errors / map conflicts / map resets | 0 / 0 / 6 |
+| Main ring evictions | 15,516 |
+| Ingress high water | 1,095 records / 351,624 bytes |
+| Output high water | 1,922 records / 4,193,804 bytes |
+| Scoped fixture Read/header-PID candidate | Observed |
+| Out-of-root path or non-null agent/instanceId in checked records | None observed |
+| Owned stop / child exit / remaining EtwFile processes | Verified / 0 / 0 |
+
+| Completed elapsed measurements | Calls | Total ms | Maximum ms |
+| --- | ---: | ---: | ---: |
+| Collector pump, including writes | 298 | 340.821 | 18.374 |
+| Collector output writes, nested | 257 | 263.684 | 6.656 |
+| Collector empty-pump signal/deadline wait | 40 | 19,589.352 | 1,983.918 |
+| Main chunk handling, including callbacks | 188 | 307.434 | 7.144 |
+| Main accepted frames, nested | 269 | 203.724 | 2.749 |
+| Main retained batches, nested | 256 | 141.158 | 2.535 |
+| Main diagnostic snapshots, separate | 717 | 781.802 | 3.059 |
+
+All measured failure counters are zero. Pump work outside writes totals 77.137 ms.
+Empty waits fell from 1,264 in the preceding run to 40; their longer durations
+reflect sleeping until a signal/deadline rather than recurring polling. The
+maximum is below the two-second heartbeat interval in this run. This verifies
+the waiting behavior; it does not establish that wake latency is negligible.
+
+Overflow remains: 50,246 versus the preceding 52,066. Paced rates were 798.81,
+804.77 and 802.62 reads/s; burst rates were 192,035.33, 354,240.61 and 300,847.79
+reads/s. Actual burst timings and ambient delivery differ. Whole-session counts
+include ambient activity and settling, so no causal throughput gain or complete
+logical-read coverage is claimed. Ring eviction is a separate retention limit.
+
+Full JS coverage passed 200 files / 3,354 tests with four skips. Renderer build,
+format/lint, TypeScript/Svelte, witness and sequence mutation gates, derived counts
+and the production dependency audit passed. Missing EOF acknowledgement remained
+unverified in the process checks.
+
+## Remaining work
+
+E3 is still open. The next measurement should resolve arrival/drain rates and
+queue occupancy over short burst intervals, with output-ready-to-resume latency
+and broker forwarding time separated from main callbacks. Whole-session totals
+are insufficient to select the next throughput change; the queue still reaches
+its byte cap after removing polling. Keep the same workload and bounded storage
+when adding those observations, and do not increase buffers on this evidence alone.
+
+E4/E5 event-time identity and safe path admission, independent session absence,
+protected crash recovery and deployment remain open. Sleep/wake remains deferred;
+the installed app was not replaced.

--- a/docs/roadmap/etw-sensor-design.md
+++ b/docs/roadmap/etw-sensor-design.md
@@ -344,6 +344,8 @@ zero durations. Output-write calls/time cannot exceed enclosing pump calls/time.
 Each stage queue has the same four uint32 fields/caps as `queues`. Main keeps its
 own fixed timing groups in local diagnostics and ended summaries; none enter IPC
 or the health loss count. See [measurement boundaries](etw-service-timings.md).
+The [output-wakeup implementation](etw-output-wakeup.md) preserves v4 fields;
+`idleWait` now measures waiting for output/lifecycle/deadline after an empty pump.
 
 Observation uint64s are strings; PID/TID fields are uint32 with the payload/issuing
 fields nullable. `generationInterval` is null or `{fromQpc, toQpc}` with ordered

--- a/docs/roadmap/etw-service-timings.md
+++ b/docs/roadmap/etw-service-timings.md
@@ -1,5 +1,9 @@
 # B5 follow-up — collector and main service measurements
 
+This records the first v4 timing run. The [output-wakeup follow-up](etw-output-wakeup.md)
+replaces the measured 10 ms polling delay with a signal/deadline wait. Its idle
+duration retains the same field but measures the updated waiting behavior.
+
 Implemented on `codex/etw-service-timings` from `4006268` (merged #432). The
 diagnostic protocol is v4. This step measures existing behavior; output overflow
 and E3 remain open. Main/helper v1–3 are rejected rather than given invented zeros.

--- a/memory-bank/next-session.md
+++ b/memory-bank/next-session.md
@@ -1,6 +1,36 @@
 # AEGIS — старт следующего чата
 
-## Актуальное продолжение — замеры ETW, 2026-09-11
+## Актуальное продолжение — пробуждение output pump, 2026-09-11
+
+В `X:/tmp/aegis-etw-burst-20260911`, ветка `codex/etw-output-wakeup` от `3d88df4`
+(слитый #433), вместо `Task.Delay(10)` реализован сигнал готовности выходной очереди.
+Один TaskCompletionSource под тем же lock, завершение при первом enqueue,
+перевзвод при последнем Take/invalidation; пустая invalidation не бросает waiter.
+`FilePumpWait` также ждёт stop, mapper/capture completion, cancellation или heartbeat.
+При drain завершённые stop/capture исключены, срок пять секунд сохранён.
+Протокол v4, build suffix `-wakeup`; main, workload и лимиты не менялись.
+
+49 C# self-tests, normal/loss-check по три сценария и все локальные проверки прошли.
+JS: 200 файлов / 3354 passed / 4 skipped. Live на тех же бинарниках: 66000 чтений
+за 19,800 с, delivered 111722, filtered 45703, overflow 50246,
+invalidation/ingress/native loss 0, map resets 6, ring evictions 15516.
+Fixture Read/PID найден, stopVerified true, exit 0, helpers 0.
+Output high water 1922 / 4193804 байта; pump 340,821 мс, write 263,684 мс,
+остальная работа pump 77,137 мс; main decode 307,434 мс. Idle waits 40 вместо 1264,
+теперь это ожидание сигнала/heartbeat, а не периодическая проверка. Idle total
+19589,352 мс включает тишину; максимум 1983,918 мс не является wake latency.
+
+Потери остаются. 50246 против прежних 52066 не доказывает throughput gain:
+реальный темп burst и фон отличаются. Следующий шаг E3 — короткие интервалы
+arrival/drain/occupancy, задержка output-ready→resume и время broker forwarding,
+затем выбирать следующую правку. Буферы вслепую не увеличивать. E4/E5 identity,
+independent absence, crash recovery и deployment открыты. Сон отложен.
+Отчёт: `docs/roadmap/etw-output-wakeup.md`; три raw JSON и 28 хешей:
+`docs/recon/evidence/etw-file-home-26200-output-wakeup.json`.
+Проверить финальный PR/CI/merge. Установленное приложение не заменялось;
+исходную грязную UI-копию сохранить.
+
+## Предыдущий шаг — замеры ETW, 2026-09-11
 
 В `X:/tmp/aegis-etw-burst-20260911`, ветка `codex/etw-service-timings` от `4006268`
 (слитый #432), реализован протокол v4: collector pump/outputWrite/idleWait и

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2284,3 +2284,36 @@ The subsequent source change only documents the intentional fail-closed clock
 check for lint; evidence records its separate final hash. Full JS coverage passed
 200 files / 3354 tests with four skips. Check this branch's final PR/CI/merge before
 the next block; preserve the original dirty UI checkout.
+
+## 2026-09-11 — wake ETW output when records arrive
+
+Implemented on `codex/etw-output-wakeup` from merged #433 / `3d88df4`. The empty
+output pump now waits on a level-triggered queue notification, lifecycle tasks,
+cancellation or the next heartbeat. Enqueue/drain/invalidation share the queue
+lock; empty invalidation preserves existing waiters. Drain excludes completed
+stop/capture tasks and keeps the existing five-second cancellation bound.
+Protocol v4 and timing fields remain; `idleWait` now measures signal/deadline
+waiting. Main, workload, buffer caps, identity and native cleanup ownership are
+unchanged. No elevated kill or automatic UAC retry was added.
+
+49 C# self-tests passed, including ten notification/race/cancellation/drain cases.
+Normal and saturation process checks passed three scenarios each; EOF without
+acknowledgement remained unverified. One live run on matching binaries completed
+66,000 reads in 19.800 s: delivered 111722, filtered 45703, output overflow 50246,
+invalidation/ingress/native losses 0, map resets 6, ring evictions 15516. Scoped
+Read/header-PID candidate observed, stop verified, child exit 0, remaining helpers 0.
+
+Empty waits were 40 versus 1264 previously. Their total 19589.352 ms includes quiet
+periods; their maximum 1983.918 ms is not enqueue-to-resume latency. Pump total
+340.821 ms contains writes 263.684 ms; main decode 307.434 ms. Output still reached
+1922 records / 4193804 bytes. Different burst rates and ambient delivery preclude
+a causal throughput claim from 50246 versus 52066 drops. E3 remains open.
+
+Next measure short burst arrival/drain rates, occupancy, output wake latency and
+broker forwarding; aggregate session totals cannot select the next throughput
+change. E4/E5, independent absence, protected crash recovery and deployment remain
+open. Sleep/wake remains deferred. Three raw reports and 28 source hashes are in
+`etw-file-home-26200-output-wakeup.json`; design/results are in `etw-output-wakeup.md`.
+Full JS coverage passed 200 files / 3354 tests / four skips, and all required local
+checks passed. Check this branch's final PR/CI/merge before continuing. Original
+dirty UI work and the installed application were preserved.

--- a/sidecar/etw-file/FileCollector.cs
+++ b/sidecar/etw-file/FileCollector.cs
@@ -37,7 +37,7 @@ internal static class FileCollector
         {
             await send.Write(pipe, "hello", new
             {
-                build = live ? "etw-file-diagnostic-dev-4" : "etw-file-synthetic-check-4",
+                build = live ? "etw-file-diagnostic-dev-4-wakeup" : "etw-file-synthetic-check-4-wakeup",
                 profile = FileWire.Profile,
                 schemas = FileWire.Schemas
             }, lifetime.Token);
@@ -94,12 +94,12 @@ internal static class FileCollector
                 lifetime.Token.ThrowIfCancellationRequested();
                 if (capture?.Consumer?.IsCompleted == true) throw new IOException();
                 if (pipeline.Worker.IsCompleted) throw new IOException();
-                if (Stopwatch.GetTimestamp() - lastSample > 2 * Stopwatch.Frequency)
+                if (Stopwatch.GetTimestamp() - lastSample >= 2 * Stopwatch.Frequency)
                 {
                     Sample();
                     await send.Write(pipe, "heartbeat", Telemetry(), lifetime.Token);
                 }
-                if (!await Pump(lifetime.Token)) await Idle(lifetime.Token);
+                if (!await Pump(lifetime.Token)) await Idle(lifetime.Token, stopSignal.Task, capture?.Consumer);
             }
             stopRequest = await stopSignal.Task;
             if (trace != null) { stats = trace.Stop(); stopped = stats.Status == 0; owns = !stopped; CheckStats(); }
@@ -177,10 +177,19 @@ internal static class FileCollector
             try { bool result = await send.WriteObservations(pipe, pipeline.Take, token); success = true; return result; }
             finally { performance.Pump.Record(performance.Now() - start, !success); }
         }
-        async Task Idle(CancellationToken token)
+        async Task Idle(CancellationToken token, Task? stop = null, Task? consumer = null)
         {
             long start = performance.Now(); bool success = false;
-            try { await Task.Delay(10, token); success = true; }
+            // During capture the next heartbeat is the only timer. During drain,
+            // mapper completion/output/cancellation suffice; completed stop and
+            // capture tasks must not keep waking an empty draining queue.
+            var timeout = stop == null ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(
+                Math.Max(0, 2 - (Stopwatch.GetTimestamp() - lastSample) / (double)Stopwatch.Frequency));
+            try
+            {
+                await FilePumpWait.WaitAsync(pipeline.OutputAvailable, pipeline.Worker, consumer, stop, timeout, token);
+                success = true;
+            }
             finally { performance.IdleWait.Record(performance.Now() - start, !success); }
         }
     }

--- a/sidecar/etw-file/FilePipeline.cs
+++ b/sidecar/etw-file/FilePipeline.cs
@@ -9,6 +9,7 @@ internal sealed class FilePipeline : IDisposable
     private sealed record Output(FileObservation Record, int Bytes);
     private readonly object gate = new();
     private readonly Queue<Output> outbound = new();
+    private TaskCompletionSource<bool> outputReady = NewReady();
     private readonly FileIngress ingress;
     private readonly FileMapping map;
     private readonly bool live;
@@ -22,6 +23,10 @@ internal sealed class FilePipeline : IDisposable
     private long lastGeneration;
     internal ulong OutputDropped { get { lock (gate) return outputOverflowDropped + outputInvalidatedDropped; } }
     internal Task Worker { get; }
+    // Level-triggered under the queue lock: enqueue before or after registration
+    // cannot lose a wakeup. One current task, no accumulating signal tokens.
+    internal Task OutputAvailable { get { lock (gate) return outputReady.Task; } }
+    private static TaskCompletionSource<bool> NewReady() => new(TaskCreationOptions.RunContinuationsAsynchronously);
     internal FilePipeline(FileIngress input, FileScope scope, bool native,
         Func<FileObservation, FileObservation>? observer = null, Func<long>? timestamp = null)
     {
@@ -37,6 +42,7 @@ internal sealed class FilePipeline : IDisposable
             map.Reset(qpc);
             invalidation++;
             outputInvalidatedDropped += (ulong)outbound.Count; outbound.Clear(); bytes = 0;
+            if (outputReady.Task.IsCompleted) outputReady = NewReady();
         }
     }
     internal void Complete() { lock (gate) completed = true; }
@@ -79,6 +85,7 @@ internal sealed class FilePipeline : IDisposable
                     { outputOverflowDropped++; continue; }
                     outbound.Enqueue(new(record, cost)); bytes += cost;
                     highRecords = Math.Max(highRecords, outbound.Count); highBytes = Math.Max(highBytes, bytes);
+                    if (outbound.Count == 1) outputReady.TrySetResult(true);
                 }
             }
         }
@@ -92,6 +99,7 @@ internal sealed class FilePipeline : IDisposable
         {
             if (!outbound.TryDequeue(out var item)) return null;
             bytes -= item.Bytes; record = item.Record; epoch = invalidation;
+            if (outbound.Count == 0) outputReady = NewReady();
         }
         // One serial reader owns the probe budget. Never hold the map/queue lock
         // across a native call, and never cache a process creation observation.

--- a/sidecar/etw-file/FilePumpWait.cs
+++ b/sidecar/etw-file/FilePumpWait.cs
@@ -1,0 +1,22 @@
+namespace Aegis.EtwLifecycle;
+
+internal static class FilePumpWait
+{
+    // Borrowed tasks outlive this wait. Cancel the losing deadline, and let
+    // WhenAny detach its other continuations when a signal wins. No queue waiter
+    // is left behind on timeout, stop, failure or cancellation.
+    internal static async Task WaitAsync(Task output, Task mapper, Task? capture, Task? stop,
+        TimeSpan timeout, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(token);
+        var delay = Task.Delay(timeout, deadline.Token);
+        try
+        {
+            var ready = await Task.WhenAny(output, mapper, capture ?? mapper, stop ?? mapper, delay);
+            token.ThrowIfCancellationRequested();
+            await ready; // Preserve mapper/capture failures for the owner's cleanup path.
+        }
+        finally { deadline.Cancel(); }
+    }
+}

--- a/sidecar/etw-file/FileTests.cs
+++ b/sidecar/etw-file/FileTests.cs
@@ -140,6 +140,7 @@ internal static class FileTests
         FileBurstTests.Run(Test);
         FileOutputTests.Run(Test);
         FilePerformanceTests.Run(Test);
+        FileWakeTests.Run(Test);
         Console.WriteLine($"{passed} self-tests passed; no ETW session or UAC requested.");
         return 0;
     }

--- a/sidecar/etw-file/FileWakeTests.cs
+++ b/sidecar/etw-file/FileWakeTests.cs
@@ -1,0 +1,134 @@
+namespace Aegis.EtwLifecycle;
+
+internal static class FileWakeTests
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(3);
+    internal static void Run(Action<string, Action> test)
+    {
+        test("empty output wakes on enqueue without a polling deadline", () =>
+        {
+            using var fixture = new Fixture();
+            var waiting = fixture.Wait();
+            Check(!waiting.IsCompleted, "empty-output-was-ready");
+            fixture.Read();
+            waiting.WaitAsync(Bound).GetAwaiter().GetResult();
+            Check(fixture.Pipeline.Take()?.eventId == 15, "woken-without-record");
+        });
+        test("enqueue between empty read and wait registration remains visible", () =>
+        {
+            using var fixture = new Fixture();
+            Check(fixture.Pipeline.Take() == null, "not-empty");
+            var signal = fixture.Pipeline.OutputAvailable;
+            fixture.Read(); signal.WaitAsync(Bound).GetAwaiter().GetResult();
+            Check(fixture.Pipeline.OutputAvailable.IsCompletedSuccessfully, "lost-ready-state");
+            fixture.Wait().WaitAsync(Bound).GetAwaiter().GetResult();
+            Check(fixture.Pipeline.Take() != null, "lost-record");
+            Check(!fixture.Pipeline.OutputAvailable.IsCompleted, "drain-did-not-reset");
+        });
+        test("repeated drain and invalidation rearm one notification", () =>
+        {
+            using var fixture = new Fixture();
+            for (int i = 0; i < 1000; i++)
+            {
+                var signal = fixture.Pipeline.OutputAvailable;
+                Check(!signal.IsCompleted && ReferenceEquals(signal, fixture.Pipeline.OutputAvailable), "extra-notification");
+                fixture.Read(); signal.WaitAsync(Bound).GetAwaiter().GetResult();
+                Check(fixture.Pipeline.Take() != null, "missed-cycle");
+            }
+            var pending = fixture.Pipeline.OutputAvailable;
+            fixture.Pipeline.Invalidate(fixture.Qpc);
+            Check(ReferenceEquals(pending, fixture.Pipeline.OutputAvailable), "empty-invalidation-orphaned-waiter");
+            fixture.Name(); fixture.Read(); pending.WaitAsync(Bound).GetAwaiter().GetResult();
+            fixture.Pipeline.Invalidate(fixture.Qpc);
+            Check(fixture.Pipeline.Take() == null && !fixture.Pipeline.OutputAvailable.IsCompleted, "stale-ready-after-invalidation");
+            Check(fixture.Pipeline.OutputDropped == 1, "invalidation-accounting");
+        });
+        test("stop wakes empty capture and is excluded from drain waits", () =>
+        {
+            using var fixture = new Fixture();
+            var stop = NewSignal();
+            var waiting = fixture.Wait(stop: stop.Task);
+            stop.SetResult(true); waiting.WaitAsync(Bound).GetAwaiter().GetResult();
+            var drain = fixture.Wait();
+            Check(!drain.IsCompleted, "completed-stop-spins-drain");
+            fixture.Pipeline.Complete(); drain.WaitAsync(Bound).GetAwaiter().GetResult();
+            Check(fixture.Pipeline.Worker.IsCompletedSuccessfully, "mapper-not-drained");
+        });
+        test("mapper cancellation wakes an empty pump", () =>
+        {
+            using var fixture = new Fixture();
+            var waiting = fixture.Wait();
+            fixture.Pipeline.Cancel(); waiting.WaitAsync(Bound).GetAwaiter().GetResult();
+            Check(fixture.Pipeline.Worker.IsCompleted, "mapper-still-running");
+        });
+        foreach (bool capture in new[] { false, true })
+        {
+            test(capture ? "capture failure wakes pump" : "mapper failure wakes pump", () =>
+            {
+                var failed = NewSignal(); var pending = NewSignal();
+                var waiting = FilePumpWait.WaitAsync(pending.Task, capture ? pending.Task : failed.Task,
+                    capture ? failed.Task : null, null, Timeout.InfiniteTimeSpan, default);
+                failed.SetException(new IOException("fixture-failure"));
+                bool rejected = false;
+                try { waiting.WaitAsync(Bound).GetAwaiter().GetResult(); } catch (IOException) { rejected = true; }
+                Check(rejected, "failure-hidden");
+            });
+        }
+        test("cancelling one idle wait does not consume or poison the next output", () =>
+        {
+            using var fixture = new Fixture();
+            using var cancel = new CancellationTokenSource();
+            var waiting = fixture.Wait(token: cancel.Token);
+            cancel.Cancel();
+            bool rejected = false;
+            try { waiting.WaitAsync(Bound).GetAwaiter().GetResult(); } catch (OperationCanceledException) { rejected = true; }
+            Check(rejected, "cancellation-hidden");
+            var next = fixture.Wait();
+            Check(!next.IsCompleted, "cancelled-shared-notification");
+            fixture.Read(); next.WaitAsync(Bound).GetAwaiter().GetResult();
+            Check(fixture.Pipeline.Take() != null, "cancellation-consumed-record");
+        });
+        test("heartbeat deadline wakes an empty pump without poisoning its signal", () =>
+        {
+            using var fixture = new Fixture();
+            var signal = fixture.Pipeline.OutputAvailable;
+            FilePumpWait.WaitAsync(signal, fixture.Pipeline.Worker, null, null,
+                TimeSpan.FromMilliseconds(20), default).WaitAsync(Bound).GetAwaiter().GetResult();
+            Check(!signal.IsCompleted, "deadline-completed-shared-signal");
+            var next = fixture.Wait(); fixture.Read();
+            next.WaitAsync(Bound).GetAwaiter().GetResult();
+            Check(fixture.Pipeline.Take() != null, "timeout-consumed-record");
+        });
+        test("completed mapper still leaves buffered output drainable", () =>
+        {
+            using var fixture = new Fixture();
+            for (int i = 0; i < 100; i++) fixture.Read();
+            fixture.Pipeline.Complete(); fixture.Pipeline.Worker.WaitAsync(Bound).GetAwaiter().GetResult();
+            fixture.Wait().WaitAsync(Bound).GetAwaiter().GetResult();
+            int count = 0;
+            while (fixture.Pipeline.Take() != null) count++;
+            Check(count == 100 && fixture.Pipeline.OutputDropped == 0, "incomplete-final-drain");
+        });
+    }
+    private static TaskCompletionSource<bool> NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static void Check(bool value, string reason) { if (!value) throw new InvalidOperationException(reason); }
+    private sealed class Fixture : IDisposable
+    {
+        private readonly FileIngress ingress = new();
+        internal readonly FilePipeline Pipeline;
+        internal long Qpc;
+        internal Fixture()
+        {
+            Pipeline = new FilePipeline(ingress, new FileScope(@"C:\fixture", false), false);
+            Name();
+        }
+        internal void Name() => ingress.Enqueue(new(0, 12, 1, ++Qpc, 71, 72, 72, null, 1, 0, @"C:\fixture\a"));
+        internal void Read() => ingress.Enqueue(new(0, 15, 1, ++Qpc, 71, 72, 72, null, 1, 0, null));
+        internal Task Wait(Task? stop = null, CancellationToken token = default) =>
+            FilePumpWait.WaitAsync(Pipeline.OutputAvailable, Pipeline.Worker, null, stop, Timeout.InfiniteTimeSpan, token);
+        public void Dispose()
+        {
+            Pipeline.Cancel(); Pipeline.Worker.WaitAsync(Bound).GetAwaiter().GetResult(); Pipeline.Dispose();
+        }
+    }
+}

--- a/sidecar/etw-file/README.md
+++ b/sidecar/etw-file/README.md
@@ -34,6 +34,12 @@ ingress/output queue depths. Ended reports retain collector and main measurement
 see [service measurements](../../docs/roadmap/etw-service-timings.md) for clock regions,
 nested durations and interpretation limits. No per-event timing history is retained.
 
+The `-wakeup` collector build waits for output availability, lifecycle signals or
+the next heartbeat after an empty pump. The prior 10 ms output polling delay is
+removed. `idleWait` now measures this signal/deadline wait; quiet periods still
+contribute to its total. See [output wakeup](../../docs/roadmap/etw-output-wakeup.md)
+for race, cancellation, drain and live-load evidence.
+
 For a separately agreed live check, run the following from normal PowerShell and
 approve **one** UAC prompt. The ordinary Node process reads its own temporary test
 file for ten seconds; only the collector elevates. This never sleeps the computer.


### PR DESCRIPTION
The ETW collector previously checked an empty output queue after `Task.Delay(10)`, even when records had arrived during that wait. It now wakes on queue availability, lifecycle completion, cancellation or the next heartbeat. A notification guarded by the queue lock covers both enqueue-before-registration and enqueue-after-registration. Final draining excludes completed stop/capture tasks and retains its five-second bound.

The unchanged 66,000-read live workload completed with verified stop and no remaining helpers. Empty waits fell from 1,264 in the preceding run to 40. Output overflow remains: 50,246 drops versus 52,066 previously; differing burst rates and ambient traffic prevent a causal throughput claim. Protocol v4, queue/frame caps, main, workload and native ownership are unchanged. `idleWait` now measures signal/deadline waiting; it is not enqueue-to-resume latency.

Validation: 49 C# self-tests, including ten notification/race/cancellation/drain cases; C# Release build/format; normal and saturation process checks (three scenarios each); one authorized live run on matching binaries. Full JS coverage passed 200 files / 3,354 tests / 4 skipped. Renderer build, format/lint, TypeScript/Svelte, witness/sequence mutation gates, derived counts and production dependency audit passed. Evidence preserves three raw reports and 28 matching source hashes. Sleep/wake and installed-app replacement remain deferred.
