### PR TITLE
feat(etw): measure bounded burst flow and broker forwarding

### DIFF
--- a/docs/recon/evidence/etw-file-home-26200-burst-diagnostics.json
+++ b/docs/recon/evidence/etw-file-home-26200-burst-diagnostics.json
@@ -1,0 +1,2443 @@
+{
+  "schema": 1,
+  "kind": "etw-file-burst-diagnostics",
+  "baseCommit": "ef5f39cbf385089f9327435f5a0a097387f91f56",
+  "liveRun": "deferred-by-user",
+  "selfTestsPassed": 54,
+  "sourceSha256": {
+    "scripts/etw-file-load.mjs": "0ef88d5a878e3e3b019e89287213dfb97699cdcf30227316c78a8c5ca0874367",
+    "scripts/etw-file-workload.mjs": "2c8710b31c388be9d2ebe791870602e83f447b1d5b100c7c7043da1dda8bf1e1",
+    "scripts/verify-etw-file.mjs": "1b6f6b3bb0b574debf2977f7f057b348d5bb7a093c983b43e8ae348d68e6e578",
+    "sidecar/etw-file/EtwFile.csproj": "5467564053a0e7ca73d00a872a6b3e2d19068eb491aaa2487ca3415b61067c79",
+    "sidecar/etw-file/FileBroker.cs": "6f31f31965c9b7905f46203d5c4b83e9092be0222ef09f87f3f56bbbd60f3de6",
+    "sidecar/etw-file/FileBurstTests.cs": "2bd34dae624444208b7ae70047e6e101e01d7f8839c88b40f96988620b1a2b70",
+    "sidecar/etw-file/FileCapture.cs": "7fc5a273ad813e1b9e63890c4510b16b585ce2b57b856a743407e01e1eb0e2a1",
+    "sidecar/etw-file/FileCollector.cs": "800dd65d1d18cc92de61831c3396366936357cc02214d1e2fa33eebcd24ac97a",
+    "sidecar/etw-file/FileForwardProfile.cs": "49e8393d59f2f33199c448e38738ef1eb9eb4c565f2bed57fc7444a457d864b6",
+    "sidecar/etw-file/FileGeneration.cs": "8f627ed4199461e4f4049b07e25df42e8c19515e160b83ed1500d5e8526b2d62",
+    "sidecar/etw-file/FileLossFixture.cs": "da8cc0750eedbcb90e12dc9cb80336e12d381f6411067f8bc292d3f24911f7eb",
+    "sidecar/etw-file/FileMapping.cs": "89666d58740be6e87f23ba4cc5a2b9e97d3f46446857fb66456e15a93bf478fa",
+    "sidecar/etw-file/FileOutputProfile.cs": "11566e2c6a10d40302e63d95c22ed4b689d6c13a69a3c96e9ddf6c9d019b2ffd",
+    "sidecar/etw-file/FileOutputProfileTests.cs": "7adc5ade47f54f5d4de0c0af87d58942b7b491e48b308f97231f831a96d3c99f",
+    "sidecar/etw-file/FileOutputTests.cs": "e11b1b566cf00eb35e1c1ef18f95167031fe79d49260c52d0a606bc49b13e4f5",
+    "sidecar/etw-file/FilePerformance.cs": "cc35230436df9133d2954b9326b0c4384d13a11df4616ea7ad16d0b1153e7cb4",
+    "sidecar/etw-file/FilePerformanceTests.cs": "79957e72ebb643d32c2ef339bc5272465d643c672c2887a659150ac2e678d58a",
+    "sidecar/etw-file/FilePipeline.cs": "2c0f3953f6bccd0307ae16f9d5aeeb461ac66a693997948c5b22c186ebc6b487",
+    "sidecar/etw-file/FilePumpWait.cs": "7459005aa5dfbd781cd1bdc5817919365fe367c1f334d861a658816e616418f9",
+    "sidecar/etw-file/FileScope.cs": "e3a3ed207fd13a62a50d15f9d0a39d2ecd44458634fa3e1f668a5dfea6c893c2",
+    "sidecar/etw-file/FileTests.cs": "6d73b809672fc7bdc2382ff225028a7575579ce18d4f89bae7ac007f1b09ed06",
+    "sidecar/etw-file/FileTrace.cs": "658bced8e51bd5a7a7f861cd242840b1c048764aa74f051d7c59cbb0a182b75c",
+    "sidecar/etw-file/FileWakeTests.cs": "a79fb19c4f5456b490baee9649ef95ccb5f3f3804ecebedcf176bafc941739b2",
+    "sidecar/etw-file/FileWire.cs": "b51571e1fd677df68837f010de875094d55645dbc39965084b7cb163f981d2bc",
+    "sidecar/etw-file/Program.cs": "2b75300789849557166c256e9e984d199f1382f682bd1daf03b03cefdef241e8",
+    "sidecar/etw-lifecycle/Security.cs": "e924b4d38d652c4c919346aab2d9733b3623ba09e85526a0d211ce7db9c64d10",
+    "src/main/platform/etw-file-diagnostics.js": "5e3a9ecd985bbfc93a8c95f49da07f376be91b27375408ae06532294f8628be0",
+    "src/main/platform/etw-file-health.js": "3772aec338e31afddd0778bb2aab3d39c7bd385a354cb97f8dba885c7bd2e7ad",
+    "src/main/platform/etw-file-protocol.js": "d398d7fecd1937c558ea6c78b13b43a2b0d12596b0df955342aae809583bf372",
+    "src/main/platform/etw-file-runtime.js": "e013e0be3f0f3ef48b1ec66016b91722fc0d982964df766925ce39185dfa7835",
+    "src/main/platform/etw-file-schema.js": "9658604fec3f540e3c43f07b4d14c64145978bb2e00c593b420ade314d516c2c",
+    "src/main/platform/etw-file-supervisor.js": "6f30f13aac635e0d3959cf76a009124867dd7567e7583deabea73fd3e59ebed5"
+  },
+  "normalProcess": {
+    "schema": 1,
+    "live": false,
+    "synthetic": true,
+    "protocol": "etw-file/5",
+    "lossCheck": false,
+    "loadCheck": false,
+    "startedAt": "2026-09-13T02:33:49.587Z",
+    "binarySha256": "3ed01bbb7029e8d02deb03c07152f5b8d682aa6611ff7cf19ebd3596aee28ced",
+    "assemblySha256": "28740026fe19f3cada8fb2f689849810dc3b8c617f15606d6b51da7275a0cf00",
+    "cases": [
+      {
+        "kind": "normal-stop",
+        "observedRead": true,
+        "observedScopedCandidate": true,
+        "observedFixturePidCandidate": false,
+        "ringBytes": 1617,
+        "ringDropped": 0,
+        "sensorState": "DEGRADED",
+        "summary": {
+          "launchId": "2e69323d-7b87-401b-a7ad-049735b391f7",
+          "sessionId": "82847ed1-049b-4563-b62a-459b72a9701d",
+          "endedAt": 1789266830137,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "217218463075",
+              "unixMs": "1789266829992",
+              "uncertaintyQpc": "10672"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "217217132944"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "217219587967",
+            "pump": {
+              "calls": "4",
+              "totalTicks": "136310",
+              "maxTicks": "135912",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "1",
+              "totalTicks": "4689",
+              "maxTicks": "4689",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "2",
+              "totalTicks": "690203",
+              "maxTicks": "576135",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            },
+            "outputFlow": {
+              "asOfQpc": "217219587613",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "1",
+                "totalTicks": "208789",
+                "maxTicks": "208789",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "217218000000",
+                  "toQpc": "217219000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 1,
+                  "highWaterBytes": 2182,
+                  "enqueued": "1",
+                  "dequeued": "1",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217219000000",
+                  "toQpc": "217219587613",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "217219627649",
+              "duration": {
+                "calls": "3",
+                "totalTicks": "130426",
+                "maxTicks": "76856",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "21721993213600",
+            "decodeChunk": {
+              "calls": "6",
+              "totalTicks": "4966900",
+              "maxTicks": "1730600",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "3059900",
+              "maxTicks": "1337600",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "138700",
+              "maxTicks": "138700",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "22",
+              "totalTicks": "2110900",
+              "maxTicks": "279100",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      },
+      {
+        "kind": "explicit-new-session",
+        "observedRead": true,
+        "observedScopedCandidate": true,
+        "observedFixturePidCandidate": false,
+        "ringBytes": 1617,
+        "ringDropped": 0,
+        "sensorState": "DEGRADED",
+        "summary": {
+          "launchId": "3175c322-586f-49fd-b1c5-f0358a0ef800",
+          "sessionId": "d1ec91e9-f81b-452f-b40c-01d0805f588a",
+          "endedAt": 1789266830769,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "217224721483",
+              "unixMs": "1789266830617",
+              "uncertaintyQpc": "10746"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "217222947391"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "217225937293",
+            "pump": {
+              "calls": "4",
+              "totalTicks": "180932",
+              "maxTicks": "180190",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "1",
+              "totalTicks": "2682",
+              "maxTicks": "2682",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "2",
+              "totalTicks": "640979",
+              "maxTicks": "615800",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            },
+            "outputFlow": {
+              "asOfQpc": "217225936772",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "1",
+                "totalTicks": "298896",
+                "maxTicks": "298896",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "217224000000",
+                  "toQpc": "217225000000",
+                  "startRecords": 0,
+                  "records": 1,
+                  "highWaterRecords": 1,
+                  "highWaterBytes": 2182,
+                  "enqueued": "1",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217225000000",
+                  "toQpc": "217225936772",
+                  "startRecords": 1,
+                  "records": 0,
+                  "highWaterRecords": 1,
+                  "highWaterBytes": 2182,
+                  "enqueued": "0",
+                  "dequeued": "1",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "217225977450",
+              "duration": {
+                "calls": "3",
+                "totalTicks": "138612",
+                "maxTicks": "74576",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "21722625206900",
+            "decodeChunk": {
+              "calls": "5",
+              "totalTicks": "2332700",
+              "maxTicks": "1134300",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "1469300",
+              "maxTicks": "803100",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "53400",
+              "maxTicks": "53400",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "24",
+              "totalTicks": "4107600",
+              "maxTicks": "283200",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      },
+      {
+        "kind": "parent-eof-unverified",
+        "summary": {
+          "launchId": "15c41f77-28ae-4af5-949d-734ed3362208",
+          "sessionId": "1ce2b670-7c2a-4528-8201-d2ff9ccc43bc",
+          "endedAt": 1789266831345,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "217231195755",
+              "unixMs": "1789266831265",
+              "uncertaintyQpc": "10776"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "217229626080"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "217231288259",
+            "pump": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 0,
+              "highWaterBytes": 0
+            },
+            "outputFlow": {
+              "asOfQpc": "217231258735",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "217231000000",
+                  "toQpc": "217231258735",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "217231501096",
+              "duration": {
+                "calls": "1",
+                "totalTicks": "81496",
+                "maxTicks": "81496",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "21723200546100",
+            "decodeChunk": {
+              "calls": "5",
+              "totalTicks": "1186300",
+              "maxTicks": "656200",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "3",
+              "totalTicks": "670200",
+              "maxTicks": "379000",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "33100",
+              "maxTicks": "33100",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "19",
+              "totalTicks": "4115600",
+              "maxTicks": "361400",
+              "failed": "0"
+            }
+          },
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      }
+    ],
+    "passed": true,
+    "observationCheck": {
+      "observed": true,
+      "named": true,
+      "fixtureRead": false,
+      "leaked": false
+    },
+    "endedSessions": [
+      {
+        "launchId": "2e69323d-7b87-401b-a7ad-049735b391f7",
+        "sessionId": "82847ed1-049b-4563-b62a-459b72a9701d",
+        "endedAt": 1789266830137,
+        "phase": "stopped",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "mapping-uncertain",
+          "identity-uncertain"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "217218463075",
+            "unixMs": "1789266829992",
+            "uncertaintyQpc": "10672"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "217217132944"
+        },
+        "finalTotals": {
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "217219587967",
+          "pump": {
+            "calls": "4",
+            "totalTicks": "136310",
+            "maxTicks": "135912",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "1",
+            "totalTicks": "4689",
+            "maxTicks": "4689",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "2",
+            "totalTicks": "690203",
+            "maxTicks": "576135",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 2,
+            "highWaterBytes": 713
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 1,
+            "highWaterBytes": 2182
+          },
+          "outputFlow": {
+            "asOfQpc": "217219587613",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "1",
+              "totalTicks": "208789",
+              "maxTicks": "208789",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "217218000000",
+                "toQpc": "217219000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182,
+                "enqueued": "1",
+                "dequeued": "1",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217219000000",
+                "toQpc": "217219587613",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "217219627649",
+            "duration": {
+              "calls": "3",
+              "totalTicks": "130426",
+              "maxTicks": "76856",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "21721993213600",
+          "decodeChunk": {
+            "calls": "6",
+            "totalTicks": "4966900",
+            "maxTicks": "1730600",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "4",
+            "totalTicks": "3059900",
+            "maxTicks": "1337600",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "138700",
+            "maxTicks": "138700",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "22",
+            "totalTicks": "2110900",
+            "maxTicks": "279100",
+            "failed": "0"
+          }
+        },
+        "stopReason": "operator-stop",
+        "exitCode": 0,
+        "stopVerified": true
+      },
+      {
+        "launchId": "3175c322-586f-49fd-b1c5-f0358a0ef800",
+        "sessionId": "d1ec91e9-f81b-452f-b40c-01d0805f588a",
+        "endedAt": 1789266830769,
+        "phase": "stopped",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "mapping-uncertain",
+          "identity-uncertain"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "217224721483",
+            "unixMs": "1789266830617",
+            "uncertaintyQpc": "10746"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "217222947391"
+        },
+        "finalTotals": {
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "217225937293",
+          "pump": {
+            "calls": "4",
+            "totalTicks": "180932",
+            "maxTicks": "180190",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "1",
+            "totalTicks": "2682",
+            "maxTicks": "2682",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "2",
+            "totalTicks": "640979",
+            "maxTicks": "615800",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 2,
+            "highWaterBytes": 713
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 1,
+            "highWaterBytes": 2182
+          },
+          "outputFlow": {
+            "asOfQpc": "217225936772",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "1",
+              "totalTicks": "298896",
+              "maxTicks": "298896",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "217224000000",
+                "toQpc": "217225000000",
+                "startRecords": 0,
+                "records": 1,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182,
+                "enqueued": "1",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217225000000",
+                "toQpc": "217225936772",
+                "startRecords": 1,
+                "records": 0,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182,
+                "enqueued": "0",
+                "dequeued": "1",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "217225977450",
+            "duration": {
+              "calls": "3",
+              "totalTicks": "138612",
+              "maxTicks": "74576",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "21722625206900",
+          "decodeChunk": {
+            "calls": "5",
+            "totalTicks": "2332700",
+            "maxTicks": "1134300",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "4",
+            "totalTicks": "1469300",
+            "maxTicks": "803100",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "53400",
+            "maxTicks": "53400",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "24",
+            "totalTicks": "4107600",
+            "maxTicks": "283200",
+            "failed": "0"
+          }
+        },
+        "stopReason": "operator-stop",
+        "exitCode": 0,
+        "stopVerified": true
+      },
+      {
+        "launchId": "15c41f77-28ae-4af5-949d-734ed3362208",
+        "sessionId": "1ce2b670-7c2a-4528-8201-d2ff9ccc43bc",
+        "endedAt": 1789266831345,
+        "phase": "failed",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "mapping-uncertain",
+          "identity-uncertain",
+          "stream-ended"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "217231195755",
+            "unixMs": "1789266831265",
+            "uncertaintyQpc": "10776"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "217229626080"
+        },
+        "finalTotals": {
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "217231288259",
+          "pump": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 2,
+            "highWaterBytes": 713
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 0,
+            "highWaterBytes": 0
+          },
+          "outputFlow": {
+            "asOfQpc": "217231258735",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "217231000000",
+                "toQpc": "217231258735",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "217231501096",
+            "duration": {
+              "calls": "1",
+              "totalTicks": "81496",
+              "maxTicks": "81496",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "21723200546100",
+          "decodeChunk": {
+            "calls": "5",
+            "totalTicks": "1186300",
+            "maxTicks": "656200",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "3",
+            "totalTicks": "670200",
+            "maxTicks": "379000",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "33100",
+            "maxTicks": "33100",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "19",
+            "totalTicks": "4115600",
+            "maxTicks": "361400",
+            "failed": "0"
+          }
+        },
+        "stopReason": null,
+        "exitCode": 2,
+        "stopVerified": false
+      }
+    ],
+    "endedAt": "2026-09-13T02:33:51.377Z"
+  },
+  "lossProcess": {
+    "schema": 1,
+    "live": false,
+    "synthetic": true,
+    "protocol": "etw-file/5",
+    "lossCheck": true,
+    "loadCheck": false,
+    "startedAt": "2026-09-13T02:33:53.264Z",
+    "binarySha256": "3ed01bbb7029e8d02deb03c07152f5b8d682aa6611ff7cf19ebd3596aee28ced",
+    "assemblySha256": "28740026fe19f3cada8fb2f689849810dc3b8c617f15606d6b51da7275a0cf00",
+    "cases": [
+      {
+        "kind": "normal-stop",
+        "observedRead": true,
+        "observedScopedCandidate": true,
+        "observedFixturePidCandidate": false,
+        "ringBytes": 116136,
+        "ringDropped": 0,
+        "sensorState": "DEGRADED",
+        "summary": {
+          "launchId": "fcddc3c5-0061-4109-85b9-da1e3e7d2028",
+          "sessionId": "af38933d-c586-4703-b681-6bb34c43accc",
+          "endedAt": 1789266834110,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "217258076307",
+              "unixMs": "1789266833953",
+              "uncertaintyQpc": "11098"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "217254199063"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "217259292479",
+            "pump": {
+              "calls": "28",
+              "totalTicks": "898965",
+              "maxTicks": "130526",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "27",
+              "totalTicks": "637896",
+              "maxTicks": "34008",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            },
+            "outputFlow": {
+              "asOfQpc": "217259291925",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "1",
+                "totalTicks": "2692952",
+                "maxTicks": "2692952",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "217254000000",
+                  "toQpc": "217255000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217255000000",
+                  "toQpc": "217256000000",
+                  "startRecords": 0,
+                  "records": 1536,
+                  "highWaterRecords": 1536,
+                  "highWaterBytes": 3351552,
+                  "enqueued": "1536",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217256000000",
+                  "toQpc": "217257000000",
+                  "startRecords": 1536,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "386",
+                  "dequeued": "0",
+                  "overflow": "2803",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217257000000",
+                  "toQpc": "217258000000",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "3467",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217258000000",
+                  "toQpc": "217259000000",
+                  "startRecords": 1922,
+                  "records": 626,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "1296",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217259000000",
+                  "toQpc": "217259291925",
+                  "startRecords": 626,
+                  "records": 0,
+                  "highWaterRecords": 626,
+                  "highWaterBytes": 1365932,
+                  "enqueued": "0",
+                  "dequeued": "626",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "217259320284",
+              "duration": {
+                "calls": "29",
+                "totalTicks": "367874",
+                "maxTicks": "82877",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "21725965001300",
+            "decodeChunk": {
+              "calls": "31",
+              "totalTicks": "27494100",
+              "maxTicks": "2984400",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "30",
+              "totalTicks": "11099900",
+              "maxTicks": "1191600",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "612300",
+              "maxTicks": "612300",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "31",
+              "totalTicks": "4232700",
+              "maxTicks": "893400",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      },
+      {
+        "kind": "explicit-new-session",
+        "observedRead": true,
+        "observedScopedCandidate": true,
+        "observedFixturePidCandidate": false,
+        "ringBytes": 116136,
+        "ringDropped": 0,
+        "sensorState": "DEGRADED",
+        "summary": {
+          "launchId": "daf769da-5158-4911-b18b-ee49d95a32e5",
+          "sessionId": "c7939111-3c50-49e6-9bcd-63c5ed64fb2e",
+          "endedAt": 1789266835010,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "217266900689",
+              "unixMs": "1789266834835",
+              "uncertaintyQpc": "11029"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "217263004704"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "217268227482",
+            "pump": {
+              "calls": "28",
+              "totalTicks": "1072661",
+              "maxTicks": "133905",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "27",
+              "totalTicks": "830608",
+              "maxTicks": "47958",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            },
+            "outputFlow": {
+              "asOfQpc": "217268226795",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "1",
+                "totalTicks": "2662698",
+                "maxTicks": "2662698",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "217263000000",
+                  "toQpc": "217264000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217264000000",
+                  "toQpc": "217265000000",
+                  "startRecords": 0,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "1922",
+                  "dequeued": "0",
+                  "overflow": "126",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217265000000",
+                  "toQpc": "217266000000",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "3584",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217266000000",
+                  "toQpc": "217267000000",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "2560",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217267000000",
+                  "toQpc": "217268000000",
+                  "startRecords": 1922,
+                  "records": 410,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "1512",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217268000000",
+                  "toQpc": "217268226795",
+                  "startRecords": 410,
+                  "records": 0,
+                  "highWaterRecords": 410,
+                  "highWaterBytes": 894620,
+                  "enqueued": "0",
+                  "dequeued": "410",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "217268257087",
+              "duration": {
+                "calls": "29",
+                "totalTicks": "339069",
+                "maxTicks": "89667",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "21726865322900",
+            "decodeChunk": {
+              "calls": "31",
+              "totalTicks": "18665200",
+              "maxTicks": "1757400",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "30",
+              "totalTicks": "7340100",
+              "maxTicks": "1221100",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "876400",
+              "maxTicks": "876400",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "33",
+              "totalTicks": "6418400",
+              "maxTicks": "424900",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      },
+      {
+        "kind": "parent-eof-unverified",
+        "summary": {
+          "launchId": "18e2da90-9230-4d75-ac2c-266456c09781",
+          "sessionId": "1c68412a-4112-4560-be0f-5f7f81c7c381",
+          "endedAt": 1789266835813,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "217275625281",
+              "unixMs": "1789266835708",
+              "uncertaintyQpc": "11275"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "217271603434"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "217275667898",
+            "pump": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 1922,
+              "bytes": 4193804,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            },
+            "outputFlow": {
+              "asOfQpc": "217275639595",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "217271000000",
+                  "toQpc": "217272000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217273000000",
+                  "toQpc": "217274000000",
+                  "startRecords": 0,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "1922",
+                  "dequeued": "0",
+                  "overflow": "1150",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217274000000",
+                  "toQpc": "217275000000",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "3111",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "217275000000",
+                  "toQpc": "217275639595",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "2009",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "217275900951",
+              "duration": {
+                "calls": "1",
+                "totalTicks": "92746",
+                "maxTicks": "92746",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "21727668349900",
+            "decodeChunk": {
+              "calls": "6",
+              "totalTicks": "3504000",
+              "maxTicks": "1088100",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "5",
+              "totalTicks": "2202500",
+              "maxTicks": "753700",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "3",
+              "totalTicks": "1274600",
+              "maxTicks": "556000",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "26",
+              "totalTicks": "6812000",
+              "maxTicks": "958100",
+              "failed": "0"
+            }
+          },
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      }
+    ],
+    "passed": true,
+    "observationCheck": {
+      "observed": true,
+      "named": true,
+      "fixtureRead": false,
+      "leaked": false
+    },
+    "endedSessions": [
+      {
+        "launchId": "fcddc3c5-0061-4109-85b9-da1e3e7d2028",
+        "sessionId": "af38933d-c586-4703-b681-6bb34c43accc",
+        "endedAt": 1789266834110,
+        "phase": "stopped",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "dropped",
+          "ingressDropped",
+          "outputDropped",
+          "outputOverflowDropped",
+          "mapResets",
+          "mapping-uncertain",
+          "identity-uncertain"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "217258076307",
+            "unixMs": "1789266833953",
+            "uncertaintyQpc": "11098"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "217254199063"
+        },
+        "finalTotals": {
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "217259292479",
+          "pump": {
+            "calls": "28",
+            "totalTicks": "898965",
+            "maxTicks": "130526",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "27",
+            "totalTicks": "637896",
+            "maxTicks": "34008",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 4096,
+            "highWaterBytes": 1048576
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 1922,
+            "highWaterBytes": 4193804
+          },
+          "outputFlow": {
+            "asOfQpc": "217259291925",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "1",
+              "totalTicks": "2692952",
+              "maxTicks": "2692952",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "217254000000",
+                "toQpc": "217255000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217255000000",
+                "toQpc": "217256000000",
+                "startRecords": 0,
+                "records": 1536,
+                "highWaterRecords": 1536,
+                "highWaterBytes": 3351552,
+                "enqueued": "1536",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217256000000",
+                "toQpc": "217257000000",
+                "startRecords": 1536,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "386",
+                "dequeued": "0",
+                "overflow": "2803",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217257000000",
+                "toQpc": "217258000000",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "3467",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217258000000",
+                "toQpc": "217259000000",
+                "startRecords": 1922,
+                "records": 626,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "1296",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217259000000",
+                "toQpc": "217259291925",
+                "startRecords": 626,
+                "records": 0,
+                "highWaterRecords": 626,
+                "highWaterBytes": 1365932,
+                "enqueued": "0",
+                "dequeued": "626",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "217259320284",
+            "duration": {
+              "calls": "29",
+              "totalTicks": "367874",
+              "maxTicks": "82877",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "21725965001300",
+          "decodeChunk": {
+            "calls": "31",
+            "totalTicks": "27494100",
+            "maxTicks": "2984400",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "30",
+            "totalTicks": "11099900",
+            "maxTicks": "1191600",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "612300",
+            "maxTicks": "612300",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "31",
+            "totalTicks": "4232700",
+            "maxTicks": "893400",
+            "failed": "0"
+          }
+        },
+        "stopReason": "operator-stop",
+        "exitCode": 0,
+        "stopVerified": true
+      },
+      {
+        "launchId": "daf769da-5158-4911-b18b-ee49d95a32e5",
+        "sessionId": "c7939111-3c50-49e6-9bcd-63c5ed64fb2e",
+        "endedAt": 1789266835010,
+        "phase": "stopped",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "dropped",
+          "ingressDropped",
+          "outputDropped",
+          "outputOverflowDropped",
+          "mapResets",
+          "mapping-uncertain",
+          "identity-uncertain"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "217266900689",
+            "unixMs": "1789266834835",
+            "uncertaintyQpc": "11029"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "217263004704"
+        },
+        "finalTotals": {
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "217268227482",
+          "pump": {
+            "calls": "28",
+            "totalTicks": "1072661",
+            "maxTicks": "133905",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "27",
+            "totalTicks": "830608",
+            "maxTicks": "47958",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 4096,
+            "highWaterBytes": 1048576
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 1922,
+            "highWaterBytes": 4193804
+          },
+          "outputFlow": {
+            "asOfQpc": "217268226795",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "1",
+              "totalTicks": "2662698",
+              "maxTicks": "2662698",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "217263000000",
+                "toQpc": "217264000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217264000000",
+                "toQpc": "217265000000",
+                "startRecords": 0,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "1922",
+                "dequeued": "0",
+                "overflow": "126",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217265000000",
+                "toQpc": "217266000000",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "3584",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217266000000",
+                "toQpc": "217267000000",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "2560",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217267000000",
+                "toQpc": "217268000000",
+                "startRecords": 1922,
+                "records": 410,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "1512",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217268000000",
+                "toQpc": "217268226795",
+                "startRecords": 410,
+                "records": 0,
+                "highWaterRecords": 410,
+                "highWaterBytes": 894620,
+                "enqueued": "0",
+                "dequeued": "410",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "217268257087",
+            "duration": {
+              "calls": "29",
+              "totalTicks": "339069",
+              "maxTicks": "89667",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "21726865322900",
+          "decodeChunk": {
+            "calls": "31",
+            "totalTicks": "18665200",
+            "maxTicks": "1757400",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "30",
+            "totalTicks": "7340100",
+            "maxTicks": "1221100",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "876400",
+            "maxTicks": "876400",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "33",
+            "totalTicks": "6418400",
+            "maxTicks": "424900",
+            "failed": "0"
+          }
+        },
+        "stopReason": "operator-stop",
+        "exitCode": 0,
+        "stopVerified": true
+      },
+      {
+        "launchId": "18e2da90-9230-4d75-ac2c-266456c09781",
+        "sessionId": "1c68412a-4112-4560-be0f-5f7f81c7c381",
+        "endedAt": 1789266835813,
+        "phase": "failed",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "dropped",
+          "ingressDropped",
+          "outputDropped",
+          "outputOverflowDropped",
+          "mapResets",
+          "mapping-uncertain",
+          "identity-uncertain",
+          "stream-ended"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "217275625281",
+            "unixMs": "1789266835708",
+            "uncertaintyQpc": "11275"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "217271603434"
+        },
+        "finalTotals": {
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "217275667898",
+          "pump": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 4096,
+            "highWaterBytes": 1048576
+          },
+          "output": {
+            "records": 1922,
+            "bytes": 4193804,
+            "highWaterRecords": 1922,
+            "highWaterBytes": 4193804
+          },
+          "outputFlow": {
+            "asOfQpc": "217275639595",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "217271000000",
+                "toQpc": "217272000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217273000000",
+                "toQpc": "217274000000",
+                "startRecords": 0,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "1922",
+                "dequeued": "0",
+                "overflow": "1150",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217274000000",
+                "toQpc": "217275000000",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "3111",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "217275000000",
+                "toQpc": "217275639595",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "2009",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "217275900951",
+            "duration": {
+              "calls": "1",
+              "totalTicks": "92746",
+              "maxTicks": "92746",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "21727668349900",
+          "decodeChunk": {
+            "calls": "6",
+            "totalTicks": "3504000",
+            "maxTicks": "1088100",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "5",
+            "totalTicks": "2202500",
+            "maxTicks": "753700",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "3",
+            "totalTicks": "1274600",
+            "maxTicks": "556000",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "26",
+            "totalTicks": "6812000",
+            "maxTicks": "958100",
+            "failed": "0"
+          }
+        },
+        "stopReason": null,
+        "exitCode": 2,
+        "stopVerified": false
+      }
+    ],
+    "endedAt": "2026-09-13T02:33:55.814Z"
+  }
+}

--- a/docs/roadmap/etw-burst-diagnostics.md
+++ b/docs/roadmap/etw-burst-diagnostics.md
@@ -1,0 +1,98 @@
+# B5 follow-up — bounded burst measurements
+
+Implemented on `codex/etw-burst-diagnostics` from `ef5f39c` (merged #449).
+The previous [live wakeup run](etw-output-wakeup.md) counted 50,246 output overflow
+drops with zero ingress/native losses. Whole-session elapsed totals did not show
+when arrival exceeded draining. This change supplies measurements for the next
+controlled experiment; it does not claim a reduction in losses.
+
+## Measurements
+
+Matching main/helper builds require `etw-file/5`, with helper marker `-5-burst`.
+Earlier protocol versions are rejected. Existing queue caps, output batching,
+notification behavior, process-witness budget and loss classifications are unchanged.
+
+`performance.outputFlow` is sampled under the existing output queue lock. Each
+window spans at most `floor(frequency / 10)` QPC ticks, on that absolute clock grid.
+It records successful `enqueued`, `dequeued`, rejected `overflow`, queued
+`invalidated`, initial/current record counts and record/byte high water. Counts
+remain canonical uint64 strings. Every window obeys:
+
+```text
+startRecords + enqueued = records + dequeued + invalidated
+```
+
+These are output-queue transitions after mapping/filtering, not kernel arrival or
+logical read counts. A dequeued record can still be invalidated during its process
+witness, fail encoding or fail transport. Such in-flight invalidations remain in
+the existing total loss counter; the window's `invalidated` counts queued discard
+only. Window `overflow` corresponds to `outputOverflowDropped`, but an evicted
+history cannot reconstruct lifetime totals.
+
+At most 256 windows are retained. A transition or snapshot in a later window adds
+one entry; intervals with neither are omitted, including arbitrarily long quiet
+gaps. `evictedWindows` counts removed entries. No per-event data or path is retained.
+Snapshots are detached; the active window ends at `outputFlow.asOfQpc`, previous
+ones at their boundary. A partial current window is not a complete 100 ms rate
+sample. The first retained window may also begin before profiling started.
+Instrumentation uses one clock read and constant work per queue transition;
+history copying/serialization is bounded. Its overhead has not been measured live.
+
+`outputFlow.readyToTake` measures from the first enqueue into an empty queue to
+the first successful dequeue of that backlog. It excludes preceding quiet time
+and is recorded once per empty-to-nonempty transition. Invalidation retires a
+pending readiness timestamp without a successful timing sample. This is reader
+response delay, including scheduling and any intervening collector work, rather
+than a pure OS scheduler measurement. It does not measure the waiting time of
+every queued record. `idleWait` keeps its earlier meaning, including quiet waits.
+
+`performance.brokerForward` is added by the normal-token broker. Its `duration`
+covers elapsed annotation, serialization and stdout header/body/flush work for
+all outbound frame kinds, including failed attempts. It excludes reading and
+decoding from the collector pipe, and includes downstream backpressure. The
+sample's `asOfQpc` is captured before forwarding its carrying telemetry frame;
+the duration covers only earlier completed forwards. Consequently final stopped
+telemetry excludes its own forwarding duration. The collector supplies a null
+placeholder, which the broker replaces; main rejects a missing/null broker sample.
+No failure text or stream data is retained in these counters.
+
+Collector `pump` and nested `outputWrite`, broker forwarding, and main callback
+timings remain distinct elapsed regions. Do not sum them as CPU time. Ingress
+depth/native loss counters remain separate; this change does not add ingress
+arrival windows or isolate broker decoding cost.
+
+## Verification and limits
+
+The initial regression failed against the old output snapshot because readiness
+delay and burst counts were absent. With the implementation, 54 C# self-tests
+pass, including controlled clock boundaries, quiet time, backlog timing,
+invalidation, a 256-entry ring with a long idle jump, snapshot isolation and broker
+failure accounting. The existing saturation fixture also reconciles retained
+window overflow/dequeue totals with actual pipeline loss and drained output.
+JS tests reject malformed, missing, oversized and inconsistent profiles, reject
+v4, and round-trip 256 windows with integers beyond Number precision under the
+existing frame/depth bounds. The process harness requires measured forwarding,
+readiness and window samples in each normal stopped summary.
+
+The [retained evidence](../recon/evidence/etw-file-home-26200-burst-diagnostics.json)
+contains the final normal/saturation process reports, matching executable and
+assembly hashes and 32 source hashes. Each process report passed two clean stops
+and one parent-EOF scenario with unverified stop/restart blocked. No EtwFile
+processes remained after those runs. The first saturation session retained 1,922
+enqueues/dequeues, 6,270 output overflows and 4,097 ingress drops. Windows show the
+queue filling before draining begins, as the synthetic fixture deliberately
+requires. These values validate instrumentation and loss accounting; they are
+not a live-provider throughput measurement.
+
+Required local checks passed: renderer build, format/lint, TypeScript/Svelte,
+production dependency audit, derived counts and both four-mutant gates. Full
+coverage passed 206 files / 3,398 tests with four skips using two workers. An
+initial run alongside build/lint had 12 failures involving UI timeouts; the
+isolated rerun preserved the same timeouts and assertions. The .NET build and
+whitespace verification also passed. Repository CI does not build this sidecar.
+
+Only normal-token synthetic/process checks are authorized for this iteration.
+The user deferred a new real-provider/UAC load run. The historical 66,000-read
+workload and earlier live reports remain unchanged. E3 stays open, as do event-time
+identity, path admission, independent absence/protected crash recovery and
+deployment. Sleep/wake and installer work remain deferred.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2317,3 +2317,37 @@ open. Sleep/wake remains deferred. Three raw reports and 28 source hashes are in
 Full JS coverage passed 200 files / 3354 tests / four skips, and all required local
 checks passed. Check this branch's final PR/CI/merge before continuing. Original
 dirty UI work and the installed application were preserved.
+
+### 2026-09-13 — ETW burst diagnostics, live run deferred
+
+Implemented on `codex/etw-burst-diagnostics` from `ef5f39c` / merged #449, in an
+isolated worktree. Installer work in `codex/installer-typography` and the dirty
+original checkout remain separate. The user authorized normal-token tests only
+and explicitly deferred the proposed new UAC/66,000-read run.
+
+Protocol v5 adds output queue transitions/high water in at most 256 active 100 ms
+windows, readiness-to-first-dequeue delay and normal-token broker forwarding
+durations. Queues, frames, identity/attribution and native ownership retain their
+existing limits. Window dequeues do not prove transport; invalidation in flight
+remains in existing loss totals. Broker duration excludes pipe reading/decoding
+and the telemetry frame carrying its own sample. Main validates closed bounded
+profiles and retains them in ended summaries; no new renderer IPC or path export.
+
+The initial missing-profile regression failed, then 54 C# self-tests and normal/
+saturation process checks passed (three scenarios each). The saturation report
+reconciles 1,922 enqueues/dequeues and 6,270 output overflows, plus 4,097 ingress
+drops. Both clean stops verified; parent EOF stayed unverified with retry blocked.
+No EtwFile helpers remained. Reports/binary hashes and 32 source hashes are in
+`docs/recon/evidence/etw-file-home-26200-burst-diagnostics.json`; measurement regions
+and limits are in `docs/roadmap/etw-burst-diagnostics.md`.
+
+Full coverage passed 206 files / 3,398 tests / four skips with two workers. An
+initial run concurrent with build/lint had 12 failures involving UI timeouts;
+the isolated rerun kept the same test timeouts and assertions. E3 remains open:
+instrumentation is implemented, but live overhead, burst cause and a throughput
+fix remain unverified. Sleep/wake, protected crash recovery, deployment and the
+installer are deferred. Check this branch's final PR/CI/merge before continuing.
+
+All required local checks passed, including both four-mutant gates; the .NET
+Release build and whitespace verification passed separately. The existing five
+repository CI contexts do not compile the diagnostic C# sidecar.

--- a/scripts/verify-etw-file.mjs
+++ b/scripts/verify-etw-file.mjs
@@ -108,6 +108,9 @@ try {
       !result.mainPerformance ||
       BigInt(result.collectorPerformance.pump.calls) === 0n ||
       BigInt(result.collectorPerformance.outputWrite.calls) === 0n ||
+      BigInt(result.collectorPerformance.brokerForward?.duration.calls ?? 0) === 0n ||
+      BigInt(result.collectorPerformance.outputFlow?.readyToTake.calls ?? 0) === 0n ||
+      !result.collectorPerformance.outputFlow?.windows.length ||
       BigInt(result.mainPerformance.decodeChunk.calls) === 0n
     )
       throw new Error('service-measurements-missing');

--- a/sidecar/etw-file/FileBroker.cs
+++ b/sidecar/etw-file/FileBroker.cs
@@ -43,11 +43,12 @@ internal static class FileBroker
             });
             var outbound = Task.Run(async () =>
             {
+                var performance = new FileForwardProfile();
                 while (true)
                 {
                     var frame = await read.Read(pipe, false, lifetime.Token);
                     if (frame.t == "stopped") Volatile.Write(ref terminalObserved, 1);
-                    await FileWire.Forward(output, frame, lifetime.Token);
+                    await performance.Forward(output, frame, lifetime.Token);
                     if (frame.t == "stopped") return;
                 }
             });

--- a/sidecar/etw-file/FileBurstTests.cs
+++ b/sidecar/etw-file/FileBurstTests.cs
@@ -166,6 +166,11 @@ internal static class FileBurstTests
             Check(Counter("decoderErrors") == 0 && Counter("filtered") == 1, "distinct-filtering");
             Check(Counter("dropped") == Counter("ingressDropped") + Counter("outputDropped"), "stage-sum");
             Check(Counter("delivered") == Counter("filtered") + Counter("dropped") + output, "total-accounting");
+            var sample = JsonSerializer.SerializeToElement(pipeline.QueueSnapshot());
+            var windows = sample.GetProperty("flow").GetProperty("windows").EnumerateArray().ToArray();
+            Check(sample.GetProperty("flow").GetProperty("evictedWindows").GetString() == "0", "fixture-window-eviction");
+            Check(windows.Sum(w => long.Parse(w.GetProperty("overflow").GetString()!)) == (long)Counter("outputOverflowDropped"), "window-overflow-accounting");
+            Check(windows.Sum(w => long.Parse(w.GetProperty("dequeued").GetString()!)) == (long)output, "window-drain-accounting");
         });
         test("output invalidation counts every queued record independently of overflow", () =>
         {

--- a/sidecar/etw-file/FileCollector.cs
+++ b/sidecar/etw-file/FileCollector.cs
@@ -37,7 +37,7 @@ internal static class FileCollector
         {
             await send.Write(pipe, "hello", new
             {
-                build = live ? "etw-file-diagnostic-dev-4-wakeup" : "etw-file-synthetic-check-4-wakeup",
+                build = live ? "etw-file-diagnostic-dev-5-burst" : "etw-file-synthetic-check-5-burst",
                 profile = FileWire.Profile,
                 schemas = FileWire.Schemas
             }, lifetime.Token);

--- a/sidecar/etw-file/FileForwardProfile.cs
+++ b/sidecar/etw-file/FileForwardProfile.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Aegis.EtwLifecycle;
+
+// One broker outbound loop owns this profile. Read/idle time is excluded.
+internal sealed class FileForwardProfile(Func<long>? timestamp = null)
+{
+    private readonly FileDuration duration = new();
+    private long Now() => (timestamp ?? Stopwatch.GetTimestamp)();
+    internal async Task Forward(Stream stream, Envelope frame, CancellationToken token)
+    {
+        long start = Now(); bool success = false;
+        try
+        {
+            if (frame.t is "ready" or "health" or "heartbeat" or "stopped")
+            {
+                var data = JsonNode.Parse(frame.data.GetRawText())!;
+                var telemetry = frame.t is "ready" or "stopped" ? data["telemetry"]! : data;
+                // This sample covers completed forwards before the carrying frame.
+                telemetry["performance"]!["brokerForward"] = JsonSerializer.SerializeToNode(new
+                {
+                    asOfQpc = start.ToString(),
+                    duration = duration.Snapshot()
+                });
+                frame = frame with { data = JsonSerializer.SerializeToElement(data) };
+            }
+            await FileWire.Forward(stream, frame, token); success = true;
+        }
+        finally { duration.Record(Now() - start, !success); }
+    }
+}

--- a/sidecar/etw-file/FileOutputProfile.cs
+++ b/sidecar/etw-file/FileOutputProfile.cs
@@ -1,0 +1,84 @@
+namespace Aegis.EtwLifecycle;
+
+// Owned by the existing output queue lock. Constant work per transition, no
+// record/path retention, and at most 256 active 100ms windows (quiet gaps omitted).
+internal sealed class FileOutputProfile
+{
+    internal const int Capacity = 256;
+    private readonly long width;
+    private readonly Queue<Window> windows = new();
+    private readonly FileDuration readyToTake = new();
+    private long? readyAt;
+    private ulong evicted;
+    private int records, bytes;
+    private sealed class Window(long from, int count, int size)
+    {
+        internal readonly long From = from;
+        internal readonly int StartRecords = count;
+        internal int Records = count, HighRecords = count, HighBytes = size;
+        internal ulong Enqueued, Dequeued, Overflow, Invalidated;
+        internal object Snapshot(long to) => new
+        {
+            fromQpc = From.ToString(),
+            toQpc = to.ToString(),
+            startRecords = StartRecords,
+            records = Records,
+            highWaterRecords = HighRecords,
+            highWaterBytes = HighBytes,
+            enqueued = Enqueued.ToString(),
+            dequeued = Dequeued.ToString(),
+            overflow = Overflow.ToString(),
+            invalidated = Invalidated.ToString()
+        };
+    }
+    private Window? current;
+    internal FileOutputProfile(long frequency)
+    {
+        if (frequency < 10) throw new ArgumentOutOfRangeException(nameof(frequency));
+        width = frequency / 10;
+    }
+    private Window At(long now)
+    {
+        long from = now - now % width;
+        if (current == null || from > current.From)
+        {
+            if (windows.Count == Capacity) { windows.Dequeue(); evicted++; }
+            current = new Window(from, records, bytes); windows.Enqueue(current);
+        }
+        return current;
+    }
+    internal void Enqueue(long now, int size)
+    {
+        var window = At(now);
+        if (records == 0) readyAt = now;
+        window.Enqueued++; records++; bytes += size;
+        window.Records = records;
+        window.HighRecords = Math.Max(window.HighRecords, records);
+        window.HighBytes = Math.Max(window.HighBytes, bytes);
+    }
+    internal void Dequeue(long now, int size)
+    {
+        var window = At(now);
+        if (readyAt is { } since) { readyToTake.Record(now - since); readyAt = null; }
+        window.Dequeued++; records--; bytes -= size; window.Records = records;
+    }
+    internal void Overflow(long now) => At(now).Overflow++;
+    internal void Invalidate(long now)
+    {
+        var window = At(now);
+        window.Invalidated += (ulong)records;
+        records = bytes = window.Records = 0; readyAt = null;
+    }
+    internal object Snapshot(long now)
+    {
+        At(now);
+        return new
+        {
+            asOfQpc = now.ToString(),
+            windowTicks = width.ToString(),
+            evictedWindows = evicted.ToString(),
+            readyToTake = readyToTake.Snapshot(),
+            windows = windows.Select(w => w.Snapshot(Math.Min(now, w.From + width))).ToArray()
+        };
+    }
+}

--- a/sidecar/etw-file/FileOutputProfileTests.cs
+++ b/sidecar/etw-file/FileOutputProfileTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+
+namespace Aegis.EtwLifecycle;
+
+internal static class FileOutputProfileTests
+{
+    internal static void Run(Action<string, Action> test)
+    {
+        test("burst windows separate enqueue drain overflow and invalidation at boundaries", () =>
+        {
+            var flow = new FileOutputProfile(1000);
+            flow.Enqueue(1, 100); flow.Enqueue(99, 200); flow.Overflow(99);
+            flow.Dequeue(100, 100); flow.Invalidate(101);
+            flow.Enqueue(102, 300); flow.Dequeue(110, 300);
+            var sample = JsonSerializer.SerializeToElement(flow.Snapshot(120));
+            var windows = sample.GetProperty("windows");
+            Check(windows.GetArrayLength() == 2);
+            Check(windows[0].GetProperty("toQpc").GetString() == "100");
+            Check(windows[0].GetProperty("records").GetInt32() == 2);
+            Check(windows[0].GetProperty("highWaterBytes").GetInt32() == 300);
+            Check(windows[0].GetProperty("overflow").GetString() == "1");
+            Check(windows[1].GetProperty("startRecords").GetInt32() == 2);
+            Check(windows[1].GetProperty("enqueued").GetString() == "1");
+            Check(windows[1].GetProperty("dequeued").GetString() == "2");
+            Check(windows[1].GetProperty("invalidated").GetString() == "1");
+            Check(windows[1].GetProperty("records").GetInt32() == 0);
+            var ready = sample.GetProperty("readyToTake");
+            Check(ready.GetProperty("calls").GetString() == "2");
+            Check(ready.GetProperty("totalTicks").GetString() == "107");
+            flow.Enqueue(125, 400);
+            Check(windows[1].GetProperty("records").GetInt32() == 0); // Detached snapshot.
+        });
+        test("invalidated readiness is not reused or counted as a successful dequeue", () =>
+        {
+            var flow = new FileOutputProfile(1000);
+            flow.Enqueue(1, 100); flow.Invalidate(90);
+            flow.Enqueue(100, 100); flow.Dequeue(107, 100);
+            var ready = JsonSerializer.SerializeToElement(flow.Snapshot(120)).GetProperty("readyToTake");
+            Check(ready.GetProperty("calls").GetString() == "1");
+            Check(ready.GetProperty("totalTicks").GetString() == "7");
+        });
+        test("profile ring remains bounded and skips arbitrarily long quiet gaps", () =>
+        {
+            var flow = new FileOutputProfile(1000);
+            for (int i = 0; i < 300; i++)
+            {
+                flow.Enqueue(i * 100, 100); flow.Dequeue(i * 100 + 1, 100);
+            }
+            var before = JsonSerializer.SerializeToElement(flow.Snapshot(29901));
+            Check(before.GetProperty("windows").GetArrayLength() == 256);
+            Check(before.GetProperty("evictedWindows").GetString() == "44");
+            // A huge jump must not allocate an entry for each idle interval.
+            var after = JsonSerializer.SerializeToElement(flow.Snapshot(1000000000000));
+            Check(after.GetProperty("windows").GetArrayLength() == 256);
+            Check(after.GetProperty("evictedWindows").GetString() == "45");
+            Check(after.GetProperty("windows")[255].GetProperty("fromQpc").GetString() == "1000000000000");
+            Check(before.GetProperty("windows")[255].GetProperty("fromQpc").GetString() == "29900");
+        });
+        test("broker reports completed forwards and accounts failed writes without error details", () =>
+        {
+            long clock = 0;
+            var forward = new FileForwardProfile(() => clock);
+            using var bad = new TimedStream(() => { clock += 5; throw new IOException("private-error"); });
+            bool failed = false;
+            try { forward.Forward(bad, Frame("observations", new { records = Array.Empty<object>() }), default).GetAwaiter().GetResult(); }
+            catch (IOException) { failed = true; }
+            Check(failed);
+            clock += 1000000; // Time waiting for the next input is not forwarding time.
+            using var good = new TimedStream(() => clock += 7);
+            var payload = new { performance = new { brokerForward = (object?)null } };
+            forward.Forward(good, Frame("heartbeat", payload), default).GetAwaiter().GetResult();
+            good.Position = 0;
+            var read = new FileWire("launch", "session").Read(good, false, default).GetAwaiter().GetResult();
+            var profile = read.data.GetProperty("performance").GetProperty("brokerForward");
+            Check(profile.GetProperty("asOfQpc").GetString() == "1000005");
+            Check(profile.GetProperty("duration").GetProperty("calls").GetString() == "1");
+            Check(profile.GetProperty("duration").GetProperty("failed").GetString() == "1");
+            Check(profile.GetProperty("duration").GetProperty("totalTicks").GetString() == "5");
+            good.SetLength(0); good.Position = 0;
+            forward.Forward(good, Frame("stopped", new { telemetry = payload }), default).GetAwaiter().GetResult();
+            good.Position = 0;
+            read = new FileWire("launch", "session").Read(good, false, default).GetAwaiter().GetResult();
+            profile = read.data.GetProperty("telemetry").GetProperty("performance").GetProperty("brokerForward");
+            Check(profile.GetProperty("duration").GetProperty("calls").GetString() == "2");
+            Check(profile.GetProperty("duration").GetProperty("totalTicks").GetString() == "26");
+            Check(!read.data.GetRawText().Contains("private-error"));
+        });
+    }
+    private static Envelope Frame(string kind, object data) =>
+        new(kind, FileWire.Protocol, "launch", "session", "1", JsonSerializer.SerializeToElement(data));
+    private static void Check(bool value) { if (!value) throw new InvalidOperationException("output-profile-check-failed"); }
+    private sealed class TimedStream(Action advance) : MemoryStream
+    {
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token = default)
+        { advance(); return base.WriteAsync(buffer, token); }
+        public override Task FlushAsync(CancellationToken token)
+        { advance(); return base.FlushAsync(token); }
+    }
+}

--- a/sidecar/etw-file/FilePerformance.cs
+++ b/sidecar/etw-file/FilePerformance.cs
@@ -34,9 +34,11 @@ internal sealed class FilePerformance(Func<long>? timestamp = null, long? freque
         outputWrite = OutputWrite.Snapshot(),
         idleWait = IdleWait.Snapshot(),
         ingress = queues.ingress,
-        output = queues.output
+        output = queues.output,
+        outputFlow = queues.flow,
+        brokerForward = (object?)null // Filled by the normal-token broker, never invented here.
     };
 }
 
 internal sealed record FileQueueDepth(int records, int bytes, int highWaterRecords, int highWaterBytes);
-internal sealed record FileQueueSnapshot(FileQueueDepth combined, FileQueueDepth ingress, FileQueueDepth output);
+internal sealed record FileQueueSnapshot(FileQueueDepth combined, FileQueueDepth ingress, FileQueueDepth output, object? flow = null);

--- a/sidecar/etw-file/FilePerformanceTests.cs
+++ b/sidecar/etw-file/FilePerformanceTests.cs
@@ -6,6 +6,28 @@ internal static class FilePerformanceTests
 {
     internal static void Run(Action<string, Action> test)
     {
+        test("output readiness timing excludes quiet time and does not repeat for a backlog", () =>
+        {
+            long clock = 100;
+            var ingress = new FileIngress();
+            using var pipeline = new FilePipeline(ingress, new FileScope(@"C:\fixture", false), false,
+                timestamp: () => Interlocked.Read(ref clock));
+            Interlocked.Exchange(ref clock, 1000000);
+            ingress.Enqueue(new(1, 12, 1, 1, 71, 72, 72, null, 1, 0, @"C:\fixture\a"));
+            for (int i = 2; i <= 4; i++) ingress.Enqueue(new((ulong)i, 15, 1, i, 71, 72, 72, null, 1, 0, null));
+            pipeline.Complete(); pipeline.Worker.WaitAsync(TimeSpan.FromSeconds(3)).GetAwaiter().GetResult();
+            Interlocked.Exchange(ref clock, 1000025);
+            Check(pipeline.Take() != null);
+            Interlocked.Exchange(ref clock, 1000050);
+            Check(pipeline.Take() != null && pipeline.Take() != null && pipeline.Take() == null);
+            var sample = JsonSerializer.SerializeToElement(pipeline.QueueSnapshot());
+            var timing = sample.GetProperty("flow").GetProperty("readyToTake");
+            Check(timing.GetProperty("calls").GetString() == "1");
+            Check(timing.GetProperty("totalTicks").GetString() == "25");
+            var windows = sample.GetProperty("flow").GetProperty("windows");
+            Check(windows.EnumerateArray().Sum(w => int.Parse(w.GetProperty("enqueued").GetString()!)) == 3);
+            Check(windows.EnumerateArray().Sum(w => int.Parse(w.GetProperty("dequeued").GetString()!)) == 3);
+        });
         test("duration totals include failures and preserve a detached snapshot", () =>
         {
             var duration = new FileDuration();

--- a/sidecar/etw-file/FilePipeline.cs
+++ b/sidecar/etw-file/FilePipeline.cs
@@ -15,6 +15,7 @@ internal sealed class FilePipeline : IDisposable
     private readonly bool live;
     private readonly Func<FileObservation, FileObservation> observe;
     private readonly Func<long> clock;
+    private readonly FileOutputProfile profile = new(Stopwatch.Frequency);
     private readonly CancellationTokenSource cancel = new();
     private int bytes, highRecords, highBytes;
     private bool completed;
@@ -41,6 +42,7 @@ internal sealed class FilePipeline : IDisposable
         {
             map.Reset(qpc);
             invalidation++;
+            profile.Invalidate(clock());
             outputInvalidatedDropped += (ulong)outbound.Count; outbound.Clear(); bytes = 0;
             if (outputReady.Task.IsCompleted) outputReady = NewReady();
         }
@@ -82,8 +84,9 @@ internal sealed class FilePipeline : IDisposable
                 {
                     if (epoch != map.Epoch) { outputInvalidatedDropped++; continue; }
                     if (outbound.Count >= 4096 || bytes + cost > 4 * 1024 * 1024)
-                    { outputOverflowDropped++; continue; }
+                    { outputOverflowDropped++; profile.Overflow(clock()); continue; }
                     outbound.Enqueue(new(record, cost)); bytes += cost;
+                    profile.Enqueue(clock(), cost);
                     highRecords = Math.Max(highRecords, outbound.Count); highBytes = Math.Max(highBytes, bytes);
                     if (outbound.Count == 1) outputReady.TrySetResult(true);
                 }
@@ -98,6 +101,7 @@ internal sealed class FilePipeline : IDisposable
         lock (gate)
         {
             if (!outbound.TryDequeue(out var item)) return null;
+            profile.Dequeue(clock(), item.Bytes);
             bytes -= item.Bytes; record = item.Record; epoch = invalidation;
             if (outbound.Count == 0) outputReady = NewReady();
         }
@@ -149,7 +153,7 @@ internal sealed class FilePipeline : IDisposable
                 new(Math.Max(input.Records, outbound.Count), Math.Max(input.Bytes, bytes),
                     Math.Max(input.HighRecords, highRecords), Math.Max(input.HighBytes, highBytes)),
                 new(input.Records, input.Bytes, input.HighRecords, input.HighBytes),
-                new(outbound.Count, bytes, highRecords, highBytes));
+                new(outbound.Count, bytes, highRecords, highBytes), profile.Snapshot(clock()));
         }
     }
     public void Dispose() { cancel.Cancel(); if (Worker.IsCompleted) cancel.Dispose(); }

--- a/sidecar/etw-file/FileTests.cs
+++ b/sidecar/etw-file/FileTests.cs
@@ -140,6 +140,7 @@ internal static class FileTests
         FileBurstTests.Run(Test);
         FileOutputTests.Run(Test);
         FilePerformanceTests.Run(Test);
+        FileOutputProfileTests.Run(Test);
         FileWakeTests.Run(Test);
         Console.WriteLine($"{passed} self-tests passed; no ETW session or UAC requested.");
         return 0;

--- a/sidecar/etw-file/FileWire.cs
+++ b/sidecar/etw-file/FileWire.cs
@@ -8,7 +8,7 @@ namespace Aegis.EtwLifecycle;
 internal sealed record Envelope(string t, string proto, string launchId, string sessionId, string seq, JsonElement data);
 internal sealed class FileWire(string launch, string session, FilePerformance? performance = null)
 {
-    internal const string Protocol = "etw-file/4", Profile = "home-26200-diagnostic-v1";
+    internal const string Protocol = "etw-file/5", Profile = "home-26200-diagnostic-v1";
     internal const int Limit = 256 * 1024;
     internal static readonly string[] Schemas = ["10:0", "12:1", "13:1", "14:1", "15:1"];
     private static readonly UTF8Encoding Utf8 = new(false, true);

--- a/sidecar/etw-file/README.md
+++ b/sidecar/etw-file/README.md
@@ -25,20 +25,29 @@ Choose a new report path on every run. Temporary fixture folders are retained.
 normal-token fixtures, requiring nonzero split losses in the final report. It
 cannot be combined with `--live` and never requests UAC or ETW.
 
-The matching main/helper now require `etw-file/4`. Each telemetry sample includes
+The matching main/helper now require `etw-file/5`. Each telemetry sample includes
 `ingressDropped` and `outputDropped` uint64 strings whose sum is exactly `dropped`.
 `outputOverflowDropped + outputInvalidatedDropped` must equal `outputDropped`.
-Versions 1–3 are rejected; rebuild the helper together with the main reader.
+Versions 1–4 are rejected; rebuild the helper together with the main reader.
 Collector telemetry also requires bounded elapsed-time aggregates and separate
 ingress/output queue depths. Ended reports retain collector and main measurements;
 see [service measurements](../../docs/roadmap/etw-service-timings.md) for clock regions,
 nested durations and interpretation limits. No per-event timing history is retained.
 
-The `-wakeup` collector build waits for output availability, lifecycle signals or
+The collector waits for output availability, lifecycle signals or
 the next heartbeat after an empty pump. The prior 10 ms output polling delay is
 removed. `idleWait` now measures this signal/deadline wait; quiet periods still
 contribute to its total. See [output wakeup](../../docs/roadmap/etw-output-wakeup.md)
 for race, cancellation, drain and live-load evidence.
+
+The `-5-burst` build adds a bounded output-queue history in 100 ms windows,
+empty-to-nonempty readiness-to-first-dequeue timing, and completed broker-forward
+timing. Ended summaries retain these measurements. Quiet intervals without queue
+activity or a telemetry sample are omitted; the last 256 windows and an eviction
+count are retained. These counters contain no observations or paths. See
+[burst measurements](../../docs/roadmap/etw-burst-diagnostics.md) for stage boundaries,
+snapshot timing and why dequeue counts do not certify delivery. This instrumentation
+has synthetic/process evidence only; a new live load check is deferred by the user.
 
 For a separately agreed live check, run the following from normal PowerShell and
 approve **one** UAC prompt. The ordinary Node process reads its own temporary test

--- a/src/main/platform/etw-file-schema.js
+++ b/src/main/platform/etw-file-schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Closed ETW diagnostic schemas, separate from framing and session validation.
-const PROTOCOL = 'etw-file/4';
+const PROTOCOL = 'etw-file/5';
 const PROFILE = 'home-26200-diagnostic-v1';
 const MAX_FRAME_BYTES = 256 * 1024;
 const MAX_DEPTH = 16;
@@ -97,6 +97,48 @@ const duration = (v) =>
   BigInt(v.maxTicks) <= BigInt(v.totalTicks) &&
   BigInt(v.totalTicks) <= BigInt(v.calls) * BigInt(v.maxTicks) &&
   (v.calls !== '0' || (v.totalTicks === '0' && v.maxTicks === '0'));
+const outputWindowShape = shape({
+  fromQpc: uint64,
+  toQpc: uint64,
+  startRecords: uint32,
+  records: uint32,
+  highWaterRecords: uint32,
+  highWaterBytes: uint32,
+  enqueued: uint64,
+  dequeued: uint64,
+  overflow: uint64,
+  invalidated: uint64,
+});
+const outputWindow = (v) =>
+  outputWindowShape(v) &&
+  BigInt(v.fromQpc) <= BigInt(v.toQpc) &&
+  v.startRecords <= v.highWaterRecords &&
+  v.records <= v.highWaterRecords &&
+  v.highWaterRecords <= 4096 &&
+  v.highWaterBytes <= 4 * 1024 * 1024 &&
+  BigInt(v.startRecords) + BigInt(v.enqueued) ===
+    BigInt(v.records) + BigInt(v.dequeued) + BigInt(v.invalidated);
+const outputFlowShape = shape({
+  asOfQpc: uint64,
+  windowTicks: positive64,
+  evictedWindows: uint64,
+  readyToTake: duration,
+  windows: array(outputWindow, 256),
+});
+const outputFlow = (v) =>
+  outputFlowShape(v) &&
+  v.readyToTake.failed === '0' &&
+  v.windows.length > 0 &&
+  v.windows.every(
+    (w, index, all) =>
+      BigInt(w.fromQpc) % BigInt(v.windowTicks) === 0n &&
+      BigInt(w.toQpc) - BigInt(w.fromQpc) <= BigInt(v.windowTicks) &&
+      BigInt(w.toQpc) <= BigInt(v.asOfQpc) &&
+      (index === 0 ||
+        (BigInt(w.fromQpc) > BigInt(all[index - 1].fromQpc) &&
+          BigInt(w.fromQpc) >= BigInt(all[index - 1].toQpc) &&
+          w.startRecords === all[index - 1].records)),
+  );
 const performanceShape = shape({
   frequency: positive64,
   asOfQpc: uint64,
@@ -105,9 +147,14 @@ const performanceShape = shape({
   idleWait: duration,
   ingress: boundedQueue,
   output: boundedQueue,
+  outputFlow,
+  brokerForward: shape({ asOfQpc: uint64, duration }),
 });
 const performance = (v) =>
   performanceShape(v) &&
+  BigInt(v.outputFlow.asOfQpc) <= BigInt(v.asOfQpc) &&
+  BigInt(v.outputFlow.windowTicks) === BigInt(v.frequency) / 10n &&
+  v.outputFlow.windows.at(-1).records === v.output.records &&
   BigInt(v.outputWrite.totalTicks) <= BigInt(v.pump.totalTicks) &&
   BigInt(v.outputWrite.calls) <= BigInt(v.pump.calls);
 const telemetryShape = shape({

--- a/tests/main/platform/etw-file-fixtures.js
+++ b/tests/main/platform/etw-file-fixtures.js
@@ -41,6 +41,27 @@ export function collectorPerformance() {
     idleWait: duration(),
     ingress: queue(),
     output: queue(),
+    outputFlow: {
+      asOfQpc: '100',
+      windowTicks: '1000000',
+      evictedWindows: '0',
+      readyToTake: duration(),
+      windows: [
+        {
+          fromQpc: '0',
+          toQpc: '100',
+          startRecords: 0,
+          records: 0,
+          highWaterRecords: 0,
+          highWaterBytes: 0,
+          enqueued: '0',
+          dequeued: '0',
+          overflow: '0',
+          invalidated: '0',
+        },
+      ],
+    },
+    brokerForward: { asOfQpc: '100', duration: duration() },
   };
 }
 
@@ -98,7 +119,7 @@ export function message(t = 'hello', seq = '1', data) {
   };
   return {
     t,
-    proto: 'etw-file/4',
+    proto: 'etw-file/5',
     launchId: 'launch-1',
     sessionId: 'session-1',
     seq,

--- a/tests/main/platform/etw-file-performance.test.js
+++ b/tests/main/platform/etw-file-performance.test.js
@@ -120,6 +120,87 @@ describe('ETW service measurements', () => {
     expect(() => protocol.validateMessage(message('health', '3', sample))).toThrow();
   });
 
+  it.each([
+    (p) => {
+      delete p.outputFlow;
+    },
+    (p) => {
+      p.brokerForward = null;
+    },
+    (p) => {
+      p.brokerForward.duration.failed = '1';
+    },
+    (p) => {
+      p.outputFlow.windows = [];
+    },
+    (p) => {
+      p.outputFlow.windowTicks = '0';
+    },
+    (p) => {
+      p.outputFlow.windowTicks = '1';
+    },
+    (p) => {
+      p.outputFlow.asOfQpc = '101';
+    },
+    (p) => {
+      p.outputFlow.windows[0].toQpc = '101';
+    },
+    (p) => {
+      p.outputFlow.windows[0].fromQpc = '1';
+    },
+    (p) => {
+      p.outputFlow.windows[0].enqueued = '1';
+    },
+    (p) => {
+      p.outputFlow.windows[0].highWaterBytes = 4194305;
+    },
+    (p) => {
+      p.outputFlow.windows[0].path = 'private';
+    },
+    (p) => {
+      p.outputFlow.windows.push({ ...p.outputFlow.windows[0] });
+    },
+    (p) => {
+      p.outputFlow.windows = Array(257).fill(p.outputFlow.windows[0]);
+    },
+  ])('rejects incomplete or inconsistent burst profiles %#', (change) => {
+    const sample = telemetry();
+    change(sample.performance);
+    expect(() => protocol.validateMessage(message('health', '3', sample))).toThrow();
+  });
+
+  it('round trips a full bounded profile including quiet gaps and exact counters', () => {
+    const sample = telemetry();
+    const flow = sample.performance.outputFlow;
+    const width = BigInt(flow.windowTicks);
+    const base = flow.windows[0];
+    flow.windows = Array.from({ length: 256 }, (_, i) => ({
+      ...base,
+      fromQpc: String(BigInt(i) * 2n * width),
+      toQpc: String((BigInt(i) * 2n + 1n) * width),
+      enqueued: '9007199254740993',
+      dequeued: '9007199254740993',
+      overflow: '123',
+      highWaterRecords: 1,
+      highWaterBytes: 2048,
+    }));
+    flow.asOfQpc = flow.windows.at(-1).toQpc;
+    sample.performance.asOfQpc = flow.asOfQpc;
+    const accepted = [];
+    const bytes = protocol.encodeFrame(message('health', '3', sample));
+    expect(bytes.length).toBeLessThanOrEqual(protocol.MAX_FRAME_BYTES + 4);
+    protocol
+      .createFrameDecoder({
+        launchId: 'launch-1',
+        sessionId: 'session-1',
+        onMessage: (value) => {
+          accepted.push(value);
+        },
+      })
+      .push(bytes);
+    expect(accepted[0].data.performance.outputFlow).toEqual(flow);
+  });
+
   it('preserves uint64 measurements beyond Number precision in frames', () => {
     const sample = telemetry();
     sample.performance.pump = {

--- a/tests/main/platform/etw-file-protocol.test.js
+++ b/tests/main/platform/etw-file-protocol.test.js
@@ -48,7 +48,8 @@ describe('offline ETW envelope', () => {
 
   it.each([
     { proto: 'etw-file/1' },
-    { proto: 'etw-file/5' },
+    { proto: 'etw-file/4' },
+    { proto: 'etw-file/6' },
     { sessionId: '' },
     { launchId: 'x'.repeat(65) },
     { t: '__proto__' },


### PR DESCRIPTION
## Description

The last live burst run still lost 50,246 records from the output queue, while whole-session service totals could not locate the overload. Add bounded output-queue counts and occupancy in 100 ms windows, readiness-to-first-dequeue delay, and completed broker-forward timing. Ended diagnostic summaries retain the measurements through the closed `etw-file/5` contract.

Window dequeue counts describe queue removal and do not certify delivery. Broker timing excludes incoming pipe reading/decoding and its carrying telemetry frame. The existing queue/frame caps and capture behavior remain unchanged. Live overhead and the cause of real-provider burst loss remain unverified; the user deferred the new UAC load run. E3 stays open.

## Type of change

- [x] New feature
- [x] Breaking change (development helper protocol v4 to v5; matching rebuild required)
- [x] Documentation update

## Testing

- Windows .NET 10 Release build, whitespace check and 54 sidecar self-tests passed. The initial missing-profile regression failed before implementation.
- Normal-token and deliberately saturated process harnesses passed three scenarios each on matching binaries, including parent EOF remaining unverified. Retained reports include binary hashes and 32 source hashes.
- Full coverage: 206 files, 3,398 passed, four skipped with `npm run test:coverage -- --maxWorkers=2`. The initial run alongside build/lint had 12 failures involving UI timeouts; the isolated rerun used unchanged timeouts/assertions.
- Renderer build, format/lint, TypeScript/Svelte, witness/sequence mutation gates, derived counts and production dependency audit passed locally.

## Checklist

- [x] Follows project code conventions
- [x] No new console logging in production code
- [x] New code files are under 300 lines
- [ ] Tested locally with `npm start` (this iteration exercised the diagnostic sidecar/process harness)
- [ ] Reviewed by a human
