### PR TITLE
feat(ui): distinguish file and network resource icons

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -214,3 +214,18 @@ open, filter, refresh, save, import/export and watchlist actions. Labels remain
 visible and icons stay hidden from assistive technology. Dense record rows,
 numeric presets, metric selectors and ordinary cancel/close actions retain their
 existing presentation to keep the interface quiet.
+
+### Resource identity icons (2026-09-11)
+
+Resource rows now share a compact bordered SVG symbol and a written type label.
+Source, configuration, document, image and database files have distinct marks;
+unrecognized extensions retain the ordinary file mark. Folders require recorded
+directory metadata or a trailing path separator. Skill resources use a book.
+Domain names use a globe, IP-only destinations use a server and unspecified
+network destinations retain the connection symbol. These categories describe
+recorded names and metadata, never inspected contents, ownership or safety.
+
+The same ResourceIcon is used in radar lists, relationship diagrams, activity
+rows and resource details. ObservationResource carries it into Events, Network,
+agent evidence and retained history. Neutral surfaces and existing risk labels
+keep resource identity separate from assessment. All labels are localized.

--- a/frontend/observatory/components/AgentEvidence.svelte
+++ b/frontend/observatory/components/AgentEvidence.svelte
@@ -5,6 +5,7 @@
   import { observationTime } from '../../../src/shared/observation-display.js';
   import ObservationResource from './ObservationResource.svelte';
   import ObservationIdentity from './ObservationIdentity.svelte';
