### PR TITLE
fix(ui): keep watchlist feedback and controls together

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -165,3 +165,15 @@ The selected roster row uses its background and a uniform border, without an
 inset stripe beside the ordinal. Horizontal padding keeps the number away from
 the edge. The radar toolbar grows with wrapped text and has no inner scrollbar.
 The viewport/theme/scale checks cover toolbar overflow and ordinal clearance.
+
+### Watchlist feedback and grouping (2026-09-11)
+
+The process watchlist loads automatically and combines the selected agent's
+status and add/remove action into one stable row. Other entries live in one
+bounded disclosure. Duplicate signature/PID entries share one displayed action;
+distinct PID scopes remain separate. Agent names resolve through the catalog.
+A shared live status survives removal of its row and reports loading, saving,
+success or failure. Concurrent mutations and refreshes are guarded. Failed
+readback after a confirmed write is reported separately and requires reloading
+before another change. Removing a focused row returns focus to the stable agent
+action. Watchlist flags remain alert-only and do not grant or block access.

--- a/frontend/observatory/components/DetailControls.svelte
+++ b/frontend/observatory/components/DetailControls.svelte
@@ -3,17 +3,15 @@
     actionTarget,
     confirmed,
     invoke,
-    records,
     type Host,
     type RecordData,
     type Telemetry,
   } from '../runtime/host';
   import Action from './Action.svelte';
+  import Watchlist from './Watchlist.svelte';
   let { row, host, telemetry }: { row: RecordData; host: Host | null; telemetry: Telemetry } =
     $props();
   let stopId = $state<string | null>(null);
