### PR TITLE
perf(scanner): index process names once per scan

### DIFF
--- a/docs/bench/process-name-index-2026-09-13.json
+++ b/docs/bench/process-name-index-2026-09-13.json
@@ -1,0 +1,79 @@
+{
+  "schema": 1,
+  "kind": "offline-process-name-index",
+  "baseline": "607faa2efd6f5cb79ac208b13f47f1bd89246f86",
+  "node": "v24.11.1",
+  "platform": "win32",
+  "arch": "x64",
+  "sourceSha256": {
+    "previous": "3e38a4c163fcbc8c8925f3869a7ea6dd71cd9c4d2be27f798f362dfa088a5ca4",
+    "current": "0bbc8f23775c059a9b1488f5af9de32d0ee92db53783f177138d52b99f0a6ed9"
+  },
+  "inputsSha256": {
+    "src/shared/agent-database.json": "c7ac5f4aab02c5561af8fd5766bd1686a8eb2d0a8c67b345a5b2f0963956b16e",
+    "src/shared/constants.js": "c3886eace9abcc220688443e81dd20243b9b2b002207c5fbf17d560f3ffd81b2",
+    "src/main/settings-validation.js": "18e94e8b09972bc00c6e9fd8d9dc7a3c1c01026bd5dd4c4f07f85f2daa73fbcf"
+  },
+  "cases": [
+    {
+      "processes": 128,
+      "agents": 8,
+      "providerCallsPerArm": 150,
+      "previous": {
+        "samples": 30,
+        "scans": 150,
+        "medianMsPerScan": 0.604219999999998,
+        "p95MsPerScan": 1.159559999999999,
+        "cpuMsPerScan": 0.7266666666666667
+      },
+      "current": {
+        "samples": 30,
+        "scans": 150,
+        "medianMsPerScan": 0.09428000000000339,
+        "p95MsPerScan": 0.15673999999999638,
+        "cpuMsPerScan": 0.21333333333333335
+      },
+      "matchingResults": true
+    },
+    {
+      "processes": 512,
+      "agents": 32,
+      "providerCallsPerArm": 150,
+      "previous": {
+        "samples": 30,
+        "scans": 150,
+        "medianMsPerScan": 2.2167000000000145,
+        "p95MsPerScan": 2.508119999999997,
+        "cpuMsPerScan": 2.3866666666666667
+      },
+      "current": {
+        "samples": 30,
+        "scans": 150,
+        "medianMsPerScan": 0.26592000000000554,
+        "p95MsPerScan": 0.39926000000000383,
+        "cpuMsPerScan": 0.32
+      },
+      "matchingResults": true
+    },
+    {
+      "processes": 2048,
+      "agents": 128,
+      "providerCallsPerArm": 150,
+      "previous": {
+        "samples": 30,
+        "scans": 150,
+        "medianMsPerScan": 8.882540000000017,
+        "p95MsPerScan": 12.233259999999973,
+        "cpuMsPerScan": 8.1
+      },
+      "current": {
+        "samples": 30,
+        "scans": 150,
+        "medianMsPerScan": 0.7851000000000112,
+        "p95MsPerScan": 1.1273000000000137,
+        "cpuMsPerScan": 1.0666666666666667
+      },
+      "matchingResults": true
+    }
+  ]
+}

