### PR TITLE
feat(ui): expose monitoring modes and add action icons

### DIFF
--- a/frontend/observatory/App.svelte
+++ b/frontend/observatory/App.svelte
@@ -418,14 +418,6 @@
             >{/if}
         </div>
         {#if isLiveWorkspace}<div class="page-actions">
-            {#if view === 'overview'}<button
-                class="button"
-                aria-pressed={detailedMonitoring}
-                onclick={() => (detailedMonitoring = !detailedMonitoring)}
-                >{detailedMonitoring
-                  ? $t('Protection overview')
-                  : $t('Detailed monitoring')}</button
-              >{/if}
             <button
               class="button"
               title={$t('Pause the displayed observations; backend monitoring continues')}
@@ -439,6 +431,22 @@
             >
           </div>{/if}
       </div>
+      {#if view === 'overview'}
+        <div class="monitoring-view-switch" role="group" aria-label={$t('Monitoring')}>
+          <button
+            class="button"
+            aria-pressed={detailedMonitoring}
+            onclick={() => (detailedMonitoring = true)}
+            ><Icon name="radar" /><span>{$t('Detailed monitoring')}</span></button
+          >
+          <button
+            class="button"
+            aria-pressed={!detailedMonitoring}
+            onclick={() => (detailedMonitoring = false)}
+            ><Icon name="shield" /><span>{$t('Protection overview')}</span></button
+          >
+        </div>
+      {/if}
       {#if isLiveWorkspace && view !== 'overview'}<AgentContext
           telemetry={displayTelemetry}
           {scope}

--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -201,3 +201,16 @@ a 44px circular surface, a thin risk-colored border and a circular ordinal at it
 lower edge. The inner artwork has a circular clip and uses normal image
 interpolation. Native CSS curves provide antialiasing without blurring the logos.
 Selection keeps a clear contrasting border. No marker shadows or pulses return.
+
+### Discoverable monitoring modes and action icons (2026-09-11)
+
+Both monitoring destinations remain visible in a bordered mode switch directly
+below the page heading. Radar and shield icons identify detailed monitoring and
+the protection overview; a filled selection and pressed state show the current
+view. Selecting the current view keeps it open. The group wraps at narrow widths.
+
+Primary navigation and operation buttons reuse the existing monochrome SVG set:
+open, filter, refresh, save, import/export and watchlist actions. Labels remain
+visible and icons stay hidden from assistive technology. Dense record rows,
+numeric presets, metric selectors and ordinary cancel/close actions retain their
+existing presentation to keep the interface quiet.

--- a/frontend/observatory/components/AgentContext.svelte
+++ b/frontend/observatory/components/AgentContext.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import { t } from '../runtime/i18n';
 
   import type { Telemetry } from '../runtime/host';
@@ -70,7 +71,7 @@
     >
   </div>
   {#if scope.agent}<button class="button" onclick={() => change({ agent: '', instanceId: '' })}
-      >{$t('All agents')}</button
+      ><Icon name="agents" />{$t('All agents')}</button
     >{/if}
 </section>
 

--- a/frontend/observatory/components/AgentWorkspace.svelte
+++ b/frontend/observatory/components/AgentWorkspace.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import { t } from '../runtime/i18n';
 
   import SectionTabs from './SectionTabs.svelte';
@@ -103,7 +104,9 @@
               : $t('Observed now')}
       </p>
     </div>
-    <button class="button" onclick={() => navigate('stats')}>{$t('Detailed statistics')}</button>
+    <button class="button" onclick={() => navigate('stats')}
+      ><Icon name="chart" />{$t('Detailed statistics')}</button
+    >
   </section>
   <SectionTabs
     {tabs}

--- a/frontend/observatory/components/Agents.svelte
+++ b/frontend/observatory/components/Agents.svelte
@@ -72,7 +72,7 @@
       ></select
     ></label
   ><button class="button" onclick={() => (descending = !descending)}
-    >{descending ? $t('Descending') : $t('Ascending')}</button
+    ><Icon name="sort" />{descending ? $t('Descending') : $t('Ascending')}</button
   ><span class="spacer"></span><span class="filter-count"
     >{agents.length}
     {$t('agents ·')}

--- a/frontend/observatory/components/Analysis.svelte
+++ b/frontend/observatory/components/Analysis.svelte
@@ -232,7 +232,7 @@
       {/snippet}
       {#snippet actions()}
         {#if !preview}<Action disabled={keyPending} action={() => saveKey(true)}
-            >{$t('Remove saved key')}</Action
+            ><Icon name="trash" />{$t('Remove saved key')}</Action
           >{/if}
         <button
           class="button"
@@ -243,7 +243,7 @@
           }}>{$t('Close settings')}</button
         >
         <Action disabled={preview || keyPending || !key.trim()} action={() => saveKey()}
-          >{$t('Save key')}</Action
+          ><Icon name="key" />{$t('Save key')}</Action
         >
       {/snippet}
     </EditorDialog>

--- a/frontend/observatory/components/Catalog.svelte
+++ b/frontend/observatory/components/Catalog.svelte
@@ -137,9 +137,10 @@
       editorSection = 'general';
       showForm = true;
     }}><Icon name="plus" />{$t('Add agent')}</button
-  ><Action disabled={mutating || !loaded} action={() => mutate(importAgents)}>{$t('Import')}</Action
+  ><Action disabled={mutating || !loaded} action={() => mutate(importAgents)}
+    ><Icon name="upload" />{$t('Import')}</Action
   ><Action action={async () => confirmed(await invoke(host, 'exportAgentDatabase'))}
-    >{$t('Export')}</Action
+    ><Icon name="download" />{$t('Export')}</Action
   >
 </div>
 

--- a/frontend/observatory/components/DetailSummary.svelte
+++ b/frontend/observatory/components/DetailSummary.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import { t } from '../runtime/i18n';
 
   import { instances, measured, type RecordData, type Telemetry } from '../runtime/host';
@@ -161,7 +162,7 @@
           : $t('This is one worker process. Its activity is linked by its recorded identity.')}
       </p>
       {#if changeSection}<button class="button" onclick={() => changeSection?.('risk')}
-          >{$t('Why this score')}</button
+          ><Icon name="shield" />{$t('Why this score')}</button
         >{/if}
     </section>{/if}
   {#if kind === 'resource'}<section class="detail-section resource-summary">

--- a/frontend/observatory/components/Events.svelte
+++ b/frontend/observatory/components/Events.svelte
@@ -116,7 +116,7 @@
       aria-expanded={filtersOpen}
       aria-controls={network ? 'network-filters' : 'event-filters'}
       onclick={() => (filtersOpen = !filtersOpen)}
-      >{$t('Filters')}
+      ><Icon name="settings" />{$t('Filters')}
       {#if effectiveKind !== 'all' || localAgentFilter || attributionFilter !== 'all' || severity !== 'all'}<span
           class="badge">{$t('Active')}</span
         >{/if}</button
@@ -131,7 +131,9 @@
           ? $t('Resume live view')
           : $t('Pause view')}</button
       >{/if}
-    <button class="button" aria-label={$t('Reset filters')} onclick={reset}>{$t('Reset')}</button>
+    <button class="button" aria-label={$t('Reset filters')} onclick={reset}
+      ><Icon name="refresh" />{$t('Reset')}</button
+    >
   </div>
 </div>
 <div

--- a/frontend/observatory/components/ObservationTable.svelte
+++ b/frontend/observatory/components/ObservationTable.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import { t } from '../runtime/i18n';
 
   import {
@@ -59,11 +60,12 @@
       <button
         class="button"
         aria-disabled={currentPage === 0}
-        onclick={() => changePage(currentPage - 1)}>{$t('Previous')}</button
+        onclick={() => changePage(currentPage - 1)}
+        ><Icon name="arrowLeft" />{$t('Previous')}</button
       ><button
         class="button"
         aria-disabled={(currentPage + 1) * 30 >= groups.length}
-        onclick={() => changePage(currentPage + 1)}>{$t('Next')}</button
+        onclick={() => changePage(currentPage + 1)}><Icon name="chevron" />{$t('Next')}</button
       >
     </div>
   </nav>

--- a/frontend/observatory/components/ProtectionDetails.svelte
+++ b/frontend/observatory/components/ProtectionDetails.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import { t } from '../runtime/i18n';
 
   import { instances, type RecordData, type Telemetry } from '../runtime/host';
@@ -59,7 +60,7 @@
       )}
     </p>
     {#if policy.agent}<button class="button" onclick={() => openPolicy(policy.agent!.instanceKey)}
-        >{$t('Edit this agent’s policy')}</button
+        ><Icon name="edit" />{$t('Edit this agent’s policy')}</button
       >{/if}
   </div>
   <h4>{$t('What you can do')}</h4>
@@ -75,14 +76,14 @@
         inspect(
           'Activity evidence',
           activity.rows.length > 1 ? { observations: activity.rows } : activity.latest,
-        )}>{$t('Open evidence')}</button
+        )}><Icon name="file" />{$t('Open evidence')}</button
     >
     <button
       class="button"
       disabled={!policy.agent || telemetry.stale}
       onclick={() =>
         policy.agent && inspect(policy.agent.name, { ...policy.agent, detailSection: 'processes' })}
