### PR TITLE
feat(ui): make agent activity and protection limits clear

### DIFF
--- a/frontend/observatory/App.svelte
+++ b/frontend/observatory/App.svelte
@@ -21,6 +21,7 @@
   import Icon from './components/Icon.svelte';
   import Notifications from './components/Notifications.svelte';
   import Monitoring from './components/Monitoring.svelte';
+  import ProtectionOverview from './components/ProtectionOverview.svelte';
   import Events from './components/Events.svelte';
   import Rules from './components/Rules.svelte';
   import Catalog from './components/Catalog.svelte';
@@ -119,6 +120,17 @@
   });
   let selected = $state<string | null>(null);
   let view = $state('overview');
+  let detailedMonitoring = $state(false);
+  let monitoringMounted = $state(false);
+  let policyRevision = $state(0);
+  let policyTarget = $state<{ key: string; revision: number }>();
+  function openPolicy(key: string) {
+    policyTarget = { key, revision: ++sectionRevision };
+    void navigate('rules');
+  }
+  $effect(() => {
+    if (detailedMonitoring || view === 'agents') monitoringMounted = true;
+  });
   let group = $derived(workspaces.find((entry) => entry.id === view)?.group);
   let isLiveWorkspace = $derived(
     ['overview', 'agents', 'events', 'network', 'stats'].includes(view),
@@ -394,6 +406,12 @@
             >{/if}
         </div>
         {#if isLiveWorkspace}<div class="page-actions">
+            {#if view === 'overview'}<button
+                class="button"
+                aria-pressed={detailedMonitoring}
+                onclick={() => (detailedMonitoring = !detailedMonitoring)}
+                >{detailedMonitoring ? 'Protection overview' : 'Detailed monitoring'}</button
+              >{/if}
             <button
               class="button"
               title="Pause the displayed observations; backend monitoring continues"
@@ -421,21 +439,38 @@
       <SensorStatus health={record(telemetry.stats.appHealth)} />
       <div id="workspace-content" role="region" aria-labelledby="page-title">
         <div id="content" class:analysis-view={view === 'analysis'}>
-          <div hidden={view !== 'overview' && (view !== 'agents' || scope.agent !== '')}>
-            <Monitoring
+          <div hidden={view !== 'overview' || detailedMonitoring}>
+            <ProtectionOverview
+              {host}
+              liveTelemetry={telemetry}
               telemetry={displayTelemetry}
-              bind:selected
               {inspect}
-              mode={view}
-              {openStatistics}
-              openAgent={(agent) => inspect(agent, { agentGroupKey: agent, name: agent })}
-              {paused}
+              {openPolicy}
+              {policyRevision}
               navigate={(target) => {
                 changeScope({ agent: '', instanceId: '' });
                 return navigate(target);
               }}
             />
           </div>
+          {#if monitoringMounted}<div
+              hidden={(view !== 'overview' || !detailedMonitoring) &&
+                (view !== 'agents' || scope.agent !== '')}
+            >
+              <Monitoring
+                telemetry={displayTelemetry}
+                bind:selected
+                {inspect}
+                mode={view}
+                {openStatistics}
+                openAgent={(agent) => inspect(agent, { agentGroupKey: agent, name: agent })}
+                paused={paused || view !== 'overview' || !detailedMonitoring}
+                navigate={(target) => {
+                  changeScope({ agent: '', instanceId: '' });
+                  return navigate(target);
+                }}
+              />
+            </div>{/if}
           {#if scope.agent}<div hidden={view !== 'agents'}>
               <AgentWorkspace
                 telemetry={displayTelemetry}
@@ -470,7 +505,12 @@
               />
             </div>{/if}
           {#if tabs.includes('rules')}<div hidden={view !== 'rules'}>
-              <Rules {host} {telemetry} />
+              <Rules
+                {host}
+                {telemetry}
+                targetRequest={policyTarget}
+                onPermissionsChanged={() => policyRevision++}
+              />
             </div>{/if}
           {#if tabs.includes('database')}<div hidden={view !== 'database'}>
               <Catalog {host} {inspect} />

--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -105,3 +105,27 @@ Startup explains restart-sensitive options, update states use readable labels,
 and failed initial settings reads can be retried. The shared save/discard bar
 stays reachable with a distinct primary action and saving/reloading status.
 Provider credentials remain outside the generic settings form and exports.
+
+### Protection overview (2026-09-11)
+
+The user's request to make protection understandable supersedes the previous
+radar-first landing composition. Monitoring starts with a compact review count,
+observed agents, and the explicit absence of automatic access blocking. A bounded,
+searchable activity list combines retained file events with the latest connection
+snapshot and puts review flags first. Repeated records retain separate process
+lifetimes, actions and attribution evidence.
+
+Selecting activity opens its path or endpoint, explanation, current saved policy
+and links to evidence, the exact policy context and existing process controls.
+Unknown destinations, inferred ownership and open handles keep their uncertainty.
+Saved allow/block values are preferences; the backend does not enforce them.
+Failed policy reads show unavailable data; successful saves invalidate the overview.
+Process navigation uses the current population even while the displayed activity
+is paused. Selected evidence survives retention changes with an explicit label.
+
+Detailed monitoring retains the radar and charts and is mounted on demand. The
+default activity model reuses immutable deliveries across resource-only updates.
+The introductory help, native controls, focus return and responsive detail panel
+support keyboard use and larger text. Existing theme tokens and template files
+remain the visual base. Browser checks cover the new default and explicitly open
+detailed monitoring when checking the preserved radar layout.

--- a/frontend/observatory/components/ProtectionActivityList.svelte
+++ b/frontend/observatory/components/ProtectionActivityList.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+  import type { ProtectionActivity } from '../runtime/protection';
+  import AgentLogo from './AgentLogo.svelte';
+  import Icon from './Icon.svelte';
+  let {
+    activity,
+    ready,
+    filter = $bindable('all'),
+    selectedKey,
+    select,
+  }: {
+    activity: ProtectionActivity[];
+    ready: boolean;
+    filter?: string;
+    selectedKey?: string;
+    select: (_item: ProtectionActivity, _button: HTMLButtonElement) => void;
+  } = $props();
+  let query = $state('');
+  let limit = $state(8);
+  $effect(() => {
+    filter;
+    query;
+    limit = 8;
+  });
+  const filtered = $derived(
+    activity.filter(
+      (item) =>
+        (filter === 'all' || item.level === filter) &&
+        `${item.actor} ${item.target} ${item.action}`
+          .toLowerCase()
+          .includes(query.trim().toLowerCase()),
+    ),
+  );
+  function chooseFilter(next: string) {
+    filter = next;
+  }
+  const labels = { review: 'Review needed', unverified: 'Unverified', observed: 'No risk flag' };
+</script>
+
+<section class="panel activity-panel" aria-label="Agent activity">
+  <div class="activity-head">
+    <h3>Who did what, and where?</h3>
+    <p>
+      Retained file activity and the latest network snapshot. Select an activity for its
+      explanation.
+    </p>
+  </div>
+  <div class="filters">
+    <div class="filter-buttons" aria-label="Activity filters">
+      {#each [['all', 'All activity'], ['review', 'Needs review'], ['unverified', 'Unverified']] as [id, label] (id)}
+        <button aria-pressed={filter === id} onclick={() => chooseFilter(id)}>{label}</button>
+      {/each}
+    </div>
+    <label class="search"
+      ><Icon name="search" /><input
+        type="search"
+        aria-label="Search agent activity"
+        placeholder="Agent, file or address…"
+        bind:value={query}
+        oninput={() => (limit = 8)}
+      /></label
+    >
+  </div>
+  <div class="activity-list">
+    {#each filtered.slice(0, limit) as item (item.key)}
+      <button
+        class="activity-row"
+        class:review={item.level === 'review'}
+        aria-label={`${item.actor}. ${item.attribution}. ${item.action}: ${item.target}. ${labels[item.level]}. ${item.rows.length} records.`}
+        aria-pressed={selectedKey === item.key}
+        onclick={(event) => select(item, event.currentTarget)}
+      >
+        <span class="who"
+          ><AgentLogo name={item.actor} size={24} /><span
+            ><strong>{item.actor}</strong><small>{item.attribution}</small></span
+          ></span
+        >
+        <span class="what"
+          ><span>{item.action}</span><strong>{item.resource}</strong><small class="path"
+            >{item.target}</small
+          ></span
+        >
+        <span class="verdict"
+          ><span class="activity-verdict">{labels[item.level]}</span><small
+            >{item.rows.length > 1 ? `${item.rows.length} records` : item.kind}</small
+          ></span
+        >
+      </button>
+    {:else}<div class="empty">
+        <h4>{!ready ? 'Waiting for observations' : 'No matching activity'}</h4>
+        <p>
+          {!ready
+            ? 'AEGIS has not received a reliable snapshot yet.'
+            : filter === 'review'
+              ? 'No retained activity has these review flags. This is not a guarantee that the computer is safe.'
+              : 'Try another filter or wait for activity. AEGIS may not observe every action.'}
+        </p>
+      </div>{/each}
+  </div>
+  <div class="list-footer">
+    <span>{Math.min(limit, filtered.length)} of {filtered.length} groups</span
+    >{#if filtered.length > limit}<button class="button" onclick={() => (limit += 8)}
+        >Show more activity</button
+      >{/if}
+  </div>
+</section>
+
+<style>
+  .activity-panel {
+    min-width: 0;
+    container-type: inline-size;
+  }
+  p {
+    color: var(--muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+  button {
+    cursor: pointer;
+  }
+  .activity-head {
+    padding: var(--space-4);
+    border-bottom: 1px solid var(--border);
+  }
+  h3 {
+    font-size: var(--text-section);
+    margin: 0 0 var(--space-2);
+  }
+  .filters {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--border);
+  }
+  .filter-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+  }
+  .filter-buttons button {
+    background: transparent;
+    color: var(--muted);
+    border: 1px solid transparent;
+    border-radius: var(--control-radius);
+    padding: var(--space-2);
+    min-height: var(--control-height);
+    font: inherit;
+  }
+  .filter-buttons button[aria-pressed='true'] {
+    background: var(--bg);
+    color: var(--text);
+    border-color: var(--strong-border);
+  }
+  .search {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+    flex: 1 1 160px;
+    max-width: 280px;
+  }
+  .search input {
+    min-width: 0;
+    width: 100%;
+    font: inherit;
+  }
+  .activity-row {
+    display: grid;
+    width: 100%;
+    grid-template-columns: minmax(150px, 0.8fr) minmax(0, 1.8fr) minmax(105px, 0.6fr);
+    gap: var(--space-4);
+    padding: var(--space-4);
+    border: 0;
+    border-bottom: 1px solid var(--border);
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    line-height: 1.5;
+  }
+  .activity-row:hover,
+  .activity-row[aria-pressed='true'] {
+    background: var(--bg);
+  }
+  .activity-row[aria-pressed='true'] {
+    box-shadow: inset 3px 0 var(--muted);
+  }
+  .who {
+    display: flex;
+    align-items: start;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+  .who > span,
+  .what {
+    min-width: 0;
+  }
+  .who strong,
+  .who small,
+  .what > *,
+  .verdict > * {
+    display: block;
+  }
+  strong,
+  .path {
+    overflow-wrap: anywhere;
+  }
+  small {
+    font-size: var(--text-caption);
+    color: var(--muted);
+  }
+  .path {
+    display: -webkit-box;
+    line-clamp: 2;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .verdict {
+    text-align: right;
+  }
+  .activity-verdict {
+    font-size: var(--text-body);
+    font-weight: 600;
+  }
+  .review .activity-verdict {
+    color: var(--amber);
+  }
+  .list-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    font-size: var(--text-caption);
+    color: var(--muted);
+    padding: var(--space-3) var(--space-4);
+  }
+  .empty {
+    padding: var(--space-5);
+  }
+  .empty h4 {
+    margin: 0 0 var(--space-2);
+  }
+
+  @container (max-width: 540px) {
+    .activity-row {
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: var(--space-2);
+    }
+    .what {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
+    .verdict {
+      grid-column: 2;
+      grid-row: 1;
+    }
+  }
+</style>

--- a/frontend/observatory/components/ProtectionDetails.svelte
+++ b/frontend/observatory/components/ProtectionDetails.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { instances, type RecordData, type Telemetry } from '../runtime/host';
+  import { protectionPolicy, type ProtectionActivity } from '../runtime/protection';
+  let {
+    activity,
+    telemetry,
+    permissions,
+    inspect,
+    openPolicy,
+  }: {
+    activity: ProtectionActivity;
+    telemetry: Telemetry;
+    permissions: RecordData | null;
+    inspect: (_title: string, _row: RecordData) => void;
+    openPolicy: (_key: string) => void;
+  } = $props();
+  const policy = $derived(protectionPolicy(activity, instances(telemetry), permissions));
+</script>
+
+<aside class="panel evidence" aria-label="Selected activity">
+  <h3>Understand this activity</h3>
+  <p class="actor">{activity.actor}</p>
+  <p>{activity.action}</p>
+  <div class="destination"><span>Where</span><code>{activity.target}</code></div>
+  {#if activity.latest.remoteIp}<p class="muted">
+      Observed IP: {String(activity.latest.remoteIp)}{activity.latest.remotePort
+        ? `:${activity.latest.remotePort}`
+        : ''}
+    </p>{/if}
+  <h4>{activity.level === 'review' ? 'Why review this?' : 'What is known?'}</h4>
+  <p>{activity.reason}</p>
+  {#if activity.latest.reason}<p class="muted">
+      Recorded reason: {String(activity.latest.reason)}
+    </p>{/if}
+  <details>
+    <summary>{activity.attribution} · how do we know?</summary>
+    <p>{activity.explanation}</p>
+    <p>Source: {activity.source}</p>
+    {#if activity.latest.action === 'holding' || activity.latest.action === 'accessed'}
+      <p>An open handle does not prove that file contents were read.</p>
+    {/if}
+    <p>
+      {activity.rows.length} retained record(s){activity.time
+        ? ` · latest ${new Date(activity.time).toLocaleString()}`
+        : ' · observation time unavailable'}
+    </p>
+  </details>
+  <div class="preference">
+    <h4>Current saved preference</h4>
+    <strong>{policy.label}</strong>
+    <p>
+      AEGIS does not automatically block file or network access. A saved rule does not prove an
+      action was allowed or denied.
+    </p>
+    {#if policy.agent}<button class="button" onclick={() => openPolicy(policy.agent!.instanceKey)}
+        >Edit this agent’s policy</button
+      >{/if}
+  </div>
+  <h4>What you can do</h4>
+  <p>
+    If this activity is unexpected, inspect the agent. Its process page offers pause and stop
+    controls.
+  </p>
+  <div class="actions">
+    <button
+      class="button"
+      onclick={() =>
+        inspect(
+          'Activity evidence',
+          activity.rows.length > 1 ? { observations: activity.rows } : activity.latest,
+        )}>Open evidence</button
+    >
+    <button
+      class="button"
+      disabled={!policy.agent || telemetry.stale}
+      onclick={() =>
+        policy.agent && inspect(policy.agent.name, { ...policy.agent, detailSection: 'processes' })}
+      >Agent &amp; controls</button
+    >
+  </div>
+  {#if !policy.agent || telemetry.stale}<p class="muted">
+      Process controls need an exact, currently observed agent.
+    </p>{/if}
+</aside>
+
+<style>
+  .evidence {
+    padding: var(--space-4);
+    align-self: start;
+    font-size: var(--text-body);
+    line-height: 1.6;
+    min-width: 0;
+  }
+  h3 {
+    font-size: var(--text-section);
+    margin: 0 0 var(--space-4);
+  }
+  h4 {
+    font-size: var(--text-body);
+    margin: var(--space-4) 0 var(--space-2);
+  }
+  p {
+    margin: var(--space-2) 0;
+    overflow-wrap: anywhere;
+  }
+  .actor {
+    font-weight: 650;
+    font-size: var(--text-section);
+  }
+  .destination {
+    background: var(--bg);
+    padding: var(--space-3);
+    border: 1px solid var(--border);
+    border-radius: var(--control-radius);
+    margin: var(--space-3) 0;
+  }
+  .destination span {
+    display: block;
+    color: var(--muted);
+    margin-bottom: var(--space-1);
+  }
+  code {
+    overflow-wrap: anywhere;
+    white-space: normal;
+    font-size: var(--text-body);
+  }
+  details {
+    margin: var(--space-4) 0;
+  }
+  summary {
+    cursor: pointer;
+  }
+  .preference {
+    border-block: 1px solid var(--border);
+    padding-bottom: var(--space-4);
+  }
+  .preference strong {
+    color: var(--amber);
+  }
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+  button {
+    white-space: normal;
+    height: auto;
+    min-height: var(--control-height);
+  }
+</style>

--- a/frontend/observatory/components/ProtectionOverview.svelte
+++ b/frontend/observatory/components/ProtectionOverview.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { invoke, record, type Host, type Telemetry, type RecordData } from '../runtime/host';
+  import { createProtectionActivityReader, type ProtectionActivity } from '../runtime/protection';
+  import ProtectionDetails from './ProtectionDetails.svelte';
+  import ProtectionActivityList from './ProtectionActivityList.svelte';
+  import Icon from './Icon.svelte';
+  let {
+    host,
+    telemetry,
+    liveTelemetry,
+    inspect,
+    openPolicy,
+    navigate,
+    policyRevision = 0,
+  }: {
+    host: Host | null;
+    telemetry: Telemetry;
+    liveTelemetry?: Telemetry;
+    inspect: (_title: string, _row: RecordData) => void;
+    openPolicy: (_key: string) => void;
+    navigate: (_view: string) => void | Promise<void>;
+    policyRevision?: number;
+  } = $props();
+  const readActivity = createProtectionActivityReader();
+  const activity = $derived(
+    readActivity(
+      telemetry.events as unknown as RecordData[],
+      telemetry.network as unknown as RecordData[],
+    ),
+  );
+  const reviewCount = $derived(activity.filter((item) => item.level === 'review').length);
+  const agentCount = $derived(new Set(telemetry.agents.map((agent) => agent.agent)).size);
+  let filter = $state('all');
+  let selected = $state.raw<ProtectionActivity | null>(null);
+  const current = $derived(
+    selected ? (activity.find((item) => item.key === selected!.key) ?? selected) : null,
+  );
+  const retained = $derived(!selected || activity.some((item) => item.key === selected!.key));
+  let permissions = $state.raw<RecordData | null>(null);
+  let policyError = $state(false);
+  let mounted = $state(false);
+  let revision = 0;
+  let alive = true;
+  async function loadPermissions() {
+    const ticket = ++revision;
+    permissions = null;
+    policyError = false;
+    try {
+      const envelope = record(await invoke(host, 'getAllPermissions'));
+      if (!envelope.permissions || !envelope.instancePermissions)
+        throw new Error('Missing policies');
+      if (alive && revision === ticket)
+        permissions = { ...record(envelope.permissions), ...record(envelope.instancePermissions) };
+    } catch {
+      if (alive && revision === ticket) policyError = true;
+    }
+  }
+  onMount(() => {
+    mounted = true;
+    return () => {
+      alive = false;
+      revision++;
+    };
+  });
+  $effect(() => {
+    policyRevision;
+    if (mounted) void loadPermissions();
+  });
+  let selectionHeading = $state<HTMLSpanElement>();
+  let selectionOrigin: HTMLButtonElement;
+  async function selectActivity(item: ProtectionActivity, button: HTMLButtonElement) {
+    selected = item;
+    selectionOrigin = button;
+    await tick();
+    selectionHeading?.focus({ preventScroll: true });
+    selectionHeading?.scrollIntoView?.({ block: 'nearest' });
+  }
+  function closeDetails() {
+    selected = null;
+    selectionOrigin?.focus();
+  }
+</script>
+
+<section class="protection" aria-label="Protection overview">
+  <div class="intro">
+    <div>
+      <h2><Icon name="shield" />Know what your agents are doing</h2>
+      <p>Files, connections and actions that need your attention.</p>
+    </div>
+  </div>
+  <div class="status-cards">
+    <button class:attention={reviewCount > 0} onclick={() => (filter = 'review')}>
+      <span>Needs your review</span><strong
+        >{telemetry.ready ? reviewCount : '—'} <small>activity groups</small></strong
+      >
+    </button>
+    <button onclick={() => navigate('agents')}
+      ><span>Agents observed</span><strong
+        >{telemetry.ready ? agentCount : '—'}
+        <small>{telemetry.stale ? 'last seen' : 'in this snapshot'}</small></strong
+      >
+    </button>
+    <div class="protection-limit">
+      <span>Automatic access blocking</span><strong><Icon name="shield" />Not active</strong>
+      <p>Saved permissions do not block access.</p>
+    </div>
+  </div>
+  <div class="activity-layout" class:has-selection={!!current}>
+    <ProtectionActivityList
+      {activity}
+      ready={telemetry.ready}
+      bind:filter
+      selectedKey={selected?.key}
+      select={selectActivity}
+    />
+    {#if current}<div class="selection">
+        <div class="selection-tools">
+          <span bind:this={selectionHeading} tabindex="-1"
+            >{retained
+              ? 'Selected activity'
+              : 'Previously selected · no longer in the current data'}</span
+          ><button class="button" onclick={closeDetails}>Close details</button>
+        </div>
+        {#if policyError}<p class="policy-error">
+            Saved preferences could not be loaded. <button class="button" onclick={loadPermissions}
+              >Retry preferences</button
+            >
+          </p>{/if}
+        <ProtectionDetails
+          activity={current}
+          telemetry={liveTelemetry ?? telemetry}
+          {permissions}
+          {inspect}
+          {openPolicy}
+        />
+      </div>{/if}
+  </div>
+  <details class="help">
+    <summary><Icon name="shield" />New to AEGIS? Start here</summary>
+    <div class="help-grid">
+      <p>
+        <strong>1. Check the action</strong>Review sensitive files and unexpected destinations.
+        “Unverified” means evidence is missing; it is not a danger verdict.
+      </p>
+      <p>
+        <strong>2. Check who did it</strong>“Indirect match” is an estimate from a path. An open
+        file handle does not prove the file was read.
+      </p>
+      <p>
+        <strong>3. Decide what to do</strong>Open the evidence or the agent’s controls. Saving
+        “Block” records a preference; automatic file and network blocking is not implemented.
+      </p>
+    </div>
+  </details>
+</section>
+
+<style>
+  .protection {
+    --body-size: calc(13px * var(--ui-scale));
+    font-size: var(--body-size);
+  }
+  .intro {
+    margin-bottom: var(--space-4);
+  }
+  h2 {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-title);
+    margin: 0 0 var(--space-2);
+  }
+  p {
+    color: var(--muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+  .status-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1.2fr;
+    gap: var(--space-3);
+    margin-bottom: var(--space-5);
+  }
+  .status-cards > * {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--surface-radius);
+    padding: var(--space-4);
+    text-align: left;
+    color: inherit;
+    font: inherit;
+  }
+  .status-cards span {
+    color: var(--muted);
+  }
+  .status-cards strong {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin: var(--space-2) 0;
+    font-size: var(--text-title);
+  }
+  .status-cards small {
+    font-size: var(--text-body);
+    font-weight: 400;
+    color: var(--muted);
+  }
+  .attention strong,
+  .protection-limit strong {
+    color: var(--amber);
+  }
+  .activity-layout {
+    display: grid;
+    gap: var(--space-4);
+    align-items: start;
+  }
+  .has-selection {
+    grid-template-columns: minmax(0, 1.6fr) minmax(280px, 1fr);
+  }
+  .selection {
+    min-width: 0;
+  }
+  .selection-tools {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    color: var(--muted);
+    font-size: var(--text-caption);
+    padding-bottom: var(--space-2);
+  }
+  .policy-error {
+    margin-bottom: var(--space-3);
+  }
+  .help {
+    border: 1px solid var(--border);
+    border-radius: var(--surface-radius);
+    padding: var(--space-4);
+    margin-top: var(--space-4);
+  }
+  summary {
+    cursor: pointer;
+  }
+  summary :global(svg) {
+    vertical-align: middle;
+    margin-right: var(--space-2);
+  }
+  .help-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-4);
+    padding-top: var(--space-4);
+  }
+  .help strong {
+    display: block;
+    color: var(--text);
+    margin-bottom: var(--space-2);
+  }
+  button {
+    cursor: pointer;
+  }
+  @media (max-width: 1100px) {
+    .has-selection {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+  @media (max-width: 750px) {
+    .status-cards,
+    .help-grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+</style>

--- a/frontend/observatory/components/Rules.svelte
+++ b/frontend/observatory/components/Rules.svelte
@@ -16,10 +16,10 @@
   import AgentLogo from './AgentLogo.svelte';
   let section = $state('permissions');
   const profiles: Record<string, [string, string]> = {
-    paranoid: ['bell', 'Alert on every category'],
-    strict: ['shield', 'More alerts for risky actions'],
-    balanced: ['balance', 'Monitor every category'],
-    developer: ['terminal', 'Fewer notifications'],
+    paranoid: ['bell', 'Request block for every category'],
+    strict: ['shield', 'Request block for sensitive actions'],
+    balanced: ['balance', 'Prefer monitoring every category'],
+    developer: ['terminal', 'Prefer allowing most categories'],
   };
   const labels: Record<string, [string, string, string]> = {
     filesystem: ['folder', 'File system', 'Read and write files'],
@@ -29,7 +29,26 @@
     clipboard: ['clipboard', 'Clipboard', 'Clipboard policy category'],
     screen: ['monitor', 'Screen', 'Screen capture policy category'],
   };
-  let { host, telemetry }: { host: Host | null; telemetry: Telemetry } = $props();
+  let {
+    host,
+    telemetry,
+    targetRequest,
+    onPermissionsChanged,
+  }: {
+    host: Host | null;
+    telemetry: Telemetry;
+    targetRequest?: { key: string; revision: number };
+    onPermissionsChanged?: () => void;
+  } = $props();
+  let appliedTargetRevision = 0;
+  $effect(() => {
+    if (!loaded || mutation || !targetRequest || targetRequest.revision === appliedTargetRevision)
+      return;
+    appliedTargetRevision = targetRequest.revision;
+    section = 'permissions';
+    scope = targetRequest.key.includes('::') ? 'instance' : 'agent';
+    target = targetRequest.key;
+  });
   let permissions = $state<RecordData>({});
   let rules = $state<RecordData[]>([]);
   let target = $state('');
@@ -140,6 +159,7 @@
   async function reset() {
     return mutate('reset', async () => {
       confirmed(await invoke(host, 'resetPermissionsToDefaults'));
+      onPermissionsChanged?.();
       for (const key of Object.keys(drafts)) delete drafts[key];
       draftBaseline = JSON.stringify(draft);
       await load();
@@ -154,6 +174,7 @@
     confirmed(
       await invoke(host, 'saveInstancePermissions', { ...context, permissions: savingDraft }),
     );
+    onPermissionsChanged?.();
     if (JSON.stringify(drafts[savingKey]) === JSON.stringify(savingDraft)) delete drafts[savingKey];
     if (activeKey === savingKey && JSON.stringify(draft) === JSON.stringify(savingDraft))
       draftBaseline = JSON.stringify(savingDraft);
@@ -169,13 +190,14 @@
   >
 </div>
 <div hidden={section !== 'permissions'}>
-  <details class="policy-explanation">
-    <summary>About monitoring permissions</summary>
+  <div class="policy-explanation">
+    <strong>Saved preferences · automatic blocking is not active</strong>
     <p>
-      Profiles control monitoring responses. Policy labels do not establish that an action was
-      blocked.
+      These settings record your intended policy. They do not currently block file or network
+      access, or change which observations are collected. To pause or stop an agent, open its
+      process controls.
     </p>
-  </details>
+  </div>
   {#if error}<p role="alert">{error}</p>{/if}
   <div class="filterbar target-toolbar">
     <label
@@ -237,8 +259,8 @@
           disabled={!target || mutation === 'reset'}
           bind:value={draft[category]}
         >
-          <option value="allow">Allow</option><option value="monitor">Monitor</option><option
-            value="block">Block</option
+          <option value="allow">Prefer allow</option><option value="monitor">Monitor</option><option
+            value="block">Request block</option
           >
         </select>
       </div>
@@ -315,11 +337,14 @@
 <style>
   .policy-explanation {
     margin: 10px 0;
+    padding: var(--space-4);
+    border: 1px solid var(--border);
+    border-radius: var(--surface-radius);
     color: var(--muted);
     font-size: calc(12px * var(--ui-scale));
   }
-  .policy-explanation summary {
-    cursor: pointer;
+  .policy-explanation strong {
+    color: var(--amber);
   }
   .policy-explanation p {
     margin-top: 8px;

--- a/frontend/observatory/runtime/protection.ts
+++ b/frontend/observatory/runtime/protection.ts
@@ -1,0 +1,159 @@
+import {
+  describeObservation,
+  canonicalObservationPath,
+} from '../../../src/shared/observation-display.js';
+import { record, type RecordData } from './host';
+import { effectivePolicy } from './policy-targets';
+
+export interface ProtectionActivity {
+  key: string;
+  kind: string;
+  actor: string;
+  action: string;
+  target: string;
+  resource: string;
+  attribution: string;
+  explanation: string;
+  source: string;
+  level: 'review' | 'unverified' | 'observed';
+  reason: string;
+  category: string;
+  rows: RecordData[];
+  latest: RecordData;
+  time: number;
+}
+
+function describe(row: RecordData, network: boolean): Omit<ProtectionActivity, 'key' | 'rows'> {
+  const evidence = describeObservation(row);
+  const actions: Record<string, string> = {
+    created: 'Created a file',
+    modified: 'Changed a file',
+    deleted: 'Deleted a file',
+    accessed: 'Had an open file handle',
+    holding: 'Held a file open',
+  };
+  let level: ProtectionActivity['level'] = 'observed';
+  let reason = 'No risk flag on this observation. This does not establish that the action is safe.';
+  if (row.sensitive === true) {
+    level = 'review';
+    reason =
+      'Sensitive file: it may contain credentials or private configuration. Check whether this access was expected.';
+  } else if (network && row.httpUnencrypted === true) {
+    level = 'review';
+    reason =
+      'An unencrypted HTTP connection was observed. Check the destination before sending private data.';
+  } else if (network && row.verdict === 'flagged') {
+    level = 'review';
+    reason =
+      'The verified destination is outside the known endpoint list. This alone does not establish malicious activity.';
+  } else if (network && row.verdict !== 'allowlisted') {
+    level = 'unverified';
+    reason = 'The destination identity could not be verified. Unknown does not mean dangerous.';
+  } else if (network) {
+    reason =
+      'The destination matches a known endpoint list. This is not an access permission or a guarantee of safety.';
+  }
+  return {
+    kind: network ? 'Network' : 'File',
+    actor: evidence.actor || 'Agent not identified',
+    action: network
+      ? 'Connection observed'
+      : (actions[String(row.action)] ?? 'File activity observed'),
+    target: evidence.path || evidence.resource,
+    resource: evidence.resource,
+    attribution: evidence.attribution,
+    explanation: evidence.explanation,
+    source: evidence.source,
+    level,
+    reason,
+    category: network ? 'network' : row.sensitive === true ? 'sensitive' : 'filesystem',
+    latest: row,
+    time: typeof row.timestamp === 'number' && Number.isFinite(row.timestamp) ? row.timestamp : 0,
+  };
+}
+
+/** Group repeated observations without merging owners, actions or evidence. Resource-only updates reuse the result.
+ * @returns Reader for immutable file and network deliveries @since 0.14.1
+ */
+export function createProtectionActivityReader() {
+  let previousFiles: readonly RecordData[] | undefined;
+  let previousNetwork: readonly RecordData[] | undefined;
+  let result: ProtectionActivity[] = [];
+  return (files: readonly RecordData[], network: readonly RecordData[]): ProtectionActivity[] => {
+    if (files === previousFiles && network === previousNetwork) return result;
+    const groups = new Map<string, ProtectionActivity>();
+    for (const [rows, isNetwork] of [
+      [files, false],
+      [network, true],
+    ] as const) {
+      for (const row of rows) {
+        const entry = describe(row, isNetwork);
+        const key = JSON.stringify([
+          entry.kind,
+          row.instanceId ?? null,
+          entry.actor,
+          record(row.attribution),
+          entry.attribution,
+          entry.action,
+          canonicalObservationPath(entry.target),
+          entry.level,
+          entry.reason,
+          entry.source,
+          row.reason ?? '',
+          row.verdictReason ?? '',
+        ]);
+        const existing = groups.get(key);
+        if (existing) {
+          existing.rows.push(row);
+          if (entry.time >= existing.time) Object.assign(existing, entry);
+        } else groups.set(key, { ...entry, key, rows: [row] });
+      }
+    }
+    const priority = { review: 0, unverified: 1, observed: 2 };
+    result = [...groups.values()].sort(
+      (a, b) => priority[a.level] - priority[b.level] || b.time - a.time,
+    );
+    previousFiles = files;
+    previousNetwork = network;
+    return result;
+  };
+}
+
+interface PolicyInstance {
+  instanceId: string | null;
+  instanceKey: string;
+  name: string;
+  parentEditor?: string | null;
+}
+
+/** Resolve policy only through a unique recorded process lifetime, never through PID or a path guess.
+ * @param activity Selected evidence @param agents Current population @param permissions Loaded preferences
+ * @returns Current context and saved preference, or unavailable @since 0.14.1
+ */
+export function protectionPolicy<T extends PolicyInstance>(
+  activity: ProtectionActivity,
+  agents: T[],
+  permissions: RecordData | null,
+): { agent: T | null; label: string } {
+  const row = activity.latest;
+  const status = record(row.attribution).status;
+  const matches =
+    typeof row.instanceId === 'string' &&
+    row.instanceId &&
+    status !== 'unattributed' &&
+    status !== 'ambiguous'
+      ? agents.filter(
+          (agent) => agent.instanceId === row.instanceId && agent.name === activity.actor,
+        )
+      : [];
+  const agent = matches.length === 1 ? matches[0] : null;
+  if (!agent) return { agent: null, label: 'Unavailable for this observation' };
+  if (!permissions) return { agent, label: 'Preferences unavailable' };
+  const value = effectivePolicy(agent.instanceKey, agents, permissions)[activity.category];
+  const labels: Record<string, string> = {
+    block: 'Block requested · not enforced',
+    allow: 'Allow preferred · not enforced',
+    monitor: 'Monitor preference',
+  };
+  return { agent, label: labels[String(value)] ?? 'No saved preference for this category' };
+}

--- a/frontend/observatory/tests/activity-check.mjs
+++ b/frontend/observatory/tests/activity-check.mjs
@@ -33,6 +33,7 @@ export async function checkActivity(browser, url, out) {
       );
     });
     await page.goto(url);
+    await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
     await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
     await page.evaluate(() => {
       window.activityFixture.onScanBatch({

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -14,6 +14,7 @@ import { checkGraphs } from './graph-check.mjs';
 import { checkDetails } from './detail-check.mjs';
 import { checkMotion } from './motion-check.mjs';
 import { checkResourceLayers } from './resource-layer-check.mjs';
+import { checkProtection } from './protection-check.mjs';
 
 const repo = process.cwd();
 const designRoot = resolve(repo, 'frontend/observatory');
@@ -84,6 +85,7 @@ const out = process.env.FRONTEND_QA_DIR || resolve(repo, 'dist/frontend-qa');
 await mkdir(out, { recursive: true });
 const errors = [];
 try {
+  await checkProtection(browser, base + '/preview/', out);
   for (const file of await readdir(resolve(roots['/desktop/'], 'assets'))) {
     if (!file.endsWith('.js')) continue;
     const js = await readFile(resolve(roots['/desktop/'], 'assets', file), 'utf8');
@@ -106,6 +108,7 @@ try {
     );
   });
   await page.goto(base + '/preview/');
+  await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
   await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
   await page.getByRole('button', { name: /Select Claude Code, 1 processes/ }).waitFor();
   assert.equal(await page.evaluate(() => window.bridgeCalls), 0);
@@ -321,6 +324,7 @@ try {
     .filter({ hasText: /^Completed$/ })
     .waitFor();
   await page.reload();
+  await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
   await page.getByRole('heading', { name: 'Monitoring', level: 1, exact: true }).waitFor();
   assert.equal(await page.evaluate(() => document.documentElement.dataset.theme), 'light-hc');
   await page.getByRole('button', { name: 'Toggle theme', exact: true }).click();

--- a/frontend/observatory/tests/clarity-check.mjs
+++ b/frontend/observatory/tests/clarity-check.mjs
@@ -34,6 +34,7 @@ export async function checkClarity(browser, url, out) {
       );
     });
     await page.goto(url);
+    await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
     await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
     await page.evaluate(() => {
       window.clarityFixture.onScanBatch({

--- a/frontend/observatory/tests/detail-check.mjs
+++ b/frontend/observatory/tests/detail-check.mjs
@@ -84,6 +84,7 @@ export async function checkDetails(browser, url, out) {
       );
     });
     await page.goto(url);
+    await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
     await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
     await page.evaluate(() => {
       const agents = Array.from({ length: 26 }, (_, i) => ({

--- a/frontend/observatory/tests/electron-smoke.mjs
+++ b/frontend/observatory/tests/electron-smoke.mjs
@@ -43,6 +43,14 @@ try {
   assert(observed, 'No reliable population observed within 55 seconds');
   // Health becomes reliable before the scan pipeline finishes publishing its batch.
   // Assert the visible renderer population separately from the backend getter.
+  await window.getByRole('region', { name: 'Protection overview' }).waitFor();
+  assert.equal(
+    await window.locator('.radar-panel').count(),
+    0,
+    'default overview eagerly mounted radar',
+  );
+  await window.screenshot({ path: resolve(out, 'protection-overview.png') });
+  await window.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
   await window.waitForFunction(
     () => /^\d+/.test(document.querySelector('.summary-stat strong')?.textContent?.trim() ?? ''),
     undefined,

--- a/frontend/observatory/tests/motion-check.mjs
+++ b/frontend/observatory/tests/motion-check.mjs
@@ -122,6 +122,7 @@ export async function checkMotion(page) {
   await page.getByRole('button', { name: 'Save settings', exact: true }).click();
   await page.waitForFunction(() => localStorage.getItem('aegis-motion') === 'reduce');
   await page.reload();
+  await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
   await page.getByRole('heading', { name: 'Monitoring', level: 1, exact: true }).waitFor();
   assert.equal(
     await page.locator('.dial-sweep').evaluate((node) => getComputedStyle(node).animationName),

--- a/frontend/observatory/tests/pagination-check.mjs
+++ b/frontend/observatory/tests/pagination-check.mjs
@@ -33,6 +33,7 @@ export async function checkPagination(browser, url, out) {
       );
     });
     await page.goto(url);
+    await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
     await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
     await page.evaluate(() => {
       window.paginationFixture.onScanBatch({

--- a/frontend/observatory/tests/protection-check.mjs
+++ b/frontend/observatory/tests/protection-check.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+/** Exercise the novice overview before entering detailed monitoring.
+ * @param {import('playwright').Browser} browser Browser @param {string} url Synthetic preview
+ * @param {string} out Screenshot directory @returns {Promise<void>} Verified @since 0.14.1
+ */
+export async function checkProtection(browser, url, out) {
+  const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  try {
+    await page.goto(url);
+    await page.getByRole('region', { name: 'Protection overview' }).waitFor();
+    assert.equal(await page.locator('.radar-panel').count(), 0, 'radar mounted before requested');
+    assert.equal(
+      await page.locator('.activity-row').count(),
+      8,
+      'initial activity must be bounded',
+    );
+    assert((await page.locator('.activity-row').first().innerText()).includes('Review needed'));
+    await page.getByRole('button', { name: 'Unverified', exact: true }).click();
+    assert.equal(await page.locator('.activity-row').count(), 4);
+    assert(
+      (await page.locator('.activity-row').first().innerText()).includes('Connection observed'),
+    );
+    await page.getByRole('button', { name: 'All activity', exact: true }).click();
+    await page.getByLabel('Search agent activity').fill('Codex');
+    assert.equal(await page.locator('.activity-row').count(), 3);
+    await page.getByLabel('Search agent activity').fill('');
+    await page.locator('.activity-row').first().focus();
+    await page.keyboard.press('Enter');
+    await page.getByRole('heading', { name: 'Understand this activity' }).waitFor();
+    assert(
+      await page
+        .locator('.selection-tools [tabindex]')
+        .evaluate((node) => document.activeElement === node),
+    );
+    await page.getByRole('button', { name: 'Edit this agent’s policy' }).click();
+    await page.getByLabel('Target', { exact: true }).waitFor();
+    assert.equal(
+      await page.getByLabel('Target', { exact: true }).inputValue(),
+      'Claude Code::X:/Preview/project-1',
+    );
+    assert(
+      (await page.locator('.policy-explanation').innerText()).includes(
+        'automatic blocking is not active',
+      ),
+    );
+    await page.locator('.sidebar').getByRole('button', { name: 'Monitoring', exact: true }).click();
+    await page.getByRole('button', { name: 'Close details' }).click();
+    assert(
+      await page
+        .locator('.activity-row')
+        .first()
+        .evaluate((node) => document.activeElement === node),
+    );
+    for (const size of [
+      { width: 1200, height: 800 },
+      { width: 900, height: 600 },
+    ]) {
+      await page.setViewportSize(size);
+      for (const scale of [1, 1.25, 1.5]) {
+        for (const theme of ['light', 'dark']) {
+          await page.evaluate(
+            ({ scale, theme }) => {
+              document.documentElement.style.setProperty('--ui-scale', String(scale));
+              document.documentElement.dataset.theme = theme;
+            },
+            { scale, theme },
+          );
+          for (const selected of [false, true]) {
+            if (selected) await page.locator('.activity-row').first().click();
+            await page.waitForFunction(() => !document.documentElement.dataset.transitionSurface);
+            const overflow = await page.evaluate(() => {
+              const nodes = [
+                ...document.querySelectorAll(
+                  '.protection, .activity-panel, .selection, .status-cards > *, .activity-row',
+                ),
+              ];
+              return nodes
+                .filter((node) => node.scrollWidth > node.clientWidth + 2)
+                .map((node) => node.className);
+            });
+            assert.deepEqual(
+              overflow,
+              [],
+              `protection overflow ${size.width}/${scale}/${theme}/${selected}`,
+            );
+            if (!selected)
+              await page.locator('main').evaluate((node) => {
+                node.scrollTop = 0;
+              });
+            await page.screenshot({
+              path: resolve(
+                out,
+                `protection-${size.width}-${scale}-${theme}${selected ? '-detail' : ''}.png`,
+              ),
+            });
+            if (selected) await page.getByRole('button', { name: 'Close details' }).click();
+          }
+        }
+      }
+    }
+    assert.deepEqual(errors, [], 'protection runtime errors');
+    console.log(
+      'Protection overview: filters, keyboard focus, exact policy navigation and 24 size/theme/scale/detail checks passed.',
+    );
+  } finally {
+    await page.close();
+  }
+}

--- a/frontend/observatory/tests/resource-layer-check.mjs
+++ b/frontend/observatory/tests/resource-layer-check.mjs
@@ -91,6 +91,7 @@ export async function checkResourceLayers(browser, url, out) {
       );
     });
     await page.goto(url);
+    await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
     await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
     await page.evaluate(() => {
       const agents = ['Claude Code', 'Codex', 'Cursor', 'Ollama', 'Zeta'].map((agent, i) => ({

--- a/frontend/observatory/tests/usability-check.mjs
+++ b/frontend/observatory/tests/usability-check.mjs
@@ -20,6 +20,7 @@ export async function checkUsability(browser, url, out) {
   };
   try {
     await page.goto(url);
+    await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
     await page.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
     for (const [width, height, scale] of [
       [1200, 800, 1],

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -37,7 +37,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (frontend/observatory/) — Svelte 5 + Vite 7
-49 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
+52 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
 
 App.svelte owns workspace tabs, history and the host connection. Monitoring groups products and exposes stamped instances for process actions; Events and ActivityChart show retained evidence; Details and EntityLinks connect observations; Rules, Catalog, Analysis, Reports, Statistics and Settings expose host actions. SensorStatus renders effective sensor IDs; Notifications tracks anomaly crossings.
 

--- a/tests/renderer/components/ObservatoryAgentWorkspace.test.js
+++ b/tests/renderer/components/ObservatoryAgentWorkspace.test.js
@@ -106,6 +106,7 @@ async function start() {
     { instanceId: agents[0].instanceId, cpu: 10, memMb: 100 },
     { instanceId: agents[1].instanceId, cpu: 70, memMb: 700 },
   ]);
+  await fireEvent.click(screen.getByRole('button', { name: 'Detailed monitoring' }));
   await waitFor(() =>
     expect(screen.getByRole('heading', { name: 'Agent radar', exact: true })).toBeVisible(),
   );

--- a/tests/renderer/components/ObservatoryProtection.test.js
+++ b/tests/renderer/components/ObservatoryProtection.test.js
@@ -1,0 +1,143 @@
+import { expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
+import App from '../../../frontend/observatory/App.svelte';
+import ProtectionOverview from '../../../frontend/observatory/components/ProtectionOverview.svelte';
+import Rules from '../../../frontend/observatory/components/Rules.svelte';
+import { emptyTelemetry } from '../../../frontend/observatory/runtime/host';
+
+const snapshot = () => ({
+  ...emptyTelemetry(),
+  ready: true,
+  stale: false,
+  agents: [{ agent: 'Codex', instanceId: '7:first', pid: 7, process: 'codex.exe', cwd: 'C:/work' }],
+  events: [
+    {
+      agent: 'Codex',
+      instanceId: '7:first',
+      pid: 7,
+      file: 'C:/work/.env',
+      action: 'holding',
+      sensitive: true,
+      timestamp: 10,
+      attribution: { status: 'inferred', evidence: ['cwd-containment'] },
+    },
+  ],
+});
+const host = () => ({
+  getAllPermissions: vi.fn(async () => ({
+    permissions: { Codex: { sensitive: 'block' } },
+    instancePermissions: {},
+  })),
+});
+const props = () => ({
+  host: host(),
+  telemetry: snapshot(),
+  inspect: vi.fn(),
+  openPolicy: vi.fn(),
+  navigate: vi.fn(),
+});
+
+it('starts with a protection overview and only mounts the radar after it is requested', async () => {
+  const mounted = render(App, { host: null });
+  expect(screen.getByRole('region', { name: 'Protection overview' })).toBeVisible();
+  expect(mounted.container.querySelector('.radar-panel')).toBeNull();
+  expect(screen.getByText('Waiting for observations')).toBeVisible();
+  await fireEvent.click(screen.getByRole('button', { name: 'Detailed monitoring' }));
+  expect(await screen.findByRole('heading', { name: 'Agent radar' })).toBeVisible();
+  await fireEvent.click(screen.getByRole('button', { name: 'Protection overview' }));
+  expect(screen.getByRole('region', { name: 'Protection overview' })).toBeVisible();
+});
+
+it('connects evidence to the intended policy and keeps inferred ownership visible', async () => {
+  const input = props();
+  render(ProtectionOverview, input);
+  await fireEvent.click(
+    screen.getByRole('button', { name: /Codex.*Indirect match.*Held a file open/ }),
+  );
+  const details = screen.getByRole('complementary', { name: 'Selected activity' });
+  expect(await within(details).findByText('Block requested · not enforced')).toBeVisible();
+  expect(within(details).getByText('C:/work/.env')).toBeVisible();
+  await fireEvent.click(within(details).getByRole('button', { name: 'Edit this agent’s policy' }));
+  expect(input.openPolicy).toHaveBeenCalledExactlyOnceWith('Codex::C:/work');
+  await fireEvent.click(within(details).getByRole('button', { name: 'Agent & controls' }));
+  expect(input.inspect.mock.calls[0][1]).toMatchObject({
+    instanceId: '7:first',
+    detailSection: 'processes',
+  });
+});
+
+it('retains the selected evidence and disables process navigation after its lifetime disappears or observations go stale', async () => {
+  const input = props();
+  const mounted = render(ProtectionOverview, input);
+  await fireEvent.click(
+    screen.getByRole('button', { name: /Codex.*Indirect match.*Held a file open/ }),
+  );
+  await mounted.rerender({ ...input, telemetry: { ...input.telemetry, stale: true } });
+  expect(screen.getByRole('button', { name: 'Agent & controls' })).toBeDisabled();
+  await mounted.rerender({
+    ...input,
+    telemetry: {
+      ...snapshot(),
+      agents: [{ ...input.telemetry.agents[0], instanceId: '7:replacement' }],
+      events: [],
+    },
+  });
+  expect(screen.getByText(/Previously selected/)).toBeVisible();
+  expect(screen.getByRole('button', { name: 'Agent & controls' })).toBeDisabled();
+  expect(screen.queryByRole('button', { name: 'Edit this agent’s policy' })).toBeNull();
+});
+
+it('shows unavailable preferences after a failed refresh instead of retaining an old allow label', async () => {
+  const input = props();
+  const mounted = render(ProtectionOverview, input);
+  await fireEvent.click(
+    screen.getByRole('button', { name: /Codex.*Indirect match.*Held a file open/ }),
+  );
+  await screen.findByText('Block requested · not enforced');
+  input.host.getAllPermissions.mockRejectedValueOnce(new Error('Unavailable'));
+  await mounted.rerender({ ...input, policyRevision: 1 });
+  await screen.findByText(/Saved preferences could not be loaded/);
+  expect(screen.getByText('Preferences unavailable')).toBeVisible();
+  input.host.getAllPermissions.mockResolvedValue({
+    permissions: { Codex: { sensitive: 'allow' } },
+    instancePermissions: {},
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Retry preferences' }));
+  expect(await screen.findByText('Allow preferred · not enforced')).toBeVisible();
+});
+
+it('uses current process availability while the displayed activity is paused', async () => {
+  const input = props();
+  render(ProtectionOverview, {
+    ...input,
+    liveTelemetry: { ...snapshot(), stale: true },
+  });
+  await fireEvent.click(
+    screen.getByRole('button', { name: /Codex.*Indirect match.*Held a file open/ }),
+  );
+  expect(screen.getByRole('button', { name: 'Agent & controls' })).toBeDisabled();
+});
+
+it('opens the requested project policy without a write, and invalidates the overview only after a successful save', async () => {
+  const transport = {
+    ...host(),
+    getRules: async () => [],
+    saveInstancePermissions: vi.fn(async () => ({ success: false, error: 'Disk full' })),
+  };
+  const changed = vi.fn();
+  render(Rules, {
+    host: transport,
+    telemetry: snapshot(),
+    targetRequest: { key: 'Codex::C:/work', revision: 1 },
+    onPermissionsChanged: changed,
+  });
+  await waitFor(() => expect(screen.getByLabelText('Target')).toHaveValue('Codex::C:/work'));
+  expect(transport.saveInstancePermissions).not.toHaveBeenCalled();
+  await fireEvent.change(screen.getByLabelText('Sensitive files'), { target: { value: 'allow' } });
+  await fireEvent.click(screen.getByRole('button', { name: 'Save permissions' }));
+  await screen.findByText('Disk full');
+  expect(changed).not.toHaveBeenCalled();
+  transport.saveInstancePermissions.mockResolvedValue({ success: true });
+  await fireEvent.click(screen.getByRole('button', { name: 'Save permissions' }));
+  await waitFor(() => expect(changed).toHaveBeenCalledTimes(1));
+});

--- a/tests/renderer/observatory-protection.test.js
+++ b/tests/renderer/observatory-protection.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createProtectionActivityReader,
+  protectionPolicy,
+} from '../../frontend/observatory/runtime/protection';
+
+const file = (patch = {}) => ({
+  agent: 'Codex',
+  instanceId: '7:first',
+  pid: 7,
+  action: 'holding',
+  file: 'C:/Users/test/.env',
+  sensitive: true,
+  timestamp: 10,
+  attribution: { status: 'confirmed', evidence: ['rm-holder-pid'] },
+  ...patch,
+});
+const agents = [{ name: 'Codex', instanceId: '7:first', instanceKey: 'Codex::C:/work' }];
+const policy = { Codex: { sensitive: 'monitor' }, 'Codex::C:/work': { sensitive: 'block' } };
+
+describe('protection activity', () => {
+  it('prioritizes review without promoting unknown endpoints or file handles to proven danger or reads', () => {
+    const read = createProtectionActivityReader();
+    const result = read(
+      [file(), file({ sensitive: false, file: '/normal.txt', timestamp: 100 })],
+      [
+        { agent: 'Codex', remoteIp: '192.0.2.1', verdict: 'unknown', flagged: true },
+        { agent: 'Codex', remoteIp: '192.0.2.2', verdict: 'allowlisted' },
+        { agent: 'Codex', remoteIp: '192.0.2.3', verdict: 'flagged' },
+      ],
+    );
+    expect(result.map((row) => row.level)).toEqual([
+      'review',
+      'review',
+      'unverified',
+      'observed',
+      'observed',
+    ]);
+    expect(result[0].action).toBe('Held a file open');
+    expect(result[1].reason).toContain('does not establish malicious');
+    expect(result[2].reason).toContain('Unknown does not mean dangerous');
+    expect(result[4].reason).toContain('not an access permission');
+  });
+
+  it('groups repeated Windows paths, preserving different process lifetimes, actions, ownership and sources', () => {
+    const result = createProtectionActivityReader()(
+      [
+        file(),
+        file({ file: 'c:\\users\\test\\.env', timestamp: 20 }),
+        file({ instanceId: '7:second' }),
+        file({ action: 'modified' }),
+        file({ attribution: { status: 'inferred', evidence: ['cwd-containment'] } }),
+        file({ source: 'another sensor' }),
+      ],
+      [],
+    );
+    expect(result).toHaveLength(5);
+    expect(result[0].rows).toHaveLength(2);
+    expect(result[0].latest.timestamp).toBe(20);
+  });
+
+  it('reuses immutable deliveries but incorporates new file or network deliveries', () => {
+    const read = createProtectionActivityReader();
+    const files = [file()];
+    const network = [];
+    const first = read(files, network);
+    expect(read(files, network)).toBe(first);
+    const next = read([...files, file({ file: '/other' })], network);
+    expect(next).not.toBe(first);
+    expect(next).toHaveLength(2);
+    expect(first[0].rows).toHaveLength(1);
+    expect(read(files, [{ remoteIp: '192.0.2.1' }])).toHaveLength(2);
+  });
+
+  it('never uses an agent directory as evidence of the actor', () => {
+    const [entry] = createProtectionActivityReader()(
+      [
+        file({
+          agent: '',
+          instanceId: null,
+          file: '/home/test/.codex/config.toml',
+          attribution: { status: 'unattributed' },
+        }),
+      ],
+      [],
+    );
+    expect(entry.actor).toBe('Agent not identified');
+    expect(protectionPolicy(entry, agents, policy).agent).toBeNull();
+  });
+
+  it('only resolves a saved preference for a unique matching lifetime, and never calls it enforced', () => {
+    const [entry] = createProtectionActivityReader()([file()], []);
+    expect(protectionPolicy(entry, agents, policy)).toEqual({
+      agent: agents[0],
+      label: 'Block requested · not enforced',
+    });
+    expect(
+      protectionPolicy(entry, [{ ...agents[0], instanceId: '7:second' }], policy).agent,
+    ).toBeNull();
+    expect(protectionPolicy(entry, [agents[0], agents[0]], policy).agent).toBeNull();
+    expect(protectionPolicy(entry, [{ ...agents[0], name: 'Other' }], policy).agent).toBeNull();
+    expect(protectionPolicy(entry, agents, null).label).toBe('Preferences unavailable');
+    expect(protectionPolicy(entry, agents, {}).label).toBe('No saved preference for this category');
+  });
+});


### PR DESCRIPTION
Monitoring now starts with a protection overview that puts the agent, action, file or destination, and reason for review together. Selecting a sensitive-file observation opens its evidence, current saved preference, and links to that agent's policy and process controls. Search, filters, grouped repetitions and a short beginner guide keep the default screen manageable; the existing radar and charts remain under Detailed monitoring.

Saved Allow/Block values are explicitly described as preferences without automatic enforcement. Unknown destinations, inferred ownership, stale populations and unavailable policy reads retain their uncertainty. Process navigation uses the current population even when the displayed activity is paused. Successful permission saves refresh the overview.

Validation:
- Repository coverage suite, type checks, both renderer builds, formatting, lint, witness/sequence gates, derived counts and production dependency audit passed locally. Lint retains 57 existing warnings; the audit reports zero vulnerabilities.
- Focused tests cover identity reuse, attribution, grouping, policy failures and refresh, and paused-view process availability.
- Browser checks cover 24 new overview layout states at 900x600 and 1200x800, light/dark themes and 100–150% scale, plus all existing workspace checks. Keyboard focus and policy navigation passed.
- Disposable-profile Electron smoke passed, including restart and existing export/configuration checks.
- Fresh four-agent preview DOM count: 917 before, 637 after. The initial list renders eight groups; immutable resource-only updates reuse the activity model. This is a DOM measurement, not a CPU or memory benchmark.