--- a/docs/bench/process-name-index-2026-09-13.md
+++ b/docs/bench/process-name-index-2026-09-13.md
@@ -1,0 +1,48 @@
+# Process-name lookup index — 2026-09-13
+
+`process-scanner.js` builds a lowercase name-to-agent map once per scan. Previously
+each observed process traversed the catalog and normalized candidate patterns.
+The map preserves first ownership, bundled precedence, custom-ID validation,
+exact case-insensitive matches, exclusions and first detected PID ordering.
+It is rebuilt after each fresh provider observation, including in-place catalog
+edits. Process observation, scan cadence and session identity are unchanged.
+
+## Controlled measurement
+
+Run from the repository root with an unused output filename:
+
+```powershell
+node scripts/bench-process-matching.cjs --baseline=607faa2efd6f5cb79ac208b13f47f1bd89246f86 --report=X:/tmp/process-name-index.json
+```
+
+The script loads the actual baseline and current scanner into separate CommonJS
+instances with the current dependencies. Both use the same deterministic process
+provider and bundled/custom catalog. After 20 warm-up scans per arm, 30 interleaved
+samples each contain five complete scanner calls. It checks equal results, unchanged
+input rows and exactly 150 measured provider calls per arm. It never invokes OS
+enumeration, monitoring timers or UAC. Only use trusted baseline commits.
+
+Windows x64, Node v24.11.1; elapsed milliseconds per scan:
+
+| Processes | Detected agents | Previous median | Indexed median | Previous p95 | Indexed p95 |
+| --- | --- | --- | --- | --- | --- |
+| 128 | 8 | 0.60422 | 0.09428 | 1.15956 | 0.15674 |
+| 512 | 32 | 2.21670 | 0.26592 | 2.50812 | 0.39926 |
+| 2,048 | 128 | 8.88254 | 0.78510 | 12.23326 | 1.12730 |
+
+Raw samples are summarized with CPU counters and source/input hashes in
+[the report](process-name-index-2026-09-13.json). Timing has no pass/fail threshold.
+These results cover JavaScript matching and scanner bookkeeping over a stubbed
+provider. They do not establish total application CPU savings, OS query latency
+or live ETW throughput. The script compares scanner source, not complete historical
+dependency trees.
+
+## Regression coverage
+
+The normalization-work regression failed on the baseline: 1,000 unrelated
+processes caused 1,000 normalizations of the sentinel catalog pattern, against
+a limit of 12 derived from the ten-process fixture. The index makes this work
+independent of process count. Other tests cover name conflicts, exclusions,
+duplicate PIDs, immediate catalog edits, process arrivals/exits and fresh shared
+maps. An unavailable observation remains unreliable; a valid snapshot containing
+only ordinary processes confirms an empty agent fleet.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2379,3 +2379,28 @@ passed. No EtwFile helpers remained. Reports and 33 source hashes are retained i
 This change does not close live burst loss E3. New live overhead/throughput and
 capture completeness remain unverified. JS/main/renderer source is unchanged;
 the required repository CI contexts must pass on this branch before merge.
+
+### 2026-09-13 — Per-scan process-name index
+
+Following merged #452 / `607faa2`, branch `codex/process-name-index` optimizes
+ordinary process recognition in the same isolated worktree. The scanner now
+normalizes the validated catalog once per scan and uses a first-owner Map lookup
+for each process. It still fetches fresh observations and reads the current custom
+catalog after the provider resolves; no cross-scan cache or scan cadence change.
+The existing shared snapshot and batched resource queries were already in place.
+
+The normalization-work regression failed on the old implementation and passed
+after the change. Five new tests cover work growth, matching precedence/exclusions,
+duplicate PIDs, catalog edits, arrivals/exits and shared-map freshness/outages.
+The offline benchmark executes both actual scanner versions against the same
+provider: median milliseconds per scan were 0.60422 to 0.09428 (128 processes),
+2.21670 to 0.26592 (512), and 8.88254 to 0.78510 (2,048). Outputs and provider-call
+counts matched. Method, limits and source hashes are retained in
+`docs/bench/process-name-index-2026-09-13.md` and its JSON report. These are controlled
+JavaScript measurements, not total application CPU or live ETW throughput results.
+No UAC/live ETW run, installer work or Claude adapter change was performed.
+
+Local coverage passed 207 files / 3,403 tests / four skips with two workers.
+Renderer build, formatting, both type checks, both four-mutant gates and production
+dependency audit passed. ESLint passed with 56 warnings in unchanged files.
+The required five CI contexts must pass on the final PR head before merge.