+  import Icon from './Icon.svelte';
   let {
     rows,
     agents,
@@ -28,7 +29,11 @@
   aria-label={network ? $t('Selected agent connections') : $t('Selected agent file activity')}
 >
   <div class="panel-head">
-    <h2>{network ? $t('Connections') : $t('File activity')} <small>{rows.length}</small></h2>
+    <h2>
+      <Icon name={network ? 'network' : 'folder'} />{network
+        ? $t('Connections')
+        : $t('File activity')} <small>{rows.length}</small>
+    </h2>
     <button class="text-button" onclick={more}>{$t('View all')}</button>
   </div>
   <div class="evidence-list">

--- a/frontend/observatory/components/DetailSummary.svelte
+++ b/frontend/observatory/components/DetailSummary.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import Icon from './Icon.svelte';
+  import ResourceIcon from './ResourceIcon.svelte';
+  import { resourceVisual } from '../runtime/resource-visual';
   import { t } from '../runtime/i18n';
 
   import { instances, measured, type RecordData, type Telemetry } from '../runtime/host';
@@ -167,8 +169,8 @@
     </section>{/if}
   {#if kind === 'resource'}<section class="detail-section resource-summary">
       <div class="section-heading">
-        <h3>{$t('Resource')}</h3>
-        <span class="badge">{info.kind}</span>
+        <h3 class="resource-heading"><ResourceIcon {row} compact />{$t('Resource')}</h3>
+        <span class="badge">{$t(resourceVisual(row).label)}</span>
       </div>
       <div class="resource-path">
         <span>{$t('Full path / address')}</span><code>{info.path}</code>
@@ -195,3 +197,11 @@
     <Metadata value={overview} />
   </section>
 {/if}
+
+<style>
+  .resource-heading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+</style>

--- a/frontend/observatory/components/ObservationResource.svelte
+++ b/frontend/observatory/components/ObservationResource.svelte
@@ -3,20 +3,22 @@
 
   import { describeObservation } from '../../../src/shared/observation-display.js';
   import type { RecordData } from '../runtime/host';
-  import Icon from './Icon.svelte';
+  import ResourceIcon from './ResourceIcon.svelte';
+  import { resourceVisual } from '../runtime/resource-visual';
   let { row }: { row: RecordData } = $props();
   let info = $derived(describeObservation(row));
+  let visual = $derived(resourceVisual(row));
 </script>
 
 <span class="observation-resource" title={info.path}>
   <span class="observation-resource-title"
-    ><Icon
-      name={info.kind === 'Skill' ? 'settings' : info.kind === 'Network' ? 'network' : 'file'}
-    /><strong>{info.resource}</strong>{#if info.kind === 'Skill'}<span class="evidence-tag"
-        >{$t('Skill')}</span
-      >{/if}</span
+    ><ResourceIcon {row} compact /><strong>{info.resource}</strong></span
   >
-  {#if info.path && info.path !== info.resource}<small>{info.path}</small>{/if}
+  <small
+    ><span class="resource-kind">{$t(visual.label)}</span
+    >{#if info.path && info.path !== info.resource}
+      · <span>{info.path}</span>{/if}</small
+  >
 </span>
 
 <style>
@@ -41,11 +43,7 @@
     font: calc(10px * var(--ui-scale))/1.45 var(--sans);
     overflow-wrap: anywhere;
   }
-  .evidence-tag {
-    padding: 1px 5px;
-    border: 1px solid var(--border);
-    border-radius: 5px;
-    color: var(--muted);
-    font: calc(10px * var(--ui-scale))/1.4 var(--sans);
+  .resource-kind {
+    font-weight: 500;
   }
 </style>

--- a/frontend/observatory/components/ProtectionActivityList.svelte
+++ b/frontend/observatory/components/ProtectionActivityList.svelte
@@ -4,6 +4,7 @@
   import type { ProtectionActivity } from '../runtime/protection';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
+  import ResourceIcon from './ResourceIcon.svelte';
   let {
     activity,
     ready,
@@ -86,9 +87,9 @@
           ></span
         >
         <span class="what"
-          ><span>{$t(item.action)}</span><strong>{item.resource}</strong><small class="path"
-            >{item.target}</small
-          ></span
+          ><span>{$t(item.action)}</span><strong class="resource-name"
+            ><ResourceIcon row={item.latest} compact />{item.resource}</strong
+          ><small class="path">{item.target}</small></span
         >
         <span class="verdict"
           ><span class="activity-verdict">{$t(labels[item.level])}</span><small
@@ -210,6 +211,11 @@
   .who > span,
   .what {
     min-width: 0;
+  }
+  .what > .resource-name {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
   }
   .who strong,
   .who small,

--- a/frontend/observatory/components/RadarLinks.svelte
+++ b/frontend/observatory/components/RadarLinks.svelte
@@ -9,6 +9,8 @@
   } from '../runtime/radar-resources';
   import AgentLogo from './AgentLogo.svelte';
   import Icon from './Icon.svelte';
+  import ResourceIcon from './ResourceIcon.svelte';
+  import { resourceVisual } from '../runtime/resource-visual';
   let {
     resource,
     layer,
@@ -53,9 +55,11 @@
 <section class="resource-investigation" aria-label={$t('Resource relationships')}>
   <header>
     <span class="eyebrow"
-      >{layer === 'files' ? $t('Selected file') : $t('Selected destination')}</span
+      >{layer === 'files' ? $t('Selected file') : $t('Selected destination')} · {$t(
+        resourceVisual(resource.rows[0]).label,
+      )}</span
     >
-    <h3><Icon name={layer === 'files' ? 'file' : 'network'} />{resource.label}</h3>
+    <h3><ResourceIcon row={resource.rows[0]} />{resource.label}</h3>
     {#if layer === 'files'}<code>{resource.address}</code>{/if}
     {#if resource.ip}<p>{$t('Observed IP:')} <code>{resource.ip}</code></p>{/if}
     {#if !retained}<p class="notice">
@@ -98,7 +102,7 @@
             aria-hidden="true"><Icon name="chevron" /></span
           >
           <span class="destination-icon" aria-hidden="true"
-            ><Icon name={layer === 'files' ? 'file' : 'network'} /></span
+            ><ResourceIcon row={resource.rows[0]} compact /></span
           >
         </div>
         <div class="actions-observed">
@@ -246,7 +250,7 @@
   }
   .relationship-route {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 40px 30px;
+    grid-template-columns: minmax(0, 1fr) 40px max-content;
     gap: var(--space-2);
     align-items: center;
   }

--- a/frontend/observatory/components/RadarResourceList.svelte
+++ b/frontend/observatory/components/RadarResourceList.svelte
@@ -3,6 +3,8 @@
 
   import type { RadarResource } from '../runtime/radar-resources';
   import Icon from './Icon.svelte';
+  import ResourceIcon from './ResourceIcon.svelte';
+  import { resourceVisual } from '../runtime/resource-visual';
   let {
     resources,
     layer,
@@ -63,8 +65,9 @@
       onclick={(event) => select(resource, event.currentTarget)}
     >
       <span class="choice-heading"
-        ><Icon name={layer === 'files' ? 'file' : 'network'} /><strong>{resource.label}</strong
-        ><span class="resource-level" class:review={resource.level === 'review'}
+        ><ResourceIcon row={resource.rows[0]} /><strong>{resource.label}</strong><span
+          class="resource-level"
+          class:review={resource.level === 'review'}
           >{resource.sensitive ? $t('Sensitive') : labels[resource.level]}</span
         ></span
       >
@@ -76,7 +79,7 @@
         >{actors.slice(0, 2).join(', ')}{actors.length > 2 ? ` +${actors.length - 2}` : ''}</span
       >
       <span class="record-count"
-        >{resource.rows.length}
+        >{$t(resourceVisual(resource.rows[0]).label)} · {resource.rows.length}
         {$t('record(s) ·')}
         {resource.relations.length}
         {$t('relationships')}</span

--- a/frontend/observatory/components/ResourceIcon.svelte
+++ b/frontend/observatory/components/ResourceIcon.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { t } from '../runtime/i18n';
+  import type { RecordData } from '../runtime/host';
+  import { resourceVisual } from '../runtime/resource-visual';
+  import Icon from './Icon.svelte';
+  let { row, compact = false }: { row: RecordData; compact?: boolean } = $props();
+  const visual = $derived(resourceVisual(row));
+</script>
+
+<span class="resource-symbol" class:compact title={$t(visual.label)} aria-hidden="true">
+  <Icon name={visual.icon} />
+</span>
+
+<style>
+  .resource-symbol {
+    display: inline-grid;
+    place-items: center;
+    flex: 0 0 auto;
+    width: calc(30px * var(--ui-scale));
+    height: calc(30px * var(--ui-scale));
+    border: 1px solid var(--strong-border);
+    border-radius: var(--control-radius);
+    background: var(--bg);
+    color: var(--ink);
+  }
+  .resource-symbol :global(.icon) {
+    width: calc(20px * var(--ui-scale));
+    height: calc(20px * var(--ui-scale));
+  }
+  .compact {
+    width: calc(24px * var(--ui-scale));
+    height: calc(24px * var(--ui-scale));
+  }
+  .compact :global(.icon) {
+    width: calc(16px * var(--ui-scale));
+    height: calc(16px * var(--ui-scale));
+  }
+</style>

--- a/frontend/observatory/runtime/icons.ts
+++ b/frontend/observatory/runtime/icons.ts
@@ -81,6 +81,28 @@ export const icons: Record<string, { tag: string; attrs: Record<string, string> 
   chevron: [{ tag: 'path', attrs: { d: 'm9 5 7 7-7 7' } }],
   arrow: [{ tag: 'path', attrs: { d: 'M4 12h16m-6-6 6 6-6 6' } }],
   file: [{ tag: 'path', attrs: { d: 'M5 2h9l5 5v15H5Zm9 0v6h5' } }],
+  fileCode: [{ tag: 'path', attrs: { d: 'M5 2h9l5 5v15H5Zm9 0v6h5M10 12l-3 3 3 3m4-6 3 3-3 3' } }],
+  fileConfig: [
+    { tag: 'path', attrs: { d: 'M5 2h9l5 5v15H5Zm9 0v6h5M8 12h8M8 17h8M11 10v4m3 1v4' } },
+  ],
+  fileText: [{ tag: 'path', attrs: { d: 'M5 2h9l5 5v15H5Zm9 0v6h5M8 12h8m-8 4h8m-8 3h5' } }],
+  fileImage: [
+    { tag: 'path', attrs: { d: 'M5 2h9l5 5v15H5Zm9 0v6h5M7 19l4-5 3 3 2-2 3 4' } },
+    { tag: 'circle', attrs: { cx: '9', cy: '10', r: '1' } },
+  ],
+  book: [
+    {
+      tag: 'path',
+      attrs: {
+        d: 'M12 5C9 3 5 3 2 4v16c3-1 7-1 10 1 3-2 7-2 10-1V4c-3-1-7-1-10 1Zm0 0v16M5 8h4m-4 4h4m6-4h4m-4 4h4',
+      },
+    },
+  ],
+  server: [
+    { tag: 'rect', attrs: { x: '3', y: '3', width: '18', height: '7', rx: '2' } },
+    { tag: 'rect', attrs: { x: '3', y: '14', width: '18', height: '7', rx: '2' } },
+    { tag: 'path', attrs: { d: 'M7 6.5h.01M7 17.5h.01M11 6.5h6M11 17.5h6' } },
+  ],
   folder: [{ tag: 'path', attrs: { d: 'M3 7V5h7l2 3h9v12H3Z' } }],
   key: [
     { tag: 'circle', attrs: { cx: '8', cy: '8', r: '5' } },

--- a/frontend/observatory/runtime/resource-visual.ts
+++ b/frontend/observatory/runtime/resource-visual.ts
@@ -1,0 +1,68 @@
+import { describeObservation } from '../../../src/shared/observation-display.js';
+import type { RecordData } from './host';
+
+export interface ResourceVisual {
+  icon: string;
+  label: string;
+}
+
+/** Choose a visual category from recorded metadata, without reading contents or implying safety.
+ * @param row Recorded resource metadata @returns Icon and translatable category @since 0.14.1
+ */
+export function resourceVisual(row: RecordData = {}): ResourceVisual {
+  const info = describeObservation(row);
+  if (info.kind === 'Network') {
+    if (typeof row.domain === 'string' && row.domain.trim())
+      return { icon: 'globe', label: 'Domain name' };
+    if (row.remoteIp || row.ip) return { icon: 'server', label: 'IP address' };
+    return { icon: 'network', label: 'Network destination' };
+  }
+  if (info.kind === 'Skill') return { icon: 'book', label: 'Skill' };
+  const path = info.path;
+  if (!path) return { icon: 'activity', label: 'Activity' };
+  if (row.isDirectory === true || /[/\\]$/.test(path)) return { icon: 'folder', label: 'Folder' };
+  const name = path.split(/[/\\]/).pop()?.toLowerCase() ?? '';
+  const extension = name.includes('.') ? name.slice(name.lastIndexOf('.') + 1) : '';
+  if (
+    /^\.env(?:\.|$)/.test(name) ||
+    ['json', 'jsonc', 'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf'].includes(extension)
+  )
+    return { icon: 'fileConfig', label: 'Configuration file' };
+  if (
+    [
+      'js',
+      'jsx',
+      'ts',
+      'tsx',
+      'mjs',
+      'cjs',
+      'svelte',
+      'py',
+      'go',
+      'rs',
+      'java',
+      'c',
+      'cpp',
+      'h',
+      'cs',
+      'rb',
+      'php',
+      'sh',
+      'ps1',
+      'bat',
+      'cmd',
+      'html',
+      'css',
+      'scss',
+      'sql',
+    ].includes(extension)
+  )
+    return { icon: 'fileCode', label: 'Source file' };
+  if (['db', 'sqlite', 'sqlite3'].includes(extension))
+    return { icon: 'database', label: 'Database file' };
+  if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico', 'bmp', 'avif'].includes(extension))
+    return { icon: 'fileImage', label: 'Image file' };
+  if (['txt', 'md', 'mdx', 'pdf', 'rtf', 'doc', 'docx', 'odt', 'log'].includes(extension))
+    return { icon: 'fileText', label: 'Document' };
+  return { icon: 'file', label: 'File' };
+}

--- a/frontend/observatory/translations/pt-BR.json
+++ b/frontend/observatory/translations/pt-BR.json
@@ -966,5 +966,14 @@
   "Monitor preference": "Preferência de monitoramento",
   "No saved preference for this category": "Nenhuma preferência salva para esta categoria",
   "Review needed": "Revisão necessária",
-  "File": "Arquivo"
+  "File": "Arquivo",
+  "Folder": "Pasta",
+  "Domain name": "Nome de domínio",
+  "IP address": "Endereço IP",
+  "Network destination": "Destino de rede",
+  "Configuration file": "Arquivo de configuração",
+  "Source file": "Código-fonte",
+  "Database file": "Arquivo de banco de dados",
+  "Image file": "Arquivo de imagem",
+  "Document": "Documento"
 }

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -37,7 +37,7 @@ Core modules:
 - tray-icon.js — system tray with procedural icon
 
 ## Renderer (frontend/observatory/) — Svelte 5 + Vite 7
-56 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
+57 Svelte components, 16 stores, 22 utils. Component count refers to frontend/observatory/components; retained store/utility counts refer to src/renderer/lib.
 
 App.svelte owns workspace tabs, history and the host connection. Monitoring groups products and exposes stamped instances for process actions; Events and ActivityChart show retained evidence; Details and EntityLinks connect observations; Rules, Catalog, Analysis, Reports, Statistics and Settings expose host actions. SensorStatus renders effective sensor IDs; Notifications tracks anomaly crossings.
 

--- a/tests/renderer/resource-visual.test.ts
+++ b/tests/renderer/resource-visual.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from 'vitest';
+import { resourceVisual } from '../../frontend/observatory/runtime/resource-visual';
+
+it('uses the final filename across Windows and POSIX paths, including extensionless configuration', () => {
+  expect(resourceVisual({ file: 'C:\\project\\src\\Main.TS' })).toEqual(
+    resourceVisual({ path: '/project/src/main.ts' }),
+  );
+  expect(resourceVisual({ file: '', path: '/project/.env.local' }).label).toBe(
+    'Configuration file',
+  );
+  expect(resourceVisual({ file: '/directory.json/unknown' }).label).toBe('File');
+});
+
+it('keeps unknown resources generic and does not infer a directory from an extensionless name', () => {
+  expect(resourceVisual({}).label).toBe('Activity');
+  expect(resourceVisual({ file: '/workspace/README' }).label).toBe('File');
+  expect(resourceVisual({ file: '/workspace/' }).label).toBe('Folder');
+  expect(resourceVisual({ file: 'C:\\workspace', isDirectory: true }).label).toBe('Folder');
+});
+
+it('distinguishes domain, IPv6 address and missing endpoint metadata without asserting verification', () => {
+  expect(resourceVisual({ domain: 'api.example.test', remoteIp: '2001:db8::1' }).label).toBe(
+    'Domain name',
+  );
+  expect(resourceVisual({ domain: ' ', remoteIp: '2001:db8::1' }).label).toBe('IP address');
+  expect(resourceVisual({ type: 'network-connection' }).label).toBe('Network destination');
+  for (const verdict of ['flagged', 'allowlisted', 'unknown']) {
+    expect(resourceVisual({ remoteIp: '2001:db8::1', verdict })).toEqual(
+      resourceVisual({ remoteIp: '2001:db8::1' }),
+    );
+  }
+});
+
+it('keeps resource categories independent of sensitivity and ownership', () => {
+  const file = { file: '/project/config.json' };
+  expect(resourceVisual({ ...file, sensitive: true, agent: 'Codex' })).toEqual(
+    resourceVisual(file),
+  );
+  expect(resourceVisual({ file: '/home/me/.agents/skills/review/SKILL.md' }).label).toBe('Skill');
+});


### PR DESCRIPTION
File and network resources previously reused generic marks, making their type difficult to distinguish in lists and details. Shared resource symbols now distinguish source/configuration/document/image/database files, folders, skills, domain names and IP-only destinations. The same mark and localized type label follow the resource through radar lists, relationships, evidence and details.

Categories use recorded metadata and filename extensions; unknown resources keep a generic fallback. They do not imply ownership, verified endpoints or safe content. Compact SVG surfaces preserve the existing neutral palette.

Validation: renderer build, formatting, lint, TypeScript/Svelte, audit, counts and both mutation gates passed. Coverage passed with 3,382 tests and 4 skipped; the local rerun used a 10-second per-test timeout after an existing full-App startup test exceeded 5 seconds. Full browser suite, 48 final resource states, 16 final Events/Network layouts and packaged Electron smoke passed. Glyphs and light/dark resource screens were visually reviewed.