-  let watch = $state<RecordData[]>([]);
-  let watchLoaded = $state(false);
   let canControl = $derived.by(() => {
     if (!row.process || typeof row.instanceId !== 'string') return false;
     try {
@@ -27,10 +25,6 @@
     const live = actionTarget(telemetry, id);
     confirmed(await invoke(host, method, { pid: live.pid, instanceId: live.instanceId }));
     stopId = null;
-  }
-  async function loadWatch() {
-    watch = records(await invoke(host, 'blocklistList'));
-    watchLoaded = true;
   }
 </script>
 
@@ -68,36 +62,4 @@
       </div>
     </div>{/if}
 </section>
-<section class="detail-section">
-  <h3>Alert watchlist</h3>
-  <p class="entity-note">Watchlist entries raise alerts; they do not block execution.</p>
-  <div class="toolbar">
-    <Action
-      action={async () => {
-        confirmed(
-          await invoke(host, 'blocklistAdd', {
-            signature: row.agent ?? row.name,
-            reason: 'Added from instance details',
-          }),
-        );
-        await loadWatch();
-      }}>Watch agent</Action
-    >
-    <Action action={loadWatch}>Refresh watchlist</Action>
-  </div>
-  {#each watch as entry (entry)}<div class="watch-entry">
-      <div>
-        <strong>{String(entry.signature)}</strong><small
-          >{entry.pid ? 'PID ' + entry.pid : 'All instances'}</small
-        >
-      </div>
-      <Action
-        action={async () => {
-          confirmed(
-            await invoke(host, 'blocklistRemove', { signature: entry.signature, pid: entry.pid }),
-          );
-          await loadWatch();
-        }}>Remove</Action
-      >
-    </div>{:else}{#if watchLoaded}<p class="entity-note">The watchlist is empty.</p>{/if}{/each}
-</section>
+{#key row.agent ?? row.name}<Watchlist {host} agent={String(row.agent ?? row.name ?? '')} />{/key}

--- a/frontend/observatory/components/Watchlist.svelte
+++ b/frontend/observatory/components/Watchlist.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { confirmed, invoke, record, records, type Host, type RecordData } from '../runtime/host';
+  let { host, agent }: { host: Host | null; agent: string } = $props();
+  let entries = $state<RecordData[]>([]);
+  let catalog = $state<RecordData[]>([]);
+  let loaded = $state(false);
+  let busy = $state(false);
+  let message = $state('Loading watchlist…');
+  let error = $state('');
+  let limit = $state(6);
+  let toggle = $state<HTMLButtonElement>();
+  let alive = true;
+  let resolved = $state('');
+  const normalize = (value: unknown) =>
+    String(value ?? '')
+      .trim()
+      .toLowerCase();
+  const signature = $derived(
+    resolved ||
+      String(
+        catalog.find((row) =>
+          [row.id, row.displayName, ...(Array.isArray(row.names) ? row.names : [])].some(
+            (name) => normalize(name) === normalize(agent),
+          ),
+        )?.id || normalize(agent),
+      ),
+  );
+  const current = $derived(entries.find((row) => row.signature === signature && row.pid == null));
+  const others = $derived(entries.filter((row) => row !== current));
+  function label(entry: RecordData): string {
+    const name = catalog.find((row) => row.id === entry.signature)?.displayName || entry.signature;
+    return String(name) + (entry.pid ? ` · PID ${entry.pid}` : ' · all processes');
+  }
+  async function read(): Promise<RecordData[]> {
+    const value = await invoke(host, 'blocklistList');
+    if (!Array.isArray(value)) throw new Error('The watchlist could not be loaded.');
+    // Imported repeated rows share one action. Separate PID scopes remain separate.
+    return [
+      ...new Map(
+        records(value).map((entry) => [
+          JSON.stringify([entry.signature, entry.pid ?? null]),
+          entry,
+        ]),
+      ).values(),
+    ];
+  }
+  async function load() {
+    if (busy) return;
+    busy = true;
+    error = '';
+    message = 'Loading watchlist…';
+    try {
+      const [next, database] = await Promise.all([
+        read(),
+        host?.getAgentDatabase ? invoke(host, 'getAgentDatabase') : Promise.resolve({ agents: [] }),
+      ]);
+      if (!alive) return;
+      entries = next;
+      catalog = records(record(database).agents);
+      loaded = true;
+      message = 'Watchlist is up to date.';
+    } catch (e) {
+      if (alive) {
+        loaded = false;
+        message = '';
+        error = e instanceof Error ? e.message : String(e);
+      }
+    } finally {
+      if (alive) busy = false;
+    }
+  }
+  async function change(entry?: RecordData, origin?: HTMLButtonElement) {
+    if (busy || !loaded || !agent.trim()) return;
+    const removing = !!entry;
+    const name = entry ? label(entry) : agent;
+    const focused = document.activeElement === origin;
+    busy = true;
+    error = '';
+    message = `${removing ? 'Removing' : 'Adding'} ${name}…`;
+    let saved = false;
+    try {
+      const result = confirmed(
+        await invoke(
+          host,
+          removing ? 'blocklistRemove' : 'blocklistAdd',
+          entry
+            ? { signature: entry.signature, pid: entry.pid ?? null }
+            : { signature: agent, reason: 'Added from agent controls' },
+        ),
+      );
+      saved = true;
+      if (!alive) return;
+      if (!removing && typeof record(result.entry).signature === 'string')
+        resolved = String(record(result.entry).signature);
+      const next = await read();
+      if (!alive) return;
+      entries = next;
+      await tick();
+      if (
+        alive &&
+        focused &&
+        origin &&
+        !origin.isConnected &&
+        document.activeElement === document.body
+      )
+        toggle?.focus();
+      message = removing
+        ? `${name} ${result.removed === false ? 'was already absent from' : 'removed from'} the watchlist.`
+        : `${name} added to the watchlist.`;
+    } catch (e) {
+      if (!alive) return;
+      const detail = e instanceof Error ? e.message : String(e);
+      if (saved) loaded = false;
+      message = '';
+      error = saved
+        ? `Change saved, but the list could not be refreshed. Reload the watchlist. ${detail}`
+        : `Change not saved. ${detail}`;
+    } finally {
+      if (alive) busy = false;
+    }
+  }
+  onMount(() => {
+    void load();
+    return () => {
+      alive = false;
+    };
+  });
+</script>
+
+<section class="detail-section watchlist" aria-label="Alert watchlist">
+  <div class="watch-heading">
+    <h3>Alert watchlist</h3>
+    <button class="button" aria-disabled={busy} onclick={load}>Reload watchlist</button>
+  </div>
+  <p class="entity-note">
+    One entry per agent and scope. Entries raise alerts; they do not block execution.
+  </p>
+  <div class="watch-subject" aria-busy={busy}>
+    <div>
+      <strong>{agent || 'Agent not identified'}</strong><small
+        >{!loaded
+          ? 'Status unavailable'
+          : current
+            ? 'On the watchlist · all processes'
+            : 'Not on the watchlist for all processes'}</small
+      >
+    </div>
+    <button
+      bind:this={toggle}
+      class="button"
+      aria-disabled={busy || !loaded || !agent.trim()}
+      onclick={(event) => change(current, event.currentTarget)}
+      >{current ? 'Remove agent' : 'Watch agent'}</button
+    >
+  </div>
+  <div class="watch-feedback">
+    <p role="status">{message}</p>
+    {#if error}<p role="alert" class="error">{error}</p>{/if}
+  </div>
+  {#if loaded && others.length}<details>
+      <summary>Other watchlist entries ({others.length})</summary>
+      <ul>
+        {#each others.slice(0, limit) as entry (JSON.stringify( [entry.signature, entry.pid ?? null] ))}<li
+          >
+            <span>{label(entry)}</span><button
+              class="button"
+              aria-label={`Remove ${label(entry)}`}
+              aria-disabled={busy}
+              onclick={(event) => change(entry, event.currentTarget)}>Remove</button
+            >
+          </li>{/each}
+      </ul>
+      {#if limit < others.length}<button class="button" onclick={() => (limit += 6)}
+          >Show more entries</button
+        >{/if}
+    </details>{/if}
+</section>
+
+<style>
+  .watchlist {
+    min-width: 0;
+  }
+  .watch-heading,
+  .watch-subject,
+  li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+  h3,
+  p {
+    margin: 0;
+  }
+  .entity-note {
+    margin-block: var(--space-2) var(--space-3);
+  }
+  .watch-subject {
+    padding: var(--space-3);
+    border: 1px solid var(--border);
+    border-radius: var(--control-radius);
+    background: var(--bg);
+  }
+  .watch-subject > div,
+  li > span {
+    flex: 1 1 160px;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+  small {
+    display: block;
+    color: var(--muted);
+    margin-top: var(--space-1);
+    font-size: var(--text-caption);
+  }
+  .watch-feedback {
+    min-height: 2.5em;
+    padding-block: var(--space-2);
+    color: var(--muted);
+    font-size: var(--text-body);
+    overflow-wrap: anywhere;
+  }
+  .error {
+    color: var(--red);
+  }
+  summary {
+    cursor: pointer;
+    padding-block: var(--space-2);
+  }
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  li {
+    padding-block: var(--space-2);
+    border-top: 1px solid var(--border);
+  }
+  button {
+    white-space: normal;
+    height: auto;
+  }
+</style>

--- a/frontend/observatory/tests/check-build.mjs
+++ b/frontend/observatory/tests/check-build.mjs
@@ -15,6 +15,7 @@ import { checkDetails } from './detail-check.mjs';
 import { checkMotion } from './motion-check.mjs';
 import { checkResourceLayers } from './resource-layer-check.mjs';
 import { checkProtection } from './protection-check.mjs';
+import { checkWatchlist } from './watchlist-check.mjs';
 
 const repo = process.cwd();
 const designRoot = resolve(repo, 'frontend/observatory');
@@ -415,6 +416,7 @@ try {
   assert.equal(await page.evaluate(() => window.bridgeCalls), 0);
   await checkMotion(page);
   await page.close();
+  await checkWatchlist(browser, base + '/desktop/', out);
   await checkClarity(browser, base + '/desktop/', out);
   await checkResourceLayers(browser, base + '/desktop/', out);
   await checkDetails(browser, base + '/desktop/', out);

--- a/frontend/observatory/tests/watchlist-check.mjs
+++ b/frontend/observatory/tests/watchlist-check.mjs
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+/** Verify persistent watchlist feedback and grouped controls with a disposable bridge.
+ * @param {import('playwright').Browser} browser Browser @param {string} url Desktop URL
+ * @param {string} out Screenshot directory @returns {Promise<void>} Checked @since 0.14.1
+ */
+export async function checkWatchlist(browser, url, out) {
+  const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  try {
+    await page.addInitScript(() => {
+      const listeners = {};
+      const fixture = {
+        listeners,
+        entries: [
+          { signature: 'other', pid: 42 },
+          { signature: 'other', pid: 42 },
+          { signature: 'other', pid: 43 },
+        ],
+        release: null,
+        fail: false,
+        adds: 0,
+      };
+      window.watchlistFixture = fixture;
+      window.aegis = new Proxy(
+        {},
+        {
+          get: (_, name) => {
+            if (name.startsWith('on'))
+              return (callback) => {
+                listeners[name] = callback;
+                return () => {};
+              };
+            if (name === 'getSettings') return async () => ({ darkMode: true, uiScale: 1 });
+            if (name === 'getFalsePositives') return async () => [];
+            if (name === 'getAgentDatabase')
+              return async () => ({
+                agents: [{ id: 'codex', displayName: 'Codex', names: ['codex.exe'] }],
+              });
+            if (name === 'blocklistList') return async () => structuredClone(fixture.entries);
+            if (name === 'blocklistAdd')
+              return () => {
+                fixture.adds++;
+                return new Promise((resolve) => {
+                  fixture.release = () => {
+                    const entry = { signature: 'codex', pid: null };
+                    fixture.entries.push(entry);
+                    resolve({ success: true, entry });
+                  };
+                });
+              };
+            if (name === 'blocklistRemove')
+              return async (entry) => {
+                if (fixture.fail) return { success: false, error: 'Storage unavailable' };
+                const before = fixture.entries.length;
+                fixture.entries = fixture.entries.filter(
+                  (r) => r.signature !== entry.signature || (r.pid ?? null) !== (entry.pid ?? null),
+                );
+                return { success: true, removed: before !== fixture.entries.length };
+              };
+            return async () => ({});
+          },
+        },
+      );
+    });
+    await page.goto(url);
+    await page.getByRole('button', { name: 'Detailed monitoring', exact: true }).click();
+    await page.evaluate(() =>
+      window.watchlistFixture.listeners.onScanBatch({
+        agents: [
+          {
+            agent: 'Codex',
+            process: 'codex.exe',
+            pid: 42,
+            instanceId: '42:watch',
+            instanceIdSource: 'os',
+          },
+        ],
+        stats: {
+          appHealth: { populationReliable: true, state: 'HEALTHY' },
+          observationGap: { state: 'NONE' },
+        },
+      }),
+    );
+    await page.getByRole('button', { name: /Select Codex,/ }).click();
+    await page.getByRole('button', { name: 'Open agent', exact: true }).click();
+    await page.getByLabel('Selected process', { exact: true }).selectOption('42:watch');
+    await page.getByRole('tab', { name: 'Processes', exact: true }).click();
+    await page.getByText('Process attributes and controls', { exact: true }).click();
+    const watch = page.getByRole('region', { name: 'Alert watchlist' });
+    await watch.getByText('Watchlist is up to date.').waitFor();
+    await watch.getByRole('button', { name: 'Watch agent', exact: true }).click();
+    await watch.getByRole('status').filter({ hasText: 'Adding Codex…' }).waitFor();
+    assert.equal(await watch.getByRole('button', { name: 'Reload watchlist' }).isEnabled(), false);
+    await page.evaluate(() => window.watchlistFixture.release());
+    await watch.getByText('Codex added to the watchlist.').waitFor();
+    assert.equal(await watch.getByRole('button', { name: 'Watch agent', exact: true }).count(), 0);
+    await watch.getByText('Other watchlist entries (2)', { exact: true }).click();
+    assert.equal(await watch.locator('li').count(), 2);
+    for (const width of [900, 1200])
+      for (const scale of [1, 1.5])
+        for (const theme of ['dark', 'light', 'dark-hc', 'light-hc']) {
+          await page.setViewportSize({ width, height: width === 900 ? 600 : 800 });
+          await page.evaluate(
+            ({ scale, theme }) => {
+              document.documentElement.style.setProperty('--ui-scale', String(scale));
+              document.documentElement.dataset.theme = theme;
+            },
+            { scale, theme },
+          );
+          assert(
+            await watch.evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
+            'watchlist overflow',
+          );
+          await watch
+            .locator('.watch-subject')
+            .screenshot({ path: resolve(out, `watchlist-${width}-${scale}-${theme}.png`) });
+        }
+    const remove = watch.getByRole('button', { name: 'Remove other · PID 42' });
+    await remove.focus();
+    await page.keyboard.press('Enter');
+    await watch.getByText('other · PID 42 removed from the watchlist.').waitFor();
+    assert(
+      await watch
+        .getByRole('button', { name: 'Remove agent', exact: true })
+        .evaluate((node) => document.activeElement === node),
+      'removed row lost keyboard focus',
+    );
+    assert.equal(await watch.locator('li').count(), 1);
+    await page.evaluate(() => (window.watchlistFixture.fail = true));
+    await watch.getByRole('button', { name: 'Remove agent', exact: true }).click();
+    await watch
+      .getByRole('alert')
+      .filter({ hasText: 'Change not saved. Storage unavailable' })
+      .waitFor();
+    assert.equal(await watch.getByText('On the watchlist · all processes').count(), 1);
+    await page.evaluate(() => (window.watchlistFixture.fail = false));
+    await watch.getByRole('button', { name: 'Remove agent', exact: true }).click();
+    await watch.getByText('Codex · all processes removed from the watchlist.').waitFor();
+    assert.equal(await page.evaluate(() => window.watchlistFixture.adds), 1);
+    assert.deepEqual(errors, []);
+    console.log(
+      'Watchlist: pending/success/failure feedback, canonical add/remove, duplicate/PID grouping, keyboard focus and 16 layouts passed.',
+    );
+  } finally {
+    await page.close();
+  }
+}

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -37,7 +37,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (frontend/observatory/) — Svelte 5 + Vite 7
-54 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
+55 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
 
 App.svelte owns workspace tabs, history and the host connection. Monitoring groups products and exposes stamped instances for process actions; Events and ActivityChart show retained evidence; Details and EntityLinks connect observations; Rules, Catalog, Analysis, Reports, Statistics and Settings expose host actions. SensorStatus renders effective sensor IDs; Notifications tracks anomaly crossings.
 

--- a/tests/renderer/components/ObservatoryInteractionPolish.test.js
+++ b/tests/renderer/components/ObservatoryInteractionPolish.test.js
@@ -12,7 +12,7 @@ const agent = {
   instanceIdSource: 'os',
 };
 const props = (host = {}) => ({
-  host,
+  host: { blocklistList: vi.fn(async () => []), ...host },
   telemetry: { ...emptyTelemetry(), ready: true, stale: false, agents: [agent] },
   request: { title: 'Codex', row: agent },
   close: vi.fn(),

--- a/tests/renderer/components/ObservatoryWatchlist.test.js
+++ b/tests/renderer/components/ObservatoryWatchlist.test.js
@@ -1,0 +1,117 @@
+import { expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import Watchlist from '../../../frontend/observatory/components/Watchlist.svelte';
+const row = (signature, pid = null) => ({ signature, pid, reason: '', addedAt: 1 });
+function bridge(initial = []) {
+  let entries = initial;
+  const host = {
+    getAgentDatabase: async () => ({
+      agents: [{ id: 'claude-code', displayName: 'Claude Code', names: ['claude.exe'] }],
+    }),
+    blocklistList: vi.fn(async () => structuredClone(entries)),
+    blocklistAdd: vi.fn(async () => {
+      const entry = row('claude-code');
+      entries = [...entries, entry];
+      return { success: true, entry };
+    }),
+    blocklistRemove: vi.fn(async (target) => {
+      const before = entries.length;
+      entries = entries.filter((r) => r.signature !== target.signature || r.pid !== target.pid);
+      return { success: true, removed: entries.length !== before };
+    }),
+  };
+  return host;
+}
+async function start(host = bridge()) {
+  const mounted = render(Watchlist, { host, agent: 'Claude Code' });
+  await screen.findByText('Watchlist is up to date.');
+  return mounted;
+}
+it('loads automatically and keeps one add/remove control with persistent result feedback', async () => {
+  const host = bridge();
+  await start(host);
+  const button = screen.getByRole('button', { name: 'Watch agent', exact: true });
+  button.focus();
+  await fireEvent.click(button);
+  await screen.findByText('Claude Code added to the watchlist.');
+  expect(screen.getByRole('button', { name: 'Remove agent' })).toBe(button);
+  expect(button).toHaveFocus();
+  await fireEvent.click(button);
+  await screen.findByText('Claude Code · all processes removed from the watchlist.');
+  expect(screen.getByRole('button', { name: 'Watch agent', exact: true })).toBe(button);
+  expect(button).toHaveFocus();
+  expect(host.blocklistRemove).toHaveBeenCalledWith({ signature: 'claude-code', pid: null });
+});
+it('combines repeated entries but preserves exact PID scopes and canonical aliases', async () => {
+  const host = bridge([
+    row('claude-code'),
+    row('claude-code'),
+    row('claude-code', 42),
+    row('claude-code', 43),
+    row('codex'),
+    row('codex'),
+  ]);
+  const mounted = await start(host);
+  expect(screen.queryByRole('button', { name: 'Watch agent', exact: true })).toBeNull();
+  await fireEvent.click(screen.getByText('Other watchlist entries (3)'));
+  const codex = screen.getByRole('button', { name: 'Remove codex · all processes' });
+  codex.focus();
+  await fireEvent.click(codex);
+  await screen.findByText('codex · all processes removed from the watchlist.');
+  expect(mounted.container.querySelectorAll('li')).toHaveLength(2);
+  expect(screen.getByRole('button', { name: 'Remove agent' })).toHaveFocus();
+  expect(screen.getByRole('button', { name: 'Remove Claude Code · PID 42' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Remove Claude Code · PID 43' })).toBeInTheDocument();
+});
+it('shows pending work and prevents overlapping commands or reloads', async () => {
+  const host = bridge();
+  let release;
+  host.blocklistAdd.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+  );
+  await start(host);
+  const button = screen.getByRole('button', { name: 'Watch agent', exact: true });
+  await fireEvent.click(button);
+  await fireEvent.click(button);
+  await fireEvent.click(screen.getByRole('button', { name: 'Reload watchlist' }));
+  expect(host.blocklistAdd).toHaveBeenCalledOnce();
+  expect(host.blocklistList).toHaveBeenCalledOnce();
+  expect(screen.getByRole('status')).toHaveTextContent('Adding Claude Code…');
+  expect(button).toHaveAttribute('aria-disabled', 'true');
+  release({ success: false, error: 'Disk unavailable' });
+  await screen.findByText('Change not saved. Disk unavailable');
+  expect(button).toHaveAttribute('aria-disabled', 'false');
+});
+it('distinguishes a saved change from failed readback and requires reloading before another mutation', async () => {
+  const host = bridge();
+  await start(host);
+  host.blocklistList.mockRejectedValueOnce(new Error('Read unavailable'));
+  await fireEvent.click(screen.getByRole('button', { name: 'Watch agent', exact: true }));
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    'Change saved, but the list could not be refreshed',
+  );
+  const button = screen.getByRole('button', { name: 'Watch agent', exact: true });
+  await fireEvent.click(button);
+  expect(host.blocklistAdd).toHaveBeenCalledOnce();
+  await fireEvent.click(screen.getByRole('button', { name: 'Reload watchlist' }));
+  await screen.findByRole('button', { name: 'Remove agent' });
+  expect(screen.queryByRole('alert')).toBeNull();
+});
+it('shows a load failure instead of an empty list and allows a nonmutating retry', async () => {
+  const host = bridge();
+  host.blocklistList.mockResolvedValueOnce({ error: 'Unavailable' });
+  render(Watchlist, { host, agent: 'Claude Code' });
+  await screen.findByRole('alert');
+  await fireEvent.click(screen.getByRole('button', { name: 'Watch agent', exact: true }));
+  expect(host.blocklistAdd).not.toHaveBeenCalled();
+  await fireEvent.click(screen.getByRole('button', { name: 'Reload watchlist' }));
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Watch agent', exact: true })).toHaveAttribute(
+      'aria-disabled',
+      'false',
+    ),
+  );
+});


### PR DESCRIPTION
Removing a watchlist entry also removed its success message, while adding an existing agent remained available. The list now loads automatically and keeps the selected agent, membership status and one add/remove button together, with persistent loading, saving, success and error feedback.

Other entries are grouped in a bounded disclosure. Repeated signature/PID entries share one action; distinct PID scopes remain separate. Canonical agent names prevent duplicate controls, overlapping commands are guarded, and deleting a focused row returns keyboard focus to the stable agent action. A confirmed write followed by failed readback is reported explicitly and requires a reload. Watchlist semantics remain alert-only.

Validation: 3373 tests passed (4 skipped), including five new watchlist scenarios; both builds; full browser suite with 16 new watchlist layouts across four themes and 100/150% scale; Electron smoke and restart; typecheck, Svelte check, format, lint (0 errors; 56 existing warnings), both mutation gates, counts and production dependency audit (0 vulnerabilities).