--- a/scripts/bench-process-matching.cjs
+++ b/scripts/bench-process-matching.cjs
@@ -1,0 +1,151 @@
+// Offline comparison of the actual scanner before/after a change. No OS process
+// enumeration, UAC, monitoring timers or user configuration writes are invoked.
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createHash } = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+const { createRequire } = require('node:module');
+const { compileFunction } = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const relative = 'src/main/process-scanner.js';
+const filename = path.join(root, relative);
+const baseline = process.argv.find((arg) => arg.startsWith('--baseline='))?.slice(11);
+const reportPath = process.argv.find((arg) => arg.startsWith('--report='))?.slice(9);
+if (!/^[0-9a-f]{40}$/.test(baseline || '') || !reportPath || fs.existsSync(reportPath))
+  throw new Error('Provide --baseline=<full commit SHA> and a new --report=<file>');
+
+const previousSource = execFileSync('git', ['show', `${baseline}:${relative}`], {
+  cwd: root,
+  encoding: 'utf8',
+  windowsHide: true,
+  maxBuffer: 1024 * 1024,
+});
+const currentSource = fs.readFileSync(filename, 'utf8');
+const hash = (source) => createHash('sha256').update(source).digest('hex');
+
+/** Load trusted repository scanner code as an isolated CJS instance with real dependencies. */
+function load(source) {
+  const module = { exports: {} };
+  compileFunction(source, ['require', 'module', 'exports', '__filename', '__dirname'], {
+    filename,
+  })(createRequire(filename), module, module.exports, filename, path.dirname(filename));
+  return module.exports;
+}
+
+const previous = load(previousSource),
+  current = load(currentSource);
+const custom = [
+  { id: 'bench-worker', displayName: 'Fixture Worker', names: ['local-fixture-worker.exe'] },
+];
+let rows = [],
+  previousCalls = 0,
+  currentCalls = 0;
+for (const scanner of [previous, current]) {
+  scanner.init({ trackSeenAgent() {}, getCustomAgents: () => custom });
+  scanner._setPlatformForTest({
+    providesStartTime: false,
+    listProcesses: async () => {
+      if (scanner === previous) previousCalls++;
+      else currentCalls++;
+      return rows;
+    },
+  });
+}
+
+/** Measure complete scanner calls over a controlled provider, including catalog and bookkeeping. */
+async function measure(scanner, iterations) {
+  const cpu = process.cpuUsage(),
+    start = performance.now();
+  for (let i = 0; i < iterations; i++) await scanner.scanProcesses();
+  const elapsed = performance.now() - start;
+  const used = process.cpuUsage(cpu);
+  return { elapsedMs: elapsed / iterations, cpuMicros: used.user + used.system };
+}
+
+/** Summarize interleaved samples without asserting a machine-dependent timing threshold. */
+function summarize(samples, iterations) {
+  const elapsed = samples.map((sample) => sample.elapsedMs).sort((a, b) => a - b);
+  return {
+    samples: samples.length,
+    scans: samples.length * iterations,
+    medianMsPerScan: elapsed[Math.floor(elapsed.length / 2)],
+    p95MsPerScan: elapsed[Math.ceil(elapsed.length * 0.95) - 1],
+    cpuMsPerScan:
+      samples.reduce((sum, sample) => sum + sample.cpuMicros, 0) /
+      (1000 * samples.length * iterations),
+  };
+}
+
+async function main() {
+  const report = {
+    schema: 1,
+    kind: 'offline-process-name-index',
+    baseline,
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    sourceSha256: { previous: hash(previousSource), current: hash(currentSource) },
+    inputsSha256: Object.fromEntries(
+      [
+        'src/shared/agent-database.json',
+        'src/shared/constants.js',
+        'src/main/settings-validation.js',
+      ].map((name) => [name, hash(fs.readFileSync(path.join(root, name)))]),
+    ),
+    cases: [],
+  };
+  const names = ['CODEX.EXE', 'ollama.exe', 'copilot-language-server', 'local-fixture-worker.exe'];
+  for (const count of [128, 512, 2048]) {
+    rows = Array.from({ length: count }, (_, index) => ({
+      pid: 1000 + index,
+      name: index % 16 === 0 ? names[(index / 16) % names.length] : `ordinary-worker-${index}.exe`,
+    }));
+    const unchanged = structuredClone(rows);
+    previous._resetForTest();
+    current._resetForTest();
+    // Reset restores catalog/capabilities, so re-arm only the supported seams.
+    for (const scanner of [previous, current]) {
+      scanner.init({ trackSeenAgent() {}, getCustomAgents: () => custom });
+      scanner._setPlatformForTest({ providesStartTime: false });
+    }
+    const expected = await previous.scanProcesses();
+    assert.deepStrictEqual(await current.scanProcesses(), expected);
+    await measure(previous, 20);
+    await measure(current, 20);
+    const beforeCalls = previousCalls,
+      afterCalls = currentCalls;
+    const oldSamples = [],
+      newSamples = [];
+    const iterations = 5;
+    for (let trial = 0; trial < 30; trial++) {
+      if (trial % 2 === 0) {
+        oldSamples.push(await measure(previous, iterations));
+        newSamples.push(await measure(current, iterations));
+      } else {
+        newSamples.push(await measure(current, iterations));
+        oldSamples.push(await measure(previous, iterations));
+      }
+    }
+    assert.equal(previousCalls - beforeCalls, 150);
+    assert.equal(currentCalls - afterCalls, 150);
+    assert.deepStrictEqual(rows, unchanged);
+    assert.deepStrictEqual(await current.scanProcesses(), await previous.scanProcesses());
+    report.cases.push({
+      processes: count,
+      agents: expected.agents.length,
+      providerCallsPerArm: 150,
+      previous: summarize(oldSamples, iterations),
+      current: summarize(newSamples, iterations),
+      matchingResults: true,
+    });
+  }
+  fs.writeFileSync(reportPath, JSON.stringify(report, null, 2) + '\n', { flag: 'wx' });
+  console.log(JSON.stringify(report, null, 2));
+}
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/main/process-scanner.js
+++ b/src/main/process-scanner.js
@@ -225,22 +225,29 @@ function _ensureAgentDb() {
 }
 
 /**
- * Merge the current validated custom catalog for this scan without mutating the bundled cache.
- * Bundled IDs and process patterns keep precedence; the first valid custom ID owns its names.
- * @returns {Array<{name: string, patterns: string[]}>} Current detection signatures
+ * Index this scan's validated catalog by lowercase process name. First ownership
+ * wins, including bundled patterns and duplicate custom IDs. Rebuild per scan so
+ * catalog edits take effect immediately; no process observation is cached here.
+ * @returns {Map<string, string>} Process name to agent display name
  * @since 0.14.1
  */