-      >{$t('Agent & controls')}</button
+      ><Icon name="cpu" />{$t('Agent & controls')}</button
     >
   </div>
   {#if !policy.agent || telemetry.stale}<p class="muted">

--- a/frontend/observatory/components/ProtectionOverview.svelte
+++ b/frontend/observatory/components/ProtectionOverview.svelte
@@ -128,7 +128,9 @@
         </div>
         {#if policyError}<p class="policy-error">
             {$t('Saved preferences could not be loaded.')}
-            <button class="button" onclick={loadPermissions}>{$t('Retry preferences')}</button>
+            <button class="button" onclick={loadPermissions}
+              ><Icon name="refresh" />{$t('Retry preferences')}</button
+            >
           </p>{/if}
         <ProtectionDetails
           activity={current}

--- a/frontend/observatory/components/Radar.svelte
+++ b/frontend/observatory/components/Radar.svelte
@@ -107,7 +107,7 @@
           >
         </div>
         {#if chosenGroup}<button class="button" onclick={clearSelection}
-            >{$t('Clear agent focus')}</button
+            ><Icon name="close" />{$t('Clear agent focus')}</button
           >{/if}
       </div>
       <div id="radar-body">
@@ -185,11 +185,11 @@
                 <p>{$t(leadingRiskReason(chosenGroup.members[0]))}</p>
                 <div>
                   <button class="button" onclick={() => chooseLayer('files')}
-                    >{$t('View files')}</button
+                    ><Icon name="folder" />{$t('View files')}</button
                   ><button class="button" onclick={() => chooseLayer('network')}
-                    >{$t('View connections')}</button
+                    ><Icon name="network" />{$t('View connections')}</button
                   ><button class="button" onclick={() => openAgent?.(chosenGroup.key)}
-                    >{$t('Open agent')}</button
+                    ><Icon name="agents" />{$t('Open agent')}</button
                   >
                 </div>
               </div>{/if}

--- a/frontend/observatory/components/RadarLinks.svelte
+++ b/frontend/observatory/components/RadarLinks.svelte
@@ -134,9 +134,9 @@
         </details>
         <div class="relation-actions">
           <button class="button" onclick={() => evidence(relation.rows)}
-            >{$t('View records')}</button
+            ><Icon name="file" />{$t('View records')}</button
           ><button class="button" disabled={!live} onclick={() => process(relation)}
-            >{$t('Inspect process')}</button
+            ><Icon name="cpu" />{$t('Inspect process')}</button
           >
         </div>
       </article>
@@ -149,14 +149,14 @@
         aria-disabled={index === 0}
         onclick={() => {
           if (index > 0) page = index - 1;
-        }}>{$t('Previous')}</button
+        }}><Icon name="arrowLeft" />{$t('Previous')}</button
       ><span>{index + 1} / {pages}</span><button
         class="button"
         aria-label={$t('Next relationships')}
         aria-disabled={index === pages - 1}
         onclick={() => {
           if (index < pages - 1) page = index + 1;
-        }}>{$t('Next')}</button
+        }}><Icon name="chevron" />{$t('Next')}</button
       >
     </nav>{/if}
   <footer>
