### PR TITLE
fix(radar): keep selection clear of agent numbers

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -158,3 +158,10 @@ the displayed view is paused. A stale or missing population disables navigation.
 Filters preserve focus; choosing a resource focuses its detail heading. Visited
 layers retain state, and unchanged observation arrays reuse the resource model.
 All new styling remains scoped; the preserved reference and cascade are unchanged.
+
+### Radar selection spacing (2026-09-11)
+
+The selected roster row uses its background and a uniform border, without an
+inset stripe beside the ordinal. Horizontal padding keeps the number away from
+the edge. The radar toolbar grows with wrapped text and has no inner scrollbar.
+The viewport/theme/scale checks cover toolbar overflow and ordinal clearance.

--- a/frontend/observatory/components/RadarSummary.svelte
+++ b/frontend/observatory/components/RadarSummary.svelte
@@ -33,3 +33,13 @@
   >
   <Icon name="chevron" />
 </button>
+
+<style>
+  button.radar-agent-card {
+    padding-inline: var(--space-4);
+  }
+  button.radar-agent-card[aria-pressed='true'] {
+    box-shadow: none;
+    border-color: var(--ink);
+  }
+</style>

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -227,7 +227,16 @@ try {
               const overlaps = (a, b) =>
                 a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
               const cards = [...document.querySelectorAll('.radar-agent-card')];
+              const toolbar = document.querySelector('.radar-resource-toolbar');
               return {
+                toolbarOverflow: toolbar.scrollHeight > toolbar.clientHeight + 1,
+                crowdedNumbers: cards.some((card) => {
+                  const number = rect(card.querySelector('.roster-number'));
+                  return (
+                    number.left < rect(card).left + 12 ||
+                    number.right > rect(card.querySelector('.agent-mark')).left - 3
+                  );
+                }),
                 collisions: points.some((p, i) => points.slice(i + 1).some((q) => overlaps(p, q))),
                 clipped: points.some(
                   (p) =>
@@ -247,6 +256,16 @@ try {
               };
             });
             assert.equal(radar.collisions, false, `radar marker collision: ${size.width} ${scale}`);
+            assert.equal(
+              radar.toolbarOverflow,
+              false,
+              `radar toolbar scrolls: ${size.width} ${scale}`,
+            );
+            assert.equal(
+              radar.crowdedNumbers,
+              false,
+              `radar number crowded: ${size.width} ${scale}`,
+            );
             assert.equal(radar.clipped, false, `clipped radar marker: ${size.width} ${scale}`);
             assert.equal(
               radar.crowdedLogos,


### PR DESCRIPTION
Remove the heavy inset selection stripe beside radar agent numbers. The selected row now uses its background and a uniform border, with 16 px horizontal padding keeping the ordinal clear of the edge.

The reported toolbar scrollbar is already fixed by #436. Extend the existing viewport matrix to check its wrapped-text overflow and the number-to-edge/logo spacing. Document the selection treatment.

Validation: production and preview builds, formatting/lint, TypeScript/Svelte, full frontend browser suite, and isolated Electron smoke (25 agents, 11 workspaces, no renderer errors). A focused rendered check covered selected rows in 16 size/scale/theme combinations, including 900×600 at 150% and high contrast.
