### PR TITLE
feat(ui): clarify process controls and resource details

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -229,3 +229,12 @@ The same ResourceIcon is used in radar lists, relationship diagrams, activity
 rows and resource details. ObservationResource carries it into Events, Network,
 agent evidence and retained history. Neutral surfaces and existing risk labels
 keep resource identity separate from assessment. All labels are localized.
+
+### Process and attribute details (2026-09-11)
+
+Worker rows and process cards pair PID with the processor symbol and recorded
+project paths with a folder. Suspend, resume and stop controls use their familiar
+pause, play and stop marks while retaining labels, capability limits and the stop
+confirmation. Selected activity repeats the resource symbol and type shown in
+the list. Known metadata labels for process IDs, paths, domains, IPs, ports and
+observation times use the same icon vocabulary; other attributes stay plain.

--- a/frontend/observatory/components/AgentProcesses.svelte
+++ b/frontend/observatory/components/AgentProcesses.svelte
@@ -4,6 +4,7 @@
   import { instances, measured, type Telemetry } from '../runtime/host';
   import { isScopedProcess, type AgentScope } from '../runtime/agent-scope';
   import { displayMeasure } from '../runtime/radar';
+  import Icon from './Icon.svelte';
   let {
     telemetry,
     scope,
@@ -18,7 +19,7 @@
 
 <section class="panel agent-processes" aria-label={$t('Agent worker processes')}>
   <div class="panel-head">
-    <h2>{$t('Worker processes')} <small>{members.length}</small></h2>
+    <h2><Icon name="cpu" />{$t('Worker processes')} <small>{members.length}</small></h2>
     {#if scope.instanceId}<button
         class="text-button"
         onclick={() => change({ agent: scope.agent, instanceId: '' })}>{$t('All processes')}</button
@@ -46,13 +47,17 @@
                   ? $t('Select this process throughout live views')
                   : $t('Process start time was not observed')}
                 onclick={() => change({ agent: scope.agent, instanceId: member.instanceId! })}
-                >{$t('PID')} {member.pid}</button
+                ><Icon name="cpu" />{$t('PID')} {member.pid}</button
               ><small>{member.process}</small>{#if !isScopedProcess(member)}<small
                   >{$t('Start time not observed · selection unavailable')}</small
                 >{/if}</td
             >
             <td class="location" title={String(member.cwd ?? '')}
-              >{member.projectName || member.cwd || $t('Working directory not recorded')}</td
+              ><span class="process-location"
+                >{#if member.projectName || member.cwd}<Icon name="folder" />{/if}<span
+                  >{member.projectName || member.cwd || $t('Working directory not recorded')}</span
+                ></span
+              ></td
             >
             <td>{displayMeasure(telemetry.stale ? null : measured(reading?.cpu), '%')}</td>
             <td>{displayMeasure(telemetry.stale ? null : measured(reading?.memMb), ' MB')}</td>
@@ -97,6 +102,11 @@
   }
   .chosen {
     background: var(--accent-bg);
+  }
+  .process-location {
+    display: flex;
+    align-items: start;
+    gap: var(--space-2);
   }
   .more {
     margin: 12px 16px;

--- a/frontend/observatory/components/DetailControls.svelte
+++ b/frontend/observatory/components/DetailControls.svelte
@@ -10,6 +10,7 @@
     type Telemetry,
   } from '../runtime/host';
   import Action from './Action.svelte';
+  import Icon from './Icon.svelte';
   import Watchlist from './Watchlist.svelte';
   let { row, host, telemetry }: { row: RecordData; host: Host | null; telemetry: Telemetry } =
     $props();
@@ -32,7 +33,7 @@
 
 <section class="detail-section">
   <div class="section-heading">
-    <h3>{$t('Process controls')}</h3>
+    <h3 class="controls-heading"><Icon name="cpu" />{$t('Process controls')}</h3>
     <span class="badge">{$t('PID')} {String(row.pid ?? 'Unavailable')}</span>
   </div>
   <p class="entity-note">
@@ -43,16 +44,18 @@
   <div class="control-grid">
     <Action
       disabled={!canControl}
-      action={() => processAction('suspendProcess', String(row.instanceId))}>{$t('Suspend')}</Action
+      action={() => processAction('suspendProcess', String(row.instanceId))}
+      ><Icon name="pause" />{$t('Suspend')}</Action
     >
     <Action
       disabled={!canControl}
-      action={() => processAction('resumeProcess', String(row.instanceId))}>{$t('Resume')}</Action
+      action={() => processAction('resumeProcess', String(row.instanceId))}
+      ><Icon name="play" />{$t('Resume')}</Action
     >
     <button
       class="button danger"
       disabled={!canControl}
-      onclick={() => (stopId = String(row.instanceId))}>{$t('Stop…')}</button
+      onclick={() => (stopId = String(row.instanceId))}><Icon name="stop" />{$t('Stop…')}</button
     >
   </div>
   {#if stopId}<div class="confirm-stop" role="alert">
@@ -61,9 +64,22 @@
         {$t('Unsaved work may be lost. The process identity is checked again before stopping.')}
       </p>
       <div class="toolbar">
-        <Action action={() => processAction('killProcess', stopId!)}>{$t('Confirm stop')}</Action>
+        <Action action={() => processAction('killProcess', stopId!)}
+          ><Icon name="stop" />{$t('Confirm stop')}</Action
+        >
         <button class="button" onclick={() => (stopId = null)}>{$t('Cancel')}</button>
       </div>
     </div>{/if}
 </section>
 {#key row.agent ?? row.name}<Watchlist {host} agent={String(row.agent ?? row.name ?? '')} />{/key}
+
+<style>
+  .control-grid {
+    align-items: start;
+  }
+  .controls-heading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+</style>

--- a/frontend/observatory/components/EntityLinks.svelte
+++ b/frontend/observatory/components/EntityLinks.svelte
@@ -81,12 +81,14 @@
           onclick={() => navigate(a.name + ' · PID ' + a.pid, a as unknown as RecordData)}
         >
           <div class="detail-card-heading">
-            <strong>{$t('PID')} {a.pid}</strong><span class="badge"
-              >{a.riskScore}{$t('/100 risk')}</span
+            <strong class="process-identity"><Icon name="cpu" />{$t('PID')} {a.pid}</strong><span
+              class="badge">{a.riskScore}{$t('/100 risk')}</span
             >
           </div>
-          <span>{a.process}</span><small title={a.cwd}
-            >{a.cwd || $t('Working directory not recorded')}</small
+          <span>{a.process}</span><small class="process-location" title={a.cwd}
+            >{#if a.cwd}<Icon name="folder" />{/if}<span
+              >{a.cwd || $t('Working directory not recorded')}</span
+            ></small
           >
           <span class="detail-card-link">{$t('Open process')}<Icon name="chevron" /></span>
         </button>
@@ -187,3 +189,15 @@
       </p>{/if}
   </section>
 {/if}
+
+<style>
+  .process-identity,
+  .process-location {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .process-location {
+    align-items: start;
+  }
+</style>

--- a/frontend/observatory/components/Metadata.svelte
+++ b/frontend/observatory/components/Metadata.svelte
@@ -2,6 +2,29 @@
   import { t } from '../runtime/i18n';
 
   import { informationFields, type InfoField } from '../runtime/detail-fields';
+  import Icon from './Icon.svelte';
+  const fieldIcons: Record<string, string> = {
+    pid: 'cpu',
+    ppid: 'cpu',
+    instanceId: 'cpu',
+    process: 'cpu',
+    names: 'cpu',
+    file: 'file',
+    path: 'file',
+    cwd: 'folder',
+    configPaths: 'fileConfig',
+    domain: 'globe',
+    knownDomains: 'globe',
+    localIp: 'server',
+    remoteIp: 'server',
+    localPort: 'network',
+    remotePort: 'network',
+    knownPorts: 'network',
+    timestamp: 'history',
+    firstSeen: 'history',
+    lastSeen: 'history',
+  };
+  const fieldIcon = (key: string) => (Object.hasOwn(fieldIcons, key) ? fieldIcons[key] : '');
   let { value }: { value: unknown } = $props();
   let fields = $derived(informationFields(value));
 </script>
@@ -10,13 +33,17 @@
   {@const simple = items.filter((field) => !field.children && !field.items)}
   {#if simple.length}<dl class="attribute-list metadata">
       {#each simple as field (field.key)}<div class="attribute">
-          <dt>{$t(field.label)}</dt>
+          <dt class="field-name">
+            {#if fieldIcon(field.key)}<Icon name={fieldIcon(field.key)} />{/if}{$t(field.label)}
+          </dt>
           <dd>{field.value}</dd>
         </div>{/each}
     </dl>{/if}
   {#each items.filter((field) => field.items) as field (field.key)}
     <div class="attribute-group">
-      <h4>{$t(field.label)}</h4>
+      <h4 class="field-name">
+        {#if fieldIcon(field.key)}<Icon name={fieldIcon(field.key)} />{/if}{$t(field.label)}
+      </h4>
       <ul class="attribute-tags">
         {#each field.items ?? [] as value, i (i)}<li>{value}</li>{:else}<li>
             {$t('None recorded')}
@@ -27,8 +54,11 @@
   {#each items.filter((field) => field.children) as field (field.key)}
     <details class="attribute-group">
       <summary
-        ><span>{$t(field.label)}</span><small>{field.children?.length} {$t('fields')}</small
-        ></summary
+        ><span class="field-name"
+          >{#if fieldIcon(field.key)}<Icon name={fieldIcon(field.key)} />{/if}{$t(
+            field.label,
+          )}</span
+        ><small>{field.children?.length} {$t('fields')}</small></summary
       >
       <div class="attribute-group-body">{@render entries(field.children ?? [])}</div>
     </details>
@@ -38,3 +68,12 @@
 {#if fields.length}{@render entries(fields)}{:else}<p class="entity-note">
     {$t('No additional information recorded.')}
   </p>{/if}
+
+<style>
+  .field-name {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+</style>

--- a/frontend/observatory/components/ProtectionDetails.svelte
+++ b/frontend/observatory/components/ProtectionDetails.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import Icon from './Icon.svelte';
+  import ResourceIcon from './ResourceIcon.svelte';
+  import { resourceVisual } from '../runtime/resource-visual';
   import { t } from '../runtime/i18n';
 
   import { instances, type RecordData, type Telemetry } from '../runtime/host';
@@ -24,7 +26,17 @@
   <h3>{$t('Understand this activity')}</h3>
   <p class="actor">{activity.actor}</p>
   <p>{$t(activity.action)}</p>
-  <div class="destination"><span>{$t('Where')}</span><code>{activity.target}</code></div>
+  <div class="destination">
+    <span class="destination-label">{$t('Where')}</span>
+    <div class="destination-resource">
+      <ResourceIcon row={activity.latest} />
+      <div>
+        <span class="destination-kind">{$t(resourceVisual(activity.latest).label)}</span><code
+          >{activity.target}</code
+        >
+      </div>
+    </div>
+  </div>
   {#if activity.latest.remoteIp}<p class="muted">
       {$t('Observed IP:')}
       {String(activity.latest.remoteIp)}{activity.latest.remotePort
@@ -122,10 +134,17 @@
     border-radius: var(--control-radius);
     margin: var(--space-3) 0;
   }
-  .destination span {
+  .destination-label,
+  .destination-kind {
     display: block;
     color: var(--muted);
     margin-bottom: var(--space-1);
+  }
+  .destination-resource {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: var(--space-2);
   }
   code {
     overflow-wrap: anywhere;


### PR DESCRIPTION
Process details lacked the visual cues already used in radar and activity lists. Worker rows and cards now distinguish process IDs from working folders; process controls show pause, resume and stop symbols, and the Stop button keeps the same height as adjacent controls. Activity details repeat the resource type and icon, while recognized metadata labels use matching process, file, address, port and time symbols.

Existing labels, translations, process identity checks and stop confirmation remain in place.

Validation: renderer build, format, lint, both type checks, production dependency audit, coverage (206 files; 3382 passed, 4 skipped), audit and sequence mutation gates, and derived counts. Local coverage used two workers and a 10-second test timeout for this Windows host; repository test settings are unchanged. Browser checks covered details, watchlist and protection layouts at 900×600 and 1200×800, 100–150% scale and light/dark themes; new controls and metadata were also visually inspected. The packaged Electron smoke check passed all 11 workspaces, restart persistence and export/configuration checks.
