### PR TITLE
perf(etw): forward validated frames without re-encoding

### DIFF
--- a/docs/recon/evidence/etw-file-home-26200-broker-forwarding.json
+++ b/docs/recon/evidence/etw-file-home-26200-broker-forwarding.json
@@ -1,0 +1,2447 @@
+{
+  "schema": 1,
+  "kind": "etw-file-broker-forwarding",
+  "baseCommit": "4fe774a1b6f0dc04bc42806954629f9ca82fba73",
+  "liveRun": "deferred-by-user",
+  "selfTestsPassed": 61,
+  "allocationRegressionFailedBeforeFix": true,
+  "initialBaseline": "BROKER_FORWARD frames=100 records=6400 previousBytes=16637576 currentBytes=16637576 previousMedianTicks=834102 currentMedianTicks=727048 frequency=10000000",
+  "benchmark": "BROKER_FORWARD frames=100 records=6400 previousBytes=16641576 currentBytes=13933888 previousMedianTicks=869696 currentMedianTicks=587634 frequency=10000000",
+  "sourceSha256": {
+    "scripts/etw-file-load.mjs": "0ef88d5a878e3e3b019e89287213dfb97699cdcf30227316c78a8c5ca0874367",
+    "scripts/etw-file-workload.mjs": "2c8710b31c388be9d2ebe791870602e83f447b1d5b100c7c7043da1dda8bf1e1",
+    "scripts/verify-etw-file.mjs": "1b6f6b3bb0b574debf2977f7f057b348d5bb7a093c983b43e8ae348d68e6e578",
+    "sidecar/etw-file/EtwFile.csproj": "5467564053a0e7ca73d00a872a6b3e2d19068eb491aaa2487ca3415b61067c79",
+    "sidecar/etw-file/FileBroker.cs": "e03eb7080de16101dfdd4bf23c3c5902e2855f6dca08884b03e53a815c3db5ad",
+    "sidecar/etw-file/FileBurstTests.cs": "2bd34dae624444208b7ae70047e6e101e01d7f8839c88b40f96988620b1a2b70",
+    "sidecar/etw-file/FileCapture.cs": "7fc5a273ad813e1b9e63890c4510b16b585ce2b57b856a743407e01e1eb0e2a1",
+    "sidecar/etw-file/FileCollector.cs": "f6ad1119e8caa130af273de58efb0d5ed0ff2e6632260676bc4afac175189f60",
+    "sidecar/etw-file/FileForwardingTests.cs": "ca06460dfc2bf741b7ee50ac857ef073f1617c27c3470f93eae970d5b961fc03",
+    "sidecar/etw-file/FileForwardProfile.cs": "e2a9f99faf50cd4e86c6b9ce65789bb5add124f8832c886044705996fe017b4e",
+    "sidecar/etw-file/FileGeneration.cs": "8f627ed4199461e4f4049b07e25df42e8c19515e160b83ed1500d5e8526b2d62",
+    "sidecar/etw-file/FileLossFixture.cs": "da8cc0750eedbcb90e12dc9cb80336e12d381f6411067f8bc292d3f24911f7eb",
+    "sidecar/etw-file/FileMapping.cs": "89666d58740be6e87f23ba4cc5a2b9e97d3f46446857fb66456e15a93bf478fa",
+    "sidecar/etw-file/FileOutputProfile.cs": "11566e2c6a10d40302e63d95c22ed4b689d6c13a69a3c96e9ddf6c9d019b2ffd",
+    "sidecar/etw-file/FileOutputProfileTests.cs": "4d583b2d088d9b80c5da43650fa651b2acb7b848263de2fa7529f8d74492dc94",
+    "sidecar/etw-file/FileOutputTests.cs": "e11b1b566cf00eb35e1c1ef18f95167031fe79d49260c52d0a606bc49b13e4f5",
+    "sidecar/etw-file/FilePerformance.cs": "cc35230436df9133d2954b9326b0c4384d13a11df4616ea7ad16d0b1153e7cb4",
+    "sidecar/etw-file/FilePerformanceTests.cs": "79957e72ebb643d32c2ef339bc5272465d643c672c2887a659150ac2e678d58a",
+    "sidecar/etw-file/FilePipeline.cs": "2c0f3953f6bccd0307ae16f9d5aeeb461ac66a693997948c5b22c186ebc6b487",
+    "sidecar/etw-file/FilePumpWait.cs": "7459005aa5dfbd781cd1bdc5817919365fe367c1f334d861a658816e616418f9",
+    "sidecar/etw-file/FileScope.cs": "e3a3ed207fd13a62a50d15f9d0a39d2ecd44458634fa3e1f668a5dfea6c893c2",
+    "sidecar/etw-file/FileTests.cs": "0503e8cbb07e7563bb3300355874c4766d0389f612a95fc22555de7523d76415",
+    "sidecar/etw-file/FileTrace.cs": "658bced8e51bd5a7a7f861cd242840b1c048764aa74f051d7c59cbb0a182b75c",
+    "sidecar/etw-file/FileWakeTests.cs": "a79fb19c4f5456b490baee9649ef95ccb5f3f3804ecebedcf176bafc941739b2",
+    "sidecar/etw-file/FileWire.cs": "d57d90b00ba7313692fa714fd12c6ff000ab56590108a97aef54840c7806b01a",
+    "sidecar/etw-file/Program.cs": "2b75300789849557166c256e9e984d199f1382f682bd1daf03b03cefdef241e8",
+    "sidecar/etw-lifecycle/Security.cs": "e924b4d38d652c4c919346aab2d9733b3623ba09e85526a0d211ce7db9c64d10",
+    "src/main/platform/etw-file-diagnostics.js": "5e3a9ecd985bbfc93a8c95f49da07f376be91b27375408ae06532294f8628be0",
+    "src/main/platform/etw-file-health.js": "3772aec338e31afddd0778bb2aab3d39c7bd385a354cb97f8dba885c7bd2e7ad",
+    "src/main/platform/etw-file-protocol.js": "d398d7fecd1937c558ea6c78b13b43a2b0d12596b0df955342aae809583bf372",
+    "src/main/platform/etw-file-runtime.js": "e013e0be3f0f3ef48b1ec66016b91722fc0d982964df766925ce39185dfa7835",
+    "src/main/platform/etw-file-schema.js": "9658604fec3f540e3c43f07b4d14c64145978bb2e00c593b420ade314d516c2c",
+    "src/main/platform/etw-file-supervisor.js": "6f30f13aac635e0d3959cf76a009124867dd7567e7583deabea73fd3e59ebed5"
+  },
+  "normalProcess": {
+    "schema": 1,
+    "live": false,
+    "synthetic": true,
+    "protocol": "etw-file/5",
+    "lossCheck": false,
+    "loadCheck": false,
+    "startedAt": "2026-09-13T04:45:23.824Z",
+    "binarySha256": "722a6674f7bb75c359a81be9c10e8e72895da0a6618e4a6d074efc3c90facc4c",
+    "assemblySha256": "4c56cc565d7624ffed1b3b22e1a5cd35f2288b9f406091c4c815a3b28f11155d",
+    "cases": [
+      {
+        "kind": "normal-stop",
+        "observedRead": true,
+        "observedScopedCandidate": true,
+        "observedFixturePidCandidate": false,
+        "ringBytes": 1617,
+        "ringDropped": 0,
+        "sensorState": "DEGRADED",
+        "summary": {
+          "launchId": "a1184944-aa2e-4dcb-8960-a67adb240811",
+          "sessionId": "b4780f4e-c961-4b15-aad8-509de8814dfd",
+          "endedAt": 1789274724289,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "296160118173",
+              "unixMs": "1789274724157",
+              "uncertaintyQpc": "10559"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "296159067886"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "296161190721",
+            "pump": {
+              "calls": "4",
+              "totalTicks": "103039",
+              "maxTicks": "102670",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "1",
+              "totalTicks": "5181",
+              "maxTicks": "5181",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "2",
+              "totalTicks": "742735",
+              "maxTicks": "589063",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            },
+            "outputFlow": {
+              "asOfQpc": "296161190415",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "1",
+                "totalTicks": "166377",
+                "maxTicks": "166377",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "296160000000",
+                  "toQpc": "296161000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 1,
+                  "highWaterBytes": 2182,
+                  "enqueued": "1",
+                  "dequeued": "1",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296161000000",
+                  "toQpc": "296161190415",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "296161212013",
+              "duration": {
+                "calls": "3",
+                "totalTicks": "74917",
+                "maxTicks": "42572",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "29616144663300",
+            "decodeChunk": {
+              "calls": "5",
+              "totalTicks": "4682500",
+              "maxTicks": "1851100",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "2812000",
+              "maxTicks": "1059400",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "108100",
+              "maxTicks": "108100",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "19",
+              "totalTicks": "1494700",
+              "maxTicks": "201400",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      },
+      {
+        "kind": "explicit-new-session",
+        "observedRead": true,
+        "observedScopedCandidate": true,
+        "observedFixturePidCandidate": false,
+        "ringBytes": 1617,
+        "ringDropped": 0,
+        "sensorState": "DEGRADED",
+        "summary": {
+          "launchId": "328ae222-c01f-4bb3-8c17-889004b61ed3",
+          "sessionId": "10038afb-2ead-415c-8208-c101c0b6560e",
+          "endedAt": 1789274724793,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "296164981789",
+              "unixMs": "1789274724643",
+              "uncertaintyQpc": "10627"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "296163732163"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "296166199501",
+            "pump": {
+              "calls": "4",
+              "totalTicks": "115277",
+              "maxTicks": "114917",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "1",
+              "totalTicks": "1677",
+              "maxTicks": "1677",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "2",
+              "totalTicks": "831719",
+              "maxTicks": "582249",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1,
+              "highWaterBytes": 2182
+            },
+            "outputFlow": {
+              "asOfQpc": "296166199070",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "1",
+                "totalTicks": "202613",
+                "maxTicks": "202613",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "296165000000",
+                  "toQpc": "296166000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 1,
+                  "highWaterBytes": 2182,
+                  "enqueued": "1",
+                  "dequeued": "1",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296166000000",
+                  "toQpc": "296166199070",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "296166235081",
+              "duration": {
+                "calls": "3",
+                "totalTicks": "94028",
+                "maxTicks": "46913",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "29616648079500",
+            "decodeChunk": {
+              "calls": "5",
+              "totalTicks": "1439100",
+              "maxTicks": "447700",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "769900",
+              "maxTicks": "239200",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "53900",
+              "maxTicks": "53900",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "20",
+              "totalTicks": "3163400",
+              "maxTicks": "284000",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      },
+      {
+        "kind": "parent-eof-unverified",
+        "summary": {
+          "launchId": "8b45849c-4b4e-4512-9580-251fba9c0afe",
+          "sessionId": "547879a6-b0af-4cd6-9ee5-5a540aab8d01",
+          "endedAt": 1789274725260,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "296170336030",
+              "unixMs": "1789274725179",
+              "uncertaintyQpc": "10593"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "296169090249"
+          },
+          "finalTotals": {
+            "delivered": "2",
+            "filtered": "1",
+            "dropped": "0",
+            "ingressDropped": "0",
+            "outputDropped": "0",
+            "outputOverflowDropped": "0",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "0",
+            "mapResets": "0",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "296170408573",
+            "pump": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 2,
+              "highWaterBytes": 713
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 0,
+              "highWaterBytes": 0
+            },
+            "outputFlow": {
+              "asOfQpc": "296170385130",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "296170000000",
+                  "toQpc": "296170385130",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "296170565858",
+              "duration": {
+                "calls": "1",
+                "totalTicks": "35377",
+                "maxTicks": "35377",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "29617115639100",
+            "decodeChunk": {
+              "calls": "4",
+              "totalTicks": "1241600",
+              "maxTicks": "453200",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "3",
+              "totalTicks": "675300",
+              "maxTicks": "335900",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "48600",
+              "maxTicks": "48600",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "16",
+              "totalTicks": "2926000",
+              "maxTicks": "265500",
+              "failed": "0"
+            }
+          },
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      }
+    ],
+    "passed": true,
+    "observationCheck": {
+      "observed": true,
+      "named": true,
+      "fixtureRead": false,
+      "leaked": false
+    },
+    "endedSessions": [
+      {
+        "launchId": "a1184944-aa2e-4dcb-8960-a67adb240811",
+        "sessionId": "b4780f4e-c961-4b15-aad8-509de8814dfd",
+        "endedAt": 1789274724289,
+        "phase": "stopped",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "mapping-uncertain",
+          "identity-uncertain"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "296160118173",
+            "unixMs": "1789274724157",
+            "uncertaintyQpc": "10559"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "296159067886"
+        },
+        "finalTotals": {
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "296161190721",
+          "pump": {
+            "calls": "4",
+            "totalTicks": "103039",
+            "maxTicks": "102670",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "1",
+            "totalTicks": "5181",
+            "maxTicks": "5181",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "2",
+            "totalTicks": "742735",
+            "maxTicks": "589063",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 2,
+            "highWaterBytes": 713
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 1,
+            "highWaterBytes": 2182
+          },
+          "outputFlow": {
+            "asOfQpc": "296161190415",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "1",
+              "totalTicks": "166377",
+              "maxTicks": "166377",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "296160000000",
+                "toQpc": "296161000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182,
+                "enqueued": "1",
+                "dequeued": "1",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296161000000",
+                "toQpc": "296161190415",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "296161212013",
+            "duration": {
+              "calls": "3",
+              "totalTicks": "74917",
+              "maxTicks": "42572",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "29616144663300",
+          "decodeChunk": {
+            "calls": "5",
+            "totalTicks": "4682500",
+            "maxTicks": "1851100",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "4",
+            "totalTicks": "2812000",
+            "maxTicks": "1059400",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "108100",
+            "maxTicks": "108100",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "19",
+            "totalTicks": "1494700",
+            "maxTicks": "201400",
+            "failed": "0"
+          }
+        },
+        "stopReason": "operator-stop",
+        "exitCode": 0,
+        "stopVerified": true
+      },
+      {
+        "launchId": "328ae222-c01f-4bb3-8c17-889004b61ed3",
+        "sessionId": "10038afb-2ead-415c-8208-c101c0b6560e",
+        "endedAt": 1789274724793,
+        "phase": "stopped",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "mapping-uncertain",
+          "identity-uncertain"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "296164981789",
+            "unixMs": "1789274724643",
+            "uncertaintyQpc": "10627"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "296163732163"
+        },
+        "finalTotals": {
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "296166199501",
+          "pump": {
+            "calls": "4",
+            "totalTicks": "115277",
+            "maxTicks": "114917",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "1",
+            "totalTicks": "1677",
+            "maxTicks": "1677",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "2",
+            "totalTicks": "831719",
+            "maxTicks": "582249",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 2,
+            "highWaterBytes": 713
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 1,
+            "highWaterBytes": 2182
+          },
+          "outputFlow": {
+            "asOfQpc": "296166199070",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "1",
+              "totalTicks": "202613",
+              "maxTicks": "202613",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "296165000000",
+                "toQpc": "296166000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 1,
+                "highWaterBytes": 2182,
+                "enqueued": "1",
+                "dequeued": "1",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296166000000",
+                "toQpc": "296166199070",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "296166235081",
+            "duration": {
+              "calls": "3",
+              "totalTicks": "94028",
+              "maxTicks": "46913",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "29616648079500",
+          "decodeChunk": {
+            "calls": "5",
+            "totalTicks": "1439100",
+            "maxTicks": "447700",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "4",
+            "totalTicks": "769900",
+            "maxTicks": "239200",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "53900",
+            "maxTicks": "53900",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "20",
+            "totalTicks": "3163400",
+            "maxTicks": "284000",
+            "failed": "0"
+          }
+        },
+        "stopReason": "operator-stop",
+        "exitCode": 0,
+        "stopVerified": true
+      },
+      {
+        "launchId": "8b45849c-4b4e-4512-9580-251fba9c0afe",
+        "sessionId": "547879a6-b0af-4cd6-9ee5-5a540aab8d01",
+        "endedAt": 1789274725260,
+        "phase": "failed",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "mapping-uncertain",
+          "identity-uncertain",
+          "stream-ended"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "296170336030",
+            "unixMs": "1789274725179",
+            "uncertaintyQpc": "10593"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "296169090249"
+        },
+        "finalTotals": {
+          "delivered": "2",
+          "filtered": "1",
+          "dropped": "0",
+          "ingressDropped": "0",
+          "outputDropped": "0",
+          "outputOverflowDropped": "0",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "0",
+          "mapResets": "0",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "296170408573",
+          "pump": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 2,
+            "highWaterBytes": 713
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 0,
+            "highWaterBytes": 0
+          },
+          "outputFlow": {
+            "asOfQpc": "296170385130",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "296170000000",
+                "toQpc": "296170385130",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "296170565858",
+            "duration": {
+              "calls": "1",
+              "totalTicks": "35377",
+              "maxTicks": "35377",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "29617115639100",
+          "decodeChunk": {
+            "calls": "4",
+            "totalTicks": "1241600",
+            "maxTicks": "453200",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "3",
+            "totalTicks": "675300",
+            "maxTicks": "335900",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "48600",
+            "maxTicks": "48600",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "16",
+            "totalTicks": "2926000",
+            "maxTicks": "265500",
+            "failed": "0"
+          }
+        },
+        "stopReason": null,
+        "exitCode": 2,
+        "stopVerified": false
+      }
+    ],
+    "endedAt": "2026-09-13T04:45:25.261Z"
+  },
+  "lossProcess": {
+    "schema": 1,
+    "live": false,
+    "synthetic": true,
+    "protocol": "etw-file/5",
+    "lossCheck": true,
+    "loadCheck": false,
+    "startedAt": "2026-09-13T04:45:26.878Z",
+    "binarySha256": "722a6674f7bb75c359a81be9c10e8e72895da0a6618e4a6d074efc3c90facc4c",
+    "assemblySha256": "4c56cc565d7624ffed1b3b22e1a5cd35f2288b9f406091c4c815a3b28f11155d",
+    "cases": [
+      {
+        "kind": "normal-stop",
+        "observedRead": true,
+        "observedScopedCandidate": true,
+        "observedFixturePidCandidate": false,
+        "ringBytes": 412928,
+        "ringDropped": 320,
+        "sensorState": "DEGRADED",
+        "summary": {
+          "launchId": "a1f77d70-a27c-466e-adbb-8e2d3947fc6a",
+          "sessionId": "3e0d4249-ad1e-427c-b926-6177ece4caba",
+          "endedAt": 1789274727641,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "296193434729",
+              "unixMs": "1789274727489",
+              "uncertaintyQpc": "10951"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "296189816509"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 320,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "296194574406",
+            "pump": {
+              "calls": "28",
+              "totalTicks": "891913",
+              "maxTicks": "115702",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "27",
+              "totalTicks": "678975",
+              "maxTicks": "38332",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            },
+            "outputFlow": {
+              "asOfQpc": "296194573881",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "1",
+                "totalTicks": "2649908",
+                "maxTicks": "2649908",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "296189000000",
+                  "toQpc": "296190000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296191000000",
+                  "toQpc": "296192000000",
+                  "startRecords": 0,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "1922",
+                  "dequeued": "0",
+                  "overflow": "1662",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296192000000",
+                  "toQpc": "296193000000",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "3584",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296193000000",
+                  "toQpc": "296194000000",
+                  "startRecords": 1922,
+                  "records": 1274,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "648",
+                  "overflow": "1024",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296194000000",
+                  "toQpc": "296194573881",
+                  "startRecords": 1274,
+                  "records": 0,
+                  "highWaterRecords": 1274,
+                  "highWaterBytes": 2779868,
+                  "enqueued": "0",
+                  "dequeued": "1274",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "296194602297",
+              "duration": {
+                "calls": "29",
+                "totalTicks": "132443",
+                "maxTicks": "66131",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "29619496532800",
+            "decodeChunk": {
+              "calls": "32",
+              "totalTicks": "27442000",
+              "maxTicks": "2347900",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "30",
+              "totalTicks": "13540100",
+              "maxTicks": "1336000",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "8",
+              "totalTicks": "3918700",
+              "maxTicks": "778300",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "29",
+              "totalTicks": "4389300",
+              "maxTicks": "1313600",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      },
+      {
+        "kind": "explicit-new-session",
+        "observedRead": true,
+        "observedScopedCandidate": true,
+        "observedFixturePidCandidate": false,
+        "ringBytes": 116136,
+        "ringDropped": 0,
+        "sensorState": "DEGRADED",
+        "summary": {
+          "launchId": "212cfc32-b7fd-462c-85b9-cbb36b20904d",
+          "sessionId": "a199f14b-cb61-4360-84fb-f27769a349df",
+          "endedAt": 1789274728428,
+          "phase": "stopped",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "296201390240",
+              "unixMs": "1789274728284",
+              "uncertaintyQpc": "10901"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "296197652235"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "296202555502",
+            "pump": {
+              "calls": "28",
+              "totalTicks": "911419",
+              "maxTicks": "150508",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "27",
+              "totalTicks": "646345",
+              "maxTicks": "45504",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            },
+            "outputFlow": {
+              "asOfQpc": "296202554991",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "1",
+                "totalTicks": "2742159",
+                "maxTicks": "2742159",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "296197000000",
+                  "toQpc": "296198000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296198000000",
+                  "toQpc": "296199000000",
+                  "startRecords": 0,
+                  "records": 512,
+                  "highWaterRecords": 512,
+                  "highWaterBytes": 1117184,
+                  "enqueued": "512",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296199000000",
+                  "toQpc": "296200000000",
+                  "startRecords": 512,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "1410",
+                  "dequeued": "0",
+                  "overflow": "2174",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296200000000",
+                  "toQpc": "296201000000",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "3072",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296201000000",
+                  "toQpc": "296202000000",
+                  "startRecords": 1922,
+                  "records": 1274,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "648",
+                  "overflow": "1024",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296202000000",
+                  "toQpc": "296202554991",
+                  "startRecords": 1274,
+                  "records": 0,
+                  "highWaterRecords": 1274,
+                  "highWaterBytes": 2779868,
+                  "enqueued": "0",
+                  "dequeued": "1274",
+                  "overflow": "0",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "296202581204",
+              "duration": {
+                "calls": "29",
+                "totalTicks": "146056",
+                "maxTicks": "82496",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "29620283247000",
+            "decodeChunk": {
+              "calls": "32",
+              "totalTicks": "16710500",
+              "maxTicks": "964800",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "30",
+              "totalTicks": "6646000",
+              "maxTicks": "590500",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "1",
+              "totalTicks": "358200",
+              "maxTicks": "358200",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "29",
+              "totalTicks": "4664000",
+              "maxTicks": "239200",
+              "failed": "0"
+            }
+          },
+          "stopReason": "operator-stop",
+          "exitCode": 0,
+          "stopVerified": true
+        }
+      },
+      {
+        "kind": "parent-eof-unverified",
+        "summary": {
+          "launchId": "ec083b67-3636-42d8-b2f3-aa70f65c1672",
+          "sessionId": "2e32abe3-8601-443e-bef3-f9afd7ebc222",
+          "endedAt": 1789274729157,
+          "phase": "failed",
+          "reasons": [
+            "experimental-correlation",
+            "unmeasured-interval",
+            "dropped",
+            "ingressDropped",
+            "outputDropped",
+            "outputOverflowDropped",
+            "mapResets",
+            "mapping-uncertain",
+            "identity-uncertain",
+            "stream-ended"
+          ],
+          "maxima": {
+            "eventsLost": "0",
+            "realTimeBuffersLost": "0",
+            "logBuffersLost": "0",
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "capture": {
+            "buffers": {
+              "count": 256,
+              "sizeKiB": 64
+            },
+            "frequency": "10000000",
+            "clock": {
+              "qpc": "296209326603",
+              "unixMs": "1789274729078",
+              "uncertaintyQpc": "11089"
+            }
+          },
+          "finalCounters": {
+            "eventsLost": null,
+            "realTimeBuffersLost": null,
+            "logBuffersLost": null,
+            "queryStatus": 50,
+            "asOfQpc": "296205523761"
+          },
+          "finalTotals": {
+            "delivered": "12290",
+            "filtered": "1",
+            "dropped": "10367",
+            "ingressDropped": "4097",
+            "outputDropped": "6270",
+            "outputOverflowDropped": "6270",
+            "outputInvalidatedDropped": "0",
+            "decoderErrors": "0",
+            "mapEpoch": "1",
+            "mapResets": "1",
+            "mapConflicts": "0"
+          },
+          "ringDropped": 0,
+          "collectorPerformance": {
+            "frequency": "10000000",
+            "asOfQpc": "296209376515",
+            "pump": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "outputWrite": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "idleWait": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "ingress": {
+              "records": 0,
+              "bytes": 0,
+              "highWaterRecords": 4096,
+              "highWaterBytes": 1048576
+            },
+            "output": {
+              "records": 1922,
+              "bytes": 4193804,
+              "highWaterRecords": 1922,
+              "highWaterBytes": 4193804
+            },
+            "outputFlow": {
+              "asOfQpc": "296209340511",
+              "windowTicks": "1000000",
+              "evictedWindows": "0",
+              "readyToTake": {
+                "calls": "0",
+                "totalTicks": "0",
+                "maxTicks": "0",
+                "failed": "0"
+              },
+              "windows": [
+                {
+                  "fromQpc": "296205000000",
+                  "toQpc": "296206000000",
+                  "startRecords": 0,
+                  "records": 0,
+                  "highWaterRecords": 0,
+                  "highWaterBytes": 0,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296206000000",
+                  "toQpc": "296207000000",
+                  "startRecords": 0,
+                  "records": 878,
+                  "highWaterRecords": 878,
+                  "highWaterBytes": 1915796,
+                  "enqueued": "878",
+                  "dequeued": "0",
+                  "overflow": "0",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296207000000",
+                  "toQpc": "296208000000",
+                  "startRecords": 878,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "1044",
+                  "dequeued": "0",
+                  "overflow": "2174",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296208000000",
+                  "toQpc": "296209000000",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "3072",
+                  "invalidated": "0"
+                },
+                {
+                  "fromQpc": "296209000000",
+                  "toQpc": "296209340511",
+                  "startRecords": 1922,
+                  "records": 1922,
+                  "highWaterRecords": 1922,
+                  "highWaterBytes": 4193804,
+                  "enqueued": "0",
+                  "dequeued": "0",
+                  "overflow": "1024",
+                  "invalidated": "0"
+                }
+              ]
+            },
+            "brokerForward": {
+              "asOfQpc": "296209627240",
+              "duration": {
+                "calls": "1",
+                "totalTicks": "38138",
+                "maxTicks": "38138",
+                "failed": "0"
+              }
+            }
+          },
+          "mainPerformance": {
+            "frequency": "1000000000",
+            "asOfQpc": "29621013028800",
+            "decodeChunk": {
+              "calls": "5",
+              "totalTicks": "3308800",
+              "maxTicks": "1408700",
+              "failed": "0"
+            },
+            "acceptFrame": {
+              "calls": "4",
+              "totalTicks": "1984300",
+              "maxTicks": "869200",
+              "failed": "0"
+            },
+            "retainBatch": {
+              "calls": "2",
+              "totalTicks": "1100200",
+              "maxTicks": "692000",
+              "failed": "0"
+            },
+            "snapshot": {
+              "calls": "24",
+              "totalTicks": "5217600",
+              "maxTicks": "479500",
+              "failed": "0"
+            }
+          },
+          "stopReason": null,
+          "exitCode": 2,
+          "stopVerified": false
+        }
+      }
+    ],
+    "passed": true,
+    "observationCheck": {
+      "observed": true,
+      "named": true,
+      "fixtureRead": false,
+      "leaked": false
+    },
+    "endedSessions": [
+      {
+        "launchId": "a1f77d70-a27c-466e-adbb-8e2d3947fc6a",
+        "sessionId": "3e0d4249-ad1e-427c-b926-6177ece4caba",
+        "endedAt": 1789274727641,
+        "phase": "stopped",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "dropped",
+          "ingressDropped",
+          "outputDropped",
+          "outputOverflowDropped",
+          "mapResets",
+          "mapping-uncertain",
+          "identity-uncertain"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "296193434729",
+            "unixMs": "1789274727489",
+            "uncertaintyQpc": "10951"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "296189816509"
+        },
+        "finalTotals": {
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 320,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "296194574406",
+          "pump": {
+            "calls": "28",
+            "totalTicks": "891913",
+            "maxTicks": "115702",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "27",
+            "totalTicks": "678975",
+            "maxTicks": "38332",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 4096,
+            "highWaterBytes": 1048576
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 1922,
+            "highWaterBytes": 4193804
+          },
+          "outputFlow": {
+            "asOfQpc": "296194573881",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "1",
+              "totalTicks": "2649908",
+              "maxTicks": "2649908",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "296189000000",
+                "toQpc": "296190000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296191000000",
+                "toQpc": "296192000000",
+                "startRecords": 0,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "1922",
+                "dequeued": "0",
+                "overflow": "1662",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296192000000",
+                "toQpc": "296193000000",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "3584",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296193000000",
+                "toQpc": "296194000000",
+                "startRecords": 1922,
+                "records": 1274,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "648",
+                "overflow": "1024",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296194000000",
+                "toQpc": "296194573881",
+                "startRecords": 1274,
+                "records": 0,
+                "highWaterRecords": 1274,
+                "highWaterBytes": 2779868,
+                "enqueued": "0",
+                "dequeued": "1274",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "296194602297",
+            "duration": {
+              "calls": "29",
+              "totalTicks": "132443",
+              "maxTicks": "66131",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "29619496532800",
+          "decodeChunk": {
+            "calls": "32",
+            "totalTicks": "27442000",
+            "maxTicks": "2347900",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "30",
+            "totalTicks": "13540100",
+            "maxTicks": "1336000",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "8",
+            "totalTicks": "3918700",
+            "maxTicks": "778300",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "29",
+            "totalTicks": "4389300",
+            "maxTicks": "1313600",
+            "failed": "0"
+          }
+        },
+        "stopReason": "operator-stop",
+        "exitCode": 0,
+        "stopVerified": true
+      },
+      {
+        "launchId": "212cfc32-b7fd-462c-85b9-cbb36b20904d",
+        "sessionId": "a199f14b-cb61-4360-84fb-f27769a349df",
+        "endedAt": 1789274728428,
+        "phase": "stopped",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "dropped",
+          "ingressDropped",
+          "outputDropped",
+          "outputOverflowDropped",
+          "mapResets",
+          "mapping-uncertain",
+          "identity-uncertain"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "296201390240",
+            "unixMs": "1789274728284",
+            "uncertaintyQpc": "10901"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "296197652235"
+        },
+        "finalTotals": {
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "296202555502",
+          "pump": {
+            "calls": "28",
+            "totalTicks": "911419",
+            "maxTicks": "150508",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "27",
+            "totalTicks": "646345",
+            "maxTicks": "45504",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 4096,
+            "highWaterBytes": 1048576
+          },
+          "output": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 1922,
+            "highWaterBytes": 4193804
+          },
+          "outputFlow": {
+            "asOfQpc": "296202554991",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "1",
+              "totalTicks": "2742159",
+              "maxTicks": "2742159",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "296197000000",
+                "toQpc": "296198000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296198000000",
+                "toQpc": "296199000000",
+                "startRecords": 0,
+                "records": 512,
+                "highWaterRecords": 512,
+                "highWaterBytes": 1117184,
+                "enqueued": "512",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296199000000",
+                "toQpc": "296200000000",
+                "startRecords": 512,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "1410",
+                "dequeued": "0",
+                "overflow": "2174",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296200000000",
+                "toQpc": "296201000000",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "3072",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296201000000",
+                "toQpc": "296202000000",
+                "startRecords": 1922,
+                "records": 1274,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "648",
+                "overflow": "1024",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296202000000",
+                "toQpc": "296202554991",
+                "startRecords": 1274,
+                "records": 0,
+                "highWaterRecords": 1274,
+                "highWaterBytes": 2779868,
+                "enqueued": "0",
+                "dequeued": "1274",
+                "overflow": "0",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "296202581204",
+            "duration": {
+              "calls": "29",
+              "totalTicks": "146056",
+              "maxTicks": "82496",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "29620283247000",
+          "decodeChunk": {
+            "calls": "32",
+            "totalTicks": "16710500",
+            "maxTicks": "964800",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "30",
+            "totalTicks": "6646000",
+            "maxTicks": "590500",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "1",
+            "totalTicks": "358200",
+            "maxTicks": "358200",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "29",
+            "totalTicks": "4664000",
+            "maxTicks": "239200",
+            "failed": "0"
+          }
+        },
+        "stopReason": "operator-stop",
+        "exitCode": 0,
+        "stopVerified": true
+      },
+      {
+        "launchId": "ec083b67-3636-42d8-b2f3-aa70f65c1672",
+        "sessionId": "2e32abe3-8601-443e-bef3-f9afd7ebc222",
+        "endedAt": 1789274729157,
+        "phase": "failed",
+        "reasons": [
+          "experimental-correlation",
+          "unmeasured-interval",
+          "dropped",
+          "ingressDropped",
+          "outputDropped",
+          "outputOverflowDropped",
+          "mapResets",
+          "mapping-uncertain",
+          "identity-uncertain",
+          "stream-ended"
+        ],
+        "maxima": {
+          "eventsLost": "0",
+          "realTimeBuffersLost": "0",
+          "logBuffersLost": "0",
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "capture": {
+          "buffers": {
+            "count": 256,
+            "sizeKiB": 64
+          },
+          "frequency": "10000000",
+          "clock": {
+            "qpc": "296209326603",
+            "unixMs": "1789274729078",
+            "uncertaintyQpc": "11089"
+          }
+        },
+        "finalCounters": {
+          "eventsLost": null,
+          "realTimeBuffersLost": null,
+          "logBuffersLost": null,
+          "queryStatus": 50,
+          "asOfQpc": "296205523761"
+        },
+        "finalTotals": {
+          "delivered": "12290",
+          "filtered": "1",
+          "dropped": "10367",
+          "ingressDropped": "4097",
+          "outputDropped": "6270",
+          "outputOverflowDropped": "6270",
+          "outputInvalidatedDropped": "0",
+          "decoderErrors": "0",
+          "mapEpoch": "1",
+          "mapResets": "1",
+          "mapConflicts": "0"
+        },
+        "ringDropped": 0,
+        "collectorPerformance": {
+          "frequency": "10000000",
+          "asOfQpc": "296209376515",
+          "pump": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "outputWrite": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "idleWait": {
+            "calls": "0",
+            "totalTicks": "0",
+            "maxTicks": "0",
+            "failed": "0"
+          },
+          "ingress": {
+            "records": 0,
+            "bytes": 0,
+            "highWaterRecords": 4096,
+            "highWaterBytes": 1048576
+          },
+          "output": {
+            "records": 1922,
+            "bytes": 4193804,
+            "highWaterRecords": 1922,
+            "highWaterBytes": 4193804
+          },
+          "outputFlow": {
+            "asOfQpc": "296209340511",
+            "windowTicks": "1000000",
+            "evictedWindows": "0",
+            "readyToTake": {
+              "calls": "0",
+              "totalTicks": "0",
+              "maxTicks": "0",
+              "failed": "0"
+            },
+            "windows": [
+              {
+                "fromQpc": "296205000000",
+                "toQpc": "296206000000",
+                "startRecords": 0,
+                "records": 0,
+                "highWaterRecords": 0,
+                "highWaterBytes": 0,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296206000000",
+                "toQpc": "296207000000",
+                "startRecords": 0,
+                "records": 878,
+                "highWaterRecords": 878,
+                "highWaterBytes": 1915796,
+                "enqueued": "878",
+                "dequeued": "0",
+                "overflow": "0",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296207000000",
+                "toQpc": "296208000000",
+                "startRecords": 878,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "1044",
+                "dequeued": "0",
+                "overflow": "2174",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296208000000",
+                "toQpc": "296209000000",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "3072",
+                "invalidated": "0"
+              },
+              {
+                "fromQpc": "296209000000",
+                "toQpc": "296209340511",
+                "startRecords": 1922,
+                "records": 1922,
+                "highWaterRecords": 1922,
+                "highWaterBytes": 4193804,
+                "enqueued": "0",
+                "dequeued": "0",
+                "overflow": "1024",
+                "invalidated": "0"
+              }
+            ]
+          },
+          "brokerForward": {
+            "asOfQpc": "296209627240",
+            "duration": {
+              "calls": "1",
+              "totalTicks": "38138",
+              "maxTicks": "38138",
+              "failed": "0"
+            }
+          }
+        },
+        "mainPerformance": {
+          "frequency": "1000000000",
+          "asOfQpc": "29621013028800",
+          "decodeChunk": {
+            "calls": "5",
+            "totalTicks": "3308800",
+            "maxTicks": "1408700",
+            "failed": "0"
+          },
+          "acceptFrame": {
+            "calls": "4",
+            "totalTicks": "1984300",
+            "maxTicks": "869200",
+            "failed": "0"
+          },
+          "retainBatch": {
+            "calls": "2",
+            "totalTicks": "1100200",
+            "maxTicks": "692000",
+            "failed": "0"
+          },
+          "snapshot": {
+            "calls": "24",
+            "totalTicks": "5217600",
+            "maxTicks": "479500",
+            "failed": "0"
+          }
+        },
+        "stopReason": null,
+        "exitCode": 2,
+        "stopVerified": false
+      }
+    ],
+    "endedAt": "2026-09-13T04:45:29.184Z"
+  }
+}

--- a/docs/roadmap/etw-broker-forwarding.md
+++ b/docs/roadmap/etw-broker-forwarding.md
@@ -1,0 +1,72 @@
+# B5 follow-up — forward validated observation bytes
+
+Implemented on `codex/etw-broker-forwarding` from merged #451 / `4fe774a`.
+The broker previously decoded and validated each incoming envelope, then encoded
+the unchanged observations again before forwarding to main. This work removes
+that extra encoding while retaining the checks and bounded transport.
+
+## Behavior and boundaries
+
+`FileWire.ReadFrame` performs the existing bounded length, exact-envelope shape,
+strict UTF-8, JSON depth, protocol, identity, sequence and direction checks. It
+returns the parsed envelope paired with its original body. The body is owned by
+that received frame, not a serialization cache attached to the mutable record.
+Cloning/changing an envelope with `with` cannot silently reuse stale body bytes.
+
+The outbound broker calls `FileForwardProfile` with this received frame. Hello,
+observations and error frames keep their original body bytes, including Unicode
+spelling and whitespace. Ready, health, heartbeat and stopped still receive broker
+timing annotations and are encoded from the updated envelope. Identity/sequence
+fields remain unchanged. The compatibility `Read` method still returns an owned
+envelope to existing control consumers; inbound controls use their existing path.
+
+Main still validates the closed payload schema, frame/depth limits and session
+state. The broker has never supplied that full observation-schema guarantee.
+Forwarding remains bounded to a 256 KiB body and the existing five-second
+header/body/flush write deadline. The received body remains alive while its write
+is pending; no pooled buffer reuse, extra queue or automatic retry is introduced.
+Collector queues, record batching, mapping, process attribution, native ownership
+and the main diagnostic ring retain their previous behavior.
+
+Protocol remains `etw-file/5`; the build marker is `-5-forward`. The meaning of
+broker duration remains completed outbound forwarding time, excluding input
+reading/decoding and the carrying telemetry frame itself. Its observations path
+now measures the preserved-body write without a redundant serializer call.
+
+## Controlled measurement
+
+The allocation regression initially failed against the old forwarding path:
+both arms allocated 16,637,576 bytes. The implemented test reads and validates the
+same 100 frames / 6,400 fixture observations in both arms. The comparison arm
+uses the retained encoder; the optimized arm calls the production forwarding
+profile. Input/output buffers and serializer warm-up are outside the measurement.
+Five trials per arm alternate order. Only allocation reduction is asserted;
+wall-time medians are reported without a flaky timing threshold.
+
+| Release build measurement | Re-encode validated frames | Forward validated bodies |
+| --- | ---: | ---: |
+| Allocated bytes per 100 frames | 16,641,576 | 13,933,888 |
+| Median elapsed milliseconds | 86.9696 | 58.7634 |
+
+Allocation decreased by about 16.27% on this workload. These are cumulative managed
+allocations, not peak memory or application-wide RAM. The measured elapsed region
+includes decoding/validation and in-memory forwarding; no native provider, real
+pipe backpressure or sustained machine-wide traffic is present. Timing varies
+with runtime warm-up and machine load. This result does not establish loss-free
+capture, a general application speedup or a causal reduction in the previous
+50,246 live output overflow drops. E3 remains open.
+
+## Verification
+
+The Windows .NET 10 Release build and whitespace check passed. All 61 C# self-tests
+passed, including fragmented consecutive input with exact observation bytes,
+Unicode/uint64 evidence, the maximum body size, rejected malformed/foreign/replayed
+input before forwarding, every telemetry kind receiving fresh annotations,
+cancellation/failure accounting and the allocation comparison.
+
+Normal-token and deliberately saturated process harnesses passed three scenarios
+each on matching binaries: two clean sessions plus parent EOF with unverified
+stop and blocked retry. These exercise collector → broker → actual main decoder
+and supervisor. No new UAC/live load or sleep/wake check was performed, as requested.
+The retained [evidence](../recon/evidence/etw-file-home-26200-broker-forwarding.json)
+contains both process reports, benchmark output and source/binary hashes.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2351,3 +2351,31 @@ installer are deferred. Check this branch's final PR/CI/merge before continuing.
 All required local checks passed, including both four-mutant gates; the .NET
 Release build and whitespace verification passed separately. The existing five
 repository CI contexts do not compile the diagnostic C# sidecar.
+
+### 2026-09-13 — ETW broker forwarding optimization
+
+The user requested backend optimization, keeping work in Astra, without Claude
+adapter work or other agents. No new UAC/live/sleep run was requested. Branch
+`codex/etw-broker-forwarding` starts from merged #451 / `4fe774a` in the clean
+`X:/tmp/aegis-etw-throughput-20260913` worktree; original dirty/installer work is
+preserved separately.
+
+`FileWire.ReadFrame` binds each validated envelope to its original bounded body.
+The broker forwards unchanged observations without re-encoding; all four telemetry
+kinds still receive current broker timings and are serialized from the updated
+envelope. Main payload validation, protocol v5, queue/frame caps and cleanup remain
+in place. The helper build marker is `-5-forward`.
+
+The allocation test first failed with equal 16,637,576-byte results. On the final
+controlled 100-frame / 6,400-record fixture, the re-encoding arm allocated 16,641,576
+bytes and production forwarding 13,933,888 bytes (16.27% less). Five interleaved
+trials reported medians 86.9696 vs 58.7634 ms; elapsed time is informational, not a
+test threshold or a live throughput claim. The .NET Release build, whitespace
+check, 61 self-tests and normal/saturation process checks (three scenarios each)
+passed. No EtwFile helpers remained. Reports and 33 source hashes are retained in
+`etw-file-home-26200-broker-forwarding.json`; behavior/limits are documented in
+`docs/roadmap/etw-broker-forwarding.md`.
+
+This change does not close live burst loss E3. New live overhead/throughput and
+capture completeness remain unverified. JS/main/renderer source is unchanged;
+the required repository CI contexts must pass on this branch before merge.

--- a/sidecar/etw-file/FileBroker.cs
+++ b/sidecar/etw-file/FileBroker.cs
@@ -46,10 +46,10 @@ internal static class FileBroker
                 var performance = new FileForwardProfile();
                 while (true)
                 {
-                    var frame = await read.Read(pipe, false, lifetime.Token);
-                    if (frame.t == "stopped") Volatile.Write(ref terminalObserved, 1);
+                    var frame = await read.ReadFrame(pipe, false, lifetime.Token);
+                    if (frame.Message.t == "stopped") Volatile.Write(ref terminalObserved, 1);
                     await performance.Forward(output, frame, lifetime.Token);
-                    if (frame.t == "stopped") return;
+                    if (frame.Message.t == "stopped") return;
                 }
             });
             try

--- a/sidecar/etw-file/FileCollector.cs
+++ b/sidecar/etw-file/FileCollector.cs
@@ -37,7 +37,7 @@ internal static class FileCollector
         {
             await send.Write(pipe, "hello", new
             {
-                build = live ? "etw-file-diagnostic-dev-5-burst" : "etw-file-synthetic-check-5-burst",
+                build = live ? "etw-file-diagnostic-dev-5-forward" : "etw-file-synthetic-check-5-forward",
                 profile = FileWire.Profile,
                 schemas = FileWire.Schemas
             }, lifetime.Token);

--- a/sidecar/etw-file/FileForwardProfile.cs
+++ b/sidecar/etw-file/FileForwardProfile.cs
@@ -9,11 +9,12 @@ internal sealed class FileForwardProfile(Func<long>? timestamp = null)
 {
     private readonly FileDuration duration = new();
     private long Now() => (timestamp ?? Stopwatch.GetTimestamp)();
-    internal async Task Forward(Stream stream, Envelope frame, CancellationToken token)
+    internal async Task Forward(Stream stream, FileWire.ReceivedFrame received, CancellationToken token)
     {
         long start = Now(); bool success = false;
         try
         {
+            var frame = received.Message;
             if (frame.t is "ready" or "health" or "heartbeat" or "stopped")
             {
                 var data = JsonNode.Parse(frame.data.GetRawText())!;
@@ -25,8 +26,10 @@ internal sealed class FileForwardProfile(Func<long>? timestamp = null)
                     duration = duration.Snapshot()
                 });
                 frame = frame with { data = JsonSerializer.SerializeToElement(data) };
+                await FileWire.Forward(stream, frame, token);
             }
-            await FileWire.Forward(stream, frame, token); success = true;
+            else await received.Forward(stream, token);
+            success = true;
         }
         finally { duration.Record(Now() - start, !success); }
     }

--- a/sidecar/etw-file/FileForwardingTests.cs
+++ b/sidecar/etw-file/FileForwardingTests.cs
@@ -1,0 +1,187 @@
+using System.Diagnostics;
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+
+namespace Aegis.EtwLifecycle;
+
+internal static class FileForwardingTests
+{
+    internal static void Run(Action<string, Action> test)
+    {
+        test("fragmented broker input forwards consecutive observation bytes without rewriting", () =>
+        {
+            var record = Observation() with
+            {
+                generationStatus = "candidate",
+                generationSource = "createTime100ns",
+                generationWitness = "9007199254740993",
+                generationInterval = new { fromQpc = "5", toQpc = "6" }
+            };
+            var unicode = new JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+            string first = Json("observations", "1", "{ \"records\" : [" + JsonSerializer.Serialize(record) + "] }");
+            string second = Json("observations", "2", "{\"records\":[" + JsonSerializer.Serialize(record with { eventSeq = "3" }, unicode) + "]}");
+            byte[] bytes = [.. Frame(first), .. Frame(second)];
+            using var input = new FragmentedStream(bytes);
+            using var output = new MemoryStream();
+            var reader = new FileWire("launch", "session");
+            var profile = new FileForwardProfile();
+            for (int i = 1; i <= 2; i++)
+            {
+                var received = reader.ReadFrame(input, false, default).GetAwaiter().GetResult();
+                Check(received.Message.seq == i.ToString(), "frame-order");
+                profile.Forward(output, received, default).GetAwaiter().GetResult();
+            }
+            Check(output.ToArray().SequenceEqual(bytes), "observation-reencoded");
+        });
+        test("maximum-size validated body stays bounded through forwarding", () =>
+        {
+            string json = Json("observations", "1", "{\"records\":[]}");
+            byte[] bytes = Frame(json.PadRight(FileWire.Limit));
+            using var input = new MemoryStream(bytes);
+            using var output = new MemoryStream();
+            var received = new FileWire("launch", "session").ReadFrame(input, false, default).GetAwaiter().GetResult();
+            new FileForwardProfile().Forward(output, received, default).GetAwaiter().GetResult();
+            Check(output.Length == FileWire.Limit + 4 && output.ToArray().SequenceEqual(bytes), "frame-limit");
+        });
+        test("invalid broker input cannot reach the forwarding stream", () =>
+        {
+            string valid = Json("observations", "1", "{\"records\":[]}");
+            var invalid = new List<byte[]>
+            {
+                Frame(valid.Replace("\"launch\"", "\"foreign\"")),
+                Frame(valid.Replace("\"session\"", "\"foreign\"")),
+                Frame(valid.Replace(FileWire.Protocol, "etw-file/4")),
+                Frame(Json("observations", "01", "{}")),
+                Frame(Json("unknown", "1", "{}")),
+                Frame(Json("start", "1", "{}")),
+                Frame(valid.Replace("\"seq\" : \"1\"", "\"seq\":\"1\",\"seq\":\"2\"")),
+                Frame(Json("observations", "1", new string('[', 20) + "0" + new string(']', 20))),
+                Frame("{"), Frame(valid)[..^1], Frame(""),
+                new byte[] { 1, 0, 0, 0, 255 }, // Invalid UTF-8.
+            };
+            var oversized = new byte[4]; BinaryPrimitives.WriteInt32LittleEndian(oversized, FileWire.Limit + 1);
+            invalid.Add(oversized);
+            foreach (var bytes in invalid)
+            {
+                using var input = new MemoryStream(bytes);
+                using var output = new MemoryStream();
+                bool rejected = false;
+                try
+                {
+                    var received = new FileWire("launch", "session").ReadFrame(input, false, default).GetAwaiter().GetResult();
+                    new FileForwardProfile().Forward(output, received, default).GetAwaiter().GetResult();
+                }
+                catch (Exception ex) when (ex is InvalidDataException or JsonException or EndOfStreamException or DecoderFallbackException)
+                { rejected = true; }
+                Check(rejected && output.Length == 0, "unvalidated-frame-forwarded");
+            }
+        });
+        test("replayed input is rejected before a second forward", () =>
+        {
+            byte[] bytes = Frame(Json("observations", "1", "{\"records\":[]}"));
+            using var input = new MemoryStream([.. bytes, .. bytes]);
+            using var output = new MemoryStream();
+            var reader = new FileWire("launch", "session");
+            var profile = new FileForwardProfile();
+            profile.Forward(output, reader.ReadFrame(input, false, default).GetAwaiter().GetResult(), default).GetAwaiter().GetResult();
+            bool rejected = false;
+            try { profile.Forward(output, reader.ReadFrame(input, false, default).GetAwaiter().GetResult(), default).GetAwaiter().GetResult(); }
+            catch (InvalidDataException) { rejected = true; }
+            Check(rejected && output.ToArray().SequenceEqual(bytes), "replay-forwarded");
+        });
+        test("every telemetry kind is annotated instead of forwarding the stale body", () =>
+        {
+            foreach (string kind in new[] { "ready", "health", "heartbeat", "stopped" })
+            {
+                const string sample = "{\"performance\":{\"brokerForward\":null}}";
+                string data = kind is "ready" or "stopped" ? "{\"telemetry\":" + sample + "}" : sample;
+                using var input = new MemoryStream(Frame(Json(kind, "1", data)));
+                using var output = new MemoryStream();
+                var received = new FileWire("launch", "session").ReadFrame(input, false, default).GetAwaiter().GetResult();
+                new FileForwardProfile(() => 123).Forward(output, received, default).GetAwaiter().GetResult();
+                output.Position = 0;
+                var frame = new FileWire("launch", "session").Read(output, false, default).GetAwaiter().GetResult();
+                Check(frame.t == kind && frame.seq == received.Message.seq, "telemetry-identity");
+                var telemetry = kind is "ready" or "stopped" ? frame.data.GetProperty("telemetry") : frame.data;
+                var original = kind is "ready" or "stopped" ? received.Message.data.GetProperty("telemetry") : received.Message.data;
+                Check(telemetry.GetProperty("performance").GetProperty("brokerForward").GetProperty("asOfQpc").GetString() == "123", "stale-telemetry");
+                Check(original.GetProperty("performance").GetProperty("brokerForward").ValueKind == JsonValueKind.Null, "input-mutated");
+            }
+        });
+        test("cancelled forwarding emits no body and does not poison a later forward", () =>
+        {
+            byte[] bytes = Frame(Json("observations", "1", "{\"records\":[]}"));
+            using var input = new MemoryStream(bytes);
+            using var output = new MemoryStream();
+            using var cancel = new CancellationTokenSource(); cancel.Cancel();
+            var received = new FileWire("launch", "session").ReadFrame(input, false, default).GetAwaiter().GetResult();
+            var profile = new FileForwardProfile();
+            bool rejected = false;
+            try { profile.Forward(output, received, cancel.Token).GetAwaiter().GetResult(); }
+            catch (OperationCanceledException) { rejected = true; }
+            Check(rejected && output.Length == 0, "cancelled-output");
+            profile.Forward(output, received, default).GetAwaiter().GetResult();
+            Check(output.ToArray().SequenceEqual(bytes), "forward-poisoned");
+        });
+        test("broker forwarding allocates less than re-encoding validated observation frames", () =>
+        {
+            var record = Observation();
+            using var source = new MemoryStream();
+            var writer = new FileWire("launch", "session");
+            for (int i = 0; i < 100; i++)
+                writer.Write(source, "observations", new { records = Enumerable.Range(0, 64).Select(n => record with { eventSeq = (i * 64 + n + 1).ToString() }).ToArray() }, default).GetAwaiter().GetResult();
+            var input = source.ToArray();
+            (long Bytes, long Ticks) Measure(bool previous)
+            {
+                using var incoming = new MemoryStream(input);
+                using var outgoing = new MemoryStream(FileWire.Limit);
+                var read = new FileWire("launch", "session");
+                var profile = new FileForwardProfile();
+                long bytes = GC.GetAllocatedBytesForCurrentThread(), start = Stopwatch.GetTimestamp();
+                for (int i = 0; i < 100; i++)
+                {
+                    outgoing.SetLength(0); outgoing.Position = 0;
+                    var frame = read.ReadFrame(incoming, false, default).GetAwaiter().GetResult();
+                    if (previous) FileWire.Forward(outgoing, frame.Message, default).GetAwaiter().GetResult();
+                    else profile.Forward(outgoing, frame, default).GetAwaiter().GetResult();
+                }
+                return (GC.GetAllocatedBytesForCurrentThread() - bytes, Stopwatch.GetTimestamp() - start);
+            }
+            Measure(true); Measure(false);
+            var before = new List<(long Bytes, long Ticks)>();
+            var after = new List<(long Bytes, long Ticks)>();
+            for (int i = 0; i < 5; i++)
+            {
+                // Alternate order to reduce warm-up and drift bias in the timing report.
+                if (i % 2 == 0) { before.Add(Measure(true)); after.Add(Measure(false)); }
+                else { after.Add(Measure(false)); before.Add(Measure(true)); }
+            }
+            before.Sort((a, b) => a.Ticks.CompareTo(b.Ticks)); after.Sort((a, b) => a.Ticks.CompareTo(b.Ticks));
+            Console.WriteLine($"BROKER_FORWARD frames=100 records=6400 previousBytes={before[2].Bytes} currentBytes={after[2].Bytes} previousMedianTicks={before[2].Ticks} currentMedianTicks={after[2].Ticks} frequency={Stopwatch.Frequency}");
+            // Allocation is deterministic; wall time is reported, never a flaky CI gate.
+            Check(after[2].Bytes < before[2].Bytes * 0.95, "broker-allocation-regression");
+        });
+    }
+    private static FileObservation Observation()
+    {
+        var map = new FileMapping(new FileScope(@"C:\fixture", false), Stopwatch.Frequency);
+        map.Accept(new(1, 12, 1, 1, 71, 72, 72, null, 1, 0, @"C:\fixture\тест&"));
+        return map.Accept(new(2, 15, 1, 2, 71, 72, 72, null, 1, 0, null))!;
+    }
+    private static string Json(string kind, string seq, string data) =>
+        $"{{ \"t\" : \"{kind}\", \"proto\" : \"{FileWire.Protocol}\", \"launchId\" : \"launch\", \"sessionId\" : \"session\", \"seq\" : \"{seq}\", \"data\" : {data} }}";
+    private static byte[] Frame(string json)
+    {
+        byte[] body = Encoding.UTF8.GetBytes(json), result = new byte[body.Length + 4];
+        BinaryPrimitives.WriteInt32LittleEndian(result, body.Length); body.CopyTo(result, 4);
+        return result;
+    }
+    private sealed class FragmentedStream(byte[] bytes) : MemoryStream(bytes)
+    {
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken token = default) =>
+            base.ReadAsync(buffer[..Math.Min(7, buffer.Length)], token);
+    }
+    private static void Check(bool value, string reason)
+    { if (!value) throw new InvalidOperationException(reason); }
+}

--- a/sidecar/etw-file/FileOutputProfileTests.cs
+++ b/sidecar/etw-file/FileOutputProfileTests.cs
@@ -86,8 +86,13 @@ internal static class FileOutputProfileTests
             Check(!read.data.GetRawText().Contains("private-error"));
         });
     }
-    private static Envelope Frame(string kind, object data) =>
-        new(kind, FileWire.Protocol, "launch", "session", "1", JsonSerializer.SerializeToElement(data));
+    private static FileWire.ReceivedFrame Frame(string kind, object data)
+    {
+        using var stream = new MemoryStream();
+        new FileWire("launch", "session").Write(stream, kind, data, default).GetAwaiter().GetResult();
+        stream.Position = 0;
+        return new FileWire("launch", "session").ReadFrame(stream, false, default).GetAwaiter().GetResult();
+    }
     private static void Check(bool value) { if (!value) throw new InvalidOperationException("output-profile-check-failed"); }
     private sealed class TimedStream(Action advance) : MemoryStream
     {

--- a/sidecar/etw-file/FileTests.cs
+++ b/sidecar/etw-file/FileTests.cs
@@ -141,6 +141,7 @@ internal static class FileTests
         FileOutputTests.Run(Test);
         FilePerformanceTests.Run(Test);
         FileOutputProfileTests.Run(Test);
+        FileForwardingTests.Run(Test);
         FileWakeTests.Run(Test);
         Console.WriteLine($"{passed} self-tests passed; no ETW session or UAC requested.");
         return 0;

--- a/sidecar/etw-file/FileWire.cs
+++ b/sidecar/etw-file/FileWire.cs
@@ -8,6 +8,13 @@ namespace Aegis.EtwLifecycle;
 internal sealed record Envelope(string t, string proto, string launchId, string sessionId, string seq, JsonElement data);
 internal sealed class FileWire(string launch, string session, FilePerformance? performance = null)
 {
+    // A validated envelope and its original bounded body travel together. Changing
+    // an Envelope via 'with' never silently reuses a stale serialized body.
+    internal sealed class ReceivedFrame(Envelope message, ReadOnlyMemory<byte> body)
+    {
+        internal Envelope Message { get; } = message;
+        internal Task Forward(Stream stream, CancellationToken token) => WriteBody(stream, body, token);
+    }
     internal const string Protocol = "etw-file/5", Profile = "home-26200-diagnostic-v1";
     internal const int Limit = 256 * 1024;
     internal static readonly string[] Schemas = ["10:0", "12:1", "13:1", "14:1", "15:1"];
@@ -21,7 +28,10 @@ internal sealed class FileWire(string launch, string session, FilePerformance? p
         if (actual.Length != names.Length || actual.Distinct().Count() != names.Length || names.Any(n => !value.TryGetProperty(n, out _)))
             throw new InvalidDataException();
     }
-    internal async Task<Envelope> Read(Stream stream, bool control, CancellationToken token)
+    internal async Task<Envelope> Read(Stream stream, bool control, CancellationToken token) =>
+        (await ReadFrame(stream, control, token)).Message;
+
+    internal async Task<ReceivedFrame> ReadFrame(Stream stream, bool control, CancellationToken token)
     {
         byte[] header = new byte[4];
         await stream.ReadExactlyAsync(header, token);
@@ -51,7 +61,7 @@ internal sealed class FileWire(string launch, string session, FilePerformance? p
         }
         else if (frame.t is not ("hello" or "ready" or "observations" or "health" or "heartbeat" or "stopped" or "error"))
             throw new InvalidDataException();
-        return frame with { data = frame.data.Clone() };
+        return new ReceivedFrame(frame with { data = frame.data.Clone() }, body);
     }
     internal Task Write(Stream stream, string kind, object data, CancellationToken token) =>
         WriteCore(stream, kind, writer => { JsonSerializer.Serialize(writer, data); return true; }, token);

--- a/sidecar/etw-file/README.md
+++ b/sidecar/etw-file/README.md
@@ -49,6 +49,13 @@ count are retained. These counters contain no observations or paths. See
 snapshot timing and why dequeue counts do not certify delivery. This instrumentation
 has synthetic/process evidence only; a new live load check is deferred by the user.
 
+The `-5-forward` build preserves that v5 contract and forwards the original bounded
+body after envelope/identity/sequence validation for outbound frames that need no
+annotation. Telemetry is re-encoded with current broker measurements. This removes
+an observation serialization/allocation in the broker; it does not bypass main's
+payload validation. See [broker forwarding](../../docs/roadmap/etw-broker-forwarding.md)
+for the controlled allocation result, byte-preservation tests and live limits.
+
 For a separately agreed live check, run the following from normal PowerShell and
 approve **one** UAC prompt. The ordinary Node process reads its own temporary test
 file for ten seconds; only the collector elevates. This never sleeps the computer.


### PR DESCRIPTION
## Description

The ETW broker decoded and validated observation envelopes, then serialized the same records again before writing to main. Keep each validated envelope paired with its original bounded body and forward that body when no annotation is required. Telemetry still receives current broker timings and is encoded from the updated envelope.

On the controlled 100-frame / 6,400-record fixture, managed allocations fell from 16,641,576 to 13,933,888 bytes (16.27%). Five interleaved trials reported median elapsed times of 86.97 vs 58.76 ms. The test asserts allocation reduction only. These are in-memory results, not peak RAM, live throughput or a loss-free capture claim.

Protocol v5, identity/sequence/direction checks, main payload validation, queue/frame bounds and write deadlines remain in place. No UAC or sleep/wake run was performed; E3 stays open.

## Type of change

- [x] Performance improvement
- [x] Documentation update

## Testing

- The allocation regression failed before implementation; the final .NET 10 Release build, whitespace check and all 61 sidecar self-tests passed.
- New tests cover fragmented/consecutive byte preservation with Unicode and uint64 evidence, maximum-size frames, rejected malformed/foreign/replayed input before forwarding, fresh annotations on all telemetry kinds, and cancellation.
- Actual normal-token and deliberate-saturation collector/broker/main checks passed three scenarios each, retaining stop/EOF distinctions. Evidence includes matching binaries, benchmark output and 33 source hashes. No helper processes remained.
- Main/renderer JavaScript and configuration are unchanged. The required five CI contexts run the repository checks on this PR.

## Checklist

- [x] Follows project code conventions
- [x] No new console logging in production paths
- [x] New code files are under 300 lines
- [ ] Tested locally with `npm start` (this iteration exercised the diagnostic sidecar/process harness)
- [ ] Reviewed by a human