@@ -166,7 +166,7 @@
         ? $t(' · latest {value0}', { value0: new Date(resource.time).toLocaleString() })
         : ''}</span
     ><button class="button" onclick={() => evidence(resource.rows)}
-      >{$t('All resource records')}</button
+      ><Icon name="database" />{$t('All resource records')}</button
     >
   </footer>
 </section>

--- a/frontend/observatory/components/RadarResourceExplorer.svelte
+++ b/frontend/observatory/components/RadarResourceExplorer.svelte
@@ -167,7 +167,7 @@
           agent = '';
           query = '';
           category = 'all';
-        }}>{$t('Clear filters')}</button
+        }}><Icon name="refresh" />{$t('Clear filters')}</button
       >{/if}
   </div>
   <div class="explorer-body">
@@ -183,7 +183,8 @@
         <h3 bind:this={heading} tabindex="-1">
           {current ? $t('Resource details') : $t('Follow an agent’s activity')}
         </h3>
-        {#if current}<button class="button" onclick={clear}>{$t('Clear resource selection')}</button
+        {#if current}<button class="button" onclick={clear}
+            ><Icon name="close" />{$t('Clear resource selection')}</button
           >{/if}
       </div>
       {#if current && retained && !filtered.some((resource) => resource.key === current.key)}<p

--- a/frontend/observatory/components/Reports.svelte
+++ b/frontend/observatory/components/Reports.svelte
@@ -197,7 +197,8 @@
         class="button"
         disabled={loading}
         aria-busy={loading}
-        onclick={() => void refresh(true).catch(() => {})}>{$t('Refresh')}</button
+        onclick={() => void refresh(true).catch(() => {})}
+        ><Icon name="refresh" />{$t('Refresh')}</button
       ><span class="spacer"></span><Action
         action={async () => confirmed(await invoke(host, 'openAuditLogDir'))}
         ><Icon name="folder" />{$t('Audit folder')}</Action
@@ -224,7 +225,8 @@
         class="button"
         disabled={exhausted || loading}
         aria-busy={loading}
-        onclick={() => void refresh().catch(() => {})}>{$t('Load older entries')}</button
+        onclick={() => void refresh().catch(() => {})}
+        ><Icon name="history" />{$t('Load older entries')}</button
       >
     </div>
   </div>

--- a/frontend/observatory/components/Rules.svelte
+++ b/frontend/observatory/components/Rules.svelte
@@ -223,7 +223,9 @@
           >{$t('Project / parent override')}</option
         ></select
       ></label
-    ><Action disabled={mutation !== null} action={load}>{$t('Refresh')}</Action>
+    ><Action disabled={mutation !== null} action={load}
+      ><Icon name="refresh" />{$t('Refresh')}</Action
+    >
   </div>
   <section class="panel">
     <div class="preset-grid">
@@ -273,7 +275,7 @@
         >{dirty ? $t('Unsaved permissions') : $t('Permissions saved')}</span
       >
       <Action disabled={!loaded || !target || !dirty || mutation !== null} action={save}
-        >{$t('Save permissions')}</Action
+        ><Icon name="check" />{$t('Save permissions')}</Action
       ><Action
         disabled={!dirty || mutation !== null}
         action={async () => {
@@ -283,13 +285,15 @@
             categories.map((cat) => [cat, String(current[cat] ?? 'monitor')]),
           );
           draftBaseline = JSON.stringify(draft);
-        }}>{$t('Discard changes')}</Action
+        }}><Icon name="close" />{$t('Discard changes')}</Action
       >
     </div>
     <details class="permission-reset">
       <summary>{$t('Restore default policy')}</summary>
       <p>{$t('This restores permissions for every agent and project.')}</p>
