### PR TITLE
fix(ui): smooth circular radar agent markers

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -193,3 +193,11 @@ language follows the selection. English source messages are the fallback for
 unknown copy; recorded names, paths, evidence text and provider responses retain
 their source language. The Portuguese vocabulary from PR #425 is reused alongside
 the Observatory message catalog in `translations/pt-BR.json`.
+
+### Circular agent markers (2026-09-11 follow-up)
+
+The user requested circular agent icons with smooth edges. Radar markers now use
+a 44px circular surface, a thin risk-colored border and a circular ordinal at its
+lower edge. The inner artwork has a circular clip and uses normal image
+interpolation. Native CSS curves provide antialiasing without blurring the logos.
+Selection keeps a clear contrasting border. No marker shadows or pulses return.

--- a/frontend/observatory/styles/radar-clarity.css
+++ b/frontend/observatory/styles/radar-clarity.css
@@ -99,29 +99,29 @@
   min-height: 44px;
   padding: 0;
   transform: translate(-50%, -50%);
-  border: 1px solid transparent;
-  border-radius: 4px;
-  background: var(--bg);
+  border: 1.5px solid var(--marker-color, var(--strong-border));
+  border-radius: 50%;
+  background: var(--panel);
   box-shadow: none;
 }
 .radar-clarity .radar-blip::before {
-  content: '';
-  position: absolute;
-  bottom: 1px;
-  left: 6px;
-  right: 6px;
-  height: 2px;
-  background: var(--marker-color);
+  content: none;
 }
 .radar-clarity .radar-blip[aria-pressed='true'] {
   border-color: var(--ink);
   box-shadow: none;
-  background: var(--bg);
+  background: var(--selection);
 }
 .radar-clarity .blip-dot {
   --marker-size: 24px;
   width: 24px;
   height: 24px;
+  border-radius: 50%;
+  overflow: hidden;
+  clip-path: circle(50%);
+}
+.radar-clarity .blip-dot img {
+  image-rendering: auto;
 }
 .radar-clarity .blip-dot::after {
   display: none;
@@ -133,13 +133,13 @@
   transform: translateX(-50%);
   display: grid;
   place-items: center;
-  min-width: 14px;
-  height: 12px;
-  padding-inline: 3px;
-  background: var(--bg);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--panel);
   color: var(--ink);
   font-size: 10px;
-  line-height: 12px;
+  line-height: 16px;
   font-variant-numeric: tabular-nums;
 }
 .radar-roster {


### PR DESCRIPTION
Radar agent markers now use circular surfaces, thin risk-colored outlines and round number badges. Circular artwork clipping and native image interpolation keep edges smooth at enlarged UI scales; selection retains a contrasting border.

Validated with all required local checks (3,378 tests passed, 4 skipped), the full browser layout suite, 150% scale at 2x pixel density, and a packaged Electron smoke test.
