### PR TITLE
fix(ci): stabilize Windows release qualification

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -29,8 +29,17 @@ jobs:
           cache: npm
           cache-dependency-path: candidate/package-lock.json
       - run: npm ci
+      - name: Check native watcher in isolation with and without coverage
+        run: |
+          $env:NODE_OPTIONS = '--require="' + "$env:GITHUB_WORKSPACE/scripts/release-test-diagnostics.cjs" + '"'
+          npx vitest run tests/main/watch-worker-integration.test.js --maxWorkers=1 --testTimeout=10000 --reporter=verbose
+          $plainExit = $LASTEXITCODE
+          npx vitest run tests/main/watch-worker-integration.test.js --coverage --maxWorkers=1 --testTimeout=10000 --reporter=verbose
+          $coverageExit = $LASTEXITCODE
+          if ($plainExit -or $coverageExit) { throw "Isolated watcher checks failed: plain=$plainExit coverage=$coverageExit" }
       - name: Verify candidate sources
         run: |
+          $env:NODE_OPTIONS = '--require="' + "$env:GITHUB_WORKSPACE/scripts/release-test-diagnostics.cjs" + '"'
           npm run format:check
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
           npm run lint

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -25,7 +25,8 @@ jobs:
           path: candidate
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
-          node-version: '24'
+          # Includes libuv's Windows short-path fs-event fix (nodejs/node#65118).
+          node-version: '24.21.0'
           cache: npm
           cache-dependency-path: candidate/package-lock.json
       - run: npm ci

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm ci
       - name: Check native watcher in isolation with and without coverage
         run: |
-          $env:NODE_OPTIONS = '--require="' + "$env:GITHUB_WORKSPACE/scripts/release-test-diagnostics.cjs" + '"'
+          $env:NODE_OPTIONS = '--require="' + ("$env:GITHUB_WORKSPACE/scripts/release-test-diagnostics.cjs".Replace('\', '/')) + '"'
           npx vitest run tests/main/watch-worker-integration.test.js --maxWorkers=1 --testTimeout=10000 --reporter=verbose
           $plainExit = $LASTEXITCODE
           npx vitest run tests/main/watch-worker-integration.test.js --coverage --maxWorkers=1 --testTimeout=10000 --reporter=verbose
@@ -39,7 +39,7 @@ jobs:
           if ($plainExit -or $coverageExit) { throw "Isolated watcher checks failed: plain=$plainExit coverage=$coverageExit" }
       - name: Verify candidate sources
         run: |
-          $env:NODE_OPTIONS = '--require="' + "$env:GITHUB_WORKSPACE/scripts/release-test-diagnostics.cjs" + '"'
+          $env:NODE_OPTIONS = '--require="' + ("$env:GITHUB_WORKSPACE/scripts/release-test-diagnostics.cjs".Replace('\', '/')) + '"'
           npm run format:check
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
           npm run lint

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -40,7 +40,6 @@ jobs:
           if ($plainExit -or $coverageExit) { throw "Isolated watcher checks failed: plain=$plainExit coverage=$coverageExit" }
       - name: Verify candidate sources
         run: |
-          $env:NODE_OPTIONS = '--require="' + ("$env:GITHUB_WORKSPACE/scripts/release-test-diagnostics.cjs".Replace('\', '/')) + '"'
           npm run format:check
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
           npm run lint

--- a/scripts/qualify-windows-installer.ps1
+++ b/scripts/qualify-windows-installer.ps1
@@ -48,8 +48,10 @@ function UninstallAndCheck {
   $process.Refresh()
   if ($process.ExitCode -ne 0) { throw "Uninstaller failed with exit $($process.ExitCode)" }
   $deadline = [DateTime]::UtcNow.AddSeconds(45)
-  while ((Test-Path -LiteralPath $appExe) -and [DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 250 }
-  if ((Test-Path -LiteralPath $appExe) -or (Registrations).Count) { throw 'Application or registration survived uninstall' }
+  # NSIS starts a temporary uninstaller process: the launcher can exit before
+  # that process removes the registry entry after deleting the application.
+  while (((Test-Path -LiteralPath $appExe) -or (Registrations).Count) -and [DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 250 }
+  if ((Test-Path -LiteralPath $appExe) -or (Registrations).Count) { throw "Uninstall did not finish: applicationPresent=$(Test-Path -LiteralPath $appExe), registrations=$(@(Registrations).Count)" }
   if ((Get-FileHash -LiteralPath $settings).Hash -ne $before -or (Get-FileHash -LiteralPath $sentinel).Hash -ne $sentinelBefore) { throw 'Uninstaller changed the preserved profile' }
 }
 RunInstaller $oldInstaller[0].FullName

--- a/scripts/release-profile-check.cjs
+++ b/scripts/release-profile-check.cjs
@@ -45,6 +45,8 @@ async function launch() {
     env,
     timeout: 60000,
   });
+  const window = await app.firstWindow();
+  await window.waitForFunction(() => typeof window.aegis?.getSettings === 'function');
   const state = await app.evaluate(({ app }) => ({
     version: app.getVersion(),
     profile: app.getPath('userData'),
@@ -53,8 +55,6 @@ async function launch() {
   assert.equal(normalize(state.profile), normalize(profile));
   assert.equal(state.version, options.version);
   assert.equal(state.packaged, true);
-  const window = await app.firstWindow();
-  await window.waitForFunction(() => typeof window.aegis?.getSettings === 'function');
   return window;
 }
 async function verify(window) {

--- a/scripts/release-test-diagnostics.cjs
+++ b/scripts/release-test-diagnostics.cjs
@@ -1,0 +1,14 @@
+/** @file Logs child exit codes during hosted qualification without logging arguments or environment. */
+'use strict';
+
+const childProcess = require('node:child_process');
+const { syncBuiltinESMExports } = require('node:module');
+const originalFork = childProcess.fork;
+childProcess.fork = function (...args) {
+  const child = originalFork.apply(this, args);
+  child.on('exit', (code, signal) => {
+    if (code !== 0) console.error('[qualification child exit]', JSON.stringify({ code, signal }));
+  });
+  return child;
+};
+syncBuiltinESMExports();


### PR DESCRIPTION
Makes the Windows release qualification complete reliably on hosted runners. Node is pinned to 24.21.0, which contains the libuv short-path filesystem watcher fix (nodejs/node#65118); isolated native watcher checks retain scoped exit diagnostics. The profile checker waits for the packaged renderer and IPC before inspecting Electron main state. Uninstall verification waits for both application files and registry cleanup by NSIS's temporary child process.

Application source and dependencies are unchanged. Full source gates remain blocking. All five PR contexts passed on bbde538d36ed0ab32e5c353b0400169440c2dbae. Hosted qualification run 34709329189 passed: 3382 tests (4 skipped), normal Windows packaging, Ed25519 manifest signing and verification, actual upgrade from 0.14.1 to 0.15.0 preserving eight settings across restarts, uninstall retaining the profile, reinstall, final uninstall, and installed payload hash checks. The downloaded final artifact also passed local signature/hash verification.

Evidence: https://github.com/antropos17/Aegis/actions/runs/34709329189. No release or tag was published.
