### PR TITLE
feat(radar): make file and network relationships explorable

### DIFF
--- a/frontend/observatory/App.svelte
+++ b/frontend/observatory/App.svelte
@@ -458,6 +458,7 @@
                 (view !== 'agents' || scope.agent !== '')}
             >
               <Monitoring
+                liveTelemetry={telemetry}
                 telemetry={displayTelemetry}
                 bind:selected
                 {inspect}

--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -129,3 +129,32 @@ The introductory help, native controls, focus return and responsive detail panel
 support keyboard use and larger text. Existing theme tokens and template files
 remain the visual base. Browser checks cover the new default and explicitly open
 detailed monitoring when checking the preserved radar layout.
+
+
+### Radar resource exploration (2026-09-11)
+
+The user's request to substantially improve Files and Network supersedes the
+previous two-resource overlay and immediate navigation on radar selection.
+Risk markers and roster rows now focus locally, with a leading risk reason and
+explicit links to files, connections and the agent workspace. The risk circle
+retains its measured score positioning.
+
+Files and Network each show a searchable resource catalog and a selected-resource
+relationship view. All radar pages, historical observations, own-file activity
+and unattributed resources remain available. Filters apply to summary counts;
+resource and relationship pagination bound the visible content. The responsive
+layout uses adjacent columns or stacked panels without absolute-positioned cards.
+
+Every resource retains all source records. Relationships separate process
+lifetimes and attribution evidence. Solid lines mean confirmed ownership; dashed
+lines mean indirect, ambiguous or legacy attribution. Unknown actors have no line.
+These static links never imply actual data transfer. A connection is not proof of
+its payload, an open handle is not proof of a read, and an endpoint allowlist is
+not access enforcement. Unknown destinations remain distinct from review flags.
+
+Selection survives layer changes and retention updates with explicit labels.
+Process navigation resolves against the unique current lifetime, including while
+the displayed view is paused. A stale or missing population disables navigation.
+Filters preserve focus; choosing a resource focuses its detail heading. Visited
+layers retain state, and unchanged observation arrays reuse the resource model.
+All new styling remains scoped; the preserved reference and cascade are unchanged.