-function detectionSignatures() {
+function detectionIndex() {
   const signatures = [..._aiAgents];
   const ids = new Set(_agentDb.agents.map((agent) => agent.id));
   const custom = _getCustomAgents();
-  if (!Array.isArray(custom)) return signatures;
-  for (const agent of custom) {
+  for (const agent of Array.isArray(custom) ? custom : []) {
     if (!validateCustomAgent(agent).valid || ids.has(agent.id)) continue;
     ids.add(agent.id);
     signatures.push({ name: agent.displayName, patterns: [...agent.names] });
   }
-  return signatures;
+  const index = new Map();
+  for (const agent of signatures) {
+    for (const pattern of agent.patterns) {
+      const name = pattern.toLowerCase();
+      if (!index.has(name)) index.set(name, agent.name);
+    }
+  }
+  return index;
 }
 
 /** Set of editor host process names (lowercased) for fast lookup */
@@ -352,22 +359,20 @@ async function scanProcesses(opts = {}) {
     // pid-set and peakAgents bookkeeping run, and the return shape stays stable.
   }
   const detected = [];
-  const signatures = detectionSignatures();
+  const signatures = detectionIndex();
   for (const proc of processes) {
     const procName = proc.name.toLowerCase();
     if (IGNORE_PROCESS_PATTERNS.some((p) => procName.includes(p))) continue;
     if (EDITOR_HOST_SET.has(procName)) continue;
-    for (const agent of signatures) {
-      if (agent.patterns.some((p) => procName === p.toLowerCase())) {
-        detected.push({
-          agent: agent.name,
-          process: proc.name,
-          pid: proc.pid,
-          status: 'running',
-          category: 'ai',
-        });
-        break;
-      }
+    const agent = signatures.get(procName);
+    if (agent !== undefined) {
+      detected.push({
+        agent,
+        process: proc.name,
+        pid: proc.pid,
+        status: 'running',
+        category: 'ai',
+      });
     }
   }
   const seen = new Set();

--- a/tests/main/process-scanner-index.test.js
+++ b/tests/main/process-scanner-index.test.js
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import scanner from '../../src/main/process-scanner.js';
+
+describe('process-name matching work and freshness', () => {
+  let listProcesses;
+  let custom;
+
+  beforeEach(() => {
+    listProcesses = vi.fn();
+    custom = [];
+    scanner._resetForTest();
+    scanner._setPlatformForTest({ listProcesses, providesStartTime: false });
+    scanner.init({ trackSeenAgent: vi.fn(), getCustomAgents: () => custom });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    scanner._resetForTest();
+  });
+
+  it('keeps catalog normalization work independent of the number of unrelated processes', async () => {
+    const pattern = 'custom-index-probe.exe';
+    custom = [{ id: 'index-probe', displayName: 'Index Probe', names: [pattern] }];
+    const lower = String.prototype.toLowerCase;
+    let normalizations = 0;
+    vi.spyOn(String.prototype, 'toLowerCase').mockImplementation(function () {
+      if (String(this) === pattern) normalizations++;
+      return lower.call(this);
+    });
+    const run = async (count) => {
+      listProcesses.mockResolvedValue(
+        Array.from({ length: count }, (_, index) => ({
+          pid: index + 1,
+          name: `ordinary-worker-${index}`,
+        })),
+      );
+      normalizations = 0;
+      const result = await scanner.scanProcesses();
+      expect(result.agents).toEqual([]);
+      expect(result.reliable).toBe(true);
+      return normalizations;
+    };
+    const small = await run(10);
+    const large = await run(1000);
+    expect(listProcesses).toHaveBeenCalledTimes(2);
+    expect(large).toBeLessThanOrEqual(small + 2);
+  });
+
+  it('preserves first ownership, exact matching, exclusions and first detected PID order', async () => {
+    custom = [
+      {
+        id: 'first-worker',
+        displayName: 'First Worker',
+        names: ['shared-worker.exe', 'codex.exe', 'code.exe', 'nvidia-worker.exe', '__proto__'],
+      },
+      { id: 'second-worker', displayName: 'Second Worker', names: ['SHARED-WORKER.EXE'] },
+    ];
+    const codex = scanner.AI_AGENTS.find((agent) =>
+      agent.patterns.some((name) => name.toLowerCase() === 'codex.exe'),
+    ).name;
+    listProcesses.mockResolvedValue([
+      { pid: 7, name: 'SHARED-WORKER.EXE' },
+      { pid: 8, name: 'CODEX.EXE' },
+      { pid: 9, name: 'prefix-shared-worker.exe' },
+      { pid: 10, name: 'code.exe' },
+      { pid: 11, name: 'nvidia-worker.exe' },
+      { pid: 12, name: '__proto__' },
+      { pid: 7, name: 'codex.exe' },
+    ]);
+    expect((await scanner.scanProcesses()).agents).toEqual([
+      {
+        pid: 7,
+        process: 'SHARED-WORKER.EXE',
+        agent: 'First Worker',
+        status: 'running',
+        category: 'ai',
+      },
+      { pid: 8, process: 'CODEX.EXE', agent: codex, status: 'running', category: 'ai' },
+      { pid: 12, process: '__proto__', agent: 'First Worker', status: 'running', category: 'ai' },
+    ]);
+  });
+
+  it('applies in-place catalog edits and newly observed/exited processes on the next scan', async () => {
+    const signature = { id: 'live-worker', displayName: 'Before', names: ['before-worker'] };
+    custom = [signature];
+    listProcesses.mockResolvedValue([{ pid: 20, name: 'before-worker' }]);
+    expect((await scanner.scanProcesses()).agents[0].agent).toBe('Before');
+    signature.displayName = 'After';
+    signature.names[0] = 'after-worker';
+    listProcesses.mockResolvedValue([
+      { pid: 21, name: 'after-worker' },
+      { pid: 20, name: 'before-worker' },
+    ]);
+    expect(await scanner.scanProcesses()).toMatchObject({
+      changed: true,
+      reliable: true,
+      agents: [{ pid: 21, agent: 'After' }],
+    });
+    listProcesses.mockResolvedValue([{ pid: 100, name: 'ordinary-worker' }]);
+    expect(await scanner.scanProcesses()).toMatchObject({
+      changed: true,
+      reliable: true,
+      agents: [],
+    });
+    expect(listProcesses).toHaveBeenCalledTimes(3);
+  });
+
+  it('reads the current catalog after the fresh process observation resolves', async () => {
+    let complete;
+    listProcesses.mockReturnValue(
+      new Promise((resolve) => {
+        complete = resolve;
+      }),
+    );
+    const pending = scanner.scanProcesses();
+    custom = [{ id: 'late-worker', displayName: 'Late Worker', names: ['late-worker'] }];
+    complete([{ pid: 1, name: 'late-worker' }]);
+    expect((await pending).agents).toEqual([
+      expect.objectContaining({ pid: 1, agent: 'Late Worker' }),
+    ]);
+  });
+
+  it('carries each fresh shared map and distinguishes an outage from a confirmed empty agent fleet', async () => {
+    const first = new Map([[31, { name: 'codex.exe', startTime: 1 }]]);
+    const reused = new Map([[31, { name: 'CODEX.EXE', startTime: 2 }]]);
+    const ordinary = new Map([[32, { name: 'ordinary-worker', startTime: 3 }]]);
+    const snapshot = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(reused)
+      .mockResolvedValueOnce(new Map())
+      .mockResolvedValueOnce(ordinary);
+    listProcesses.mockResolvedValue([]);
+    scanner._setPlatformForTest({ providesStartTime: true, getParentProcessMap: snapshot });
+    const a = await scanner.scanProcesses({ sharedObservation: true });
+    const b = await scanner.scanProcesses({ sharedObservation: true });
+    expect(a.processMap).toBe(first);
+    expect(b.processMap).toBe(reused);
+    expect(b.agents[0]).toMatchObject({ pid: 31, process: 'CODEX.EXE' });
+    const unavailable = await scanner.scanProcesses({ sharedObservation: true });
+    expect(unavailable).toMatchObject({ agents: [], reliable: false });
+    expect(scanner.getProcessSensorHealth().state).toBe('DEGRADED');
+    const empty = await scanner.scanProcesses({ sharedObservation: true });
+    expect(empty).toMatchObject({ agents: [], reliable: true });
+    expect(empty.processMap).toBe(ordinary);
+    expect(scanner.getProcessSensorHealth().state).toBe('HEALTHY');
+    expect(snapshot).toHaveBeenCalledTimes(4);
+    expect(listProcesses).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

Every process scan previously traversed and lowercased catalog patterns for each observed process. Build a lowercase name-to-agent Map once per scan, preserving first ownership, bundled precedence, validation, exact matching, exclusions and PID order. Fresh OS observations and catalog edits still take effect on the next scan; polling and identity handling are unchanged.

The included offline benchmark executes both actual scanner versions with the same controlled provider. At 512 processes, median scanner time was 2.21670 ms before and 0.26592 ms after, with identical results and provider-call counts. This measures JavaScript matching/bookkeeping, not total application CPU or OS enumeration. The report includes source/input hashes and reproduction instructions.

## Type of change

- [x] Performance optimization
- [x] Documentation update

## Testing

- The catalog-normalization work regression failed before the change and passes with the index; five new cases also cover conflicts, exclusions, catalog updates, arrivals/exits and shared snapshot freshness/outages.
- Full coverage: 207 files, 3,403 tests passed, four skipped (`--maxWorkers=2`).
- Renderer build, formatting, lint, TypeScript and Svelte checks, both four-mutant gates, counts check and production dependency audit passed. Lint has 56 warnings in unchanged files; audit found zero vulnerabilities.
- Controlled benchmark: 128 / 512 / 2,048 processes, 30 interleaved samples per arm, five scans per sample. All output/provider parity assertions passed.

## Checklist

- [x] Follows code style guidelines (CommonJS main, Svelte 5 renderer)
- [x] No console.log in production code
- [ ] Files under 300 lines — new files are below the target; the existing scanner remains above it.
- [ ] I have tested this locally with `npm start`
- [ ] This code has been reviewed by a human (not solely AI-generated)
