### PR TITLE
feat(ui): add section navigation icons

### DIFF
--- a/frontend/observatory/DESIGN.md
+++ b/frontend/observatory/DESIGN.md
@@ -238,3 +238,14 @@ pause, play and stop marks while retaining labels, capability limits and the sto
 confirmation. Selected activity repeats the resource symbol and type shown in
 the list. Known metadata labels for process IDs, paths, domains, IPs, ports and
 observation times use the same icon vocabulary; other attributes stay plain.
+
+### Section navigation cues (2026-09-12)
+
+Agent sections and detail tabs pair their existing labels with optional neutral
+SVG symbols. Risk uses the shield, resource usage a chart, activity the activity
+line and processes the processor. Attributes, retained records, recognition and
+related entities use clipboard, history, search and connection symbols. Catalog
+and provider editor tabs use the same vocabulary. Tab labels, counts, selection
+and keyboard navigation remain visible and operable at enlarged scale. The
+radar's individual-process action also uses the processor symbol. Worker counts
+in the agent heading follow the selected language.

--- a/frontend/observatory/components/AgentWorkspace.svelte
+++ b/frontend/observatory/components/AgentWorkspace.svelte
@@ -69,10 +69,15 @@
   let section = $state('risk');
   let riskOpen = $state(true);
   let tabs = $derived([
-    { id: 'risk', label: 'Risk' },
-    { id: 'resources', label: 'Resources' },
-    { id: 'activity', label: 'Activity', count: files.length + connections.length },
-    { id: 'processes', label: 'Processes' },
+    { id: 'risk', label: 'Risk', icon: 'shield' },
+    { id: 'resources', label: 'Resources', icon: 'chart' },
+    {
+      id: 'activity',
+      label: 'Activity',
+      icon: 'activity',
+      count: files.length + connections.length,
+    },
+    { id: 'processes', label: 'Processes', icon: 'cpu' },
   ]);
   let lastRequest = -1;
   function selectSection(id: string) {
@@ -94,8 +99,10 @@
       <h2>{scope.instanceId ? $t('Process overview') : $t('Agent overview')}</h2>
       <p>
         {scope.instanceId
-          ? 'PID ' + String(process?.pid ?? scope.instanceId.split(':')[0])
-          : String(workerCount) + (workerCount === 1 ? ' worker process' : ' worker processes')} · {paused
+          ? $t('PID') + ' ' + String(process?.pid ?? scope.instanceId.split(':')[0])
+          : String(workerCount) +
+            ' ' +
+            $t(workerCount === 1 ? 'worker process' : 'worker processes')} · {paused
           ? $t('View paused')
           : telemetry.stale
             ? $t('Last reliable observation')

--- a/frontend/observatory/components/Analysis.svelte
+++ b/frontend/observatory/components/Analysis.svelte
@@ -181,8 +181,8 @@
       title={$t('Anthropic connection')}
       caption={$t('AI analysis')}
       tabs={[
-        { id: 'connection', label: 'Connection' },
-        { id: 'usage', label: 'Usage' },
+        { id: 'connection', label: 'Connection', icon: 'network' },
+        { id: 'usage', label: 'Usage', icon: 'chart' },
       ]}
       bind:selected={providerSection}
       close={() => {

--- a/frontend/observatory/components/Catalog.svelte
+++ b/frontend/observatory/components/Catalog.svelte
@@ -242,8 +242,8 @@
     title={editing ? $t('Edit custom agent') : $t('Add custom agent')}
     caption={$t('Agent catalog')}
     tabs={[
-      { id: 'general', label: 'General' },
-      { id: 'recognition', label: 'Recognition' },
+      { id: 'general', label: 'General', icon: 'agents' },
+      { id: 'recognition', label: 'Recognition', icon: 'search' },
     ]}
     bind:selected={editorSection}
     close={() => (showForm = false)}

--- a/frontend/observatory/components/RadarInspector.svelte
+++ b/frontend/observatory/components/RadarInspector.svelte
@@ -150,7 +150,9 @@
               >{/each}
           </select></label
         >
-        <button class="button" onclick={openProcess} disabled={!chosen}>{$t('Process')}</button>
+        <button class="button" onclick={openProcess} disabled={!chosen}
+          ><Icon name="cpu" />{$t('Process')}</button
+        >
       </details>
     {:else}
       <div class="radar-no-selection">

--- a/frontend/observatory/components/SectionTabs.svelte
+++ b/frontend/observatory/components/SectionTabs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { t } from '../runtime/i18n';
   import { tick } from 'svelte';
+  import Icon from './Icon.svelte';
   import type { DetailTab } from '../runtime/detail-model';
   let {
     tabs,
@@ -55,7 +56,9 @@
       onclick={() => change(tab.id)}
       onkeydown={(event) => keydown(event, i)}
     >
-      {$t(tab.label)}{#if tab.count !== undefined}<span class="tab-count">{tab.count}</span>{/if}
+      {#if tab.icon}<Icon name={tab.icon} />{/if}{$t(tab.label)}{#if tab.count !== undefined}<span
+          class="tab-count">{tab.count}</span
+        >{/if}
     </button>
   {/each}
 </div>

--- a/frontend/observatory/runtime/detail-model.ts
+++ b/frontend/observatory/runtime/detail-model.ts
@@ -4,6 +4,7 @@ import { describeObservation } from '../../../src/shared/observation-display.js'
 export interface DetailTab {
   id: string;
   label: string;
+  icon?: string;
   count?: number;
 }
 export type DetailKind = 'group' | 'process' | 'records' | 'catalog' | 'resource' | 'information';
@@ -49,34 +50,54 @@ export function detailActivity(row: RecordData, state: Telemetry): RecordData[] 
 }
 /** Sections available for this entity. @param row Record @param state Telemetry @returns Tabs @since 0.14.1 */
 export function detailTabs(row: RecordData, state: Telemetry): DetailTab[] {
-  const overview = { id: 'overview', label: 'Overview' };
-  const attributes = { id: 'attributes', label: 'Attributes' };
-  const risk = { id: 'risk', label: 'Risk explanation' };
+  const overview = { id: 'overview', label: 'Overview', icon: 'report' };
+  const attributes = { id: 'attributes', label: 'Attributes', icon: 'clipboard' };
+  const risk = { id: 'risk', label: 'Risk explanation', icon: 'shield' };
   switch (detailKind(row)) {
     case 'group':
       return [
         overview,
         risk,
-        { id: 'processes', label: 'Processes', count: detailMembers(row, state).length },
-        { id: 'activity', label: 'Activity', count: detailActivity(row, state).length },
+        {
+          id: 'processes',
+          label: 'Processes',
+          icon: 'cpu',
+          count: detailMembers(row, state).length,
+        },
+        {
+          id: 'activity',
+          label: 'Activity',
+          icon: 'activity',
+          count: detailActivity(row, state).length,
+        },
       ];
     case 'process':
       return [
         overview,
         risk,
-        { id: 'activity', label: 'Activity', count: detailActivity(row, state).length },
+        {
+          id: 'activity',
+          label: 'Activity',
+          icon: 'activity',
+          count: detailActivity(row, state).length,
+        },
         attributes,
-        { id: 'controls', label: 'Controls' },
+        { id: 'controls', label: 'Controls', icon: 'settings' },
       ];
     case 'records':
       return [
         overview,
-        { id: 'records', label: 'Records', count: records(row.observations).length },
+        {
+          id: 'records',
+          label: 'Records',
+          icon: 'history',
+          count: records(row.observations).length,
+        },
       ];
     case 'catalog':
-      return [overview, { id: 'signatures', label: 'Recognition' }];
+      return [overview, { id: 'signatures', label: 'Recognition', icon: 'search' }];
     case 'resource':
-      return [overview, attributes, { id: 'related', label: 'Related' }];
+      return [overview, attributes, { id: 'related', label: 'Related', icon: 'network' }];
     default:
       return [overview, attributes];
   }


### PR DESCRIPTION
Agent and detail sections now pair their labels with consistent icons for risk, resource usage, activity, processes, attributes and related records. Catalog and provider editor tabs use the same optional icon support. The individual-process action in the radar also has a process icon, and the agent heading's worker count follows the selected language.

Labels, counts, tab selection, keyboard navigation and process targeting are preserved. Numeric selectors and unchanged sections keep their existing presentation.

Validation: both builds; format, lint and both type checks; production audit; coverage (206 files, 3382 passed and 4 skipped) with two workers and a 10-second timeout on the local Windows host; witness/sequence mutation gates; derived counts. The full browser suite passed, including 264 shared view checks and the detail, localization, keyboard, stale-state and layout checks. Additional Portuguese checks verified the worker-count translation and Home/End navigation in light/dark at 1200×800/100% and 900×600/150%. Rendered tabs and dialogs were inspected. Packaged Electron smoke passed all 11 workspaces, restart persistence, six exports and the key-free configuration round trip.