-      <Action disabled={mutation !== null} action={reset}>{$t('Reset all to defaults')}</Action>
+      <Action disabled={mutation !== null} action={reset}
+        ><Icon name="refresh" />{$t('Reset all to defaults')}</Action
+      >
     </details>
   </section>
   <p class="policy-note">
@@ -305,7 +309,7 @@
       action={async () => {
         confirmed(await invoke(host, 'reloadRules'));
         await load();
-      }}>{$t('Reload rules')}</Action
+      }}><Icon name="refresh" />{$t('Reload rules')}</Action
     >
   </div>
   <div class="filterbar rules-filter">

--- a/frontend/observatory/components/Settings.svelte
+++ b/frontend/observatory/components/Settings.svelte
@@ -263,7 +263,7 @@
       action={async () => {
         await load();
         if (alive) error = '';
-      }}>{$t('Retry loading')}</Action
+      }}><Icon name="refresh" />{$t('Retry loading')}</Action
     >
   </div>{/if}
 {#if refreshWarning}<p role="status" class="notice">{refreshWarning}</p>{/if}
@@ -361,9 +361,9 @@
             action={() => update('checkForUpdates')}
             ><Icon name="refresh" />{$t('Check for updates')}</Action
           >{#if updates.status === 'available'}<Action action={() => update('downloadUpdate')}
-              >{$t('Download update')}</Action
+              ><Icon name="download" />{$t('Download update')}</Action
             >{/if}{#if updates.status === 'ready'}<Action action={() => update('installUpdate')}
-              >{$t('Install and restart')}</Action
+              ><Icon name="refresh" />{$t('Install and restart')}</Action
             >{/if}
         </div>
       </SettingsGroup>

--- a/frontend/observatory/components/StatsChart.svelte
+++ b/frontend/observatory/components/StatsChart.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import { t } from '../runtime/i18n';
 
   import type { StatisticsSample } from '../runtime/statistics-history';
@@ -166,7 +167,7 @@
         onclick={() => {
           pinnedAt = null;
           hoverAt = null;
-        }}>{$t('Latest')}</button
+        }}><Icon name="activity" />{$t('Latest')}</button
       >
     </div>
     <div class="monitor-summary">

--- a/frontend/observatory/components/StatsTokens.svelte
+++ b/frontend/observatory/components/StatsTokens.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import { t } from '../runtime/i18n';
 
   import { instances, measured, type Telemetry, type RecordData } from '../runtime/host';
@@ -35,7 +36,7 @@
       <p>{$t('Current processes · exact identity coverage · estimates are labeled')}</p>
     </div>
     <button class="button" aria-expanded={showSources} onclick={() => (showSources = !showSources)}
-      >{$t('Source samples ·')} {telemetry.tokens.length}</button
+      ><Icon name="database" />{$t('Source samples ·')} {telemetry.tokens.length}</button
     >
   </header>
   <div class="table-wrap">

--- a/frontend/observatory/components/Watchlist.svelte
+++ b/frontend/observatory/components/Watchlist.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
   import { t } from '../runtime/i18n';
 
   import { onMount, tick } from 'svelte';
@@ -133,7 +134,9 @@
 <section class="detail-section watchlist" aria-label={$t('Alert watchlist')}>
   <div class="watch-heading">
     <h3>{$t('Alert watchlist')}</h3>
-    <button class="button" aria-disabled={busy} onclick={load}>{$t('Reload watchlist')}</button>
+    <button class="button" aria-disabled={busy} onclick={load}
+      ><Icon name="refresh" />{$t('Reload watchlist')}</button
+    >
   </div>
   <p class="entity-note">
     {$t('One entry per agent and scope. Entries raise alerts; they do not block execution.')}
@@ -153,7 +156,9 @@
       class="button"
       aria-disabled={busy || !loaded || !agent.trim()}
       onclick={(event) => change(current, event.currentTarget)}
-      >{current ? $t('Remove agent') : $t('Watch agent')}</button
+      ><Icon name={current ? 'trash' : 'eye'} />{current
+        ? $t('Remove agent')
+        : $t('Watch agent')}</button
     >
   </div>
   <div class="watch-feedback">
@@ -169,7 +174,8 @@
               class="button"
               aria-label={$t('Remove {value0}', { value0: label(entry) })}
               aria-disabled={busy}
-              onclick={(event) => change(entry, event.currentTarget)}>{$t('Remove')}</button
+              onclick={(event) => change(entry, event.currentTarget)}
+              ><Icon name="trash" />{$t('Remove')}</button
             >
           </li>{/each}
       </ul>

--- a/frontend/observatory/styles/comfort.css
+++ b/frontend/observatory/styles/comfort.css
@@ -45,6 +45,30 @@
   color: var(--muted);
   font-size: calc(12px * var(--ui-scale));
 }