--- a/frontend/observatory/components/Monitoring.svelte
+++ b/frontend/observatory/components/Monitoring.svelte
@@ -14,6 +14,7 @@
   } from '../../../src/shared/observation-display.js';
   let {
     telemetry,
+    liveTelemetry,
     selected = $bindable(null),
     inspect,
     mode = 'overview',
@@ -23,6 +24,7 @@
     paused = false,
   }: {
     telemetry: Telemetry;
+    liveTelemetry?: Telemetry;
     selected: string | null;
     inspect: (_title: string, _row: RecordData) => void;
     mode?: string;
@@ -105,7 +107,7 @@
       </p>
     </div>
   </div>
-  <Radar {telemetry} bind:selected {inspect} {openStatistics} {openAgent} />
+  <Radar {telemetry} {liveTelemetry} bind:selected {inspect} {openStatistics} {openAgent} />
   <div class="monitoring-activity">
     <ActivityChart
       events={telemetry.events}

--- a/frontend/observatory/components/Radar.svelte
+++ b/frontend/observatory/components/Radar.svelte
@@ -1,21 +1,23 @@
 <script lang="ts">
   import { instances, type Telemetry, type RecordData } from '../runtime/host';
-  import { radarGroups, groupRecord, riskBand, type RadarGroup } from '../runtime/radar';
+  import { radarGroups, riskBand, type RadarGroup } from '../runtime/radar';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   import RadarSummary from './RadarSummary.svelte';
   import RadarInspector from './RadarInspector.svelte';
-  import RadarLinks from './RadarLinks.svelte';
+  import RadarResourceExplorer from './RadarResourceExplorer.svelte';
+  import { leadingRiskReason } from '../runtime/risk-context';
   import { reveal } from '../runtime/motion';
-  import { radarResources } from '../runtime/radar-resources';
   let {
     telemetry,
+    liveTelemetry,
     selected = $bindable(null),
     inspect,
     openStatistics,
     openAgent,
   }: {
     telemetry: Telemetry;
+    liveTelemetry?: Telemetry;
     openStatistics?: (_agent: string) => void;
     openAgent?: (_agent: string) => void;
     selected: string | null;
@@ -25,37 +27,37 @@
   let groups = $derived(radarGroups(agents));
   let page = $state(0);
   let layer = $state('radar');
-  let resourcePage = $state(0);
+  let visited = $state<string[]>([]);
+  let resourceAgent = $state('');
+  let focusedGroup = $state('');
   let pages = $derived(Math.max(1, Math.ceil(groups.length / 4)));
   let plotted = $derived(
     groups.slice(Math.min(page, pages - 1) * 4, Math.min(page, pages - 1) * 4 + 4),
   );
   let chosen = $derived(agents.find((a) => !!selected && a.instanceId === selected));
   let chosenGroup = $derived(
-    groups.find((g) => g.members.some((a) => !!selected && a.instanceId === selected)),
+    groups.find((g) => g.key === focusedGroup) ??
+      groups.find((g) => g.members.some((a) => !!selected && a.instanceId === selected)),
   );
-  let resources = $derived(radarResources(telemetry, layer, plotted, chosenGroup));
-  let uniqueResourceCount = $derived(new Set(resources.map((entry) => entry.resourceKey)).size);
-  let resourcePages = $derived(Math.max(1, Math.ceil(resources.length / 2)));
-  let resourceIndex = $derived(Math.min(resourcePage, resourcePages - 1));
-  let linked = $derived(resources.slice(resourceIndex * 2, resourceIndex * 2 + 2));
-  $effect(() => {
-    layer;
-    selected;
-    page;
-    resourcePage = 0;
-  });
+  function chooseLayer(next: string) {
+    if (layer === 'radar' && next !== 'radar') resourceAgent = chosenGroup?.name ?? '';
+    layer = next;
+    if (!visited.includes(next)) visited = [...visited, next];
+  }
+  function clearSelection() {
+    selected = null;
+    focusedGroup = '';
+  }
   function changePage(offset: number) {
     page = Math.max(0, Math.min(pages - 1, page + offset));
-    selected = null;
+    clearSelection();
   }
   function select(g: RadarGroup) {
+    focusedGroup = g.key;
     selected =
       g.members.find((a) => a.instanceId === selected)?.instanceId ??
       g.members.find((a) => a.instanceId)?.instanceId ??
       null;
-    if (openAgent) openAgent(g.key);
-    else if (!selected) inspect(g.name, groupRecord(g));
   }
   function position(g: RadarGroup, i: number) {
     const count = plotted.length;
@@ -74,7 +76,13 @@
     <div class="panel-head">
       <div>
         <h2><Icon name="radar" />Agent radar</h2>
-        <p>One marker per agent · risk rises toward the edge</p>
+        <p>
+          {layer === 'radar'
+            ? 'Select an agent to focus · risk rises toward the edge'
+            : layer === 'files'
+              ? 'Find who touched a file, what changed and why it matters'
+              : 'Find who connected, where and what is known about the destination'}
+        </p>
       </div>
       <div
         class="segmented radar-layers"
@@ -83,140 +91,122 @@
       >
         {#each [['radar', 'Radar', 'radar'], ['files', 'Files', 'folder'], ['network', 'Network', 'network']] as [id, title, icon] (id)}<button
             aria-pressed={layer === id}
-            onclick={() => (layer = id)}><Icon name={icon} />{title}</button
+            onclick={() => chooseLayer(id)}><Icon name={icon} />{title}</button
           >{/each}
       </div>
     </div>
-    <div class="radar-resource-toolbar">
-      {#if layer === 'radar'}<div class="resource-scope">
-          <strong>Agent risk</strong><span>Select an agent for usage, activity and statistics</span>
-        </div>{:else}
+    <div hidden={layer !== 'radar'}>
+      <div class="radar-resource-toolbar">
         <div class="resource-scope">
-          <strong>{chosenGroup?.name ?? 'All agents on this page'}</strong>
-          <span
-            >{uniqueResourceCount} unique {layer === 'files'
-              ? uniqueResourceCount === 1
-                ? 'file'
-                : 'files'
-              : uniqueResourceCount === 1
-                ? 'endpoint'
-                : 'endpoints'}{uniqueResourceCount !== resources.length
-              ? ' · ' + resources.length + ' observation groups'
-              : ''} · {telemetry.stale
-              ? 'Last reliable snapshot'
-              : layer === 'files'
-                ? 'Retained observations'
-                : 'Current snapshot'}</span
+          <strong>Agent risk</strong><span
+            >Choose a marker or row. Open the focused agent when you need its controls.</span
           >
         </div>
-        {#if chosenGroup}<button class="text-button" onclick={() => (selected = null)}
-            >Show all agents</button
+        {#if chosenGroup}<button class="button" onclick={clearSelection}>Clear agent focus</button
           >{/if}
-        {#if resourcePages > 1}<div class="radar-pages resource-pages" aria-label="Resource pages">
+      </div>
+      <div id="radar-body">
+        <div class="radar-workspace">
+          <div class="radar-stage" class:stale={telemetry.stale} data-layer="radar">
+            <button class="radar-empty" aria-label="Clear radar selection" onclick={clearSelection}
+            ></button>
+            <div class="radar-coordinate">
+              {telemetry.stale ? 'Last reliable snapshot' : 'Live observation'}
+            </div>
+            <div class="radar-dial">
+              <div class="dial-grid"></div>
+              <div class="dial-ticks"></div>
+              <div class="dial-sweep"></div>
+              <div class="radar-center"><Icon name="shield" /></div>
+              {#each plotted as group, i (group.key)}{@const point = position(group, i)}<button
+                  class={`radar-blip ${riskBand(group.risk)}`}
+                  data-group={group.key}
+                  style={`left:${point.x}%;top:${point.y}%;--echo-delay:${point.angle / 60 - 6}s`}
+                  aria-label={`Select ${group.name}, ${group.members.length} processes, risk ${group.risk}`}
+                  title={`${group.name} · ${group.members.length} processes · risk ${group.risk}/100`}
+                  aria-pressed={group === chosenGroup}
+                  onclick={() => select(group)}
+                  onkeydown={(e) => {
+                    if (e.key === 'Escape') clearSelection();
+                  }}
+                >
+                  <span class="blip-dot"
+                    ><AgentLogo id={group.key} name={group.name} size={24} /></span
+                  >
+                  <span class="marker-number" aria-hidden="true"
+                    >{Math.min(page, pages - 1) * 4 + i + 1}</span
+                  >
+                </button>{/each}
+            </div>
+            {#if !groups.length && layer === 'radar'}<p class="radar-message">
+                {telemetry.ready ? 'No agents in this snapshot' : 'Waiting for a reliable scan'}
+              </p>{/if}
+            <div class="radar-scale">Centre: lower observed risk · Edge: higher observed risk</div>
+          </div>
+          <aside class="radar-roster" aria-label="Observed agents">
+            <div class="roster-heading">
+              <h3>Agents</h3>
+              <span>{groups.length}</span>
+            </div>
+            <div class="roster-items" use:reveal={String(Math.min(page, pages - 1))}>
+              {#each plotted as group, i (group.key)}<RadarSummary
+                  {group}
+                  ordinal={Math.min(page, pages - 1) * 4 + i + 1}
+                  {selected}
+                  active={group === chosenGroup}
+                  {select}
+                />{/each}
+            </div>
+            {#if !groups.length}<p class="entity-note">
+                {telemetry.ready ? 'No agents observed.' : 'Waiting for a scan.'}
+              </p>{/if}
+            {#if openAgent && chosenGroup}<div class="radar-focus">
+                <strong>{chosenGroup.name} · {chosenGroup.risk}/100</strong>
+                <p>{leadingRiskReason(chosenGroup.members[0])}</p>
+                <div>
+                  <button class="button" onclick={() => chooseLayer('files')}>View files</button
+                  ><button class="button" onclick={() => chooseLayer('network')}
+                    >View connections</button
+                  ><button class="button" onclick={() => openAgent?.(chosenGroup.key)}
+                    >Open agent</button
+                  >
+                </div>
+              </div>{/if}
+            <p class="roster-note">{agents.length} processes grouped by agent</p>
+          </aside>
+        </div>
+      </div>
+      <div class="radar-bottom">
+        <div class="radar-legend">
+          <span class="low"><i></i>Low 0–34</span><span class="medium"><i></i>Medium 35–65</span
+          ><span class="high"><i></i>High 66–100</span>
+        </div>
+        {#if pages > 1}<div class="radar-pages">
             <button
-              aria-label="Previous radar resources"
-              disabled={resourceIndex === 0}
-              onclick={() => (resourcePage = resourceIndex - 1)}><Icon name="arrowLeft" /></button
-            >
-            <span
-              >{resourceIndex * 2 + 1}–{Math.min(resources.length, resourceIndex * 2 + 2)} / {resources.length}</span
-            >
-            <button
-              aria-label="Next radar resources"
-              disabled={resourceIndex >= resourcePages - 1}
-              onclick={() => (resourcePage = resourceIndex + 1)}><Icon name="chevron" /></button
+              aria-label="Previous radar agents"
+              disabled={page === 0}
+              onclick={() => changePage(-1)}><Icon name="arrowLeft" /></button
+            ><span>{Math.min(page, pages - 1) + 1}/{pages}</span><button
+              aria-label="Next radar agents"
+              disabled={page >= pages - 1}
+              onclick={() => changePage(1)}><Icon name="chevron" /></button
             >
           </div>{/if}
-      {/if}
-    </div>
-    <div id="radar-body">
-      <div class="radar-workspace">
-        <div class="radar-stage" class:stale={telemetry.stale} data-layer={layer}>
-          <button
-            class="radar-empty"
-            aria-label="Clear radar selection"
-            onclick={() => (selected = null)}
-          ></button>
-          <div class="radar-coordinate">
-            {telemetry.stale ? 'Last reliable snapshot' : 'Live observation'}
-          </div>
-          <div class="radar-dial">
-            <div class="dial-grid"></div>
-            <div class="dial-ticks"></div>
-            <div class="dial-sweep"></div>
-            <div class="radar-center"><Icon name="shield" /></div>
-            {#each plotted as group, i (group.key)}{@const point = position(group, i)}<button
-                class={`radar-blip ${riskBand(group.risk)}`}
-                data-group={group.key}
-                style={`left:${point.x}%;top:${point.y}%;--echo-delay:${point.angle / 60 - 6}s`}
-                aria-label={`Select ${group.name}, ${group.members.length} processes, risk ${group.risk}`}
-                title={`${group.name} · ${group.members.length} processes · risk ${group.risk}/100`}
-                aria-pressed={group === chosenGroup}
-                onclick={() => select(group)}
-                onkeydown={(e) => {
-                  if (e.key === 'Escape') selected = null;
-                }}
-              >
-                <span class="blip-dot"
-                  ><AgentLogo id={group.key} name={group.name} size={24} /></span
-                >
-                <span class="marker-number" aria-hidden="true"
-                  >{Math.min(page, pages - 1) * 4 + i + 1}</span
-                >
-              </button>{/each}
-          </div>
-          {#if !groups.length && layer === 'radar'}<p class="radar-message">
-              {telemetry.ready ? 'No agents in this snapshot' : 'Waiting for a reliable scan'}
-            </p>{/if}
-          {#if layer !== 'radar'}<RadarLinks
-              rows={linked}
-              {layer}
-              {inspect}
-              ready={telemetry.ready}
-              scoped={!!chosenGroup}
-            />{/if}
-          <div class="radar-scale">Select a marker or an agent in the list</div>
-        </div>
-        <aside class="radar-roster" aria-label="Observed agents">
-          <div class="roster-heading">
-            <h3>Agents</h3>
-            <span>{groups.length}</span>
-          </div>
-          <div class="roster-items" use:reveal={String(Math.min(page, pages - 1))}>
-            {#each plotted as group, i (group.key)}<RadarSummary
-                {group}
-                ordinal={Math.min(page, pages - 1) * 4 + i + 1}
-                {selected}
-                {select}
-              />{/each}
-          </div>
-          {#if !groups.length}<p class="entity-note">
-              {telemetry.ready ? 'No agents observed.' : 'Waiting for a scan.'}
-            </p>{/if}
-          <p class="roster-note">{agents.length} processes grouped by agent</p>
-        </aside>
       </div>
     </div>
-    <div class="radar-bottom">
-      <div class="radar-legend">
-        <span class="low"><i></i>Low 0–34</span><span class="medium"><i></i>Medium 35–65</span><span
-          class="high"><i></i>High 66–100</span
-        >
-      </div>
-      {#if pages > 1}<div class="radar-pages">
-          <button
-            aria-label="Previous radar agents"
-            disabled={page === 0}
-            onclick={() => changePage(-1)}><Icon name="arrowLeft" /></button
-          ><span>{Math.min(page, pages - 1) + 1}/{pages}</span><button
-            aria-label="Next radar agents"
-            disabled={page >= pages - 1}
-            onclick={() => changePage(1)}><Icon name="chevron" /></button
-          >
+    {#each ['files', 'network'] as resourceLayer (resourceLayer)}
+      {#if visited.includes(resourceLayer)}<div hidden={layer !== resourceLayer}>
+          <RadarResourceExplorer
+            {telemetry}
+            {liveTelemetry}
+            layer={resourceLayer}
+            {inspect}
+            bind:agent={resourceAgent}
+          />
         </div>{/if}
-    </div>
+    {/each}
   </section>
-  {#if !openAgent}<RadarInspector
+  {#if !openAgent && layer === 'radar'}<RadarInspector
       {chosen}
       group={chosenGroup}
       {telemetry}
@@ -227,6 +217,30 @@
 </div>
 
 <style>
+  .radar-resource-toolbar {
+    height: auto;
+    min-height: var(--control-height);
+    overflow: visible;
+    scrollbar-gutter: auto;
+  }
+  .radar-focus {
+    margin-top: var(--space-3);
+    border: 1px solid var(--strong-border);
+    border-radius: var(--control-radius);
+    padding: var(--space-3);
+    font-size: var(--text-body);
+    line-height: 1.6;
+  }
+  .radar-focus p {
+    color: var(--muted);
+    margin: var(--space-2) 0;
+  }
+  .radar-focus > div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
   .overview-grid.radar-clarity.agent-launcher {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/frontend/observatory/components/RadarLinks.svelte
+++ b/frontend/observatory/components/RadarLinks.svelte
@@ -1,210 +1,314 @@
 <script lang="ts">
-  import { onMount, tick } from 'svelte';
-  import type { RecordData } from '../runtime/host';
-  import type { RadarResource } from '../runtime/radar-resources';
+  import type { RecordData, Telemetry } from '../runtime/host';
+  import {
+    resourceProcess,
+    type RadarResource,
+    type ResourceRelation,
+  } from '../runtime/radar-resources';
+  import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
   let {
-    rows,
+    resource,
     layer,
+    telemetry,
     inspect,
-    ready,
-    scoped,
+    retained = true,
   }: {
-    rows: RadarResource[];
+    resource: RadarResource;
     layer: string;
+    telemetry: Telemetry;
     inspect: (_title: string, _row: RecordData) => void;
-    ready: boolean;
-    scoped: boolean;
+    retained?: boolean;
   } = $props();
-  let svg: SVGSVGElement;
-  let stage: HTMLElement | null = null;
-  function align(): void {
-    if (!stage || !svg) return;
-    const bounds = svg.getBoundingClientRect();
-    if (!bounds.width || !bounds.height) return;
-    svg.setAttribute('viewBox', `0 0 ${bounds.width} ${bounds.height}`);
-    const routes = svg.querySelectorAll('g');
-    stage.querySelectorAll<HTMLElement>('.resource-node').forEach((resource, index) => {
-      const key = rows[index]?.group;
-      const dot = key
-        ? [...stage!.querySelectorAll<HTMLElement>('.radar-blip')]
-            .find((el) => el.dataset.group === key)
-            ?.querySelector('.blip-dot')
-        : null;
-      const route = routes[index];
-      if (!route) return;
-      route.style.display = dot ? '' : 'none';
-      if (!dot) return;
-      const a = dot.getBoundingClientRect(),
-        b = resource.getBoundingClientRect();
-      const x = a.left + a.width / 2 - bounds.left,
-        y = a.top + a.height / 2 - bounds.top;
-      const ex = b.left + b.width / 2 - bounds.left,
-        ey = b.top + b.height / 2 - bounds.top;
-      const path = `M${x} ${y} Q${(x + ex) / 2} ${y} ${ex} ${ey}`;
-      route.querySelector('path')?.setAttribute('d', path);
-      route.querySelector('animateMotion')?.setAttribute('path', path);
-    });
-    svg.dataset.routes = 'ready';
-  }
+  let page = $state(0);
+  let previousKey = '';
   $effect(() => {
-    rows;
-    layer;
-    void tick().then(align);
+    if (resource.key !== previousKey) {
+      previousKey = resource.key;
+      page = 0;
+    }
   });
-  onMount(() => {
-    stage = svg.parentElement;
-    const resize = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(align);
-    if (stage) resize?.observe(stage);
-    const app = stage?.closest('.observatory-app');
-    const media = window.matchMedia?.('(prefers-reduced-motion: reduce)');
-    const syncMotion = () => {
-      const frozen =
-        media?.matches ||
-        document.documentElement.dataset.motion === 'reduce' ||
-        app?.classList.contains('paused') ||
-        stage?.classList.contains('stale');
-      if (frozen) svg.pauseAnimations?.();
-      else svg.unpauseAnimations?.();
-    };
-    const observer = new MutationObserver(syncMotion);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-motion'],
-    });
-    if (app) observer.observe(app, { attributes: true, attributeFilter: ['class'] });
-    if (stage) observer.observe(stage, { attributes: true, attributeFilter: ['class'] });
-    media?.addEventListener('change', syncMotion);
-    align();
-    syncMotion();
-    return () => {
-      resize?.disconnect();
-      observer.disconnect();
-      media?.removeEventListener('change', syncMotion);
-      stage = null;
-    };
-  });
+  const pages = $derived(Math.max(1, Math.ceil(resource.relations.length / 4)));
+  const index = $derived(Math.min(page, pages - 1));
+  const relations = $derived(resource.relations.slice(index * 4, index * 4 + 4));
+  const labels = {
+    review: 'Review needed',
+    unverified: 'Unverified destination',
+    observed: 'No risk flag',
+  };
+  function evidence(rows: RecordData[]) {
+    inspect(
+      layer === 'files' ? 'File observation' : 'Network observation',
+      rows.length === 1 ? rows[0] : { observationGroup: resource.label, observations: rows },
+    );
+  }
+  function process(relation: ResourceRelation) {
+    const agent = resourceProcess(relation, telemetry);
+    if (agent) inspect(agent.agent, { ...agent, name: agent.agent, detailSection: 'processes' });
+  }
 </script>
 
-<svg
-  bind:this={svg}
-  class="radar-links"
-  aria-hidden="true"
-  data-routes="pending"
-  preserveAspectRatio="none"
->
-  {#each rows as entry, i (entry.key)}<g data-resource-key={entry.key}
-      ><path /><circle r="2" opacity="0"
-        ><animateMotion dur={`${4 + i}s`} repeatCount="indefinite" /><animate
-          attributeName="opacity"
-          values="0;1;1;0"
-          keyTimes="0;0.12;0.88;1"
-          dur={`${4 + i}s`}
-          repeatCount="indefinite"
-        /></circle
-      ></g
-    >{/each}
-</svg>
-{#each rows as entry, i (entry.key)}<button
-    class="resource-node"
-    data-route-index={i}
-    data-resource-key={entry.key}
-    data-resource-group={entry.group}
-    title={entry.address}
-    onclick={() =>
-      inspect(
-        layer === 'files' ? 'File observation' : 'Network observation',
-        entry.rows.length > 1
-          ? { observationGroup: entry.label, observations: entry.rows }
-          : entry.row,
-      )}
-    ><span class="resource-title"
-      ><Icon name={layer === 'files' ? 'file' : 'network'} /><strong>{entry.label}</strong><span
-        class="resource-count">{entry.count}×</span
-      ></span
-    >
-    <span class="resource-detail">{entry.detail}</span>
-    <span class="resource-owner">{entry.name} · {entry.attribution}</span></button
-  >{:else}<div class="resource-empty" role="status">
-    <Icon name={layer === 'files' ? 'folder' : 'network'} />
-    <strong
-      >{ready
-        ? `No ${layer === 'files' ? 'file observations' : 'connections'}${scoped ? ' for this agent' : ' on this page'}`
-        : 'Waiting for a reliable scan'}</strong
-    >
+<section class="resource-investigation" aria-label="Resource relationships">
+  <header>
+    <span class="eyebrow">{layer === 'files' ? 'Selected file' : 'Selected destination'}</span>
+    <h3><Icon name={layer === 'files' ? 'file' : 'network'} />{resource.label}</h3>
+    {#if layer === 'files'}<code>{resource.address}</code>{/if}
+    {#if resource.ip}<p>Observed IP: <code>{resource.ip}</code></p>{/if}
+    {#if !retained}<p class="notice">
+        No longer in the current data. These are the records you selected earlier.
+      </p>{/if}
+    {#if telemetry.stale}<p class="notice">
+        Observation is stale. Current process navigation is unavailable.
+      </p>{/if}
+  </header>
+  <div class="resource-assessment" class:review={resource.level === 'review'}>
+    <strong>{labels[resource.level]}</strong>
+    <p>{resource.reason}</p>
+  </div>
+  <div class="relation-heading">
+    <h4>Who is linked to this resource?</h4>
+    <span>{resource.relations.length} relationships</span>
+  </div>
+  <div class="relations">
+    {#each relations as relation (relation.key)}
+      {@const live = resourceProcess(relation, telemetry)}
+      <article class="relation" data-evidence={relation.status}>
+        <div class="relationship-route">
+          <div class="source">
+            <AgentLogo name={relation.actor || 'Unknown'} size={26} />
+            <div>
+              <strong>{relation.actor || 'Agent not identified'}</strong><small
+                >{relation.instanceId
+                  ? `PID ${relation.rows[0].pid ?? live?.pid ?? 'not recorded'} · ${live ? 'currently observed' : 'no current process link'}`
+                  : 'No process identity recorded'}</small
+              >
+            </div>
+          </div>
+          <span
+            class="relationship-line"
+            class:inferred={relation.status !== 'confirmed'}
+            class:unlinked={!relation.actor}
+            aria-hidden="true"><Icon name="chevron" /></span
+          >
+          <span class="destination-icon" aria-hidden="true"
+            ><Icon name={layer === 'files' ? 'file' : 'network'} /></span
+          >
+        </div>
+        <div class="actions-observed">
+          {#each relation.actions as action (action)}<span>{action}</span>{/each}
+        </div>
+        <p class="attribution">{relation.attribution} · {relation.rows.length} record(s)</p>
+        <details>
+          <summary>How was this link established?</summary>
+          <p>{relation.explanation}</p>
+          <p>
+            Sources: {[
+              ...new Set(
+                relation.rows.map((row) =>
+                  String(row.source || (layer === 'network' ? 'Network snapshot' : 'Not recorded')),
+                ),
+              ),
+            ].join(', ')}
+          </p>
+          {#if relation.rows.some((row) => row.action === 'holding' || row.action === 'accessed')}<p
+            >
+              An open file handle does not prove that the contents were read.
+            </p>{/if}
+          {#if relation.rows.some((row) => row.selfAccess === true)}<p>
+              Includes activity in the agent’s own files.
+            </p>{/if}
+          {#if layer === 'network'}<p>
+              Connection states: {[
+                ...new Set(relation.rows.map((row) => String(row.state || 'Not recorded'))),
+              ].join(', ')}. A connection does not show what was sent.
+            </p>{/if}
+        </details>
+        <div class="relation-actions">
+          <button class="button" onclick={() => evidence(relation.rows)}>View records</button
+          ><button class="button" disabled={!live} onclick={() => process(relation)}
+            >Inspect process</button
+          >
+        </div>
+      </article>
+    {/each}
+  </div>
+  {#if pages > 1}<nav class="relation-pages" aria-label="Relationship pages">
+      <button
+        class="button"
+        aria-label="Previous relationships"
+        aria-disabled={index === 0}
+        onclick={() => {
+          if (index > 0) page = index - 1;
+        }}>Previous</button
+      ><span>{index + 1} / {pages}</span><button
+        class="button"
+        aria-label="Next relationships"
+        aria-disabled={index === pages - 1}
+        onclick={() => {
+          if (index < pages - 1) page = index + 1;
+        }}>Next</button
+      >
+    </nav>{/if}
+  <footer>
     <span
-      >{scoped
-        ? 'Choose another agent or show all agents.'
-        : layer === 'files'
-          ? 'Recorded file activity will appear here.'
-          : 'Observed endpoints will appear here.'}</span
-    >
-  </div>{/each}
+      >{resource.rows.length} retained record(s){resource.time
+        ? ` · latest ${new Date(resource.time).toLocaleString()}`
+        : ''}</span
+    ><button class="button" onclick={() => evidence(resource.rows)}>All resource records</button>
+  </footer>
+</section>
 
 <style>
-  .resource-empty {
-    position: absolute;
-    inset: auto 16px 16px;
-    padding: 14px;
-    display: grid;
-    justify-items: center;
-    gap: 6px;
+  .resource-investigation {
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: var(--surface-radius);
     background: var(--panel);
-    text-align: center;
-    font-size: calc(11px * var(--ui-scale));
-    color: var(--muted);
-    pointer-events: none;
-  }
-  :global(.radar-stage) .resource-node {
-    display: grid;
-    gap: 4px;
-    width: min(300px, calc(100% - 32px));
-    max-width: calc(100% - 32px);
-    padding: 10px 12px;
-    text-align: left;
-    color: var(--ink);
-    border-color: var(--strong-border);
-    box-shadow: 0 2px 6px #0001;
-    animation: resource-arrive 220ms ease-out;
-  }
-  .resource-title {
-    display: flex;
-    align-items: center;
-    gap: 7px;
     min-width: 0;
+    font-size: var(--text-body);
+    line-height: 1.55;
   }
-  .resource-title strong {
-    overflow: hidden;
-    text-overflow: ellipsis;
+  header,
+  footer,
+  .resource-assessment,
+  .relation-heading {
+    padding: var(--space-4);
   }
-  .resource-title :global(svg) {
+  header {
+    border-bottom: 1px solid var(--border);
+  }
+  .eyebrow,
+  small,
+  footer,
+  .relation-heading span {
+    color: var(--muted);
+    font-size: var(--text-caption);
+  }
+  h3 {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    overflow-wrap: anywhere;
+    margin: var(--space-2) 0;
+    font-size: var(--text-section);
+  }
+  h3 :global(svg),
+  .source :global(.agent-mark) {
     flex: none;
   }
-  .resource-count {
-    margin-left: auto;
-    color: var(--muted);
-    font-size: calc(10px * var(--ui-scale));
+  code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    font-size: var(--text-body);
   }
-  .resource-detail,
-  .resource-owner {
+  p {
+    margin: var(--space-2) 0 0;
+    overflow-wrap: anywhere;
+  }
+  .notice,
+  .review strong {
+    color: var(--amber);
+  }
+  .resource-assessment {
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+  }
+  .resource-assessment p {
+    color: var(--muted);
+  }
+  .relation-heading {
+    padding-bottom: var(--space-2);
+  }
+  h4 {
+    font-size: var(--text-body);
+    margin: 0 0 var(--space-1);
+  }
+  .relations {
+    padding-inline: var(--space-4);
+  }
+  .relation {
+    border: 1px solid var(--border);
+    border-radius: var(--control-radius);
+    padding: var(--space-3);
+    margin-bottom: var(--space-3);
+  }
+  .relationship-route {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 40px 30px;
+    gap: var(--space-2);
+    align-items: center;
+  }
+  .source {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+  .source strong,
+  small {
     display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
+  }
+  .relationship-line {
+    border-top: 2px solid var(--muted);
+    position: relative;
+  }
+  .relationship-line :global(svg) {
+    position: absolute;
+    right: -5px;
+    top: -9px;
+  }
+  .relationship-line.inferred {
+    border-top-style: dashed;
+  }
+  .relationship-line.unlinked {
+    visibility: hidden;
+  }
+  .destination-icon {
     color: var(--muted);
-    font-size: calc(10px * var(--ui-scale));
   }
-  .resource-owner {
-    padding-top: 4px;
+  .actions-observed {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+  }
+  .actions-observed span {
+    background: var(--bg);
+    border-radius: var(--control-radius);
+    padding: var(--space-1) var(--space-2);
+  }
+  .attribution {
+    color: var(--muted);
+  }
+  details {
+    margin-top: var(--space-2);
+    color: var(--muted);
+  }
+  summary {
+    cursor: pointer;
+  }
+  .relation-actions,
+  .relation-pages,
+  footer {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+  .relation-actions {
+    margin-top: var(--space-3);
+  }
+  .relation-pages {
+    flex-direction: row;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+  }
+  footer {
     border-top: 1px solid var(--border);
+    justify-content: space-between;
   }
-  @keyframes resource-arrive {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
+  button {
+    white-space: normal;
+    height: auto;
   }
 </style>

--- a/frontend/observatory/components/RadarResourceExplorer.svelte
+++ b/frontend/observatory/components/RadarResourceExplorer.svelte
@@ -1,0 +1,321 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import type { Telemetry, RecordData } from '../runtime/host';
+  import { radarResources, type RadarResource } from '../runtime/radar-resources';
+  import RadarResourceList from './RadarResourceList.svelte';
+  import RadarLinks from './RadarLinks.svelte';
+  import Icon from './Icon.svelte';
+  let {
+    telemetry,
+    liveTelemetry,
+    layer,
+    inspect,
+    agent = $bindable(''),
+  }: {
+    telemetry: Telemetry;
+    liveTelemetry?: Telemetry;
+    layer: string;
+    inspect: (_title: string, _row: RecordData) => void;
+    agent?: string;
+  } = $props();
+  let previous:
+    | {
+        agents: Telemetry['agents'];
+        rows: Telemetry['events'] | Telemetry['network'];
+        result: RadarResource[];
+      }
+    | undefined;
+  function read() {
+    const rows = layer === 'files' ? telemetry.events : telemetry.network;
+    if (previous?.agents === telemetry.agents && previous.rows === rows) return previous.result;
+    const result = radarResources(telemetry, layer);
+    previous = { agents: telemetry.agents, rows, result };
+    return result;
+  }
+  const resources = $derived(read());
+  const ready = $derived(telemetry.ready && (layer === 'files' || telemetry.networkAt !== null));
+  const actors = $derived(
+    [
+      ...new Set(
+        [
+          ...resources.flatMap((resource) => resource.relations.map((relation) => relation.actor)),
+          agent,
+        ].filter(Boolean),
+      ),
+    ].sort(),
+  );
+  let query = $state('');
+  let category = $state('all');
+  let selected = $state.raw<RadarResource | null>(null);
+  let heading = $state<HTMLHeadingElement>();
+  let origin: HTMLButtonElement;
+  const filtered = $derived(
+    resources.filter(
+      (resource) =>
+        (!agent || resource.relations.some((relation) => relation.actor === agent)) &&
+        (category === 'all' ||
+          category === resource.level ||
+          (category === 'unattributed' &&
+            resource.relations.some((relation) => !relation.actor))) &&
+        `${resource.label} ${resource.address} ${resource.ip} ${resource.rows.map((row) => String(row.domain || '')).join(' ')} ${resource.relations.map((relation) => relation.actor + ' ' + relation.actions.join(' ')).join(' ')}`
+          .toLowerCase()
+          .includes(query.trim().toLowerCase()),
+    ),
+  );
+  const current = $derived(
+    selected ? (resources.find((resource) => resource.key === selected!.key) ?? selected) : null,
+  );
+  const retained = $derived(
+    !selected || resources.some((resource) => resource.key === selected!.key),
+  );
+  const attention = $derived(filtered.filter((resource) => resource.level === 'review').length);
+  const uncertain = $derived(
+    filtered.filter((resource) =>
+      layer === 'network'
+        ? resource.level === 'unverified'
+        : resource.relations.some((relation) => !relation.actor),
+    ).length,
+  );
+  async function select(resource: RadarResource, button: HTMLButtonElement) {
+    selected = resource;
+    origin = button;
+    await tick();
+    heading?.focus({ preventScroll: true });
+    heading?.scrollIntoView?.({ block: 'nearest' });
+  }
+  function clear() {
+    selected = null;
+    if (origin?.isConnected) origin.focus();
+  }
+</script>
+
+<section
+  class="resource-explorer"
+  aria-label={layer === 'files' ? 'File activity explorer' : 'Network activity explorer'}
+>
+  <div class="explorer-summary">
+    <div>
+      <strong
+        >{telemetry.ready && (layer === 'files' || telemetry.networkAt !== null)
+          ? filtered.length
+          : '—'}</strong
+      ><span>{layer === 'files' ? 'unique files' : 'unique destinations'}</span>
+    </div>
+    <div>
+      <strong class:attention={attention > 0}
+        >{telemetry.ready && (layer === 'files' || telemetry.networkAt !== null)
+          ? attention
+          : '—'}</strong
+      ><span>need review</span>
+    </div>
+    <div>
+      <strong
+        >{telemetry.ready && (layer === 'files' || telemetry.networkAt !== null)
+          ? uncertain
+          : '—'}</strong
+      ><span>{layer === 'files' ? 'without an identified agent' : 'unverified destinations'}</span>
+    </div>
+  </div>
+  <p class="scope-note">
+    {!ready
+      ? 'Waiting for observations'
+      : telemetry.stale
+        ? 'Last available observations'
+        : layer === 'files'
+          ? 'Retained file observations'
+          : 'Latest connection snapshot'} · All radar pages are included. {layer === 'files'
+      ? 'Activity in agents’ own files is included.'
+      : 'Connections do not establish what data was sent.'}
+  </p>
+  <div class="explorer-filters">
+    <label
+      >Agent<select aria-label="Resource agent" bind:value={agent}
+        ><option value="">All agents</option>{#each actors as name (name)}<option value={name}
+            >{name}</option
+          >{/each}</select
+      ></label
+    >
+    <label
+      >Show<select aria-label="Resource attention" bind:value={category}
+        ><option value="all">All observations</option><option value="review">Needs review</option
+        >{#if layer === 'network'}<option value="unverified">Unverified destinations</option
+          >{/if}<option value="unattributed">Agent not identified</option></select
+      ></label
+    >
+    <label class="resource-search"
+      >Search<input
+        type="search"
+        aria-label={layer === 'files' ? 'Search radar files' : 'Search radar destinations'}
+        placeholder={layer === 'files' ? 'File, path, agent or action…' : 'Domain, IP or agent…'}
+        bind:value={query}
+      /></label
+    >
+    {#if agent || query || category !== 'all'}<button
+        class="button"
+        onclick={() => {
+          agent = '';
+          query = '';
+          category = 'all';
+        }}>Clear filters</button
+      >{/if}
+  </div>
+  <div class="explorer-body">
+    {#key JSON.stringify([agent, category, query])}<RadarResourceList
+        resources={filtered}
+        {layer}
+        selected={selected?.key}
+        {select}
+        {ready}
+      />{/key}
+    <div class="resource-details">
+      <div class="detail-heading">
+        <h3 bind:this={heading} tabindex="-1">
+          {current ? 'Resource details' : 'Follow an agent’s activity'}
+        </h3>
+        {#if current}<button class="button" onclick={clear}>Clear resource selection</button>{/if}
+      </div>
+      {#if current && retained && !filtered.some((resource) => resource.key === current.key)}<p
+          class="scope-note"
+        >
+          The selected resource is outside the current filters.
+        </p>{/if}
+      {#if current}<RadarLinks
+          resource={current}
+          {layer}
+          telemetry={liveTelemetry ?? telemetry}
+          {inspect}
+          {retained}
+        />
+      {:else}<div class="resource-guide">
+          <Icon name={layer === 'files' ? 'folder' : 'network'} />
+          <h4>
+            {layer === 'files'
+              ? 'Choose a file to see who touched it'
+              : 'Choose a destination to see who connected'}
+          </h4>
+          <p>Each resource keeps its recorded agents, process identities and actions together.</p>
+          <div class="guide-flow">
+            <span>Agent / process</span><Icon name="chevron" /><span
+              >{layer === 'files' ? 'File + action' : 'Address + connection'}</span
+            >
+          </div>
+          <p>
+            Solid links have confirmed ownership evidence. Dashed links carry indirect or older
+            attribution. Unidentified actors have no connecting line.
+          </p>
+        </div>{/if}
+    </div>
+  </div>
+</section>
+
+<style>
+  .resource-explorer {
+    padding: var(--space-4);
+    font-size: var(--text-body);
+    min-width: 0;
+  }
+  .explorer-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-5);
+    align-items: center;
+  }
+  .explorer-summary > div {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+  }
+  .explorer-summary strong {
+    font-size: var(--text-title);
+  }
+  .explorer-summary span,
+  .scope-note {
+    color: var(--muted);
+  }
+  .attention {
+    color: var(--amber);
+  }
+  .scope-note {
+    margin: var(--space-2) 0 var(--space-4);
+    line-height: 1.6;
+  }
+  .explorer-filters {
+    display: flex;
+    align-items: end;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    margin-bottom: var(--space-4);
+  }
+  label {
+    display: grid;
+    gap: var(--space-1);
+    color: var(--muted);
+    min-width: 0;
+    flex: 1 1 150px;
+  }
+  .resource-search {
+    flex: 2 1 210px;
+  }
+  input,
+  select {
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+  }
+  .explorer-body {
+    display: grid;
+    grid-template-columns: minmax(250px, 0.85fr) minmax(0, 1.15fr);
+    gap: var(--space-4);
+    align-items: start;
+  }
+  .resource-details {
+    min-width: 0;
+  }
+  .detail-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-3);
+    min-height: var(--control-height);
+  }
+  h3 {
+    font-size: var(--text-section);
+    margin: 0;
+  }
+  h4 {
+    font-size: var(--text-section);
+    margin: var(--space-3) 0;
+  }
+  .resource-guide {
+    padding: var(--space-5);
+    border: 1px dashed var(--strong-border);
+    border-radius: var(--surface-radius);
+    background: var(--bg);
+    color: var(--muted);
+    line-height: 1.7;
+  }
+  .resource-guide p {
+    margin: var(--space-3) 0 0;
+  }
+  .guide-flow {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    margin: var(--space-4) 0;
+    color: var(--ink);
+  }
+  .guide-flow span {
+    padding: var(--space-2);
+    border: 1px solid var(--border);
+    border-radius: var(--control-radius);
+    background: var(--panel);
+  }
+  @media (max-width: 1000px) {
+    .explorer-body {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+</style>

--- a/frontend/observatory/components/RadarResourceList.svelte
+++ b/frontend/observatory/components/RadarResourceList.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+  import type { RadarResource } from '../runtime/radar-resources';
+  import Icon from './Icon.svelte';
+  let {
+    resources,
+    layer,
+    selected,
+    select,
+    ready,
+  }: {
+    resources: RadarResource[];
+    layer: string;
+    selected?: string;
+    select: (_resource: RadarResource, _button: HTMLButtonElement) => void;
+    ready: boolean;
+  } = $props();
+  let page = $state(0);
+  const pages = $derived(Math.max(1, Math.ceil(resources.length / 6)));
+  const index = $derived(Math.min(page, pages - 1));
+  const visible = $derived(resources.slice(index * 6, index * 6 + 6));
+  const labels = { review: 'Review', unverified: 'Unverified', observed: 'No risk flag' };
+  // Parent keys this list by the user filters, so new telemetry never resets pagination.
+</script>
+
+<section
+  class="resource-catalog"
+  aria-label={layer === 'files' ? 'Observed files' : 'Observed destinations'}
+>
+  <div class="catalog-pages">
+    <span
+      >{resources.length ? `${index * 6 + 1}–${Math.min(resources.length, index * 6 + 6)}` : '0'} of {resources.length}</span
+    >
+    <nav aria-label="Resource pages">
+      <button
+        class="button"
+        aria-label="Previous radar resources"
+        aria-disabled={index === 0}
+        onclick={() => {
+          if (index > 0) page = index - 1;
+        }}><Icon name="arrowLeft" /></button
+      ><button
+        class="button"
+        aria-label="Next radar resources"
+        aria-disabled={index === pages - 1}
+        onclick={() => {
+          if (index < pages - 1) page = index + 1;
+        }}><Icon name="chevron" /></button
+      >
+    </nav>
+  </div>
+  {#each visible as resource (resource.key)}
+    {@const actors = [
+      ...new Set(resource.relations.map((relation) => relation.actor || 'Agent not identified')),
+    ]}
+    <button
+      class="resource-choice"
+      aria-label={`Inspect ${resource.address}`}
+      aria-pressed={selected === resource.key}
+      onclick={(event) => select(resource, event.currentTarget)}
+    >
+      <span class="choice-heading"
+        ><Icon name={layer === 'files' ? 'file' : 'network'} /><strong>{resource.label}</strong
+        ><span class="resource-level" class:review={resource.level === 'review'}
+          >{resource.sensitive ? 'Sensitive' : labels[resource.level]}</span
+        ></span
+      >
+      {#if layer === 'files'}<span class="resource-path">{resource.address}</span>{/if}
+      {#if resource.ip && !resource.address.includes(resource.ip)}<span class="ip"
+          >{resource.ip}</span
+        >{/if}
+      <span class="resource-actors"
+        >{actors.slice(0, 2).join(', ')}{actors.length > 2 ? ` +${actors.length - 2}` : ''}</span
+      >
+      <span class="record-count"
+        >{resource.rows.length} record(s) · {resource.relations.length} relationships</span
+      >
+    </button>
+  {:else}<div class="resource-empty" role="status">
+      <Icon name={layer === 'files' ? 'folder' : 'network'} /><strong
+        >{ready ? 'No matching observations' : 'Waiting for a reliable scan'}</strong
+      >
+      <p>
+        {ready
+          ? 'Try another agent or filter. An empty list does not establish that no activity occurred.'
+          : 'Resources appear when observations are available.'}
+      </p>
+    </div>{/each}
+</section>
+
+<style>
+  .resource-catalog {
+    min-width: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--surface-radius);
+    overflow: hidden;
+    background: var(--panel);
+  }
+  .catalog-pages,
+  nav {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .catalog-pages {
+    justify-content: space-between;
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--border);
+    font-size: var(--text-caption);
+    color: var(--muted);
+  }
+  .resource-choice {
+    display: block;
+    width: 100%;
+    padding: var(--space-4);
+    background: transparent;
+    color: var(--ink);
+    border: 0;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--text-body);
+    line-height: 1.55;
+  }
+  .resource-choice:last-child {
+    border-bottom: 0;
+  }
+  .resource-choice:hover,
+  .resource-choice[aria-pressed='true'] {
+    background: var(--bg);
+  }
+  .resource-choice[aria-pressed='true'] {
+    box-shadow: inset 3px 0 var(--ink);
+  }
+  .choice-heading {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: center;
+    margin-bottom: var(--space-2);
+  }
+  .choice-heading strong {
+    overflow-wrap: anywhere;
+    min-width: 0;
+    flex: 1;
+    font-size: var(--text-section);
+  }
+  .choice-heading :global(svg) {
+    flex: none;
+  }
+  .resource-level {
+    color: var(--muted);
+    font-size: var(--text-caption);
+  }
+  .resource-level.review {
+    color: var(--amber);
+  }
+  .resource-path {
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    line-clamp: 2;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    color: var(--muted);
+  }
+  .ip,
+  .resource-actors,
+  .record-count {
+    display: block;
+    overflow-wrap: anywhere;
+  }
+  .resource-actors {
+    margin-top: var(--space-2);
+  }
+  .record-count,
+  .ip {
+    font-size: var(--text-caption);
+    color: var(--muted);
+  }
+  .resource-empty {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-5);
+    color: var(--muted);
+    font-size: var(--text-body);
+    line-height: 1.6;
+  }
+  .resource-empty p {
+    margin: 0;
+  }
+</style>

--- a/frontend/observatory/components/RadarSummary.svelte
+++ b/frontend/observatory/components/RadarSummary.svelte
@@ -6,14 +6,18 @@
     group,
     ordinal,
     selected,
+    active,
     select,
   }: {
     group: RadarGroup;
     ordinal: number;
     selected: string | null;
-    select: (group: RadarGroup) => void;
+    active?: boolean;
+    select: (_group: RadarGroup) => void;
   } = $props();
-  let chosen = $derived(group.members.some((a) => !!selected && a.instanceId === selected));
+  let chosen = $derived(
+    active ?? group.members.some((a) => !!selected && a.instanceId === selected),
+  );
 </script>
 
 <button class="radar-agent-card" aria-pressed={chosen} onclick={() => select(group)}>

--- a/frontend/observatory/runtime/protection.ts
+++ b/frontend/observatory/runtime/protection.ts
@@ -23,7 +23,13 @@ export interface ProtectionActivity {
   time: number;
 }
 
-function describe(row: RecordData, network: boolean): Omit<ProtectionActivity, 'key' | 'rows'> {
+/** Explain one observation without inferring authorization or contents.
+ * @param row Recorded metadata @param network Connection flag @returns Display facts @since 0.14.1
+ */
+export function describeProtectionObservation(
+  row: RecordData,
+  network: boolean,
+): Omit<ProtectionActivity, 'key' | 'rows'> {
   const evidence = describeObservation(row);
   const actions: Record<string, string> = {
     created: 'Created a file',
@@ -87,7 +93,7 @@ export function createProtectionActivityReader() {
       [network, true],
     ] as const) {
       for (const row of rows) {
-        const entry = describe(row, isNetwork);
+        const entry = describeProtectionObservation(row, isNetwork);
         const key = JSON.stringify([
           entry.kind,
           row.instanceId ?? null,

--- a/frontend/observatory/runtime/radar-resources.ts
+++ b/frontend/observatory/runtime/radar-resources.ts
@@ -1,26 +1,36 @@
-import type { Telemetry, RecordData } from './host';
-import type { RadarGroup } from './radar';
+import { record, type Telemetry, type RecordData } from './host';
+import { isScopedProcess } from './agent-scope';
+import { describeProtectionObservation, type ProtectionActivity } from './protection';
 import {
   describeObservation,
   canonicalObservationPath,
 } from '../../../src/shared/observation-display.js';
 
+export interface ResourceRelation {
+  key: string;
+  actor: string;
+  instanceId: string | null;
+  attribution: string;
+  status: string;
+  explanation: string;
+  actions: string[];
+  rows: RecordData[];
+}
 export interface RadarResource {
   key: string;
-  row: RecordData;
-  rows: RecordData[];
-  resourceKey: string;
-  group: string | null;
-  name: string;
   label: string;
   address: string;
-  detail: string;
-  count: number;
-  attribution: string;
+  ip: string;
+  level: ProtectionActivity['level'];
+  reason: string;
+  sensitive: boolean;
+  time: number;
+  rows: RecordData[];
+  relations: ResourceRelation[];
 }
 
-/** Format an observed endpoint, falling back to its IP when DNS is empty.
- * @param row Connection metadata @returns Address with an optional port @since 0.14.1
+/** Format an observed endpoint without discarding its port or IPv6 boundary.
+ * @param row Connection metadata @returns Address @since 0.14.1
  */
 export function networkAddress(row: RecordData): string {
   const host = String(row.domain || '').trim() || String(row.remoteIp || '').trim();
@@ -28,83 +38,112 @@ export function networkAddress(row: RecordData): string {
   return host ? `${host.includes(':') ? `[${host}]` : host}${port ? `:${port}` : ''}` : '';
 }
 
-/** Collect unique resources, keeping exact process attribution and the newest file evidence.
- * @param state Observed telemetry @param layer Resource layer @param plotted Visible agent groups
- * @param chosen Selected group @returns Resources available on this radar page @since 0.14.1
+/** Group all resources independently of radar pagination; retain every process lifetime and attribution boundary.
+ * @param state Recorded population and activity @param layer Resource kind @returns Unique resources @since 0.14.1
  */
-export function radarResources(
-  state: Telemetry,
-  layer: string,
-  plotted: RadarGroup[],
-  chosen?: RadarGroup,
-): RadarResource[] {
-  const owners = new Map(
-    plotted.flatMap((g) =>
-      g.members.filter((a) => a.instanceId).map((a) => [a.instanceId, g] as const),
-    ),
-  );
-  const allIds = new Set(state.agents.map((a) => a.instanceId).filter(Boolean));
-  const resources = new Map<string, RadarResource>();
-  const source = layer === 'files' ? state.events : state.network;
-  for (const entry of source) {
-    const row = entry as unknown as RecordData;
-    const info = describeObservation(row);
-    const evidence = row.attribution as { status?: string } | undefined;
-    if (row.selfAccess === true) continue;
-    const owner = evidence?.status === 'unattributed' ? undefined : owners.get(entry.instanceId);
-    if (chosen && owner?.key !== chosen.key) continue;
-    // Other radar pages have their own resources. Historical/unknown owners stay unlinked.
-    if (!chosen && !owner && entry.instanceId && allIds.has(entry.instanceId)) continue;
-    const file = String(row.file || '').trim();
-    const ip = String(row.remoteIp || '').trim();
-    const domain = String(row.domain || '').trim();
-    const port = typeof row.remotePort === 'number' && row.remotePort > 0 ? row.remotePort : null;
-    const address = layer === 'files' ? file : networkAddress(row);
-    if (!address) continue;
-    const status = owner
-      ? evidence?.status === 'inferred'
-        ? 'Indirect attribution'
-        : evidence?.status === 'confirmed'
-          ? 'Confirmed'
-          : 'Recorded owner'
-      : info.context || info.skill
-        ? 'Resource context · actor not recorded'
-        : 'No current agent link';
-    // Ports and distinct IPs remain distinct even when reverse DNS returns the same name.
-    const identity =
-      layer === 'files' ? canonicalObservationPath(file) : `${ip || domain}:${port ?? ''}`;
-    const key = JSON.stringify([owner?.key ?? entry.instanceId ?? null, identity]);
-    const existing = resources.get(key);
-    if (existing) {
-      existing.count++;
-      existing.rows.push(row);
-      if (existing.attribution !== status) existing.attribution = 'Mixed attribution';
-      if (Number(row.timestamp || 0) > Number(existing.row.timestamp || 0)) existing.row = row;
-      continue;
-    }
-    resources.set(key, {
-      key,
-      row,
-      rows: [row],
-      resourceKey: identity,
-      group: owner?.key ?? null,
-      name: owner?.name ?? info.label,
-      label:
-        layer === 'files' ? (info.skill ? 'Skill · ' + info.skill.name : info.resource) : address,
-      address,
-      detail:
-        layer === 'files'
-          ? file
-          : [domain && ip !== domain ? ip : '', row.state].filter(Boolean).join(' · '),
-      count: 1,
-      attribution: status,
-    });
+export function radarResources(state: Telemetry, layer: string): RadarResource[] {
+  const network = layer === 'network';
+  const grouped = new Map<string, RadarResource>();
+  const priority = { review: 0, unverified: 1, observed: 2 };
+  const identities = new Map<string, Telemetry['agents']>();
+  for (const agent of state.agents) {
+    if (agent.instanceId)
+      identities.set(agent.instanceId, [...(identities.get(agent.instanceId) ?? []), agent]);
   }
-  return [...resources.values()].sort((a, b) =>
-    layer === 'files'
-      ? Number(b.row.timestamp || 0) - Number(a.row.timestamp || 0) || a.key.localeCompare(b.key)
-      : a.name.localeCompare(b.name) ||
-        a.address.localeCompare(b.address) ||
-        a.key.localeCompare(b.key),
+  for (const entry of network ? state.network : state.events) {
+    const row = entry as unknown as RecordData;
+    const exact = typeof row.instanceId === 'string' ? (identities.get(row.instanceId) ?? []) : [];
+    const info = describeObservation(
+      row,
+      exact.length === 1 ? (exact as unknown as RecordData[]) : [],
+    );
+    const facts = describeProtectionObservation(row, network);
+    const address = network ? networkAddress(row) : String(row.file || '').trim();
+    if (!address) continue;
+    const ip = String(row.remoteIp || '').trim();
+    const key = network
+      ? JSON.stringify([
+          ip.toLowerCase() || String(row.domain || '').toLowerCase(),
+          row.remotePort ?? null,
+        ])
+      : canonicalObservationPath(address);
+    const resource: RadarResource = grouped.get(key) ?? {
+      key,
+      label: network ? address : info.resource,
+      address,
+      ip,
+      level: facts.level,
+      reason: facts.reason,
+      sensitive: row.sensitive === true,
+      time: facts.time,
+      rows: [],
+      relations: [],
+    };
+    if (priority[facts.level] < priority[resource.level]) {
+      resource.level = facts.level;
+      resource.reason = facts.reason;
+    }
+    resource.sensitive ||= row.sensitive === true;
+    resource.time = Math.max(resource.time, facts.time);
+    resource.rows.push(row);
+    const status = String(
+      record(row.attribution).status ??
+        (typeof row.attribution === 'string'
+          ? row.attribution
+          : info.actor
+            ? 'recorded'
+            : 'unattributed'),
+    );
+    const actor = status === 'unattributed' ? '' : info.actor;
+    const relationKey = JSON.stringify([
+      row.instanceId ?? null,
+      actor,
+      status,
+      record(row.attribution).evidence ?? [],
+    ]);
+    let relation = resource.relations.find((item) => item.key === relationKey);
+    if (!relation) {
+      relation = {
+        key: relationKey,
+        actor,
+        instanceId: typeof row.instanceId === 'string' ? row.instanceId : null,
+        attribution: info.attribution,
+        status,
+        explanation: info.explanation,
+        actions: [],
+        rows: [],
+      };
+      resource.relations.push(relation);
+    }
+    relation.rows.push(row);
+    if (!relation.actions.includes(facts.action)) relation.actions.push(facts.action);
+    grouped.set(key, resource);
+  }
+  return [...grouped.values()].sort(
+    (a, b) =>
+      priority[a.level] - priority[b.level] ||
+      b.time - a.time ||
+      a.address.localeCompare(b.address),
   );
+}
+
+/** Resolve navigation against the current lifetime; a PID, path or product name alone is insufficient.
+ * @param relation Recorded ownership @param state Current population @returns Exact current agent or null @since 0.14.1
+ */
+export function resourceProcess(
+  relation: ResourceRelation,
+  state: Telemetry,
+): Telemetry['agents'][number] | null {
+  if (
+    !state.ready ||
+    state.stale ||
+    !relation.actor ||
+    !relation.instanceId ||
+    ['unattributed', 'ambiguous'].includes(relation.status)
+  )
+    return null;
+  const matches = state.agents.filter((agent) => agent.instanceId === relation.instanceId);
+  return matches.length === 1 && matches[0].agent === relation.actor && isScopedProcess(matches[0])
+    ? matches[0]
+    : null;
 }

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -140,6 +140,7 @@ try {
   assert.equal(await page.locator('.radar-agent-card').count(), 4);
   const sweep = await page.locator('.dial-sweep').elementHandle();
   await page.getByRole('button', { name: /Select Claude Code, 1 processes/ }).click();
+  await page.getByRole('button', { name: 'Open agent', exact: true }).click();
   await page.locator('.agent-workspace:visible').waitFor();
   assert.equal(await page.getByRole('dialog').count(), 0);
   await page
@@ -371,6 +372,7 @@ try {
   );
   await page.screenshot({ path: resolve(out, 'monitoring.png') });
   await page.getByRole('button', { name: /Select Claude Code, 1 processes/ }).click();
+  await page.getByRole('button', { name: 'Open agent', exact: true }).click();
   await page.locator('.agent-workspace:visible').waitFor();
   assert.equal(await page.getByRole('dialog').count(), 0);
   await page

--- a/frontend/observatory/tests/detail-check.mjs
+++ b/frontend/observatory/tests/detail-check.mjs
@@ -126,6 +126,7 @@ export async function checkDetails(browser, url, out) {
       ]);
     });
     await page.getByRole('button', { name: /Select Codex, 26 processes/ }).click();
+    await page.getByRole('button', { name: 'Open agent', exact: true }).click();
     const workspace = page.locator('.agent-workspace:visible');
     const context = page.locator('.agent-context');
     await workspace.waitFor();

--- a/frontend/observatory/tests/electron-smoke.mjs
+++ b/frontend/observatory/tests/electron-smoke.mjs
@@ -67,6 +67,7 @@ try {
   assert.equal(await window.locator('.radar-blip').count(), rosterNames.length);
   assert.equal(await window.locator('.radar-info, .radar-mini-chart').count(), 0);
   await window.locator('.radar-agent-card').first().click();
+  await window.getByRole('button', { name: 'Open agent', exact: true }).click();
   await window.locator('.agent-workspace:visible').waitFor();
   assert.equal(await window.getByRole('dialog').count(), 0);
   const context = window.locator('.agent-context');
@@ -95,13 +96,13 @@ try {
   await window.getByRole('heading', { name: 'Monitoring', level: 1, exact: true }).waitFor();
   for (const layer of ['Files', 'Network']) {
     await window.locator('.radar-layers').getByRole('button', { name: layer, exact: true }).click();
-    const all = window.getByRole('button', { name: 'Show all agents', exact: true });
+    const all = window.getByRole('button', { name: 'Clear filters', exact: true });
     if (await all.isVisible()) await all.click();
     await window.mouse.move(0, 0);
     await checkResourceGeometry(window);
     // Check every endpoint currently visible to the native sensors, including empty DNS.
-    const next = window.getByLabel('Next radar resources');
-    while ((await next.isVisible()) && (await next.isEnabled())) {
+    const next = window.locator('.resource-explorer:visible').getByLabel('Next radar resources');
+    while ((await next.isVisible()) && (await next.getAttribute('aria-disabled')) !== 'true') {
       await next.click();
       await window.mouse.move(0, 0);
       await checkResourceGeometry(window);

--- a/frontend/observatory/tests/motion-check.mjs
+++ b/frontend/observatory/tests/motion-check.mjs
@@ -45,6 +45,8 @@ export async function checkMotion(page) {
   await page.mouse.down();
   stable(await geometry(), beforeHover, 'press moved or resized the marker');
   await page.mouse.up();
+  assert.equal(await page.locator('.agent-workspace:visible').count(), 0);
+  await page.getByRole('button', { name: 'Open agent', exact: true }).click();
   await page.locator('.agent-workspace:visible').waitFor();
   await page.waitForFunction(() => !document.documentElement.dataset.transitionSurface);
   const context = page.locator('.agent-context');
@@ -63,7 +65,13 @@ export async function checkMotion(page) {
   const pillAfter = await layers.evaluate((node) => getComputedStyle(node, '::before').transform);
   assert.notEqual(pillBefore, pillAfter, 'layer indicator did not move');
   await page.getByRole('button', { name: 'Pause view', exact: true }).click();
-  assert.equal(await page.locator('.radar-links').evaluate((svg) => svg.animationsPaused()), true);
+  assert.equal(await page.locator('.resource-explorer:visible').count(), 1);
+  assert.equal(
+    await page
+      .locator('.resource-explorer:visible')
+      .evaluate((node) => node.getAnimations({ subtree: true }).length),
+    0,
+  );
   assert.equal(
     await page.locator('.dial-sweep').evaluate((node) => getComputedStyle(node).animationPlayState),
     'paused',
@@ -76,7 +84,12 @@ export async function checkMotion(page) {
     'paused',
   );
   await page.getByRole('button', { name: 'Resume view', exact: true }).click();
-  assert.equal(await page.locator('.radar-links').evaluate((svg) => svg.animationsPaused()), false);
+  assert.equal(
+    await page
+      .locator('.resource-explorer:visible')
+      .evaluate((node) => node.getAnimations({ subtree: true }).length),
+    0,
+  );
   await layers.getByRole('button', { name: 'Radar', exact: true }).click();
 
   const lastKey = await page.evaluate(() => {
@@ -88,6 +101,12 @@ export async function checkMotion(page) {
     return expected;
   });
   await page.waitForFunction(() => !document.documentElement.dataset.transitionSurface);
+  assert.equal(
+    await page.locator('.radar-blip[aria-pressed=true]').getAttribute('data-group'),
+    lastKey,
+  );
+  await page.getByRole('button', { name: 'Open agent', exact: true }).click();
+  await page.locator('.agent-workspace:visible').waitFor();
   assert.equal(await context.getByLabel('Selected agent', { exact: true }).inputValue(), lastKey);
   assert.equal(
     await page.locator('.agent-workspace:visible').count(),
@@ -102,6 +121,7 @@ export async function checkMotion(page) {
     'none',
   );
   await page.locator('.radar-agent-card').nth(1).click();
+  await page.getByRole('button', { name: 'Open agent', exact: true }).click();
   await page.locator('.agent-workspace:visible').waitFor();
   assert.equal(await page.getByRole('dialog').count(), 0);
   await context.getByLabel('Selected agent', { exact: true }).selectOption('');

--- a/frontend/observatory/tests/resource-layer-check.mjs
+++ b/frontend/observatory/tests/resource-layer-check.mjs
@@ -1,60 +1,46 @@
 import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
 
-/** Check resource routes against rendered anchors after motion, resizing and data refresh.
+/** Check readable resources and evidence links at the current desktop size.
  * @param {import('playwright').Page} page Observatory page @returns {Promise<void>} Verified geometry @since 0.14.1
  */
 export async function checkResourceGeometry(page) {
-  await page.waitForFunction(
-    () => document.querySelector('.radar-links')?.dataset.routes === 'ready',
-  );
-  await page.waitForTimeout(350);
-  const issues = await page.locator('.radar-stage').evaluate((stage) => {
+  const explorer = page.locator('.resource-explorer:visible');
+  await explorer.waitFor();
+  if (await explorer.locator('.resource-choice').count()) {
+    await explorer.locator('.resource-choice').first().click();
+    await explorer.locator('.resource-investigation').waitFor();
+  }
+  const issues = await explorer.evaluate((root) => {
     const issues = [];
-    const svg = stage.querySelector('.radar-links');
-    const bounds = stage.getBoundingClientRect();
-    const nodes = [...stage.querySelectorAll('.resource-node')];
-    const center = (r) => ({ x: r.x + r.width / 2, y: r.y + r.height / 2 });
-    for (const node of nodes) {
+    const bounds = root.getBoundingClientRect();
+    for (const node of root.querySelectorAll(
+      '.resource-choice, .resource-details, .relation, button, select, input',
+    )) {
       const box = node.getBoundingClientRect();
-      if (
-        box.left < bounds.left ||
-        box.right > bounds.right + 1 ||
-        box.top < bounds.top ||
-        box.bottom > bounds.bottom + 1
-      )
-        issues.push('resource outside stage');
-      if (!node.querySelector('strong')?.textContent.trim()) issues.push('empty resource label');
-      const route = [...svg.querySelectorAll('g')].find(
-        (g) => g.dataset.resourceKey === node.dataset.resourceKey,
-      );
-      const marker = [...stage.querySelectorAll('.radar-blip')].find(
-        (m) => m.dataset.group === node.dataset.resourceGroup,
-      );
-      if (!marker) {
-        if (getComputedStyle(route).display !== 'none')
-          issues.push('unattributed resource has a route');
-        continue;
-      }
-      for (const other of stage.querySelectorAll('.radar-blip')) {
-        const b = other.getBoundingClientRect();
-        if (box.left < b.right && box.right > b.left && box.top < b.bottom && box.bottom > b.top)
-          issues.push('resource overlaps marker');
-      }
-      const path = route.querySelector('path');
-      const matrix = path.getScreenCTM();
-      const start = path.getPointAtLength(0).matrixTransform(matrix);
-      const end = path.getPointAtLength(path.getTotalLength()).matrixTransform(matrix);
-      const dot = center(marker.querySelector('.blip-dot').getBoundingClientRect());
-      const resource = center(box);
-      if (Math.hypot(start.x - dot.x, start.y - dot.y) > 1.5)
-        issues.push('route detached from marker');
-      if (Math.hypot(end.x - resource.x, end.y - resource.y) > 1.5)
-        issues.push('route detached from resource');
+      if (box.width && (box.left < bounds.left - 1 || box.right > bounds.right + 1))
+        issues.push('content outside explorer: ' + node.className);
     }
+    for (const relation of root.querySelectorAll('.relation')) {
+      const line = relation.querySelector('.relationship-line');
+      if (line.classList.contains('unlinked')) {
+        if (getComputedStyle(line).visibility !== 'hidden') issues.push('unknown actor has a line');
+      } else {
+        const style = getComputedStyle(line);
+        if (
+          style.borderTopStyle !== (relation.dataset.evidence === 'confirmed' ? 'solid' : 'dashed')
+        )
+          issues.push('ownership style is misleading');
+        if (line.getAnimations({ subtree: true }).length)
+          issues.push('link implies live data transfer');
+      }
+    }
+    if (root.scrollWidth > root.clientWidth + 1) issues.push('explorer overflows');
+    if (root.querySelectorAll('.resource-choice').length > 6)
+      issues.push('resource pagination unbounded');
     return issues;
   });
-  assert.deepEqual(issues, [], 'resource layer geometry');
+  assert.deepEqual(issues, [], 'resource explorer geometry');
 }
 
 /** Exercise populated desktop resource layers through an isolated bridge fixture.
@@ -108,7 +94,7 @@ export async function checkResourceLayers(browser, url, out) {
       };
       window.resourceFixture.onScanBatch({ agents, stats: window.resourceStats });
       window.resourceFixture.onNetworkUpdate([
-        ...[443, 443, 80, 8080, 8443].map((remotePort) => ({
+        ...[443, 443, 80, 8080, 8443, 9000, 9443].map((remotePort) => ({
           instanceId: agents[0].instanceId,
           domain: '',
           remoteIp: '192.0.2.10',
@@ -118,9 +104,9 @@ export async function checkResourceLayers(browser, url, out) {
         { instanceId: agents[4].instanceId, domain: '', remoteIp: '2001:db8::1', remotePort: 443 },
       ]);
       window.resourceFixture.onFileAccess(
-        Array.from({ length: 8 }, (_, i) => ({
+        Array.from({ length: 14 }, (_, i) => ({
           instanceId: agents[0].instanceId,
-          file: `X:/Fixture/project-${i % 4}/settings.json`,
+          file: `X:/Fixture/project-${i % 7}/settings.json`,
           timestamp: Date.now() - i * 1000,
           attribution: { status: 'inferred' },
           action: 'modified',
@@ -129,22 +115,34 @@ export async function checkResourceLayers(browser, url, out) {
     });
     const layer = (name) =>
       page.locator('.radar-layers').getByRole('button', { name, exact: true });
+    const explorer = page.locator('.resource-explorer:visible');
     await layer('Network').click();
-    assert.match(await page.locator('.resource-scope').innerText(), /4 unique endpoints/);
-    await page.locator('.resource-node').first().click();
-    await page.getByRole('dialog').waitFor();
+    assert.match(
+      await explorer.locator('.explorer-summary').innerText(),
+      /7\s*unique destinations/,
+    );
+    await explorer.getByRole('button', { name: 'Inspect 192.0.2.10:443', exact: true }).click();
+    await explorer.getByRole('button', { name: 'All resource records' }).click();
     const dialog = page.getByRole('dialog');
+    await dialog.waitFor();
     assert.match(await dialog.getByRole('heading', { level: 2 }).innerText(), /192\.0\.2\.10:443/);
     await dialog.getByRole('tab', { name: /Records/ }).click();
     assert.equal(await dialog.locator('.observation-history .recent-event').count(), 2);
     for (const entry of await dialog.locator('.observation-history .recent-event').all())
       assert.match(await entry.innerText(), /192\.0\.2\.10:443/);
     await page.keyboard.press('Escape');
-    await page.getByRole('dialog').waitFor({ state: 'hidden' });
-    await page.mouse.move(0, 0);
+    await dialog.waitFor({ state: 'hidden' });
+    await explorer.getByRole('button', { name: 'Inspect process' }).click();
+    await page.locator('.agent-workspace:visible').waitFor();
+    assert.equal(
+      await page.getByLabel('Selected process', { exact: true }).inputValue(),
+      'resource-test:0',
+    );
+    await page.getByLabel('Selected agent', { exact: true }).selectOption('');
+    await page.locator('.sidebar').getByRole('button', { name: 'Monitoring', exact: true }).click();
     for (const size of [
       { width: 1200, height: 800 },
-      { width: 900, height: 700 },
+      { width: 900, height: 600 },
       { width: 1779, height: 1146 },
     ]) {
       await page.setViewportSize(size);
@@ -157,16 +155,24 @@ export async function checkResourceLayers(browser, url, out) {
           await page.evaluate((theme) => (document.documentElement.dataset.theme = theme), theme);
           for (const name of ['Files', 'Network']) {
             await layer(name).click();
+            const previous = explorer.getByLabel('Previous radar resources');
+            if (await previous.isEnabled()) await previous.click();
             await checkResourceGeometry(page);
-            await page.getByLabel('Next radar resources').click();
+            assert.equal(
+              await explorer.getByLabel('Next radar resources').getAttribute('aria-disabled'),
+              'false',
+            );
+            await explorer.getByLabel('Next radar resources').click();
             await checkResourceGeometry(page);
+            assert.equal(
+              await explorer.getByLabel('Next radar resources').getAttribute('aria-disabled'),
+              'true',
+            );
           }
         }
       }
     }
-    await page.locator('.radar-stage').screenshot({ path: resolve(out, 'resources-network.png') });
-    // Same identities with new objects must not recreate resource nodes or detach routes.
-    const first = await page.locator('.resource-node').first().elementHandle();
+    const first = await explorer.locator('.resource-choice').first().elementHandle();
     await page.evaluate(() =>
       window.resourceFixture.onScanBatch({
         agents: structuredClone(window.resourceAgents),
@@ -174,23 +180,34 @@ export async function checkResourceLayers(browser, url, out) {
       }),
     );
     await checkResourceGeometry(page);
-    assert(await first.evaluate((node) => node.isConnected), 'scan recreated unchanged resources');
-    await page.getByLabel('Next radar agents').click();
-    await checkResourceGeometry(page);
-    assert.match(await page.locator('.resource-node').innerText(), /\[2001:db8::1\]:443/);
-    await layer('Files').click();
-    assert.match(
-      await page.locator('.resource-empty').innerText(),
-      /No file observations on this page/,
+    assert(
+      await first.evaluate((node) => node.isConnected),
+      'scan recreated unchanged resource buttons',
     );
-    await page.getByLabel('Previous radar agents').click();
+    await explorer.getByLabel('Resource agent').selectOption('Zeta');
+    assert.match(await explorer.locator('.resource-choice').innerText(), /\[2001:db8::1\]:443/);
+    await layer('Files').click();
+    assert.match(await explorer.locator('.resource-empty').innerText(), /No matching observations/);
+    await explorer.getByRole('button', { name: 'Clear filters' }).click();
     await checkResourceGeometry(page);
-    await page.locator('.radar-stage').screenshot({ path: resolve(out, 'resources-files.png') });
     await page.evaluate(() =>
       window.resourceFixture.onStatsUpdate({ appHealth: { populationReliable: false } }),
     );
-    await page.waitForFunction(() => document.querySelector('.radar-links').animationsPaused());
-    assert.match(await page.locator('.resource-scope').innerText(), /Last reliable snapshot/);
+    await explorer
+      .getByText('Observation is stale. Current process navigation is unavailable.')
+      .waitFor();
+    assert.match(
+      await explorer.locator('.scope-note').first().innerText(),
+      /Last available observations/,
+    );
+    for (const button of await explorer.getByRole('button', { name: 'Inspect process' }).all())
+      assert(await button.isDisabled());
+    for (const name of ['Files', 'Network']) {
+      await layer(name).click();
+      await explorer.getByLabel('Resource agent').selectOption('');
+      await checkResourceGeometry(page);
+      await explorer.screenshot({ path: resolve(out, 'resources-' + name.toLowerCase() + '.png') });
+    }
 
     // Product processes and skill observations have distinct, expandable grouping.
     await page.setViewportSize({ width: 1200, height: 800 });
@@ -250,7 +267,7 @@ export async function checkResourceLayers(browser, url, out) {
 
     assert.deepEqual(errors, []);
     console.log(
-      'Resource layers: 48 theme/scale/viewport combinations, all pages, exact route anchors, empty DNS, deduplication, refreshed identities, details, stale motion, product/skill grouping and keyboard disclosure passed.',
+      'Resource layers: 48 theme/scale/viewport combinations, all pages, readable relationship geometry, empty DNS, deduplication, refreshed identities, process navigation, stale controls, product/skill grouping and keyboard disclosure passed.',
     );
   } finally {
     await page.close();

--- a/frontend/observatory/tests/usability-check.mjs
+++ b/frontend/observatory/tests/usability-check.mjs
@@ -44,19 +44,25 @@ export async function checkUsability(browser, url, out) {
             .evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
           'sidebar text overflows at enlarged scale',
         );
-        const heights = () =>
-          page.evaluate(() =>
-            ['.radar-panel', '.radar-stage'].map(
-              (selector) => document.querySelector(selector).getBoundingClientRect().height,
-            ),
-          );
-        const before = await heights();
         for (const layer of ['Files', 'Network', 'Radar']) {
           await page
             .locator('.radar-layers')
             .getByRole('button', { name: layer, exact: true })
             .click();
-          assert.deepEqual(await heights(), before, 'radar layer moved surrounding content');
+          assert.equal(
+            await page.locator('.radar-stage:visible').count(),
+            layer === 'Radar' ? 1 : 0,
+          );
+          assert.equal(
+            await page.locator('.resource-explorer:visible').count(),
+            layer === 'Radar' ? 0 : 1,
+          );
+          assert(
+            await page
+              .locator('#main')
+              .evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
+            'layer overflows the workspace',
+          );
         }
         const monitoringScroll = await page.locator('#main').evaluate((node) => {
           node.scrollTop = 120;
@@ -64,6 +70,9 @@ export async function checkUsability(browser, url, out) {
         });
         // Trigger the same click handler without Playwright first scrolling the source page.
         await page.getByRole('button', { name: /Select Codex,/ }).evaluate((node) => node.click());
+        await page
+          .getByRole('button', { name: 'Open agent', exact: true })
+          .evaluate((node) => node.click());
         await page.locator('.agent-workspace:visible').waitFor();
         assert.equal(await page.getByRole('dialog').count(), 0, 'agent opened in a modal');
         assert.equal(await agent.inputValue(), 'Codex');

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -37,7 +37,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (frontend/observatory/) — Svelte 5 + Vite 7
-52 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
+54 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
 
 App.svelte owns workspace tabs, history and the host connection. Monitoring groups products and exposes stamped instances for process actions; Events and ActivityChart show retained evidence; Details and EntityLinks connect observations; Rules, Catalog, Analysis, Reports, Statistics and Settings expose host actions. SensorStatus renders effective sensor IDs; Notifications tracks anomaly crossings.
 

--- a/tests/renderer/components/ObservatoryRadarClarity.test.js
+++ b/tests/renderer/components/ObservatoryRadarClarity.test.js
@@ -68,6 +68,8 @@ it('opens metadata for an unstamped agent without inventing a process identity',
     inspect,
   });
   await fireEvent.click(screen.getByRole('button', { name: /Select ChatGPT Desktop,/ }));
+  expect(inspect).not.toHaveBeenCalled();
+  await fireEvent.click(screen.getByRole('button', { name: 'Open agent', exact: true }));
   expect(inspect.mock.calls[0][1]).toEqual({
     agentGroupKey: 'ChatGPT Desktop',
     name: 'ChatGPT Desktop',

--- a/tests/renderer/components/ObservatoryRadarResources.test.js
+++ b/tests/renderer/components/ObservatoryRadarResources.test.js
@@ -1,137 +1,189 @@
 import { expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/svelte';
 import Radar from '../../../frontend/observatory/components/Radar.svelte';
-import DetailSummary from '../../../frontend/observatory/components/DetailSummary.svelte';
+import RadarResourceExplorer from '../../../frontend/observatory/components/RadarResourceExplorer.svelte';
 import { emptyTelemetry } from '../../../frontend/observatory/runtime/host';
 
 const agents = ['Alpha', 'Beta', 'Delta', 'Gamma', 'Zeta'].map((agent, i) => ({
   agent,
   pid: i + 1,
   process: 'agent.exe',
-  instanceId: `${i}:live`,
+  instanceId: `test:${i}:live`,
   instanceIdSource: 'os',
 }));
 const events = Array.from({ length: 7 }, (_, i) => ({
   file: `X:/project/file-${i}.ts`,
-  instanceId: i < 6 ? '0:live' : '4:live',
+  instanceId: i < 6 ? 'test:0:live' : 'test:4:live',
   timestamp: i,
   attribution: { status: 'confirmed' },
 }));
+const state = (overrides = {}) => ({
+  ...emptyTelemetry(),
+  ready: true,
+  stale: false,
+  agents,
+  events,
+  networkAt: 1,
+  ...overrides,
+});
+const layer = (name) =>
+  fireEvent.click(
+    within(screen.getByLabelText('Radar layer')).getByRole('button', { name, exact: true }),
+  );
 
-it('pages through every unique file, opens the recorded observation and resets scope across agent pages', async () => {
-  const inspect = vi.fn();
-  const mounted = render(Radar, {
-    telemetry: { ...emptyTelemetry(), ready: true, stale: false, agents, events },
-    selected: '0:live',
-    inspect,
-  });
-  await fireEvent.click(
-    within(screen.getByLabelText('Radar layer')).getByRole('button', {
-      name: 'Files',
-      exact: true,
-    }),
-  );
-  expect(screen.getByText(/6 unique files/)).toBeInTheDocument();
-  await fireEvent.click(
-    within(mounted.container.querySelector('.radar-stage')).getByRole('button', {
-      name: /file-5.ts/,
-    }),
-  );
-  expect(inspect).toHaveBeenLastCalledWith('File observation', events[5]);
+it('shows resources from every radar page, searches owners and preserves pagination across scans', async () => {
+  const telemetry = state();
+  const mounted = render(Radar, { telemetry, selected: null, inspect: vi.fn() });
+  await layer('Files');
+  expect(screen.getByRole('button', { name: 'Inspect X:/project/file-6.ts' })).toBeInTheDocument();
   await fireEvent.click(screen.getByLabelText('Next radar resources'));
-  await fireEvent.click(screen.getByLabelText('Next radar resources'));
-  expect(screen.getByRole('button', { name: /file-0.ts/ })).toBeInTheDocument();
-  expect(screen.getByLabelText('Next radar resources')).toBeDisabled();
-  await fireEvent.click(screen.getByLabelText('Next radar agents'));
-  expect(screen.getByText('All agents on this page')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /file-6.ts/ })).toBeInTheDocument();
-  expect(mounted.container.querySelectorAll('.radar-blip[aria-pressed="true"]')).toHaveLength(0);
+  expect(screen.getByRole('button', { name: 'Inspect X:/project/file-0.ts' })).toBeInTheDocument();
+  expect(screen.getByLabelText('Next radar resources')).toHaveAttribute('aria-disabled', 'true');
+  await mounted.rerender({ telemetry: { ...telemetry, agents: structuredClone(agents) } });
+  expect(screen.getByRole('button', { name: 'Inspect X:/project/file-0.ts' })).toBeInTheDocument();
+  await fireEvent.input(screen.getByLabelText('Search radar files'), { target: { value: 'Zeta' } });
+  expect(screen.getByRole('button', { name: 'Inspect X:/project/file-6.ts' })).toBeInTheDocument();
+  expect(mounted.container.querySelectorAll('.resource-choice')).toHaveLength(1);
 });
-
-it('explains an empty selected agent and allows showing other agents without losing the layer', async () => {
-  render(Radar, {
-    telemetry: { ...emptyTelemetry(), ready: true, stale: false, agents, events },
-    selected: '1:live',
-    inspect: vi.fn(),
-  });
-  await fireEvent.click(
-    within(screen.getByLabelText('Radar layer')).getByRole('button', {
-      name: 'Files',
-      exact: true,
-    }),
-  );
-  expect(screen.getByRole('status')).toHaveTextContent('No file observations for this agent');
-  await fireEvent.click(screen.getByRole('button', { name: 'Show all agents' }));
-  expect(screen.getByRole('button', { name: /file-5.ts/ })).toBeInTheDocument();
+it('focuses an agent locally and opens resource scope without navigating away', async () => {
+  const openAgent = vi.fn();
+  render(Radar, { telemetry: state(), selected: null, inspect: vi.fn(), openAgent });
+  await fireEvent.click(screen.getByRole('button', { name: /Select Beta,/ }));
+  expect(openAgent).not.toHaveBeenCalled();
+  await fireEvent.click(screen.getByRole('button', { name: 'View files' }));
+  expect(screen.getByLabelText('Resource agent')).toHaveValue('Beta');
+  expect(screen.getByText('No matching observations')).toBeInTheDocument();
+  await fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+  expect(screen.getByRole('button', { name: 'Inspect X:/project/file-6.ts' })).toBeInTheDocument();
+  await layer('Radar');
+  await fireEvent.click(screen.getByRole('button', { name: 'Open agent', exact: true }));
+  expect(openAgent).toHaveBeenCalledOnce();
 });
-
-it('shows the endpoint in both the radar and its detail view when DNS is empty', async () => {
-  const row = { instanceId: '0:live', domain: '', remoteIp: '192.0.2.8', remotePort: 443 };
-  const telemetry = { ...emptyTelemetry(), ready: true, stale: false, agents, network: [row] };
-  const inspect = vi.fn();
-  const mounted = render(Radar, { telemetry, selected: null, inspect });
-  await fireEvent.click(
-    within(screen.getByLabelText('Radar layer')).getByRole('button', {
-      name: 'Network',
-      exact: true,
-    }),
-  );
-  await fireEvent.click(screen.getByRole('button', { name: /192.0.2.8:443/ }));
-  expect(inspect).toHaveBeenCalledWith('Network observation', row);
-  mounted.unmount();
-  render(DetailSummary, { row, telemetry });
-  expect(screen.getByText('192.0.2.8:443')).toBeInTheDocument();
-});
-
-it('counts a shared resource once while keeping separate agent links and all retained observations', async () => {
+it('counts a shared file once and exposes separate evidence and all retained rows', async () => {
   const shared = [
-    { ...events[0], file: 'X:/project/shared.ts', timestamp: 1 },
+    { ...events[0], file: 'X:/project/shared.ts' },
     { ...events[0], file: 'X:\\project\\shared.ts', timestamp: 2 },
-    { ...events[0], instanceId: '1:live', file: 'X:/project/shared.ts', timestamp: 3 },
+    {
+      ...events[0],
+      file: 'X:/project/shared.ts',
+      instanceId: 'test:1:live',
+      attribution: { status: 'inferred' },
+    },
   ];
   const inspect = vi.fn();
-  const mounted = render(Radar, {
-    telemetry: { ...emptyTelemetry(), ready: true, stale: false, agents, events: shared },
-    selected: null,
-    inspect,
-  });
-  await fireEvent.click(
-    within(screen.getByLabelText('Radar layer')).getByRole('button', {
-      name: 'Files',
-      exact: true,
-    }),
-  );
-  expect(screen.getByText(/1 unique file.*2 observation groups/)).toBeInTheDocument();
-  const cards = mounted.container.querySelectorAll('.resource-node');
-  expect(cards).toHaveLength(2);
-  const alpha = [...cards].find((card) => card.dataset.resourceGroup === 'Alpha');
-  await fireEvent.click(alpha);
+  const mounted = render(Radar, { telemetry: state({ events: shared }), selected: null, inspect });
+  await layer('Files');
+  expect(mounted.container.querySelectorAll('.resource-choice')).toHaveLength(1);
+  await fireEvent.click(screen.getByRole('button', { name: 'Inspect X:/project/shared.ts' }));
+  expect(screen.getByRole('heading', { name: 'Resource details' })).toHaveFocus();
+  const relations = mounted.container.querySelectorAll('.relation');
+  expect(relations).toHaveLength(2);
+  expect(relations[0]).toHaveAttribute('data-evidence', 'confirmed');
+  expect(relations[1]).toHaveAttribute('data-evidence', 'inferred');
+  await fireEvent.click(within(relations[0]).getByRole('button', { name: 'View records' }));
   expect(inspect).toHaveBeenLastCalledWith('File observation', {
     observationGroup: 'shared.ts',
     observations: shared.slice(0, 2),
   });
-});
-
-it('opens all current connections represented by an aggregated endpoint marker', async () => {
-  const connections = [
-    { instanceId: '0:live', domain: '', remoteIp: '192.0.2.8', remotePort: 443, localPort: 1000 },
-    { instanceId: '0:live', domain: '', remoteIp: '192.0.2.8', remotePort: 443, localPort: 2000 },
-  ];
-  const inspect = vi.fn();
-  render(Radar, {
-    telemetry: { ...emptyTelemetry(), ready: true, stale: false, agents, network: connections },
-    selected: null,
-    inspect,
+  await fireEvent.click(screen.getByRole('button', { name: 'All resource records' }));
+  expect(inspect).toHaveBeenLastCalledWith('File observation', {
+    observationGroup: 'shared.ts',
+    observations: shared,
   });
-  await fireEvent.click(
-    within(screen.getByLabelText('Radar layer')).getByRole('button', {
-      name: 'Network',
-      exact: true,
-    }),
-  );
-  await fireEvent.click(screen.getByRole('button', { name: /192.0.2.8:443/ }));
+});
+it('shows empty DNS, groups sockets and retains selection across layers', async () => {
+  const network = [1000, 2000].map((localPort) => ({
+    instanceId: 'test:0:live',
+    domain: '',
+    remoteIp: '192.0.2.8',
+    remotePort: 443,
+    localPort,
+  }));
+  const inspect = vi.fn();
+  render(Radar, { telemetry: state({ network }), selected: null, inspect });
+  await layer('Network');
+  await fireEvent.click(screen.getByRole('button', { name: 'Inspect 192.0.2.8:443' }));
+  expect(screen.getByText('Unverified destination')).toBeInTheDocument();
+  await layer('Files');
+  await layer('Network');
+  expect(screen.getByRole('heading', { name: 'Resource details' })).toBeInTheDocument();
+  await fireEvent.click(screen.getByRole('button', { name: 'All resource records' }));
   expect(inspect).toHaveBeenLastCalledWith('Network observation', {
     observationGroup: '192.0.2.8:443',
-    observations: connections,
+    observations: network,
   });
+});
+it('retains selected evidence but disables navigation when live identity changes during pause', async () => {
+  const inspect = vi.fn();
+  const telemetry = state({ events: [events[0]] });
+  const mounted = render(RadarResourceExplorer, {
+    telemetry,
+    liveTelemetry: telemetry,
+    layer: 'files',
+    inspect,
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Inspect X:/project/file-0.ts' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Inspect process' }));
+  expect(inspect).toHaveBeenLastCalledWith(
+    'Alpha',
+    expect.objectContaining({ instanceId: 'test:0:live', detailSection: 'processes' }),
+  );
+  await mounted.rerender({
+    liveTelemetry: state({ agents: [{ ...agents[0], instanceId: 'test:0:new' }] }),
+  });
+  expect(screen.getByRole('button', { name: 'Inspect process' })).toBeDisabled();
+  await mounted.rerender({ telemetry: state({ events: [] }) });
+  expect(screen.getByText(/No longer in the current data/)).toBeInTheDocument();
+  await fireEvent.click(screen.getByRole('button', { name: 'View records' }));
+  expect(inspect).toHaveBeenLastCalledWith('File observation', events[0]);
+});
+it('draws no ownership link for path context and distinguishes waiting from an empty network scan', async () => {
+  const mounted = render(RadarResourceExplorer, {
+    telemetry: state({ networkAt: null }),
+    layer: 'network',
+    inspect: vi.fn(),
+  });
+  expect(screen.getByText('Waiting for a reliable scan')).toBeInTheDocument();
+  mounted.unmount();
+  const view = render(RadarResourceExplorer, {
+    telemetry: state({
+      events: [{ file: 'X:/.codex/config.toml', attribution: { status: 'unattributed' } }],
+    }),
+    layer: 'files',
+    inspect: vi.fn(),
+  });
+  await fireEvent.click(screen.getByRole('button', { name: 'Inspect X:/.codex/config.toml' }));
+  expect(view.container.querySelector('.relationship-line')).toHaveClass('unlinked');
+  expect(screen.getByRole('button', { name: 'Inspect process' })).toBeDisabled();
+  await fireEvent.input(screen.getByLabelText('Search radar files'), {
+    target: { value: 'missing' },
+  });
+  expect(
+    screen.getByText('The selected resource is outside the current filters.'),
+  ).toBeInTheDocument();
+});
+
+it('keeps the selected relationship page during live updates to a shared resource', async () => {
+  const shared = agents.map((owner) => ({
+    ...events[0],
+    instanceId: owner.instanceId,
+    agent: owner.agent,
+  }));
+  const telemetry = state({ events: shared });
+  const mounted = render(RadarResourceExplorer, { telemetry, layer: 'files', inspect: vi.fn() });
+  await fireEvent.click(screen.getByRole('button', { name: 'Inspect X:/project/file-0.ts' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Next relationships' }));
+  expect(
+    within(screen.getByLabelText('Resource relationships')).getByText('Zeta'),
+  ).toBeInTheDocument();
+  await mounted.rerender({
+    telemetry: { ...telemetry, events: [...shared, { ...shared[0], timestamp: 100 }] },
+  });
+  expect(
+    within(screen.getByLabelText('Resource relationships')).getByText('Zeta'),
+  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Next relationships' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
 });

--- a/tests/renderer/observatory-radar-resources.test.js
+++ b/tests/renderer/observatory-radar-resources.test.js
@@ -1,7 +1,9 @@
 import { expect, it } from 'vitest';
-import { emptyTelemetry, instances } from '../../frontend/observatory/runtime/host';
-import { radarGroups } from '../../frontend/observatory/runtime/radar';
-import { radarResources } from '../../frontend/observatory/runtime/radar-resources';
+import { emptyTelemetry } from '../../frontend/observatory/runtime/host';
+import {
+  radarResources,
+  resourceProcess,
+} from '../../frontend/observatory/runtime/radar-resources';
 
 const agent = (pid, name = 'Codex') => ({
   agent: name,
@@ -24,103 +26,135 @@ const connection = (overrides = {}) => ({
   state: 'Established',
   ...overrides,
 });
-
-it('deduplicates files across grouped processes, retains newest evidence and distinct paths', () => {
-  const state = {
-    ...emptyTelemetry(),
-    agents: [agent(1), agent(2)],
-    events: [
-      file('X:/a/config.ts', 2),
-      file('X:\\a\\config.ts', 9, 2),
-      file('X:/b/config.ts', 3),
-      { ...file('X:/self', 5), selfAccess: true },
-    ],
-  };
-  const rows = radarResources(state, 'files', radarGroups(instances(state)));
-  expect(rows).toHaveLength(2);
-  expect(rows[0]).toMatchObject({ label: 'config.ts', count: 2, group: 'Codex' });
-  expect(rows[0].row).toBe(state.events[1]);
-  expect(rows.map((r) => r.key)).toHaveLength(new Set(rows.map((r) => r.key)).size);
+const state = (overrides = {}) => ({
+  ...emptyTelemetry(),
+  ready: true,
+  stale: false,
+  agents: [agent(1), agent(2, 'Cursor')],
+  ...overrides,
 });
 
-it('renders empty DNS as IP and port, distinguishing ports and IPv6 without duplicate sockets', () => {
-  const state = {
-    ...emptyTelemetry(),
-    agents: [agent(1), agent(2)],
-    network: [
-      connection(),
-      connection({ instanceId: '2:now' }),
-      connection({ remotePort: 80 }),
-      connection({ remoteIp: '2001:db8::1' }),
-      connection({ remoteIp: '', domain: '' }),
-    ],
-  };
-  const rows = radarResources(state, 'network', radarGroups(instances(state)));
-  expect(rows.map((r) => r.label)).toEqual(
-    expect.arrayContaining(['192.0.2.8:443', '192.0.2.8:80', '[2001:db8::1]:443']),
-  );
+it('includes self access, groups canonical paths, and retains distinct process relationships and all evidence', () => {
+  const events = [
+    file('X:/a/config.ts', 2),
+    file('X:\\a\\config.ts', 9, 2),
+    file('X:/b/config.ts', 3),
+    { ...file('X:/self', 5), selfAccess: true },
+  ];
+  const rows = radarResources(state({ events }), 'files');
   expect(rows).toHaveLength(3);
-  expect(rows.find((r) => r.label === '192.0.2.8:443').count).toBe(2);
+  expect(rows[0]).toMatchObject({ label: 'config.ts', time: 9, rows: events.slice(0, 2) });
+  expect(rows[0].relations.map((r) => r.actor)).toEqual(['Codex', 'Cursor']);
+  expect(rows[0].relations.map((r) => r.instanceId)).toEqual(['1:now', '2:now']);
+  expect(rows.some((r) => r.rows[0].selfAccess)).toBe(true);
 });
-
-it('only links exact current instances and scopes resources to the visible radar page', () => {
-  const state = {
-    ...emptyTelemetry(),
-    agents: [agent(1), agent(2, 'Cursor')],
+it('distinguishes ports, IPv6 and IPs sharing DNS while retaining every socket', () => {
+  const rows = radarResources(
+    state({
+      network: [
+        connection(),
+        connection({ instanceId: '2:now' }),
+        connection({ remotePort: 80 }),
+        connection({ remoteIp: '2001:db8::1' }),
+        connection({ remoteIp: '', domain: '' }),
+        connection({ domain: 'api.example.com' }),
+        connection({ remoteIp: '192.0.2.9', domain: 'api.example.com' }),
+      ],
+    }),
+    'network',
+  );
+  expect(rows.map((r) => r.label)).toEqual(
+    expect.arrayContaining([
+      '192.0.2.8:443',
+      '192.0.2.8:80',
+      '[2001:db8::1]:443',
+      'api.example.com:443',
+    ]),
+  );
+  expect(rows).toHaveLength(4);
+  expect(rows.find((r) => r.label === '192.0.2.8:443').rows).toHaveLength(3);
+});
+it('includes all radar pages, historical owners and unknown resources without guessing from path context', () => {
+  const telemetry = state({
+    agents: Array.from({ length: 8 }, (_, i) => agent(i + 1, `Agent ${i + 1}`)),
     events: [
       file('X:/current', 1),
-      file('X:/other-page', 2, 2),
+      file('X:/other-page', 2, 8),
       { ...file('X:/old', 3), instanceId: '1:old', agent: 'Codex', pid: 1 },
-      { ...file('X:/unknown', 4), instanceId: null, agent: 'Codex', pid: 1 },
+      {
+        ...file('X:/.codex/config.toml', 4),
+        instanceId: null,
+        attribution: { status: 'unattributed' },
+      },
     ],
-  };
-  const groups = radarGroups(instances(state));
-  const rows = radarResources(state, 'files', [groups[0]]);
-  expect(rows).toHaveLength(3);
-  expect(rows.filter((r) => r.group)).toHaveLength(1);
-  expect(rows.filter((r) => !r.group).every((r) => r.attribution === 'No current agent link')).toBe(
-    true,
-  );
-  expect(radarResources(state, 'files', [groups[0]], groups[0]).map((r) => r.label)).toEqual([
-    'current',
+  });
+  const rows = radarResources(telemetry, 'files');
+  expect(rows).toHaveLength(4);
+  expect(rows.find((r) => r.label === 'other-page').relations[0].actor).toBe('Agent 8');
+  const old = rows.find((r) => r.label === 'old').relations[0];
+  expect(old.actor).toBe('Codex');
+  expect(resourceProcess(old, telemetry)).toBeNull();
+  expect(rows.find((r) => r.label === 'config.toml').relations[0].actor).toBe('');
+});
+it('preserves mixed attribution and actions in separate relationships for one process', () => {
+  const events = [
+    { ...file('X:/config', 1), action: 'holding', attribution: { status: 'inferred' } },
+    { ...file('X:/config', 2), action: 'modified' },
+    { ...file('X:/config', 3), action: 'accessed' },
+    { ...file('X:/config', 4), attribution: 'ambiguous', agent: 'Codex' },
+  ];
+  const row = radarResources(state({ events }), 'files')[0];
+  expect(row.relations.map((r) => r.attribution)).toEqual([
+    'Indirect match',
+    'PID confirmed',
+    'Ambiguous ownership',
   ]);
+  expect(row.relations[1].actions).toEqual(['Changed a file', 'Had an open file handle']);
+  expect(row.rows).toEqual(events);
+  expect(resourceProcess(row.relations[2], state())).toBeNull();
 });
-
-it('does not turn inferred file ownership into confirmed attribution', () => {
-  const state = {
-    ...emptyTelemetry(),
-    agents: [agent(1)],
-    events: [{ ...file('X:/config', 1), attribution: { status: 'inferred' } }],
-  };
-  expect(radarResources(state, 'files', radarGroups(instances(state)))[0].attribution).toBe(
-    'Indirect attribution',
+it('resolves only a unique reliable current lifetime, never a recycled PID or duplicate identity', () => {
+  const telemetry = state({ events: [{ ...file('X:/config', 1), agent: 'Codex', pid: 1 }] });
+  const relation = radarResources(telemetry, 'files')[0].relations[0];
+  expect(resourceProcess(relation, telemetry)).toBe(telemetry.agents[0]);
+  for (const change of [
+    { stale: true },
+    { ready: false },
+    { agents: [{ ...agent(1), instanceId: '1:new' }] },
+    { agents: [agent(1), agent(1, 'Other')] },
+    { agents: [agent(1, 'Other')] },
+    { agents: [{ ...agent(1), instanceIdSource: 'synthetic' }] },
+    { agents: [{ ...agent(1), instanceIdSource: 'unknown' }] },
+  ])
+    expect(resourceProcess(relation, { ...telemetry, ...change })).toBeNull();
+});
+it('retains strongest classification without claiming unknown destinations are malicious', () => {
+  const files = radarResources(
+    state({ events: [{ ...file('X:/config', 1), sensitive: true }, file('X:/config', 2)] }),
+    'files',
   );
+  expect(files[0]).toMatchObject({ level: 'review', sensitive: true });
+  const network = radarResources(
+    state({
+      network: [
+        connection({ verdict: 'flagged' }),
+        connection({ verdict: 'allowlisted' }),
+        connection({ remotePort: 80, verdict: 'unknown' }),
+      ],
+    }),
+    'network',
+  );
+  expect(network[0].level).toBe('review');
+  expect(network[1]).toMatchObject({
+    level: 'unverified',
+    reason: expect.stringContaining('Unknown does not mean dangerous'),
+  });
 });
-
-it('retains source rows while unique resource identity excludes agent ownership', () => {
-  const state = {
-    ...emptyTelemetry(),
-    agents: [agent(1), agent(2, 'Cursor')],
-    events: [
-      file('X:/Project/Config.ts', 1),
-      file('x:\\project\\config.ts', 2),
-      file('X:/Project/Config.ts', 3, 2),
-    ],
-  };
-  const rows = radarResources(state, 'files', radarGroups(instances(state)));
-  expect(rows).toHaveLength(2);
-  expect(new Set(rows.map((entry) => entry.resourceKey)).size).toBe(1);
-  const codex = rows.find((entry) => entry.group === 'Codex');
-  expect(codex.rows).toEqual(state.events.slice(0, 2));
-  expect(codex.count).toBe(2);
-  expect(codex.row).toBe(state.events[1]);
-});
-
 it('keeps differently cased POSIX paths separate', () => {
-  const state = {
-    ...emptyTelemetry(),
-    agents: [agent(1)],
-    events: [file('/project/Config.ts', 1), file('/project/config.ts', 2)],
-  };
-  expect(radarResources(state, 'files', radarGroups(instances(state)))).toHaveLength(2);
+  expect(
+    radarResources(
+      state({ events: [file('/project/Config.ts', 1), file('/project/config.ts', 2)] }),
+      'files',
+    ),
+  ).toHaveLength(2);
 });


### PR DESCRIPTION
Files and Network hid observations behind the four-agent radar page and two floating resource cards; selecting an agent also left Monitoring immediately. They now show searchable file/destination catalogs with a selected-resource view linking recorded agents, process lifetimes, actions and evidence. Radar selection stays local with explicit links to files, connections and the agent workspace.

Resources include all radar pages, retained historical and own-file activity. Shared paths/endpoints retain every record and separate attribution boundaries. Confirmed and indirect links are visually distinct; unattributed resources have no ownership line. Current process navigation requires a unique reliable identity, including during a paused view. Visited layers and pagination retain state across updates.

Validated with production and preview builds, TypeScript/Svelte, formatting/lint, full coverage suite (202 files), both mutation gates, derived counts and production dependency audit. Browser QA passed the full suite including 48 resource theme/scale/viewport combinations; isolated Electron smoke passed with 25 observed agents and 11 workspaces. Added focused coverage for grouping, all-agent scope, selection retention, recycled identities and relationship pagination.
