### PR TITLE
ci(release): qualify signed Windows candidate without publishing

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -1,0 +1,93 @@
+name: Qualify Windows release candidate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  qualify:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      CANDIDATE_SHA: d62e589f2f56e9bcab153fef73df205f814fcc7d
+      CANDIDATE_TAG: aegis-v0.15.0-alpha
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: candidate
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: d62e589f2f56e9bcab153fef73df205f814fcc7d
+          path: candidate
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: candidate/package-lock.json
+      - run: npm ci
+      - name: Verify candidate sources
+        run: |
+          npm run format:check
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npm run lint
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npm run typecheck
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npm run typecheck:svelte
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npm run test:coverage -- --maxWorkers=2 --testTimeout=10000
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npm run verify:gate
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npm run verify:seq-gate
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npm run counts:check
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npm audit --audit-level=high --omit=dev
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+      - name: Verify renderer and package candidate
+        run: |
+          npm run build:renderer
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          npx electron-builder --win --x64 --publish never
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          $signed = Join-Path $env:RUNNER_TEMP 'aegis-release-qa/signed'
+          New-Item -ItemType Directory -Path $signed -Force | Out-Null
+          Copy-Item -Path 'dist/*.exe' -Destination $signed
+      - name: Sign candidate manifest and verify against repository public key
+        env:
+          AEGIS_RELEASE_SIGNING_KEY: ${{ secrets.AEGIS_RELEASE_SIGNING_KEY }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:AEGIS_RELEASE_SIGNING_KEY)) { throw 'Release signing key is unavailable' }
+          $signed = Join-Path $env:RUNNER_TEMP 'aegis-release-qa/signed'
+          node scripts/release-sign.js --dir $signed --tag $env:CANDIDATE_TAG --commit $env:CANDIDATE_SHA --repository antropos17/Aegis
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          node scripts/release-verify.js --dir $signed
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+      - name: Download and verify previous released installer
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $previous = Join-Path $env:RUNNER_TEMP 'aegis-release-qa/previous'
+          gh release download aegis-v0.14.1-alpha --repo antropos17/Aegis --dir $previous
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          node scripts/release-verify.js --dir $previous
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+      - name: Install previous version, upgrade, uninstall and reinstall
+        run: |
+          & "$env:GITHUB_WORKSPACE/scripts/qualify-windows-installer.ps1" -CandidateRoot (Get-Location).Path -ProfileChecker "$env:GITHUB_WORKSPACE/scripts/release-profile-check.cjs"
+      - name: Preserve qualification results and signed candidate as Actions artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: aegis-0.15.0-alpha-qualification
+          retention-days: 7
+          path: |
+            ${{ runner.temp }}/aegis-release-qa/signed
+            ${{ runner.temp }}/aegis-release-qa/*.json
+            ${{ runner.temp }}/aegis-release-qa/*.png
+            candidate/dist/builder-debug.yml

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ src/main/.mutants/
 .DS_Store
 Thumbs.db
 *.ps1
+!/scripts/qualify-windows-installer.ps1
 !/sidecar/etw-lifecycle/Capture-SuspendContext.ps1
 cdp_*.js
 # Local assistant tooling — kept on disk, not part of the public tree

--- a/scripts/qualify-windows-installer.ps1
+++ b/scripts/qualify-windows-installer.ps1
@@ -1,0 +1,68 @@
+param([Parameter(Mandatory)][string]$CandidateRoot, [Parameter(Mandatory)][string]$ProfileChecker)
+$ErrorActionPreference = 'Stop'
+if ($env:GITHUB_ACTIONS -ne 'true' -or $env:RUNNER_ENVIRONMENT -ne 'github-hosted' -or $env:RUNNER_OS -ne 'Windows') { throw 'Installer qualification is restricted to a disposable GitHub-hosted Windows runner.' }
+$qaRoot = [IO.Path]::GetFullPath((Join-Path $env:RUNNER_TEMP 'aegis-release-qa'))
+$installRoot = [IO.Path]::GetFullPath((Join-Path $qaRoot 'install'))
+if (-not $installRoot.StartsWith([IO.Path]::GetFullPath($env:RUNNER_TEMP) + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) { throw 'Installation target escaped runner temp' }
+$profile = Join-Path $env:APPDATA 'aegis'
+$exeName = 'AEGIS - AI Monitoring & Threat Detection.exe'
+$appExe = Join-Path $installRoot $exeName
+$candidateInstaller = @(Get-ChildItem -LiteralPath (Join-Path $qaRoot 'signed') -Filter '*.exe' -File)
+$oldInstaller = @(Get-ChildItem -LiteralPath (Join-Path $qaRoot 'previous') -Filter '*.exe' -File)
+if ($candidateInstaller.Count -ne 1 -or $oldInstaller.Count -ne 1) { throw 'Expected exactly one installer for each version' }
+function Registrations {
+  @(Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -like 'AEGIS*' })
+}
+if ((Test-Path -LiteralPath $installRoot) -or (Test-Path -LiteralPath $profile) -or (Registrations).Count) { throw 'Runner is not clean; refusing to overwrite an installation or profile' }
+function RunInstaller([string]$installer) {
+  $process = Start-Process -FilePath $installer -ArgumentList @('/S', '/currentuser', ('/D=' + $installRoot)) -WindowStyle Hidden -PassThru
+  if (-not $process.WaitForExit(180000)) { throw 'Installer exceeded three minutes' }
+  $process.Refresh()
+  if ($process.ExitCode -ne 0) { throw "Installer failed with exit $($process.ExitCode)" }
+  if (-not (Test-Path -LiteralPath $appExe)) { throw 'Installed application is missing' }
+}
+function CheckRegistration([string]$version) {
+  $entries = @(Registrations)
+  if ($entries.Count -ne 1 -or $entries[0].DisplayVersion -ne $version) { throw 'Uninstall registration version/count differs' }
+}
+function CheckProfile([string]$phase, [string]$version) {
+  & node $ProfileChecker --exe $appExe --root $qaRoot --phase $phase --version $version
+  if ($LASTEXITCODE) { throw 'Packaged profile check failed' }
+}
+function CheckPayload {
+  foreach ($relative in @($exeName, 'resources/app.asar', 'resources/sidecar/aegis-procsnap.exe')) {
+    $built = Join-Path (Join-Path $CandidateRoot 'dist/win-unpacked') $relative
+    $installed = Join-Path $installRoot $relative
+    if ((Get-FileHash -LiteralPath $built).Hash -ne (Get-FileHash -LiteralPath $installed).Hash) { throw "Installed payload differs: $relative" }
+  }
+}
+function UninstallAndCheck {
+  $settings = Join-Path $profile 'settings.json'
+  $before = (Get-FileHash -LiteralPath $settings).Hash
+  $sentinel = Join-Path $profile 'qualification-sentinel.txt'
+  $sentinelBefore = (Get-FileHash -LiteralPath $sentinel).Hash
+  $uninstallers = @(Get-ChildItem -LiteralPath $installRoot -Filter 'Uninstall*.exe' -File)
+  if ($uninstallers.Count -ne 1) { throw 'Expected one uninstaller' }
+  $process = Start-Process -FilePath $uninstallers[0].FullName -ArgumentList '/S' -WindowStyle Hidden -PassThru
+  if (-not $process.WaitForExit(180000)) { throw 'Uninstaller exceeded three minutes' }
+  $process.Refresh()
+  if ($process.ExitCode -ne 0) { throw "Uninstaller failed with exit $($process.ExitCode)" }
+  $deadline = [DateTime]::UtcNow.AddSeconds(45)
+  while ((Test-Path -LiteralPath $appExe) -and [DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 250 }
+  if ((Test-Path -LiteralPath $appExe) -or (Registrations).Count) { throw 'Application or registration survived uninstall' }
+  if ((Get-FileHash -LiteralPath $settings).Hash -ne $before -or (Get-FileHash -LiteralPath $sentinel).Hash -ne $sentinelBefore) { throw 'Uninstaller changed the preserved profile' }
+}
+RunInstaller $oldInstaller[0].FullName
+CheckRegistration '0.14.1-alpha'
+CheckProfile 'seed' '0.14.1-alpha'
+RunInstaller $candidateInstaller[0].FullName
+CheckRegistration '0.15.0-alpha'
+CheckPayload
+CheckProfile 'verify' '0.15.0-alpha'
+UninstallAndCheck
+RunInstaller $candidateInstaller[0].FullName
+CheckRegistration '0.15.0-alpha'
+CheckPayload
+CheckProfile 'verify' '0.15.0-alpha'
+UninstallAndCheck
+[pscustomobject]@{ oldVersion = '0.14.1-alpha'; candidateVersion = '0.15.0-alpha'; upgrade = 'passed'; retainedProfileAfterUninstall = 'passed'; reinstall = 'passed'; finalUninstall = 'passed'; installedPayloadHashes = 'matched'; hostedRunner = $true } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $qaRoot 'installer-result.json') -Encoding utf8

--- a/scripts/release-profile-check.cjs
+++ b/scripts/release-profile-check.cjs
@@ -1,0 +1,140 @@
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { createRequire } = require('node:module');
+const { _electron: electron } = createRequire(path.join(process.cwd(), 'package.json'))(
+  'playwright',
+);
+const options = {};
+for (let i = 2; i < process.argv.length; i += 2) {
+  assert(['--exe', '--root', '--phase', '--version'].includes(process.argv[i]), 'Unknown argument');
+  assert(process.argv[i + 1], 'Missing argument');
+  options[process.argv[i].slice(2)] = process.argv[i + 1];
+}
+for (const name of ['exe', 'root', 'phase', 'version']) assert(options[name], 'Missing ' + name);
+assert(['seed', 'verify'].includes(options.phase), 'Invalid phase');
+const root = path.resolve(options.root);
+const hosted =
+  process.env.GITHUB_ACTIONS === 'true' && process.env.RUNNER_ENVIRONMENT === 'github-hosted';
+const allowed = path.resolve(hosted ? process.env.RUNNER_TEMP : 'X:/tmp');
+assert(
+  root.toLowerCase().startsWith((allowed + path.sep).toLowerCase()),
+  'QA output must be in the disposable temp directory',
+);
+const profile = hosted ? path.join(process.env.APPDATA, 'aegis') : path.join(root, 'profile');
+const expected = {
+  scanIntervalSec: 20,
+  notificationsEnabled: false,
+  startMinimized: false,
+  autoStartWithWindows: false,
+  darkMode: true,
+  uiScale: 1.25,
+  timelineZoom: 12,
+  ignoreCommonBuildDirs: false,
+};
+const sentinel = 'AEGIS isolated upgrade fixture — no user data';
+const normalize = (value) => path.resolve(value).toLowerCase();
+let app;
+async function launch() {
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  app = await electron.launch({
+    executablePath: path.resolve(options.exe),
+    args: ['--user-data-dir=' + profile],
+    env,
+    timeout: 60000,
+  });
+  const state = await app.evaluate(({ app }) => ({
+    version: app.getVersion(),
+    profile: app.getPath('userData'),
+    packaged: app.isPackaged,
+  }));
+  assert.equal(normalize(state.profile), normalize(profile));
+  assert.equal(state.version, options.version);
+  assert.equal(state.packaged, true);
+  const window = await app.firstWindow();
+  await window.waitForFunction(() => typeof window.aegis?.getSettings === 'function');
+  return window;
+}
+async function verify(window) {
+  const actual = await window.evaluate(async (keys) => {
+    const settings = await window.aegis.getSettings();
+    return Object.fromEntries(keys.map((key) => [key, settings[key]]));
+  }, Object.keys(expected));
+  assert.deepEqual(actual, expected);
+  if (options.version === '0.15.0-alpha') {
+    assert.equal(
+      await window.evaluate(async () => (await window.aegis.getSettings()).automaticUpdatesEnabled),
+      false,
+      'Upgrade must not enable automatic updates without consent',
+    );
+  }
+  assert.equal(
+    await fs.readFile(path.join(profile, 'qualification-sentinel.txt'), 'utf8'),
+    sentinel,
+  );
+}
+(async () => {
+  await fs.mkdir(root, { recursive: true });
+  if (options.phase === 'seed') {
+    try {
+      await fs.access(profile);
+      throw new Error('Seed profile already exists; refusing to overwrite it');
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+    await fs.mkdir(profile, { recursive: true });
+    await fs.writeFile(path.join(profile, 'settings.json'), JSON.stringify(expected));
+    await fs.writeFile(path.join(profile, 'qualification-sentinel.txt'), sentinel);
+  }
+  try {
+    let window = await launch();
+    if (options.phase === 'seed') {
+      const saved = await window.evaluate(async (patch) => {
+        const current = await window.aegis.getSettings();
+        return window.aegis.saveSettings({ ...current, ...patch });
+      }, expected);
+      assert.equal(saved.success, true, saved.error || 'Old version rejected fixture settings');
+    }
+    await verify(window);
+    await app.close();
+    app = null;
+    window = await launch();
+    await verify(window);
+    if (options.version === '0.15.0-alpha') {
+      await window.getByRole('heading', { name: 'Agent radar', exact: true }).waitFor();
+      await window.screenshot({ path: path.join(root, 'upgraded-radar.png') });
+    }
+    await fs.writeFile(
+      path.join(root, options.phase + '.json'),
+      JSON.stringify(
+        {
+          version: options.version,
+          executable: path.resolve(options.exe),
+          profile,
+          phase: options.phase,
+          checkedSettings: expected,
+          sentinelRetained: true,
+          restartPassed: true,
+          installerWasExecutedByThisScript: false,
+        },
+        null,
+        2,
+      ),
+    );
+    console.log(
+      JSON.stringify({
+        version: options.version,
+        phase: options.phase,
+        settings: Object.keys(expected).length,
+        restartPassed: true,
+      }),
+    );
+  } finally {
+    if (app) await app.close();
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Adds a manually dispatched Windows qualification run for the pinned 0.15.0-alpha candidate. It runs source gates, builds the installer, signs and verifies its manifest, and checks upgrading from the verified 0.14.1-alpha release, retained settings, uninstall, and reinstall on a disposable hosted runner.

The workflow has read-only repository permissions and stores results as temporary Actions artifacts. It does not create tags or publish a release. The signing key is scoped to the signing step; the installer helper refuses execution outside a GitHub-hosted Windows runner.

Validation: JavaScript syntax and ESLint, PowerShell parser, YAML parsing, and diff checks passed. The packaged profile checker already passed an isolated local migration and restart test for eight settings; actual installer execution is the purpose of this workflow.