+.monitoring-view-switch {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  width: fit-content;
+  max-width: 100%;
+  margin-bottom: var(--space-4);
+  padding: var(--space-1);
+  border: 1px solid var(--strong-border);
+  border-radius: var(--surface-radius);
+  background: var(--panel);
+}
+.observatory-app .monitoring-view-switch .button {
+  flex: 1 1 auto;
+  white-space: normal;
+  border-color: transparent;
+  background: transparent;
+  font-weight: 600;
+}
+.observatory-app .monitoring-view-switch .button[aria-pressed='true'] {
+  border-color: var(--strong-border);
+  background: var(--selection);
+  color: var(--ink);
+}
 .page-head .live-badge {
   flex-shrink: 0;
 }

--- a/tests/renderer/components/ObservatoryProtection.test.js
+++ b/tests/renderer/components/ObservatoryProtection.test.js
@@ -41,7 +41,15 @@ it('starts with the radar and keeps the protection overview reachable', async ()
   const mounted = render(App, { host: null });
   expect(await screen.findByRole('heading', { name: 'Agent radar' })).toBeVisible();
   expect(mounted.container.querySelector('.radar-panel')).toBeVisible();
+  const radar = screen.getByRole('button', { name: 'Detailed monitoring' });
+  const protection = screen.getByRole('button', { name: 'Protection overview' });
+  expect(radar).toHaveAttribute('aria-pressed', 'true');
+  expect(protection).toHaveAttribute('aria-pressed', 'false');
+  await fireEvent.click(radar);
+  expect(mounted.container.querySelector('.radar-panel')).toBeVisible();
   await fireEvent.click(screen.getByRole('button', { name: 'Protection overview' }));
+  expect(radar).toHaveAttribute('aria-pressed', 'false');
+  expect(protection).toHaveAttribute('aria-pressed', 'true');
   expect(screen.getByRole('region', { name: 'Protection overview' })).toBeVisible();
   expect(mounted.container.querySelector('.radar-panel')).not.toBeVisible();
   await fireEvent.click(screen.getByRole('button', { name: 'Detailed monitoring' }));


### PR DESCRIPTION
Monitoring previously offered only a text button for the other view, making detailed monitoring difficult to discover. Both destinations now stay visible below the page heading, with radar/shield icons and a stable selected state. Selecting the active mode keeps it open.

Action buttons across monitoring, investigations and configuration reuse the monochrome SVG set for navigation, filtering, saving, refreshing and import/export. Text labels remain accessible; dense rows and numeric controls keep their existing presentation.

Validation: all required local checks passed (3,378 tests, 4 skipped); the full browser suite passed. Rendered and exercised both modes with keyboard input across 32 language/theme/size/scale states, including Portuguese at 900×600 and 150%. Packaged Electron smoke passed with no renderer errors.
